### PR TITLE
Remove Box references in enums

### DIFF
--- a/RxCocoa/iOS/UIImageView+Rx.swift
+++ b/RxCocoa/iOS/UIImageView+Rx.swift
@@ -22,8 +22,7 @@ extension ObservableType where E == UIImage? {
             MainScheduler.ensureExecutingOnScheduler()
             
             switch event {
-            case .Next(let boxedValue):
-                let value = boxedValue
+            case .Next(let value):
                 if animated && value != nil {
                     let transition = CATransition()
                     transition.duration = 0.25

--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -9,18 +9,10 @@
 import Foundation
 
 
-/// Due to current swift limitations, we have to include this Box in RxResult.
-/// Swift cannot handle an enum with multiple associated data (A, NSError) where one is of unknown size (A)
-/// This can be swiftified once the compiler is completed
-
 /**
 *   Represents event that happened
-*   `Box` is there because of a bug in swift compiler
-*       >> error: unimplemented IR generation feature non-fixed multi-payload enum layout
 */
 public enum Event<Element> : CustomStringConvertible {
-    // Box is used because swift compiler doesn't know
-    // how to handle `Next(Element)` and it crashes.
     case Next(Element) // next element of a sequence
     case Error(ErrorType)   // sequence failed with error
     case Completed          // sequence terminated successfully
@@ -28,8 +20,8 @@ public enum Event<Element> : CustomStringConvertible {
     public var description: String {
         get {
             switch self {
-            case .Next(let boxedValue):
-                return "Next(\(boxedValue))"
+            case .Next(let value):
+                return "Next(\(value))"
             case .Error(let error):
                 return "Error(\(error))"
             case .Completed:

--- a/RxSwift/RxBox.swift
+++ b/RxSwift/RxBox.swift
@@ -8,6 +8,20 @@
 
 import Foundation
 
+// Wrapper for any value type
+public class RxBox<T> : CustomStringConvertible {
+    public let value : T
+    public init (_ value: T) {
+        self.value = value
+    }
+    
+    public var description: String {
+        get {
+            return "Box(\(self.value))"
+        }
+    }
+}
+
 // Wrapper for any value type that can be mutated
 public class RxMutableBox<T> : CustomStringConvertible {
     public var value : T

--- a/RxSwift/RxBox.swift
+++ b/RxSwift/RxBox.swift
@@ -8,24 +8,6 @@
 
 import Foundation
 
-// Because ... Swift
-// Because ... Crash
-// Because ... compiler bugs
-
-// Wrapper for any value type
-public class RxBox<T> : CustomStringConvertible {
-    public let value : T
-    public init (_ value: T) {
-        self.value = value
-    }
-    
-    public var description: String {
-        get {
-            return "Box(\(self.value))"
-        }
-    }
-}
-
 // Wrapper for any value type that can be mutated
 public class RxMutableBox<T> : CustomStringConvertible {
     public var value : T

--- a/RxSwift/RxResult.swift
+++ b/RxSwift/RxResult.swift
@@ -25,8 +25,6 @@ import Foundation
 // result types.
 //
 public enum RxResult<T> {
-    // Box is used is because swift compiler doesn't know
-    // how to handle `Success(ResultType)` and it crashes.
     case Success(T)
     case Failure(ErrorType)
 }


### PR DESCRIPTION
Those are not used/necessary any more in Swift 2.