### PR TITLE
Add rx_enabled to UIBarButtonItem extension

### DIFF
--- a/RxCocoa/iOS/UIBarButtonItem+Rx.swift
+++ b/RxCocoa/iOS/UIBarButtonItem+Rx.swift
@@ -13,6 +13,25 @@ import RxSwift
 
 extension UIBarButtonItem {
     
+	/**
+	Bindable sink for `enabled` property.
+	*/
+	public var rx_enabled: ObserverOf<Bool> {
+		return ObserverOf { [weak self] event in
+			MainScheduler.ensureExecutingOnScheduler()
+			
+			switch event {
+			case .Next(let value):
+				self?.enabled = value
+			case .Error(let error):
+				bindingErrorToInterface(error)
+				break
+			case .Completed:
+				break
+			}
+		}
+	}
+	
     /**
     Reactive wrapper for target action pattern on `self`.
     */


### PR DESCRIPTION
Since UIBarButtonItem doesn't inherit from UIControl, I had to add this.

I'll leave it to someone else to refactor it, unless I get the chance later.