### PR TITLE
Using wrong cache

### DIFF
--- a/Rx.playground/Pages/Combining_Observables.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Combining_Observables.xcplaygroundpage/Contents.swift
@@ -78,7 +78,7 @@ example("combineLatest 2") {
 
 
 
-//: Combine latest has versions with more then 2 arguments.
+//: Combine latest has versions with more than 2 arguments.
 
 example("combineLatest 3") {
     let intOb1 = just(2)

--- a/RxCocoa/Common/CLLocationManager+Rx.swift
+++ b/RxCocoa/Common/CLLocationManager+Rx.swift
@@ -13,18 +13,18 @@ import RxSwift
 
 
 extension CLLocationManager {
-    
+
     /**
     Reactive wrapper for `delegate`.
-    
+
     For more information take a look at `DelegateProxyType` protocol documentation.
     */
     public var rx_delegate: DelegateProxy {
         return proxyForObject(self) as RxCLLocationManagerDelegateProxy
     }
-    
+
     // MARK: Responding to Location Events
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -34,7 +34,7 @@ extension CLLocationManager {
                 return a[1] as? [CLLocation]
             }
     }
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -44,7 +44,7 @@ extension CLLocationManager {
                 return a[1] as? NSError
             }
     }
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -54,9 +54,9 @@ extension CLLocationManager {
                 return a[1] as? NSError
             }
     }
-    
+
     // MARK: Pausing Location Updates
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -66,7 +66,7 @@ extension CLLocationManager {
                 return ()
             }
     }
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -76,21 +76,23 @@ extension CLLocationManager {
                 return ()
             }
     }
-    
+
     // MARK: Responding to Heading Events
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
+    #if os(iOS) || os(OSX)
     public var rx_didUpdateHeading: Observable<CLHeading!> {
         return rx_delegate.observe("locationManager:didUpdateHeading:")
             .map { a in
                 return a[1] as? CLHeading
             }
     }
-    
+    #endif
+
     // MARK: Responding to Region Events
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -100,7 +102,7 @@ extension CLLocationManager {
                 return a[1] as? CLRegion
             }
     }
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -110,10 +112,11 @@ extension CLLocationManager {
                 return a[1] as? CLRegion
             }
     }
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
+    #if os(iOS) || os(OSX)
     @available(OSX 10.10, *)
     public var rx_didDetermineStateForRegion: Observable<(state: CLRegionState, region: CLRegion!)> {
         return rx_delegate.observe("locationManager:didDetermineState:forRegion:")
@@ -122,7 +125,8 @@ extension CLLocationManager {
                 return (state: CLRegionState(rawValue: stateNumber.integerValue) ?? CLRegionState.Unknown, region: a[2] as? CLRegion)
             }
     }
-    
+    #endif
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -132,7 +136,7 @@ extension CLLocationManager {
                 return (region: a[1] as? CLRegion, error: a[2] as? NSError)
             }
     }
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -142,11 +146,11 @@ extension CLLocationManager {
                 return a[1] as? CLRegion
             }
     }
-    
+
     // MARK: Responding to Ranging Events
-    
+
 #if os(iOS)
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -156,7 +160,7 @@ extension CLLocationManager {
                 return (beacons: a[1] as? [CLBeacon], region: a[2] as? CLBeaconRegion)
             }
     }
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -166,9 +170,9 @@ extension CLLocationManager {
                 return (region: a[1] as? CLBeaconRegion, error: a[2] as? NSError)
             }
     }
-    
+
     // MARK: Responding to Visit Events
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -179,11 +183,11 @@ extension CLLocationManager {
                 return a[1] as? CLVisit
             }
     }
-    
+
 #endif
-    
+
     // MARK: Responding to Authorization Changes
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -194,7 +198,7 @@ extension CLLocationManager {
                 return CLAuthorizationStatus(rawValue: Int32(number.integerValue))
             }
     }
-    
-    
-    
+
+
+
 }

