### PR TITLE
Handling network errors with Reachability api in RxExample -> AutoLoading

### DIFF
--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		07E300071B14995F00F00100 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E300061B14995F00F00100 /* TableViewController.swift */; };
 		07E300091B149A2A00F00100 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E300081B149A2A00F00100 /* User.swift */; };
 		07E3C2331B03605B0010338D /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E3C2321B03605B0010338D /* Dependencies.swift */; };
+		B18F3BBC1BD92EC8000AAC79 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */; };
 		C803973A1BD3E17D009D8B26 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
 		C803973B1BD3E17D009D8B26 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
 		C80397491BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397481BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift */; };
@@ -311,7 +312,7 @@
 		C8DF92EA1B0B38C0009BCF9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8DF92E91B0B38C0009BCF9A /* Images.xcassets */; };
 		C8DF92EB1B0B38C0009BCF9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8DF92E91B0B38C0009BCF9A /* Images.xcassets */; };
 		C8DF92F61B0B43A4009BCF9A /* IntroductionExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8DF92F51B0B43A4009BCF9A /* IntroductionExampleViewController.swift */; };
-		C8E9D2AF1BD3FD960079D0DB /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; settings = {ASSET_TAGS = (); }; };
+		C8E9D2AF1BD3FD960079D0DB /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
 		D2AF91981BD3D95900A008C1 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AF91881BD2C51900A008C1 /* Using.swift */; };
 		EC91FB951BBA144400973245 /* GitHubSearchRepositoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC91FB941BBA144400973245 /* GitHubSearchRepositoriesViewController.swift */; };
 /* End PBXBuildFile section */
@@ -449,6 +450,7 @@
 		07E300061B14995F00F00100 /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		07E300081B149A2A00F00100 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		07E3C2321B03605B0010338D /* Dependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Dependencies.swift; path = Examples/Dependencies.swift; sourceTree = "<group>"; };
+		B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
 		C80397481BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSearchRepositoriesAPI.swift; sourceTree = "<group>"; };
 		C80DDE7A1BCDA952006A1832 /* SkipWhile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipWhile.swift; sourceTree = "<group>"; };
@@ -866,6 +868,7 @@
 		C83367101AD029AE00C668A7 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */,
 				C83367111AD029AE00C668A7 /* HtmlParsing.swift */,
 				C83367121AD029AE00C668A7 /* ImageService.swift */,
 				C8A2A2C71B4049E300F11F09 /* PseudoRandomGenerator.swift */,
@@ -1866,6 +1869,7 @@
 				075F13101B4E9D5A000D7861 /* APIWrappersViewController.swift in Sources */,
 				C83367311AD029AE00C668A7 /* Wireframe.swift in Sources */,
 				07E300071B14995F00F00100 /* TableViewController.swift in Sources */,
+				B18F3BBC1BD92EC8000AAC79 /* Reachability.swift in Sources */,
 				C859B9A41B45C5D900D012D7 /* PartialUpdatesViewController.swift in Sources */,
 				07E3C2331B03605B0010338D /* Dependencies.swift in Sources */,
 				C84B913A1B8A282000C9CCCF /* RxTableViewSectionedReloadDataSource.swift in Sources */,

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		07E300091B149A2A00F00100 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E300081B149A2A00F00100 /* User.swift */; };
 		07E3C2331B03605B0010338D /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E3C2321B03605B0010338D /* Dependencies.swift */; };
 		B18F3BBC1BD92EC8000AAC79 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */; };
+		B18F3BBE1BD93C2E000AAC79 /* Reachability+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F3BBD1BD93C2E000AAC79 /* Reachability+Rx.swift */; };
+		B18F3BBF1BD93DFF000AAC79 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */; };
+		B18F3BC01BD93DFF000AAC79 /* Reachability+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F3BBD1BD93C2E000AAC79 /* Reachability+Rx.swift */; };
+		B18F3BC11BD93E00000AAC79 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */; };
+		B18F3BC21BD93E00000AAC79 /* Reachability+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18F3BBD1BD93C2E000AAC79 /* Reachability+Rx.swift */; };
 		C803973A1BD3E17D009D8B26 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
 		C803973B1BD3E17D009D8B26 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
 		C80397491BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397481BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift */; };
