### PR TITLE
Adding data for failed NSURLRequest with status code > 300

### DIFF
--- a/RxCocoa/Common/Observables/NSURLSession+Rx.swift
+++ b/RxCocoa/Common/Observables/NSURLSession+Rx.swift
@@ -136,7 +136,7 @@ extension NSURLSession {
                 return data ?? NSData()
             }
             else {
-                throw rxError(.NetworkError, message: "Server returned failure", userInfo: [RxCocoaErrorHTTPResponseKey: response])
+                throw rxError(.NetworkError, message: "Server returned failure", userInfo: [RxCocoaErrorHTTPResponseKey: response, RxCocoaErrorHTTPResponseDataKey : data ?? NSData()])
             }
         }
     }

--- a/RxCocoa/Common/RxCocoa.swift
+++ b/RxCocoa/Common/RxCocoa.swift
@@ -30,6 +30,7 @@ public let RxCocoaErrorDomain = "RxCocoaError"
 `userInfo` key for `NSURLResponse` object when `RxCocoaError.NetworkError` happens.
 */
 public let RxCocoaErrorHTTPResponseKey = "RxCocoaErrorHTTPResponseKey"
+public let RxCocoaErrorHTTPResponseDataKey = "RxCocoaErrorHTTPResponseDataKey"
 
 func rxError(errorCode: RxCocoaError, _ message: String) -> NSError {
     return NSError(domain: RxCocoaErrorDomain, code: errorCode.rawValue, userInfo: [NSLocalizedDescriptionKey: message])


### PR DESCRIPTION
Currently we just return "Server returned failure" and a `NSHTTPURLResponse` where we can only get the status code.  

Now we also always return `NSData` in `NSError` userInfo with the key `RxCocoaErrorHTTPResponseDataKey`.  The data will be an empty there if is no data. (`NSData()`)

This allows us to have more detail on failed requests with the data being retuned in raw data for the receiver to handle.