--- a/RxCocoa/Common/CLLocationManager+Rx.swift
+++ b/RxCocoa/Common/CLLocationManager+Rx.swift
@@ -118,7 +118,8 @@ extension CLLocationManager {
     public var rx_didDetermineStateForRegion: Observable<(state: CLRegionState, region: CLRegion!)> {
         return rx_delegate.observe("locationManager:didDetermineState:forRegion:")
             .map { a in
-                return (state: a[1] as! CLRegionState, region: a[2] as? CLRegion)
+                let stateNumber = a[1] as! NSNumber
+                return (state: CLRegionState(rawValue: stateNumber.integerValue) ?? CLRegionState.Unknown, region: a[2] as? CLRegion)
             }
     }
     
@@ -189,7 +190,8 @@ extension CLLocationManager {
     public var rx_didChangeAuthorizationStatus: Observable<CLAuthorizationStatus?> {
         return rx_delegate.observe("locationManager:didChangeAuthorizationStatus:")
             .map { a in
-                return CLAuthorizationStatus(rawValue: Int32((a[1] as! NSNumber).integerValue))
+                let number = a[1] as! NSNumber
+                return CLAuthorizationStatus(rawValue: Int32(number.integerValue))
             }
     }
     

--- a/RxCocoa/Common/Observables/NSURLSession+Rx.swift
+++ b/RxCocoa/Common/Observables/NSURLSession+Rx.swift
@@ -136,7 +136,10 @@ extension NSURLSession {
                 return data ?? NSData()
             }
             else {
-                throw rxError(.NetworkError, message: "Server returned failure", userInfo: [RxCocoaErrorHTTPResponseKey: response])
+                throw rxError(.NetworkError, message: "Server returned failure", userInfo: [
+                    RxCocoaErrorHTTPResponseKey: response,
+                    RxCocoaErrorHTTPResponseDataKey: data ?? NSData()
+                ])
             }
         }
     }

--- a/RxCocoa/Common/RxCocoa.swift
+++ b/RxCocoa/Common/RxCocoa.swift
@@ -31,6 +31,11 @@ public let RxCocoaErrorDomain = "RxCocoaError"
 */
 public let RxCocoaErrorHTTPResponseKey = "RxCocoaErrorHTTPResponseKey"
 
+/**
+`userInfo` key for `NSData` object when `RxCocoaError.NetworkError` happens.
+*/
+public let RxCocoaErrorHTTPResponseDataKey = "RxCocoaErrorHTTPResponseDataKey"
+
 func rxError(errorCode: RxCocoaError, _ message: String) -> NSError {
     return NSError(domain: RxCocoaErrorDomain, code: errorCode.rawValue, userInfo: [NSLocalizedDescriptionKey: message])
 }

