### PR TITLE
Using wrong cache

### DIFF
--- a/RxExample/RxExample/Services/ImageService.swift
+++ b/RxExample/RxExample/Services/ImageService.swift
@@ -61,7 +61,7 @@ class DefaultImageService: ImageService {
     
     func imageFromURL(URL: NSURL) -> Observable<Image> {
         return deferred {
-            let maybeImage = self.imageDataCache.objectForKey(URL) as? Image
+            let maybeImage = self.imageCache.objectForKey(URL) as? Image
             
             let decodedImage: Observable<Image>
             

--- a/RxExample/RxExample/Services/ImageService.swift
+++ b/RxExample/RxExample/Services/ImageService.swift
@@ -28,7 +28,7 @@ class DefaultImageService: ImageService {
 	
 	let $: Dependencies = Dependencies.sharedDependencies
 	
-    // 1rst level cache
+    // 1st level cache
     let imageCache = NSCache()
     
     // 2nd level cache


### PR DESCRIPTION
Previously, the 1st-level `imageCache` was never utilized. Items would be place into the cache, but the code would only check the 2nd-level cache for both an `Image` or `NSData`