### PR TITLE
Fixed Typo in Subjects Playground

### DIFF
--- a/Playgrounds/Subjects.playground/Contents.swift
+++ b/Playgrounds/Subjects.playground/Contents.swift
@@ -55,10 +55,10 @@ example("ReplaySubject") {
 
 ## BehaviorSubject a.k.a. Variable
 
-ReplaySubject emits to any observer all of the items, in the buffer, that were emitted by the source 
+[Edit me too] ReplaySubject emits to any observer all of the items, in the buffer, that were emitted by the source 
 
 */
-example("ReplaySubject") {
+example("BehaviorSubject") {
     let subject = BehaviorSubject(value: "z")
     writeSequenceToConsole("1", subject)
     sendNext(subject, "a")

--- a/Playgrounds/Subjects.playground/Contents.swift
+++ b/Playgrounds/Subjects.playground/Contents.swift
@@ -55,8 +55,7 @@ example("ReplaySubject") {
 
 ## BehaviorSubject a.k.a. Variable
 
-[Edit me too] ReplaySubject emits to any observer all of the items, in the buffer, that were emitted by the source 
-
+BehaviorSubject is similar to ReplaySubject except it only remembers the last item. This means that all subscribers will receive a value immediately (unless it is already completed).
 */
 example("BehaviorSubject") {
     let subject = BehaviorSubject(value: "z")


### PR DESCRIPTION
Note - BehaviorSubject still also needs a description (seems to be copy pasted from ReplaySubject)