### PR TITLE
Feature/swift2.0 - Added WatchOS 2 support in Cocoapods Spec File

### DIFF
--- a/RxCocoa.podspec
+++ b/RxCocoa.podspec
@@ -16,6 +16,9 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
+  if s.respond_to?(:watchos)
+    s.watchos.deployment_target = '2.0'
+  end
 
   s.source_files          = 'RxCocoa/RxCocoa/RxCocoa.h', 'RxCocoa/RxCocoa/Common/**/*.{swift,h,m}'
   s.ios.source_files      = 'RxCocoa/RxCocoa/iOS/**/*.swift'

--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -33,6 +33,9 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
+  if s.respond_to?(:watchos)
+    s.watchos.deployment_target = '2.0'
+  end
 
   s.source_files          = 'RxSwift/RxSwift/**/*.swift'
 end


### PR DESCRIPTION
In order to use RxSwift also on WatchOS 2 we need to declare the support in the Spec File like so:

```
  if s.respond_to?(:watchos)
    s.watchos.deployment_target = '2.0'
  end