--- a/RxCocoa/iOS/UIBarButtonItem+Rx.swift
+++ b/RxCocoa/iOS/UIBarButtonItem+Rx.swift
@@ -13,6 +13,25 @@ import RxSwift
 
 extension UIBarButtonItem {
     
+	/**
+	Bindable sink for `enabled` property.
+	*/
+	public var rx_enabled: ObserverOf<Bool> {
+		return ObserverOf { [weak self] event in
+			MainScheduler.ensureExecutingOnScheduler()
+			
+			switch event {
+			case .Next(let value):
+				self?.enabled = value
+			case .Error(let error):
+				bindingErrorToInterface(error)
+				break
+			case .Completed:
+				break
+			}
+		}
+	}
+	
     /**
     Reactive wrapper for target action pattern on `self`.
     */

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaAPI.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaAPI.swift
@@ -56,13 +56,11 @@ class DefaultWikipediaAPI: WikipediaAPI {
     // http://en.wikipedia.org/w/api.php?action=parse&page=rx&format=json
     func articleContent(searchResult: WikipediaSearchResult) -> Observable<WikipediaPage> {
         let escapedPage = URLEscape(searchResult.title)
-        let url = NSURL(string: "http://en.wikipedia.org/w/api.php?action=parse&page=\(escapedPage)&format=json")
-        
-        if url == nil {
+        guard let url = NSURL(string: "http://en.wikipedia.org/w/api.php?action=parse&page=\(escapedPage)&format=json") else {
             return failWith(apiError("Can't create url"))
         }
         
-        return $.URLSession.rx_JSON(url!)
+        return $.URLSession.rx_JSON(url)
             .map { jsonResult in
                 guard let json = jsonResult as? NSDictionary else {
                     throw exampleError("Parsing error")

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaPage.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaPage.swift
@@ -22,13 +22,11 @@ struct WikipediaPage {
     
     // tedious parsing part
     static func parseJSON(json: NSDictionary) throws -> WikipediaPage {
-        let title = json.valueForKey("parse")?.valueForKey("title") as? String
-        let text = json.valueForKey("parse")?.valueForKey("text")?.valueForKey("*") as? String
-        
-        if title == nil || text == nil {
+        guard let title = json.valueForKey("parse")?.valueForKey("title") as? String,
+              let text = json.valueForKey("parse")?.valueForKey("text")?.valueForKey("*") as? String else {
             throw apiError("Error parsing page content")
         }
         
-        return WikipediaPage(title: title!, text: text!)
+        return WikipediaPage(title: title, text: text)
     }
 }

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaSearchResult.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaSearchResult.swift
@@ -39,20 +39,14 @@ struct WikipediaSearchResult: CustomStringConvertible {
             let (first, url) = result
             let (title, description) = first
 
-            let titleString = title as? String,
-            descriptionString = description as? String,
-            urlString = url as? String
-
-            if titleString == nil || descriptionString == nil || urlString == nil {
+            guard let titleString = title as? String,
+                  let descriptionString = description as? String,
+                  let urlString = url as? String,
+                  let URL = NSURL(string: urlString) else {
                 throw WikipediaParseError
             }
 
-            let URL = NSURL(string: urlString!)
-            if URL == nil {
-                throw WikipediaParseError
-            }
-
-            return WikipediaSearchResult(title: titleString!, description: descriptionString!, URL: URL!)
+            return WikipediaSearchResult(title: titleString, description: descriptionString, URL: URL)
         })
 
         return searchResults

--- a/RxExample/RxExample/Services/ImageService.swift
+++ b/RxExample/RxExample/Services/ImageService.swift
@@ -45,15 +45,10 @@ class DefaultImageService: ImageService {
         return just(imageData)
             .observeOn($.backgroundWorkScheduler)
             .map { data in
-                let maybeImage = Image(data: data)
-                
-                if maybeImage == nil {
+                guard let image = Image(data: data) else {
                     // some error
                     throw apiError("Decoding image error")
                 }
-                
-                let image = maybeImage!
-                
                 return image
             }
             .observeOn($.mainScheduler)

--- a/RxSwift/Disposables/AnonymousDisposable.swift
+++ b/RxSwift/Disposables/AnonymousDisposable.swift
@@ -45,9 +45,10 @@ public final class AnonymousDisposable : DisposeBase, Cancelable {
     */
     public func dispose() {
         if OSAtomicCompareAndSwap32(0, 1, &_disposed) {
-            let action = self.disposeAction!
-            self.disposeAction = nil
-            action()
+            if let action = self.disposeAction {
+                self.disposeAction = nil
+                action()
+            }
         }
     }
 }

--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -74,10 +74,8 @@ extension Event {
     public var isStopEvent: Bool {
         get {
             switch self {
-            case .Next:
-                return false
-            case .Error: fallthrough
-            case .Completed: return true
+            case .Next: return false
+            case .Error, .Completed: return true
             }
         }
     }

--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -87,12 +87,10 @@ extension Event {
     */
     public var element: Element? {
         get {
-            switch self {
-            case .Next(let value):
+            if case .Next(let value) = self {
                 return value
-            case .Error: fallthrough
-            case .Completed: return nil
             }
+            return nil
         }
     }
     
@@ -101,14 +99,10 @@ extension Event {
     */
     public var error: ErrorType? {
         get {
-            switch self {
-            case .Next:
-                return nil
-            case .Error(let error):
+            if case .Error(let error) = self {
                 return error
-            case .Completed:
-                return nil
             }
+            return nil
         }
     }
 }

--- a/RxSwift/Observable+Extensions.swift
+++ b/RxSwift/Observable+Extensions.swift
@@ -72,11 +72,8 @@ extension ObservableType {
     public func subscribeNext(onNext: (E) -> Void)
         -> Disposable {
         let observer = AnonymousObserver<E> { e in
-            switch e {
-            case .Next(let value):
+            if case .Next(let value) = e {
                 onNext(value)
-            default:
-                break
             }
         }
         return self.subscribeSafe(observer)
@@ -91,11 +88,8 @@ extension ObservableType {
     public func subscribeError(onError: (ErrorType) -> Void)
         -> Disposable {
         let observer = AnonymousObserver<E> { e in
-            switch e {
-            case .Error(let error):
+            if case .Error(let error) = e {
                 onError(error)
-            default:
-                break
             }
         }
         return self.subscribeSafe(observer)
@@ -110,11 +104,8 @@ extension ObservableType {
     public func subscribeCompleted(onCompleted: () -> Void)
         -> Disposable {
         let observer = AnonymousObserver<E> { e in
-            switch e {
-            case .Completed:
+            if case .Completed = e {
                 onCompleted()
-            default:
-                break
             }
         }
         return self.subscribeSafe(observer)

--- a/RxSwift/Observables/Implementations/AnonymousObservable.swift
+++ b/RxSwift/Observables/Implementations/AnonymousObservable.swift
@@ -27,9 +27,7 @@ class AnonymousObservableSink<O: ObserverType> : Sink<O>, ObserverType {
                 return
             }
             self.observer?.on(event)
-        case .Error:
-            fallthrough
-        case .Completed:
+        case .Error, .Completed:
             if OSAtomicCompareAndSwap32(0, 1, &isStopped) {
                 self.observer?.on(event)
                 self.dispose()

--- a/RxSwift/Observables/Implementations/AsObservable.swift
+++ b/RxSwift/Observables/Implementations/AsObservable.swift
@@ -19,8 +19,7 @@ class AsObservableSink<O: ObserverType> : Sink<O>, ObserverType {
         observer?.on(event)
         
         switch event {
-        case .Error: fallthrough
-        case .Completed:
+        case .Error, .Completed:
             self.dispose()
         default: break
         }

--- a/RxSwift/Observables/Implementations/ConnectableObservable.swift
+++ b/RxSwift/Observables/Implementations/ConnectableObservable.swift
@@ -28,7 +28,9 @@ class Connection<S: SubjectType> : Disposable {
             }
             
             self.subscription = nil
-            self.parent!.connection = nil
+            if let parent = self.parent {
+                parent.connection = nil
+            }
             self.parent = nil
             
             oldSubscription.dispose()

--- a/RxSwift/Observables/Implementations/DistinctUntilChanged.swift
+++ b/RxSwift/Observables/Implementations/DistinctUntilChanged.swift
@@ -43,8 +43,7 @@ class DistinctUntilChangedSink<O: ObserverType, Key>: Sink<O>, ObserverType {
                 observer?.on(.Error(error))
                 self.dispose()
             }
-        case .Error: fallthrough
-        case .Completed:
+        case .Error, .Completed:
             observer?.on(event)
             self.dispose()
         }

--- a/RxSwift/Observables/Implementations/Filter.swift
+++ b/RxSwift/Observables/Implementations/Filter.swift
@@ -33,8 +33,7 @@ class FilterSink<O : ObserverType>: Sink<O>, ObserverType {
                     observer?.on(.Error(e))
                     self.dispose()
                 }
-            case .Completed: fallthrough
-            case .Error:
+            case .Completed, .Error:
                 observer?.on(event)
                 self.dispose()
         }

--- a/RxSwift/Observables/Implementations/Multicast.swift
+++ b/RxSwift/Observables/Implementations/Multicast.swift
@@ -43,8 +43,8 @@ class MulticastSink<S: SubjectType, O: ObserverType>: Sink<O>, ObserverType {
         observer?.on(event)
         switch event {
             case .Next: break
-            case .Error: fallthrough
-            case .Completed: self.dispose()
+            case .Error, .Completed:
+                self.dispose()
         }
     }
 }

--- a/RxSwift/Observables/Implementations/RefCount.swift
+++ b/RxSwift/Observables/Implementations/RefCount.swift
@@ -54,8 +54,7 @@ class RefCountSink<CO: ConnectableObservableType, O: ObserverType where CO.E == 
         switch event {
         case .Next:
             observer?.on(event)
-        case .Error: fallthrough
-        case .Completed:
+        case .Error, .Completed:
             observer?.on(event)
             self.dispose()
         }

--- a/RxSwift/Observables/Implementations/Switch.swift
+++ b/RxSwift/Observables/Implementations/Switch.swift
@@ -89,8 +89,8 @@ class SwitchSinkIter<S: ObservableType, O: ObserverType where S.E == O.E> : Obse
             
             switch event {
             case .Next: break
-            case .Error: fallthrough
-            case .Completed: self._self.dispose()
+            case .Error, .Completed:
+                self._self.dispose()
             }
             
             if parent.latest != self.id {

--- a/RxSwift/Observables/Implementations/Throttle.swift
+++ b/RxSwift/Observables/Implementations/Throttle.swift
@@ -38,10 +38,8 @@ class ThrottleSink<O: ObserverType, Scheduler: SchedulerType> : Sink<O>, Observe
         switch event {
         case .Next:
             break
-        case .Error: fallthrough
-        case .Completed:
+        case .Error, .Completed:
             cancellable.dispose()
-            break
         }
        
         let latestId = self.lock.calculateLocked { () -> UInt64 in

--- a/RxSwift/ObserverType.swift
+++ b/RxSwift/ObserverType.swift
@@ -25,3 +25,32 @@ public protocol ObserverType {
     func on(event: Event<E>)
 }
 
+/**
+Convienence API extensions to provide alternate next, error, completed events
+*/
+public extension ObserverType {
+    
+    /**
+    Convienence method equivalent to `on(.Next(element: E))`
+    
+    - parameter element: Next element to send to observer(s)
+    */
+    final func onNext(element: E) {
+        on(.Next(element))
+    }
+    
+    /**
+    Convienence method equivalent to `on(.Completed)`
+    */
+    final func onComplete() {
+        on(.Completed)
+    }
+    
+    /**
+    Convienence method equivalent to `on(.Error(error: ErrorType))`
+    - parameter error: ErrorType to send to observer(s)
+    */
+    final func onError(error: ErrorType) {
+        on(.Error(error))
+    }
+}

--- a/RxSwift/Observers/ObserverBase.swift
+++ b/RxSwift/Observers/ObserverBase.swift
@@ -23,14 +23,13 @@ class ObserverBase<ElementType> : Disposable, ObserverType {
             if isStopped == 0 {
                 onCore(event)
             }
-        case .Error: fallthrough
-        case .Completed:
+        case .Error, .Completed:
            
             if !OSAtomicCompareAndSwap32(0, 1, &isStopped) {
                 return
             }
             
-            self.onCore(event)
+            onCore(event)
         }
     }
     

--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -46,7 +46,13 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
             return NSThread.currentThread().threadDictionary[CurrentThreadSchedulerKeyInstance] as? ScheduleQueue
         }
         set {
-            NSThread.currentThread().threadDictionary[CurrentThreadSchedulerKeyInstance] = newValue
+            let threadDictionary = NSThread.currentThread().threadDictionary
+            if let newValue = newValue {
+                threadDictionary[CurrentThreadSchedulerKeyInstance] = newValue
+            }
+            else {
+                threadDictionary.removeObjectForKey(CurrentThreadSchedulerKeyInstance)
+            }
         }
     }
     

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -89,8 +89,7 @@ public class PublishSubject<Element> : Observable<Element>, SubjectType, Cancela
                 }
                 
                 observers.forEach { $0.on(event) }
-            case .Completed: fallthrough
-            case .Error:
+            case .Completed, .Error:
                 if stoppedEvent == nil {
                     self.stoppedEvent = event
                     observers.forEach { $0.on(event) }

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -99,8 +99,7 @@ class ReplayBufferBase<Element> : ReplaySubject<Element> {
                 addValueToBuffer(value)
                 trim()
                 self.observers.forEach { $0.on(event) }
-            case .Error: fallthrough
-            case .Completed:
+            case .Error, .Completed:
                 stoppedEvent = event
                 trim()
                 self.observers.forEach { $0.on(event) }

--- a/RxSwift/Subjects/Variable.swift
+++ b/RxSwift/Subjects/Variable.swift
@@ -12,8 +12,6 @@ import Foundation
 Variable is a wrapper for `BehaviorSubject`.
 
 Unlike `BehaviorSubject` it can't terminate with error.
-
-Before variable is deallocated, `Completed` event will be sent to all observers.
 */
 public class Variable<Element> : ObservableType {
     public typealias E = Element
@@ -73,9 +71,5 @@ public class Variable<Element> : ObservableType {
     */
     public func asObservable() -> Observable<E> {
         return self.subject
-    }
-    
-    deinit {
-        self.subject.on(.Completed)
     }
 }

--- a/RxTests/RxCocoaTests/UI+RxTests.swift
+++ b/RxTests/RxCocoaTests/UI+RxTests.swift
@@ -49,20 +49,17 @@ class UIRxTests : RxTest {
         // We have some async Wolfram Alpha API that calculates is number prime.
         let WolframAlphaIsPrime: (Int) -> Observable<PrimeNumber> = { just(PrimeNumber($0, isPrime($0))) }
         
-        let text = Variable<String>("")
-        let resultText = ""
-        
         let primeTextField = UITextFieldMock()
         
         let resultLabel = UILabelMock()
         
-        let disposable = primeTextField.rx_text()
+        let _ = primeTextField.rx_text()
             .map { WolframAlphaIsPrime(Int($0) ?? 0) }
             .concat()
             .map { "number \($0.n) is prime? \($0.isPrime)" }
             .subscribeTextOf(resultLabel)
-            .scopedDispose
-        
+            .scopedDispose()
+
         // this will set resultLabel.text! == "number 43 is prime? true"
         primeTextField.text = "43"
     }

--- a/RxTests/RxSwiftTests/Tests/ObserverTests.swift
+++ b/RxTests/RxSwiftTests/Tests/ObserverTests.swift
@@ -1,0 +1,88 @@
+//
+//  ObserverTests.swift
+//  RxTests
+//
+//  Created by Rob Cheung on 9/15/15.
+//
+//
+
+import XCTest
+import RxSwift
+
+class ObserverTests: RxTest { }
+
+extension ObserverTests {
+    
+    func testConvenienceOn_Next() {
+        var observer: ObserverOf<Int>!
+        let a: Observable<Int> = create { o in
+            observer = o
+            return NopDisposable.instance
+        }
+        
+        var elements = [Int]()
+        
+        a.subscribeNext { n in
+            elements.append(n)
+        }
+        
+        XCTAssertEqual(elements, [])
+        
+        observer.onNext(0)
+        
+        XCTAssertEqual(elements, [0])
+    }
+    
+    func testConvenienceOn_Error() {
+        var observer: ObserverOf<Int>!
+        let a: Observable<Int> = create { o in
+            observer = o
+            return NopDisposable.instance
+        }
+        
+        var elements = [Int]()
+        var errrorNotification: NSError!
+        
+        a.subscribe(
+            next: { n in elements.append(n) },
+            error: { e in
+                errrorNotification = e as NSError
+            }
+        )
+        
+        XCTAssertEqual(elements, [])
+        
+        observer.onNext(0)
+        XCTAssertEqual(elements, [0])
+        
+        observer.onError(testError)
+        
+        observer.onNext(1)
+        XCTAssertEqual(elements, [0])
+        XCTAssertEqual(errrorNotification, testError)
+    }
+    
+    func testConvenienceOn_Complete() {
+        var observer: ObserverOf<Int>!
+        let a: Observable<Int> = create { o in
+            observer = o
+            return NopDisposable.instance
+        }
+        
+        var elements = [Int]()
+        
+        a.subscribeNext { n in
+            elements.append(n)
+        }
+        
+        XCTAssertEqual(elements, [])
+        
+        observer.onNext(0)
+        XCTAssertEqual(elements, [0])
+        
+        observer.onComplete()
+        
+        observer.onNext(1)
+        XCTAssertEqual(elements, [0])
+    }
+}

--- a/RxTests/RxSwiftTests/Tests/VariableTest.swift
+++ b/RxTests/RxSwiftTests/Tests/VariableTest.swift
@@ -19,9 +19,10 @@ class VariableTest : RxTest {
         
         var latestValue: Int?
         
-        let subscription = c .subscribeNext { next in
-            latestValue = next
-        }
+        let subscription = c
+            .subscribeNext { next in
+                latestValue = next
+            }
         
         XCTAssertEqual(latestValue!, 3)
         
@@ -39,34 +40,7 @@ class VariableTest : RxTest {
 
         XCTAssertEqual(latestValue!, 14)
     }
-    
-    func testVariable_Completed() {
-        var a = Variable(1)
-        var b = Variable(2)
-        
-        let c = combineLatest(a, b, +)
-        
-        var latestValue: Int?
-        var completed = false
-        
-        let subscription = c.subscribe(next: { next in
-            latestValue = next
-        }, completed: {
-            completed = true
-        })
-        
-        XCTAssertEqual(latestValue!, 3)
-        
-        a.value = 5
-        
-        XCTAssertEqual(latestValue!, 7)
-        
-        XCTAssertTrue(!completed)
-        a = Variable(0)
-        b = Variable(0)
-        XCTAssertTrue(completed)
-    }
-    
+
     func testVariable_READMEExample() {
         
         // Two simple Rx variables
@@ -87,10 +61,12 @@ class VariableTest : RxTest {
         // because variables have initial values (starting element)
         var latestValueOfC : Int? = nil
         // let _ = doesn't retain.
-        let d/*: Disposable*/  = c .subscribeNext { c in
-            //print("Next value of c = \(c)")
-            latestValueOfC = c
-        } .scopedDispose
+        let d/*: Disposable*/  = c
+            .subscribeNext { c in
+                //print("Next value of c = \(c)")
+                latestValueOfC = c
+            }
+            .scopedDispose()
         
         XCTAssertEqual(latestValueOfC!, 3)
         

--- a/RxTests/RxTests.xcodeproj/project.pbxproj
+++ b/RxTests/RxTests.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		5E5D10BB1B48355200432B25 /* UIControl+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5D10BA1B48355200432B25 /* UIControl+RxTests.swift */; };
+		C69B65001BA88FAC00A7FA73 /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C69B64FF1BA88FAC00A7FA73 /* ObserverTests.swift */; settings = {ASSET_TAGS = (); }; };
+		C69B65011BA8957C00A7FA73 /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C69B64FF1BA88FAC00A7FA73 /* ObserverTests.swift */; settings = {ASSET_TAGS = (); }; };
 		C801EB5A1B97951100C4D8C4 /* Observable+CreationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801EB591B97951100C4D8C4 /* Observable+CreationTest.swift */; settings = {ASSET_TAGS = (); }; };
 		C801EB5B1B97951100C4D8C4 /* Observable+CreationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801EB591B97951100C4D8C4 /* Observable+CreationTest.swift */; settings = {ASSET_TAGS = (); }; };
 		C811084D1AF50E2A001C13E4 /* NSNotificationCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C811082B1AF50E2A001C13E4 /* NSNotificationCenterTests.swift */; };
@@ -105,6 +107,7 @@
 
 /* Begin PBXFileReference section */
 		5E5D10BA1B48355200432B25 /* UIControl+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+RxTests.swift"; sourceTree = "<group>"; };
+		C69B64FF1BA88FAC00A7FA73 /* ObserverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObserverTests.swift; sourceTree = "<group>"; };
 		C801EB591B97951100C4D8C4 /* Observable+CreationTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+CreationTest.swift"; sourceTree = "<group>"; };
 		C81108201AF50E11001C13E4 /* RxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C81108241AF50E11001C13E4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -310,6 +313,7 @@
 				C811084A1AF50E2A001C13E4 /* Observable+TimeTest.swift */,
 				C811084B1AF50E2A001C13E4 /* QueueTests.swift */,
 				C814CEA21AF5622600E98087 /* VariableTest.swift */,
+				C69B64FF1BA88FAC00A7FA73 /* ObserverTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -414,6 +418,7 @@
 				C81108531AF50E2A001C13E4 /* MySubject.swift in Sources */,
 				C814CEA71AF642D600E98087 /* UI+RxTests.swift in Sources */,
 				C81108611AF50E2A001C13E4 /* Observable+BindingTest.swift in Sources */,
+				C69B65001BA88FAC00A7FA73 /* ObserverTests.swift in Sources */,
 				C85F4E431B7F70EA00A866C7 /* CompositeObserverTest.swift in Sources */,
 				C811084D1AF50E2A001C13E4 /* NSNotificationCenterTests.swift in Sources */,
 				C81108621AF50E2A001C13E4 /* Observable+MultipleTest+CombineLatest.swift in Sources */,
@@ -494,6 +499,7 @@
 				C88BB8A91B07E64B0064D411 /* Observable+AggregateTest.swift in Sources */,
 				C88BB8AA1B07E64B0064D411 /* MockObserver.swift in Sources */,
 				C8AF26F01B499E5C00131C03 /* DelegateProxyTest.swift in Sources */,
+				C69B65011BA8957C00A7FA73 /* ObserverTests.swift in Sources */,
 				C8633AE61B0AA0ED00375D60 /* KVOObservableTests.swift in Sources */,
 				C88BB8AB1B07E64B0064D411 /* TestExtensions.swift in Sources */,
 				C88BB8AC1B07E64B0064D411 /* AssumptionsTest.swift in Sources */,


### PR DESCRIPTION
Previously, the 1st-level imageCache was never utilized. Items would be place into the cache, but the code would only check the 2nd-level cache for both an Image or NSData.