### PR TITLE
Fix outdated comments on UISearchBar's rx_searchText property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ extension UISearchBar {
         return proxyForObject(self) as RxSearchBarDelegateProxy
     }
 
-    public var rx_searchText: Observable<String> {
+    public var rx_text: Observable<String> {
         return defer { [weak self] in
             let text = self?.text ?? ""
 
@@ -341,7 +341,7 @@ This is how that API can be now used
 
 ```swift
 
-searchBar.rx_searchText
+searchBar.rx_text
     .subscribeNext { searchText in
         print("Current search text '\(searchText)'")
     }

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -160,7 +160,7 @@ Returns existing proxy for object or installs new instance of delegate proxy.
             return proxyForObject(self) as RxSearchBarDelegateProxy
         }
         
-        public var rx_searchText: ControlProperty<String> {
+        public var rx_text: ControlProperty<String> {
             let source: Observable<String> = self.rx_delegate.observe("searchBar:textDidChange:")
             ...
         }


### PR DESCRIPTION
This pull request fixes some outdated comments :)
Since UISearchBar's rx_searchText property has been changed to rx_text property, so we should sync this. 
Could you review this?