### PR TITLE
Fix renamed and deprecated zero rect and join

### DIFF
--- a/RxDataSourceStarterKit/Changeset.swift
+++ b/RxDataSourceStarterKit/Changeset.swift
@@ -48,7 +48,7 @@ public struct Changeset<S: SectionModelType> : CustomStringConvertible {
 
     public var description : String {
         get {
-            let serializedSections = "[\n" + ",\n".join(finalSections.map { "\($0)" }) + "\n]\n"
+            let serializedSections = "[\n" + finalSections.map { "\($0)" }.joinWithSeparator(",\n") + "\n]\n"
             return " >> Final sections"
             + "   \n\(serializedSections)"
             + (insertedSections.count > 0 || deletedSections.count > 0 || movedSections.count > 0 || updatedSections.count > 0 ? "\nSections:" : "")

--- a/RxExample/RxExample/Examples/TableView/TableViewController.swift
+++ b/RxExample/RxExample/Examples/TableView/TableViewController.swift
@@ -111,7 +111,7 @@ class TableViewController: ViewController, UITableViewDelegate {
     func tableView(tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let title = dataSource.sectionAtIndex(section)
         
-        let label = UILabel(frame: CGRect.zeroRect)
+        let label = UILabel(frame: CGRect.zero)
         // hacky I know :)
         label.text = "  \(title)"
         label.textColor = UIColor.whiteColor()


### PR DESCRIPTION
Changes:

- Use `SequenceType.joinWithSeperator` instead of `Array.join`. I cannot seem to find verification for why `Array.join` doesn't work (it's like it doesn't exist (●__●)), but it doesn't work in any case, and `SequenceType.joinWithSeparator` does.
- `CGRect.zeroRect` has been renamed to `CGRect.zero`