### PR TITLE
Use guard for simplification.

### DIFF
--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaAPI.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaAPI.swift
@@ -56,13 +56,11 @@ class DefaultWikipediaAPI: WikipediaAPI {
     // http://en.wikipedia.org/w/api.php?action=parse&page=rx&format=json
     func articleContent(searchResult: WikipediaSearchResult) -> Observable<WikipediaPage> {
         let escapedPage = URLEscape(searchResult.title)
-        let url = NSURL(string: "http://en.wikipedia.org/w/api.php?action=parse&page=\(escapedPage)&format=json")
-        
-        if url == nil {
+        guard let url = NSURL(string: "http://en.wikipedia.org/w/api.php?action=parse&page=\(escapedPage)&format=json") else {
             return failWith(apiError("Can't create url"))
         }
         
-        return $.URLSession.rx_JSON(url!)
+        return $.URLSession.rx_JSON(url)
             .map { jsonResult in
                 guard let json = jsonResult as? NSDictionary else {
                     throw exampleError("Parsing error")

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaPage.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaPage.swift
@@ -22,13 +22,11 @@ struct WikipediaPage {
     
     // tedious parsing part
     static func parseJSON(json: NSDictionary) throws -> WikipediaPage {
-        let title = json.valueForKey("parse")?.valueForKey("title") as? String
-        let text = json.valueForKey("parse")?.valueForKey("text")?.valueForKey("*") as? String
-        
-        if title == nil || text == nil {
+        guard let title = json.valueForKey("parse")?.valueForKey("title") as? String,
+              let text = json.valueForKey("parse")?.valueForKey("text")?.valueForKey("*") as? String else {
             throw apiError("Error parsing page content")
         }
         
-        return WikipediaPage(title: title!, text: text!)
+        return WikipediaPage(title: title, text: text)
     }
 }

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaSearchResult.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaSearchResult.swift
@@ -39,20 +39,14 @@ struct WikipediaSearchResult: CustomStringConvertible {
             let (first, url) = result
             let (title, description) = first
 
-            let titleString = title as? String,
-            descriptionString = description as? String,
-            urlString = url as? String
-
-            if titleString == nil || descriptionString == nil || urlString == nil {
+            guard let titleString = title as? String,
+                  let descriptionString = description as? String,
+                  let urlString = url as? String,
+                  let URL = NSURL(string: urlString) else {
                 throw WikipediaParseError
             }
 
-            let URL = NSURL(string: urlString!)
-            if URL == nil {
-                throw WikipediaParseError
-            }
-
-            return WikipediaSearchResult(title: titleString!, description: descriptionString!, URL: URL!)
+            return WikipediaSearchResult(title: titleString, description: descriptionString, URL: URL)
         })
 
         return searchResults

--- a/RxExample/RxExample/Services/ImageService.swift
+++ b/RxExample/RxExample/Services/ImageService.swift
@@ -45,15 +45,10 @@ class DefaultImageService: ImageService {
         return just(imageData)
             .observeOn($.backgroundWorkScheduler)
             .map { data in
-                let maybeImage = Image(data: data)
-                
-                if maybeImage == nil {
+                guard let image = Image(data: data) else {
                     // some error
                     throw apiError("Decoding image error")
                 }
-                
-                let image = maybeImage!
-                
                 return image
             }
             .observeOn($.mainScheduler)


### PR DESCRIPTION
When I was looking into the RxExample code, I thought it could be improved by using `guard` statements introduced in Swift 2.
Though it is not essential change for RxExample, if it is good for you, please consider merge it.
Thanks :)