@@ -451,6 +456,7 @@
 		07E300081B149A2A00F00100 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		07E3C2321B03605B0010338D /* Dependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Dependencies.swift; path = Examples/Dependencies.swift; sourceTree = "<group>"; };
 		B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
+		B18F3BBD1BD93C2E000AAC79 /* Reachability+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Reachability+Rx.swift"; sourceTree = "<group>"; };
 		C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
 		C80397481BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSearchRepositoriesAPI.swift; sourceTree = "<group>"; };
 		C80DDE7A1BCDA952006A1832 /* SkipWhile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipWhile.swift; sourceTree = "<group>"; };
@@ -868,12 +874,13 @@
 		C83367101AD029AE00C668A7 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */,
 				C83367111AD029AE00C668A7 /* HtmlParsing.swift */,
 				C83367121AD029AE00C668A7 /* ImageService.swift */,
 				C8A2A2C71B4049E300F11F09 /* PseudoRandomGenerator.swift */,
 				C8A2A2CA1B404A1200F11F09 /* Randomizer.swift */,
 				C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */,
+				B18F3BBB1BD92EC8000AAC79 /* Reachability.swift */,
+				B18F3BBD1BD93C2E000AAC79 /* Reachability+Rx.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1680,6 +1687,7 @@
 				C89464D61BC6C2B00055219D /* Producer.swift in Sources */,
 				C894658A1BC6C2BC0055219D /* RxTableViewDataSourceProxy.swift in Sources */,
 				C894656F1BC6C2BC0055219D /* DelegateProxyType.swift in Sources */,
+				B18F3BC21BD93E00000AAC79 /* Reachability+Rx.swift in Sources */,
 				C89465721BC6C2BC0055219D /* ControlTarget.swift in Sources */,
 				C89464EC1BC6C2B00055219D /* Observable+Binding.swift in Sources */,
 				C8297E3A1B6CF905000589EA /* WikipediaSearchViewController.swift in Sources */,
@@ -1746,6 +1754,7 @@
 				C89465861BC6C2BC0055219D /* RxCollectionViewDataSourceProxy.swift in Sources */,
 				C89465981BC6C2BC0055219D /* UISearchBar+Rx.swift in Sources */,
 				C89464E21BC6C2B00055219D /* Take.swift in Sources */,
+				B18F3BC11BD93E00000AAC79 /* Reachability.swift in Sources */,
 				C89465901BC6C2BC0055219D /* UIButton+Rx.swift in Sources */,
 				C89464BC1BC6C2B00055219D /* AsObservable.swift in Sources */,
 				C89464DD1BC6C2B00055219D /* Sink.swift in Sources */,
@@ -1853,6 +1862,7 @@
 				0706E1961B14AF5100BA2D3A /* DetailViewController.swift in Sources */,
 				C88C78991B4012A90061C5AB /* SectionModelType.swift in Sources */,
 				C83367251AD029AE00C668A7 /* ImageService.swift in Sources */,
+				B18F3BBE1BD93C2E000AAC79 /* Reachability+Rx.swift in Sources */,
 				C86E2F471AE5A0CA00C31024 /* WikipediaSearchResult.swift in Sources */,
 				C80397491BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift in Sources */,
 				C890A65A1AEBD28A00AFF7E6 /* GitHubAPI.swift in Sources */,
@@ -1891,8 +1901,10 @@
 				C88BB8BD1B07E6C90064D411 /* SearchViewModel.swift in Sources */,
 				C8E9D2AF1BD3FD960079D0DB /* ActivityIndicator.swift in Sources */,
 				C88BB8BE1B07E6C90064D411 /* ImageService.swift in Sources */,
+				B18F3BC01BD93DFF000AAC79 /* Reachability+Rx.swift in Sources */,
 				C88BB8BF1B07E6C90064D411 /* WikipediaSearchResult.swift in Sources */,
 				C8DF92F61B0B43A4009BCF9A /* IntroductionExampleViewController.swift in Sources */,
+				B18F3BBF1BD93DFF000AAC79 /* Reachability.swift in Sources */,
 				C88BB8C31B07E6C90064D411 /* Example.swift in Sources */,
 				C88BB8C41B07E6C90064D411 /* ViewController.swift in Sources */,
 				C88BB8C61B07E6C90064D411 /* Wireframe.swift in Sources */,

--- a/RxExample/RxExample/Services/Reachability+Rx.swift
+++ b/RxExample/RxExample/Services/Reachability+Rx.swift
@@ -1,0 +1,39 @@
+//
+//  Reachability+Rx.swift
+//  RxExample
+//
+//  Created by Vodovozov Gleb on 22.10.2015.
+//  Copyright © 2015 Krunoslav Zaher. All rights reserved.
+//
+
+import RxSwift
+
+public enum ReachabilityStatus{
+    case Reachable,Unreachable
+}
+
+extension Reachability{
+
+    /**
+    Reactive wrapper for reachability state changes
+    */
+    public var rx_reachable: Observable<ReachabilityStatus> {
+
+        return create { observer in
+
+            self.whenReachable = { reachability in
+                observer.on(.Next(.Reachable))
+            }
+            self.whenUnreachable = { reachability in
+                observer.on(.Next(.Unreachable))
+            }
+            do{
+                try self.startNotifier()
+            }catch let error{
+                observer.on(.Error(error))
+            }
+            return NopDisposable.instance
+        }
+
+    }
+}

