### PR TITLE
Reorganized the GitHub Signup Example

### DIFF
--- a/RxExample/RxExample/Examples/GitHubSignup/Views/GitHubSignupViewController.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/Views/GitHubSignupViewController.swift
@@ -108,7 +108,7 @@ class GitHubSignupViewController : ViewController {
                 let validationColor: UIColor
                 
                 if let valid = v.valid {
-                    validationColor = valid ? okColor : errorColor
+                    validationColor = valid ? self.okColor : self.errorColor
                 } else {
                    validationColor = UIColor.grayColor()
                 }

--- a/RxExample/RxExample/Examples/GitHubSignup/Views/GitHubSignupViewController.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/Views/GitHubSignupViewController.swift
@@ -229,8 +229,8 @@ class GitHubSignupViewController : ViewController {
     // while navigation stack is popping.
     
     // This will work well with UINavigationController, but has an assumption that view controller will
-    // never be readded as a child view controller.
-    // If it was readded the UI wouldn't be bound anymore.
+    // never be added as a child view controller. If we didn't recreate the dispose bag here,
+    // then our resources would never be properly released.
     override func willMoveToParentViewController(parent: UIViewController?) {
         if let parent = parent {
             assert(parent.isKindOfClass(UINavigationController), "Please read comments")


### PR DESCRIPTION
Fixed a typo, used the type alias everywhere, and reorganized a few minor things for readability.