--- a/RxExample/RxExample/Services/Reachability.swift
+++ b/RxExample/RxExample/Services/Reachability.swift
@@ -1,0 +1,388 @@
+/*
+Copyright (c) 2014, Ashley Mills
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import SystemConfiguration
+import Foundation
+
+enum ReachabilityError: ErrorType {
+    case FailedToCreateWithAddress(sockaddr_in)
+    case FailedToCreateWithHostname(String)
+    case UnableToSetCallback
+    case UnableToSetDispatchQueue
+}
+
+public let ReachabilityChangedNotification = "ReachabilityChangedNotification"
+
+func callback(reachability:SCNetworkReachability, flags: SCNetworkReachabilityFlags, info: UnsafeMutablePointer<Void>) {
+    let reachability = Unmanaged<Reachability>.fromOpaque(COpaquePointer(info)).takeUnretainedValue()
+
+    dispatch_async(dispatch_get_main_queue()) {
+        reachability.reachabilityChanged(flags)
+    }
+}
+
+
+public class Reachability: NSObject {
+
+    public typealias NetworkReachable = (Reachability) -> ()
+    public typealias NetworkUnreachable = (Reachability) -> ()
+
+    public enum NetworkStatus: CustomStringConvertible {
+
+        case NotReachable, ReachableViaWiFi, ReachableViaWWAN
+
+        public var description: String {
+            switch self {
+            case .ReachableViaWWAN:
+                return "Cellular"
+            case .ReachableViaWiFi:
+                return "WiFi"
+            case .NotReachable:
+                return "No Connection"
+            }
+        }
+    }
+
+    // MARK: - *** Public properties ***
+
+    public var whenReachable: NetworkReachable?
+    public var whenUnreachable: NetworkUnreachable?
+    public var reachableOnWWAN: Bool
+    public var notificationCenter = NSNotificationCenter.defaultCenter()
+
+    public var currentReachabilityStatus: NetworkStatus {
+        if isReachable() {
+            if isReachableViaWiFi() {
+                return .ReachableViaWiFi
+            }
+            if isRunningOnDevice {
+                return .ReachableViaWWAN
+            }
+        }
+
+        return .NotReachable
+    }
+
+    public var currentReachabilityString: String {
+        return "\(currentReachabilityStatus)"
+    }
+
+    // MARK: - *** Initialisation methods ***
+    
+    required public init(reachabilityRef: SCNetworkReachability) {
+        reachableOnWWAN = true
+        self.reachabilityRef = reachabilityRef
+    }
+    
+    public convenience init(hostname: String) throws {
+        
+        let nodename = (hostname as NSString).UTF8String
+        guard let ref = SCNetworkReachabilityCreateWithName(nil, nodename) else { throw ReachabilityError.FailedToCreateWithHostname(hostname) }
+
+        self.init(reachabilityRef: ref)
+    }
+
+    public class func reachabilityForInternetConnection() throws -> Reachability {
+        
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(sizeofValue(zeroAddress))
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+        
+        guard let ref = withUnsafePointer(&zeroAddress, {
+            SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
+        }) else { throw ReachabilityError.FailedToCreateWithAddress(zeroAddress) }
+        
+        return Reachability(reachabilityRef: ref)
+    }
+
+    public class func reachabilityForLocalWiFi() throws -> Reachability {
+
+        var localWifiAddress: sockaddr_in = sockaddr_in(sin_len: __uint8_t(0), sin_family: sa_family_t(0), sin_port: in_port_t(0), sin_addr: in_addr(s_addr: 0), sin_zero: (0, 0, 0, 0, 0, 0, 0, 0))
+        localWifiAddress.sin_len = UInt8(sizeofValue(localWifiAddress))
+        localWifiAddress.sin_family = sa_family_t(AF_INET)
+
+        // IN_LINKLOCALNETNUM is defined in <netinet/in.h> as 169.254.0.0
+        let address: UInt32 = 0xA9FE0000
+        localWifiAddress.sin_addr.s_addr = in_addr_t(address.bigEndian)
+
+        guard let ref = withUnsafePointer(&localWifiAddress, {
+            SCNetworkReachabilityCreateWithAddress(nil, UnsafePointer($0))
+        }) else { throw ReachabilityError.FailedToCreateWithAddress(localWifiAddress) }
+        
+        return Reachability(reachabilityRef: ref)
+    }
+
+    // MARK: - *** Notifier methods ***
+    public func startNotifier() throws {
+
+        if notifierRunning { return }
+        
+        var context = SCNetworkReachabilityContext(version: 0, info: nil, retain: nil, release: nil, copyDescription: nil)
+        context.info = UnsafeMutablePointer(Unmanaged.passUnretained(self).toOpaque())
+        
+        if !SCNetworkReachabilitySetCallback(reachabilityRef!, callback, &context) {
+            stopNotifier()
+            throw ReachabilityError.UnableToSetCallback
+        }
+
+        if !SCNetworkReachabilitySetDispatchQueue(reachabilityRef!, reachabilitySerialQueue) {
+            stopNotifier()
+            throw ReachabilityError.UnableToSetDispatchQueue
+        }
+
+        notifierRunning = true
+    }
+    
+
+    public func stopNotifier() {
+        if let reachabilityRef = reachabilityRef {
+            SCNetworkReachabilitySetCallback(reachabilityRef, nil, nil)
+            SCNetworkReachabilitySetDispatchQueue(reachabilityRef, nil)
+        }
+        notifierRunning = false
+    }
+
+    // MARK: - *** Connection test methods ***
+    public func isReachable() -> Bool {
+        return isReachableWithTest({ (flags: SCNetworkReachabilityFlags) -> (Bool) in
+            return self.isReachableWithFlags(flags)
+        })
+    }
+
+    public func isReachableViaWWAN() -> Bool {
+
+        if isRunningOnDevice {
+            return isReachableWithTest() { flags -> Bool in
+                // Check we're REACHABLE
+                if self.isReachable(flags) {
+
+                    // Now, check we're on WWAN
+                    if self.isOnWWAN(flags) {
+                        return true
+                    }
+                }
+                return false
+            }
+        }
+        return false
+    }
+
+    public func isReachableViaWiFi() -> Bool {
+
+        return isReachableWithTest() { flags -> Bool in
+
+            // Check we're reachable
+            if self.isReachable(flags) {
+
+                if self.isRunningOnDevice {
+                    // Check we're NOT on WWAN
+                    if self.isOnWWAN(flags) {
+                        return false
+                    }
+                }
+                return true
+            }
+
+            return false
+        }
+    }
+
+    // MARK: - *** Private methods ***
+    private var isRunningOnDevice: Bool = {
+        #if (arch(i386) || arch(x86_64)) && os(iOS)
+            return false
+            #else
+            return true
+        #endif
+        }()
+
+    private var notifierRunning = false
+    private var reachabilityRef: SCNetworkReachability?
+    private let reachabilitySerialQueue = dispatch_queue_create("uk.co.ashleymills.reachability", DISPATCH_QUEUE_SERIAL)
+
+    private func reachabilityChanged(flags: SCNetworkReachabilityFlags) {
+        if isReachableWithFlags(flags) {
+            if let block = whenReachable {
+                block(self)
+            }
+        } else {
+            if let block = whenUnreachable {
+                block(self)
+            }
+        }
+
+        notificationCenter.postNotificationName(ReachabilityChangedNotification, object:self)
+    }
+
+    private func isReachableWithFlags(flags: SCNetworkReachabilityFlags) -> Bool {
+
+        let reachable = isReachable(flags)
+
+        if !reachable {
+            return false
+        }
+
+        if isConnectionRequiredOrTransient(flags) {
+            return false
+        }
+
+        if isRunningOnDevice {
+            if isOnWWAN(flags) && !reachableOnWWAN {
+                // We don't want to connect when on 3G.
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private func isReachableWithTest(test: (SCNetworkReachabilityFlags) -> (Bool)) -> Bool {
+
+        if let reachabilityRef = reachabilityRef {
+            
+            var flags = SCNetworkReachabilityFlags(rawValue: 0)
+            let gotFlags = withUnsafeMutablePointer(&flags) {
+                SCNetworkReachabilityGetFlags(reachabilityRef, UnsafeMutablePointer($0))
+            }
+            
+            if gotFlags {
+                return test(flags)
+            }
+        }
+
+        return false
+    }
+
+    // WWAN may be available, but not active until a connection has been established.
+    // WiFi may require a connection for VPN on Demand.
+    private func isConnectionRequired() -> Bool {
+        return connectionRequired()
+    }
+
+    private func connectionRequired() -> Bool {
+        return isReachableWithTest({ (flags: SCNetworkReachabilityFlags) -> (Bool) in
+            return self.isConnectionRequired(flags)
+        })
+    }
+
+    // Dynamic, on demand connection?
+    private func isConnectionOnDemand() -> Bool {
+        return isReachableWithTest({ (flags: SCNetworkReachabilityFlags) -> (Bool) in
+            return self.isConnectionRequired(flags) && self.isConnectionOnTrafficOrDemand(flags)
+        })
+    }
+
+    // Is user intervention required?
+    private func isInterventionRequired() -> Bool {
+        return isReachableWithTest({ (flags: SCNetworkReachabilityFlags) -> (Bool) in
+            return self.isConnectionRequired(flags) && self.isInterventionRequired(flags)
+        })
+    }
+
+    private func isOnWWAN(flags: SCNetworkReachabilityFlags) -> Bool {
+        #if os(iOS)
+            return flags.contains(.IsWWAN)
+        #else
+            return false
+        #endif
+    }
+    private func isReachable(flags: SCNetworkReachabilityFlags) -> Bool {
+        return flags.contains(.Reachable)
+    }
+    private func isConnectionRequired(flags: SCNetworkReachabilityFlags) -> Bool {
+        return flags.contains(.ConnectionRequired)
+    }
+    private func isInterventionRequired(flags: SCNetworkReachabilityFlags) -> Bool {
+        return flags.contains(.InterventionRequired)
+    }
+    private func isConnectionOnTraffic(flags: SCNetworkReachabilityFlags) -> Bool {
+        return flags.contains(.ConnectionOnTraffic)
+    }
+    private func isConnectionOnDemand(flags: SCNetworkReachabilityFlags) -> Bool {
+        return flags.contains(.ConnectionOnDemand)
+    }
+    func isConnectionOnTrafficOrDemand(flags: SCNetworkReachabilityFlags) -> Bool {
+        return !flags.intersect([.ConnectionOnTraffic, .ConnectionOnDemand]).isEmpty
+    }
+    private func isTransientConnection(flags: SCNetworkReachabilityFlags) -> Bool {
+        return flags.contains(.TransientConnection)
+    }
+    private func isLocalAddress(flags: SCNetworkReachabilityFlags) -> Bool {
+        return flags.contains(.IsLocalAddress)
+    }
+    private func isDirect(flags: SCNetworkReachabilityFlags) -> Bool {
+        return flags.contains(.IsDirect)
+    }
+    private func isConnectionRequiredOrTransient(flags: SCNetworkReachabilityFlags) -> Bool {
+        let testcase:SCNetworkReachabilityFlags = [.ConnectionRequired, .TransientConnection]
+        return flags.intersect(testcase) == testcase
+    }
+
+    private var reachabilityFlags: SCNetworkReachabilityFlags {
+        if let reachabilityRef = reachabilityRef {
+            
+            var flags = SCNetworkReachabilityFlags(rawValue: 0)
+            let gotFlags = withUnsafeMutablePointer(&flags) {
+                SCNetworkReachabilityGetFlags(reachabilityRef, UnsafeMutablePointer($0))
+            }
+            
+            if gotFlags {
+                return flags
+            }
+        }
+
+        return []
+    }
+
+    override public var description: String {
+
+        var W: String
+        if isRunningOnDevice {
+            W = isOnWWAN(reachabilityFlags) ? "W" : "-"
+        } else {
+            W = "X"
+        }
+        let R = isReachable(reachabilityFlags) ? "R" : "-"
+        let c = isConnectionRequired(reachabilityFlags) ? "c" : "-"
+        let t = isTransientConnection(reachabilityFlags) ? "t" : "-"
+        let i = isInterventionRequired(reachabilityFlags) ? "i" : "-"
+        let C = isConnectionOnTraffic(reachabilityFlags) ? "C" : "-"
+        let D = isConnectionOnDemand(reachabilityFlags) ? "D" : "-"
+        let l = isLocalAddress(reachabilityFlags) ? "l" : "-"
+        let d = isDirect(reachabilityFlags) ? "d" : "-"
+
+        return "\(W)\(R) \(c)\(t)\(i)\(C)\(D)\(l)\(d)"
+    }
+
+    deinit {
+        stopNotifier()
+
+        reachabilityRef = nil
+        whenReachable = nil
+        whenUnreachable = nil
+    }
+}


### PR DESCRIPTION
simple handling network errors when querying github repositories in RxExample -> AutoLoading.
Using Reachability (https://github.com/ashleymills/Reachability.swift) with reactive wrapper
Reference: https://github.com/ReactiveX/RxSwift/issues/187