### PR TITLE
Feature/fix build warnings

### DIFF
--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -21,6 +21,8 @@ Operators are stateless by default.
  * [`never`](http://reactivex.io/documentation/operators/empty-never-throw.html)
  * [`returnElement` / `just`](http://reactivex.io/documentation/operators/just.html)
  * [`returnElements`](http://reactivex.io/documentation/operators/from.html)
+ * [`range`](http://reactivex.io/documentation/operators/range.html)
+ * [`repeatElement`](http://reactivex.io/documentation/operators/repeat.html)
  * [`timer`](http://reactivex.io/documentation/operators/timer.html)
 
 #### Transforming Observables
@@ -32,10 +34,12 @@ Operators are stateless by default.
 #### Filtering Observables
   * [`debounce` / `throttle`](http://reactivex.io/documentation/operators/debounce.html)
   * [`distinctUntilChanged`](http://reactivex.io/documentation/operators/distinct.html)
+  * [`ElementAt`](http://reactivex.io/documentation/operators/elementat.html)
   * [`filter` / `where`](http://reactivex.io/documentation/operators/filter.html)
   * [`sample`](http://reactivex.io/documentation/operators/sample.html)
   * [`skip`](http://reactivex.io/documentation/operators/skip.html)
   * [`take`](http://reactivex.io/documentation/operators/take.html)
+  * [`takeLast`](http://reactivex.io/documentation/operators/takelast.html)
 
 #### Combining Observables
 
@@ -57,11 +61,13 @@ Operators are stateless by default.
   * [`observeOn` / `observeSingleOn`](http://reactivex.io/documentation/operators/observeon.html)
   * [`subscribe`](http://reactivex.io/documentation/operators/subscribe.html)
   * [`subscribeOn`](http://reactivex.io/documentation/operators/subscribeon.html)
+  * [`using`](http://reactivex.io/documentation/operators/using.html)
   * debug
 
 #### Conditional and Boolean Operators
   * [`amb`](http://reactivex.io/documentation/operators/amb.html)
   * [`skipWhile`](http://reactivex.io/documentation/operators/skipwhile.html)
+  * [`skipUntil`](http://reactivex.io/documentation/operators/skipuntil.html)
   * [`takeUntil`](http://reactivex.io/documentation/operators/takeuntil.html)
   * [`takeWhile`](http://reactivex.io/documentation/operators/takewhile.html)
 
@@ -69,6 +75,7 @@ Operators are stateless by default.
 
   * [`concat`](http://reactivex.io/documentation/operators/concat.html)
   * [`reduce` / `aggregate`](http://reactivex.io/documentation/operators/reduce.html)
+  * [`toArray`](http://reactivex.io/documentation/operators/to.html)
 
 #### Connectable Observable Operators
 

--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -34,7 +34,7 @@ Operators are stateless by default.
 #### Filtering Observables
   * [`debounce` / `throttle`](http://reactivex.io/documentation/operators/debounce.html)
   * [`distinctUntilChanged`](http://reactivex.io/documentation/operators/distinct.html)
-  * [`ElementAt`](http://reactivex.io/documentation/operators/elementat.html)
+  * [`elementAt`](http://reactivex.io/documentation/operators/elementat.html)
   * [`filter` / `where`](http://reactivex.io/documentation/operators/filter.html)
   * [`sample`](http://reactivex.io/documentation/operators/sample.html)
   * [`skip`](http://reactivex.io/documentation/operators/skip.html)
@@ -441,6 +441,6 @@ extension NSTextField {
     public var rx_delegate: DelegateProxy {}
 
     public var rx_text: ControlProperty<String> {}
-      
+
 }
 ```

--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -304,7 +304,7 @@ Let's create a function which creates a sequence that returns one element upon s
 func myJust<E>(element: E) -> Observable<E> {
     return create { observer in
         observer.on(.Next(element))
-        obsever.on(.Completed)
+        observer.on(.Completed)
         return NopDisposable.instance
     }
 }

--- a/Rx.playground/Pages/Combining_Observables.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Combining_Observables.xcplaygroundpage/Contents.swift
@@ -45,7 +45,7 @@ example("combineLatest 1") {
     let intOb1 = PublishSubject<String>()
     let intOb2 = PublishSubject<Int>()
 
-    combineLatest(intOb1, intOb2) {
+    _ = combineLatest(intOb1, intOb2) {
         "\($0) \($1)"
         }
         .subscribe {
@@ -68,7 +68,7 @@ example("combineLatest 2") {
     let intOb1 = just(2)
     let intOb2 = sequenceOf(0, 1, 2, 3, 4)
 
-    combineLatest(intOb1, intOb2) {
+    _ = combineLatest(intOb1, intOb2) {
             $0 * $1
         }
         .subscribe {
@@ -85,7 +85,7 @@ example("combineLatest 3") {
     let intOb2 = sequenceOf(0, 1, 2, 3)
     let intOb3 = sequenceOf(0, 1, 2, 3, 4)
 
-    combineLatest(intOb1, intOb2, intOb3) {
+    _ = combineLatest(intOb1, intOb2, intOb3) {
         ($0 + $1) * $2
         }
         .subscribe {
@@ -108,7 +108,7 @@ example("zip 1") {
     let intOb1 = PublishSubject<String>()
     let intOb2 = PublishSubject<Int>()
 
-    zip(intOb1, intOb2) {
+    _ = zip(intOb1, intOb2) {
         "\($0) \($1)"
         }
         .subscribe {
@@ -132,7 +132,7 @@ example("zip 2") {
 
     let intOb2 = sequenceOf(0, 1, 2, 3, 4)
 
-    zip(intOb1, intOb2) {
+    _ = zip(intOb1, intOb2) {
             $0 * $1
         }
         .subscribe {
@@ -146,7 +146,7 @@ example("zip 3") {
     let intOb2 = sequenceOf(0, 1, 2, 3)
     let intOb3 = sequenceOf(0, 1, 2, 3, 4)
 
-    zip(intOb1, intOb2, intOb3) {
+    _ = zip(intOb1, intOb2, intOb3) {
             ($0 + $1) * $2
         }
         .subscribe {
@@ -170,7 +170,7 @@ example("merge 1") {
     let subject1 = PublishSubject<Int>()
     let subject2 = PublishSubject<Int>()
 
-    sequenceOf(subject1, subject2)
+    _ = sequenceOf(subject1, subject2)
         .merge()
         .subscribeNext { int in
             print(int)
@@ -190,7 +190,7 @@ example("merge 2") {
     let subject1 = PublishSubject<Int>()
     let subject2 = PublishSubject<Int>()
 
-    sequenceOf(subject1, subject2)
+    _ = sequenceOf(subject1, subject2)
         .merge(maxConcurrent: 2)
         .subscribe {
             print($0)

--- a/Rx.playground/Pages/Conditional_and_Boolean_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Conditional_and_Boolean_Operators.xcplaygroundpage/Contents.swift
@@ -23,7 +23,7 @@ example("takeUntil") {
     let originalSequence = PublishSubject<Int>()
     let whenThisSendsNextWorldStops = PublishSubject<Int>()
 
-    originalSequence
+    _ = originalSequence
         .takeUntil(whenThisSendsNextWorldStops)
         .subscribe {
             print($0)
@@ -53,7 +53,7 @@ example("takeWhile") {
 
     let sequence = PublishSubject<Int>()
 
-    sequence
+    _ = sequence
         .takeWhile { int in
             int < 4
         }

--- a/Rx.playground/Pages/Connectable_Observable_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Connectable_Observable_Operators.xcplaygroundpage/Contents.swift
@@ -1,7 +1,6 @@
 //: [<< Previous](@previous) - [Index](Index)
 
 import RxSwift
-import XCPlayground
 
 /*:
 ## Connectable Observable Operators
@@ -15,13 +14,13 @@ func sampleWithoutConnectableOperators() {
 
     let int1 = interval(1, MainScheduler.sharedInstance)
 
-    int1
+    _ = int1
         .subscribe {
             print("first subscription \($0)")
         }
 
     delay(5) {
-        int1
+        _ = int1
             .subscribe {
                 print("second subscription \($0)")
             }
@@ -44,7 +43,7 @@ func sampleWithMulticast() {
 
     let subject1 = PublishSubject<Int64>()
 
-    subject1
+    _ = subject1
         .subscribe {
             print("Subject \($0)")
         }
@@ -52,7 +51,7 @@ func sampleWithMulticast() {
     let int1 = interval(1, MainScheduler.sharedInstance)
         .multicast(subject1)
 
-    int1
+    _ = int1
         .subscribe {
             print("first subscription \($0)")
         }
@@ -62,14 +61,14 @@ func sampleWithMulticast() {
     }
 
     delay(4) {
-        int1
+        _ = int1
             .subscribe {
                 print("second subscription \($0)")
             }
     }
 
     delay(6) {
-        int1
+        _ = int1
             .subscribe {
                 print("third subscription \($0)")
             }
@@ -95,7 +94,7 @@ func sampleWithReplayBuffer0() {
     let int1 = interval(1, MainScheduler.sharedInstance)
         .replay(0)
 
-    int1
+    _ = int1
         .subscribe {
             print("first subscription \($0)")
         }
@@ -105,14 +104,14 @@ func sampleWithReplayBuffer0() {
     }
 
     delay(4) {
-        int1
+        _ = int1
             .subscribe {
                 print("second subscription \($0)")
             }
     }
 
     delay(6) {
-        int1
+        _ = int1
             .subscribe {
                 print("third subscription \($0)")
             }
@@ -130,7 +129,7 @@ func sampleWithReplayBuffer2() {
     let int1 = interval(1, MainScheduler.sharedInstance)
         .replay(2)
 
-    int1
+    _ = int1
         .subscribe {
             print("first subscription \($0)")
         }
@@ -140,14 +139,14 @@ func sampleWithReplayBuffer2() {
     }
 
     delay(4) {
-        int1
+        _ = int1
             .subscribe {
                 print("second subscription \($0)")
             }
     }
 
     delay(6) {
-        int1
+        _ = int1
             .subscribe {
                 print("third subscription \($0)")
             }
@@ -173,7 +172,7 @@ func sampleWithPublish() {
     let int1 = interval(1, MainScheduler.sharedInstance)
         .publish()
 
-    int1
+    _ = int1
         .subscribe {
             print("first subscription \($0)")
         }
@@ -183,14 +182,14 @@ func sampleWithPublish() {
     }
 
     delay(4) {
-        int1
+        _ = int1
             .subscribe {
                 print("second subscription \($0)")
             }
     }
 
     delay(6) {
-        int1
+        _ = int1
             .subscribe {
                 print("third subscription \($0)")
             }
@@ -200,6 +199,6 @@ func sampleWithPublish() {
 
 // sampleWithPublish()
 
-XCPSetExecutionShouldContinueIndefinitely(true)
+playgroundShouldContinueIndefinitely()
 
 //: [Index](Index)

--- a/Rx.playground/Pages/Error_Handling_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Error_Handling_Operators.xcplaygroundpage/Contents.swift
@@ -21,7 +21,7 @@ example("catchError 1") {
     let sequenceThatFails = PublishSubject<Int>()
     let recoverySequence = sequenceOf(100, 200, 300, 400)
 
-    sequenceThatFails
+    _ = sequenceThatFails
         .catchError { error in
             return recoverySequence
         }
@@ -40,7 +40,7 @@ example("catchError 1") {
 example("catchError 2") {
     let sequenceThatFails = PublishSubject<Int>()
 
-    sequenceThatFails
+    _ = sequenceThatFails
         .catchErrorJustReturn(100)
         .subscribe {
             print($0)
@@ -83,7 +83,7 @@ example("retry") {
         return NopDisposable.instance
     }
 
-    funnyLookingSequence
+    _ = funnyLookingSequence
         .retry()
         .subscribe {
             print($0)

--- a/Rx.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
@@ -149,12 +149,12 @@ example("deferred") {
         }
     }
 
-    deferredSequence
+    _ = deferredSequence
         .subscribe { event in
             print(event)
     }
 
-    deferredSequence
+    _ = deferredSequence
         .subscribe { event in
             print(event)
         }

--- a/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
@@ -65,7 +65,7 @@ This function will perform a function on each element in the sequence until it i
 
 */
 example("reduce") {
-    sequenceOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    _ = sequenceOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
         .reduce(0, +)
         .subscribe {
             print($0)

--- a/Rx.playground/Pages/Observable_Utility_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Observable_Utility_Operators.xcplaygroundpage/Contents.swift
@@ -18,7 +18,7 @@ A toolbox of useful Operators for working with Observables.
 example("subscribe") {
     let sequenceOfInts = PublishSubject<Int>()
 
-    sequenceOfInts
+    _ = sequenceOfInts
         .subscribe {
             print($0)
         }
@@ -40,7 +40,7 @@ There are several variants of the `subscribe` operator.
 example("subscribeNext") {
     let sequenceOfInts = PublishSubject<Int>()
 
-    sequenceOfInts
+    _ = sequenceOfInts
         .subscribeNext {
             print($0)
         }
@@ -58,7 +58,7 @@ example("subscribeNext") {
 example("subscribeCompleted") {
     let sequenceOfInts = PublishSubject<Int>()
 
-    sequenceOfInts
+    _ = sequenceOfInts
         .subscribeCompleted {
             print("It's completed")
         }
@@ -76,7 +76,7 @@ example("subscribeCompleted") {
 example("subscribeError") {
     let sequenceOfInts = PublishSubject<Int>()
 
-    sequenceOfInts
+    _ = sequenceOfInts
         .subscribeError { error in
             print(error)
         }
@@ -98,7 +98,7 @@ register an action to take upon a variety of Observable lifecycle events
 example("doOn") {
     let sequenceOfInts = PublishSubject<Int>()
 
-    sequenceOfInts
+    _ = sequenceOfInts
         .doOn {
             print("Intercepted event \($0)")
         }

--- a/Rx.playground/Pages/Subjects.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Subjects.xcplaygroundpage/Contents.swift
@@ -8,7 +8,7 @@ A Subject is a sort of bridge or proxy that is available in some implementations
 */
 
 func writeSequenceToConsole<O: ObservableType>(name: String, sequence: O) {
-    sequence
+    _ = sequence
         .subscribe { e in
             print("Subscription: \(name), event: \(e)")
         }

--- a/Rx.playground/Pages/Transforming_Observables.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Transforming_Observables.xcplaygroundpage/Contents.swift
@@ -21,7 +21,7 @@ Transform the items emitted by an Observable by applying a function to each item
 example("map") {
     let originalSequence = sequenceOf(Character("A"), Character("B"), Character("C"))
 
-    originalSequence
+    _ = originalSequence
         .map { char in
             char.hashValue
         }
@@ -43,7 +43,7 @@ example("flatMap") {
 
     let sequenceString = sequenceOf("A", "B", "C", "D", "E", "F", "--")
 
-    sequenceInt
+    _ = sequenceInt
         .flatMap { int in
             sequenceString
         }
@@ -65,7 +65,7 @@ Apply a function to each item emitted by an Observable, sequentially, and emit e
 example("scan") {
     let sequenceToSum = sequenceOf(0, 1, 2, 3, 4, 5)
 
-    sequenceToSum
+    _ = sequenceToSum
         .scan(0) { acum, elem in
             acum + elem
         }

--- a/Rx.playground/Sources/SupportCode.swift
+++ b/Rx.playground/Sources/SupportCode.swift
@@ -14,3 +14,18 @@ public func delay(delay:Double, closure:()->()) {
         ),
         dispatch_get_main_queue(), closure)
 }
+
+#if NOT_IN_PLAYGROUND
+
+public func playgroundShouldContinueIndefinitely() {
+}
+
+#else
+
+import XCPlayground
+
+public func playgroundShouldContinueIndefinitely() {
+    XCPSetExecutionShouldContinueIndefinitely(true)
+}
+
+#endif

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B1B7C3BD1BDD39DB0076934E /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B7C3BC1BDD39DB0076934E /* TakeLast.swift */; };
+		B1B7C3BE1BDD39DB0076934E /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B7C3BC1BDD39DB0076934E /* TakeLast.swift */; };
+		B1B7C3BF1BDD39DB0076934E /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B7C3BC1BDD39DB0076934E /* TakeLast.swift */; };
+		B1B7C3C01BDD39DB0076934E /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B7C3BC1BDD39DB0076934E /* TakeLast.swift */; };
 		C8093CC51B8A72BE0088E94D /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C491B8A72BE0088E94D /* Cancelable.swift */; };
 		C8093CC61B8A72BE0088E94D /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C491B8A72BE0088E94D /* Cancelable.swift */; };
 		C8093CC71B8A72BE0088E94D /* AsyncLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C4B1B8A72BE0088E94D /* AsyncLock.swift */; };
@@ -782,6 +786,7 @@
 
 /* Begin PBXFileReference section */
 		A111CE961B91C97C00D0DCEE /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B1B7C3BC1BDD39DB0076934E /* TakeLast.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TakeLast.swift; sourceTree = "<group>"; };
 		C809396D1B8A71760088E94D /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C80939E71B8A71840088E94D /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8093BC71B8A71F00088E94D /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1215,6 +1220,7 @@
 				C8093C8B1B8A72BE0088E94D /* SubscribeOn.swift */,
 				C8093C8C1B8A72BE0088E94D /* Switch.swift */,
 				C8093C8D1B8A72BE0088E94D /* Take.swift */,
+				B1B7C3BC1BDD39DB0076934E /* TakeLast.swift */,
 				C8093C8E1B8A72BE0088E94D /* TakeUntil.swift */,
 				C8093C8F1B8A72BE0088E94D /* TakeWhile.swift */,
 				C8093C901B8A72BE0088E94D /* Throttle.swift */,
@@ -2138,6 +2144,7 @@
 				C8093D1A1B8A72BE0088E94D /* DistinctUntilChanged.swift in Sources */,
 				C8093D561B8A72BE0088E94D /* Observable+Binding.swift in Sources */,
 				C8093D7A1B8A72BE0088E94D /* TailRecursiveSink.swift in Sources */,
+				B1B7C3BE1BDD39DB0076934E /* TakeLast.swift in Sources */,
 				C8093CC81B8A72BE0088E94D /* AsyncLock.swift in Sources */,
 				C8093CD81B8A72BE0088E94D /* BinaryDisposable.swift in Sources */,
 				C89CDB371BCB0DD7002063D9 /* ShareReplay1.swift in Sources */,
@@ -2259,6 +2266,7 @@
 				C8093D191B8A72BE0088E94D /* DistinctUntilChanged.swift in Sources */,
 				C8093D551B8A72BE0088E94D /* Observable+Binding.swift in Sources */,
 				C8093D791B8A72BE0088E94D /* TailRecursiveSink.swift in Sources */,
+				B1B7C3BD1BDD39DB0076934E /* TakeLast.swift in Sources */,
 				C8093CC71B8A72BE0088E94D /* AsyncLock.swift in Sources */,
 				C8093CD71B8A72BE0088E94D /* BinaryDisposable.swift in Sources */,
 				C89CDB361BCB0DD7002063D9 /* ShareReplay1.swift in Sources */,
@@ -2380,6 +2388,7 @@
 				C8F0BFB21BBBFB8B001B112F /* DistinctUntilChanged.swift in Sources */,
 				C8F0BFB31BBBFB8B001B112F /* Observable+Binding.swift in Sources */,
 				C8F0BFB41BBBFB8B001B112F /* TailRecursiveSink.swift in Sources */,
+				B1B7C3C01BDD39DB0076934E /* TakeLast.swift in Sources */,
 				C8F0BFB51BBBFB8B001B112F /* AsyncLock.swift in Sources */,
 				C8F0BFB61BBBFB8B001B112F /* BinaryDisposable.swift in Sources */,
 				C89CDB391BCB0DD7002063D9 /* ShareReplay1.swift in Sources */,
@@ -2651,6 +2660,7 @@
 				D2EBEB3A1BB9B6D8003A27DC /* MainScheduler.swift in Sources */,
 				D2EBEB101BB9B6C1003A27DC /* Just.swift in Sources */,
 				D2EBEB181BB9B6C1003A27DC /* Range.swift in Sources */,
+				B1B7C3BF1BDD39DB0076934E /* TakeLast.swift in Sources */,
 				D2EBEAE21BB9B697003A27DC /* Observable.swift in Sources */,
 				D2EBEB091BB9B6C1003A27DC /* DistinctUntilChanged.swift in Sources */,
 				D2EBEB2A1BB9B6C5003A27DC /* Zip+CollectionType.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -59,8 +59,6 @@
 		C8093CFE1B8A72BE0088E94D /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C681B8A72BE0088E94D /* Observable.swift */; };
 		C8093CFF1B8A72BE0088E94D /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6B1B8A72BE0088E94D /* Amb.swift */; };
 		C8093D001B8A72BE0088E94D /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6B1B8A72BE0088E94D /* Amb.swift */; };
-		C8093D031B8A72BE0088E94D /* AsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6D1B8A72BE0088E94D /* AsObservable.swift */; };
-		C8093D041B8A72BE0088E94D /* AsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6D1B8A72BE0088E94D /* AsObservable.swift */; };
 		C8093D051B8A72BE0088E94D /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6E1B8A72BE0088E94D /* Catch.swift */; };
 		C8093D061B8A72BE0088E94D /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6E1B8A72BE0088E94D /* Catch.swift */; };
 		C8093D071B8A72BE0088E94D /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6F1B8A72BE0088E94D /* CombineLatest+arity.swift */; };
@@ -393,7 +391,6 @@
 		C8F0BFA81BBBFB8B001B112F /* Observable+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C9D1B8A72BE0088E94D /* Observable+Time.swift */; };
 		C8F0BFA91BBBFB8B001B112F /* Observable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C671B8A72BE0088E94D /* Observable+Extensions.swift */; };
 		C8F0BFAA1BBBFB8B001B112F /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C901B8A72BE0088E94D /* Throttle.swift */; };
-		C8F0BFAB1BBBFB8B001B112F /* AsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6D1B8A72BE0088E94D /* AsObservable.swift */; };
 		C8F0BFAC1BBBFB8B001B112F /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6E1B8A72BE0088E94D /* Catch.swift */; };
 		C8F0BFAD1BBBFB8B001B112F /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C711B8A72BE0088E94D /* CombineLatest.swift */; };
 		C8F0BFAE1BBBFB8B001B112F /* Observable+Multiple.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C9A1B8A72BE0088E94D /* Observable+Multiple.swift */; };
@@ -647,7 +644,6 @@
 		D2EBEAFB1BB9B6B2003A27DC /* StableCompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C611B8A72BE0088E94D /* StableCompositeDisposable.swift */; };
 		D2EBEAFC1BB9B6BA003A27DC /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6B1B8A72BE0088E94D /* Amb.swift */; };
 		D2EBEAFD1BB9B6BA003A27DC /* AnonymousObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C3DA111B93A3EA004D233E /* AnonymousObservable.swift */; };
-		D2EBEAFE1BB9B6BA003A27DC /* AsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6D1B8A72BE0088E94D /* AsObservable.swift */; };
 		D2EBEAFF1BB9B6BA003A27DC /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C821DBA11BA4DCAB008F3809 /* Buffer.swift */; };
 		D2EBEB001BB9B6BA003A27DC /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C6E1B8A72BE0088E94D /* Catch.swift */; };
 		D2EBEB011BB9B6BA003A27DC /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C711B8A72BE0088E94D /* CombineLatest.swift */; };
@@ -818,7 +814,6 @@
 		C8093C671B8A72BE0088E94D /* Observable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+Extensions.swift"; sourceTree = "<group>"; };
 		C8093C681B8A72BE0088E94D /* Observable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Observable.swift; sourceTree = "<group>"; };
 		C8093C6B1B8A72BE0088E94D /* Amb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Amb.swift; sourceTree = "<group>"; };
-		C8093C6D1B8A72BE0088E94D /* AsObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsObservable.swift; sourceTree = "<group>"; };
 		C8093C6E1B8A72BE0088E94D /* Catch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Catch.swift; sourceTree = "<group>"; };
 		C8093C6F1B8A72BE0088E94D /* CombineLatest+arity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CombineLatest+arity.swift"; sourceTree = "<group>"; };
 		C8093C701B8A72BE0088E94D /* CombineLatest+arity.tt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "CombineLatest+arity.tt"; sourceTree = "<group>"; };
@@ -1180,7 +1175,6 @@
 				D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */,
 				C8093C6B1B8A72BE0088E94D /* Amb.swift */,
 				C8C3DA111B93A3EA004D233E /* AnonymousObservable.swift */,
-				C8093C6D1B8A72BE0088E94D /* AsObservable.swift */,
 				C821DBA11BA4DCAB008F3809 /* Buffer.swift */,
 				C8093C6E1B8A72BE0088E94D /* Catch.swift */,
 				C8093C711B8A72BE0088E94D /* CombineLatest.swift */,
@@ -2133,7 +2127,6 @@
 				C8093D641B8A72BE0088E94D /* Observable+Time.swift in Sources */,
 				C8093CFC1B8A72BE0088E94D /* Observable+Extensions.swift in Sources */,
 				C8093D4A1B8A72BE0088E94D /* Throttle.swift in Sources */,
-				C8093D041B8A72BE0088E94D /* AsObservable.swift in Sources */,
 				C8B145011BD2D80100267DCE /* ImmediateScheduler.swift in Sources */,
 				C8093D061B8A72BE0088E94D /* Catch.swift in Sources */,
 				C8093D0C1B8A72BE0088E94D /* CombineLatest.swift in Sources */,
@@ -2255,7 +2248,6 @@
 				C8093D631B8A72BE0088E94D /* Observable+Time.swift in Sources */,
 				C8093CFB1B8A72BE0088E94D /* Observable+Extensions.swift in Sources */,
 				C8093D491B8A72BE0088E94D /* Throttle.swift in Sources */,
-				C8093D031B8A72BE0088E94D /* AsObservable.swift in Sources */,
 				C8B145001BD2D80100267DCE /* ImmediateScheduler.swift in Sources */,
 				C8093D051B8A72BE0088E94D /* Catch.swift in Sources */,
 				C8093D0B1B8A72BE0088E94D /* CombineLatest.swift in Sources */,
@@ -2377,7 +2369,6 @@
 				C8F0BFA81BBBFB8B001B112F /* Observable+Time.swift in Sources */,
 				C8F0BFA91BBBFB8B001B112F /* Observable+Extensions.swift in Sources */,
 				C8F0BFAA1BBBFB8B001B112F /* Throttle.swift in Sources */,
-				C8F0BFAB1BBBFB8B001B112F /* AsObservable.swift in Sources */,
 				C8B145031BD2D80100267DCE /* ImmediateScheduler.swift in Sources */,
 				C8F0BFAC1BBBFB8B001B112F /* Catch.swift in Sources */,
 				C8F0BFAD1BBBFB8B001B112F /* CombineLatest.swift in Sources */,
@@ -2722,7 +2713,6 @@
 				D2EBEAED1BB9B6A4003A27DC /* Bag.swift in Sources */,
 				D2EBEB1A1BB9B6C1003A27DC /* RefCount.swift in Sources */,
 				D2EBEB141BB9B6C1003A27DC /* Never.swift in Sources */,
-				D2EBEAFE1BB9B6BA003A27DC /* AsObservable.swift in Sources */,
 				D2EBEAE01BB9B697003A27DC /* Event.swift in Sources */,
 				D2EBEB411BB9B6DE003A27DC /* PublishSubject.swift in Sources */,
 				D2EBEB431BB9B6DE003A27DC /* SubjectType.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -593,6 +593,10 @@
 		D2138C981BB9BEEE00339B5C /* RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093E9B1B8A732E0088E94D /* RxCocoa.swift */; };
 		D2138C991BB9BEEE00339B5C /* RxTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093E9C1B8A732E0088E94D /* RxTarget.swift */; };
 		D21C29311BC6A1C300448E70 /* SkipUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D285BAC31BC0231000B3F602 /* SkipUntil.swift */; };
+		D2245A1B1BD5657300E7146F /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */; };
+		D2245A1C1BD63C4600E7146F /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */; };
+		D2245A1D1BD63C4700E7146F /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */; };
+		D2245A1E1BD63C4A00E7146F /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */; };
 		D22B6D261BC8504A00BCE0AB /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */; };
 		D235B23E1BD003DD007E84DA /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = D235B23D1BD003DD007E84DA /* Using.swift */; };
 		D235B23F1BD003DD007E84DA /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = D235B23D1BD003DD007E84DA /* Using.swift */; };
@@ -975,6 +979,7 @@
 		C8F0C04B1BBBFBB9001B112F /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8F0C0581BBBFBCE001B112F /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2138C751BB9BE9800339B5C /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithLatestFrom.swift; sourceTree = "<group>"; };
 		D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipWhile.swift; sourceTree = "<group>"; };
 		D235B23D1BD003DD007E84DA /* Using.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Using.swift; sourceTree = "<group>"; };
 		D285BAC31BC0231000B3F602 /* SkipUntil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipUntil.swift; sourceTree = "<group>"; };
@@ -1161,6 +1166,7 @@
 		C8093C6A1B8A72BE0088E94D /* Implementations */ = {
 			isa = PBXGroup;
 			children = (
+				D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */,
 				C8093C6B1B8A72BE0088E94D /* Amb.swift */,
 				C8C3DA111B93A3EA004D233E /* AnonymousObservable.swift */,
 				C8093C6D1B8A72BE0088E94D /* AsObservable.swift */,
@@ -2100,6 +2106,7 @@
 				C8093D3C1B8A72BE0088E94D /* Skip.swift in Sources */,
 				C8B144FC1BD2D44500267DCE /* ConcurrentMainScheduler.swift in Sources */,
 				C8093CF01B8A72BE0088E94D /* StableCompositeDisposable.swift in Sources */,
+				D2245A1C1BD63C4600E7146F /* WithLatestFrom.swift in Sources */,
 				C8093D4E1B8A72BE0088E94D /* Zip+arity.swift in Sources */,
 				C8093D4C1B8A72BE0088E94D /* Timer.swift in Sources */,
 				C8C3DA071B9393AC004D233E /* Empty.swift in Sources */,
@@ -2219,6 +2226,7 @@
 				C8093D3B1B8A72BE0088E94D /* Skip.swift in Sources */,
 				C8B144FB1BD2D44500267DCE /* ConcurrentMainScheduler.swift in Sources */,
 				C8093CEF1B8A72BE0088E94D /* StableCompositeDisposable.swift in Sources */,
+				D2245A1B1BD5657300E7146F /* WithLatestFrom.swift in Sources */,
 				C8093D4D1B8A72BE0088E94D /* Zip+arity.swift in Sources */,
 				C8093D4B1B8A72BE0088E94D /* Timer.swift in Sources */,
 				C8C3DA061B9393AC004D233E /* Empty.swift in Sources */,
@@ -2338,6 +2346,7 @@
 				C8F0BF9B1BBBFB8B001B112F /* Skip.swift in Sources */,
 				C8B144FE1BD2D44500267DCE /* ConcurrentMainScheduler.swift in Sources */,
 				C8F0BF9C1BBBFB8B001B112F /* StableCompositeDisposable.swift in Sources */,
+				D2245A1E1BD63C4A00E7146F /* WithLatestFrom.swift in Sources */,
 				C8F0BF9D1BBBFB8B001B112F /* Zip+arity.swift in Sources */,
 				C8F0BF9E1BBBFB8B001B112F /* Timer.swift in Sources */,
 				C8F0BF9F1BBBFB8B001B112F /* Empty.swift in Sources */,
@@ -2607,6 +2616,7 @@
 				D2EBEAF11BB9B6AE003A27DC /* BinaryDisposable.swift in Sources */,
 				C8B144FD1BD2D44500267DCE /* ConcurrentMainScheduler.swift in Sources */,
 				D2EBEB1B1BB9B6C1003A27DC /* Repeat.swift in Sources */,
+				D2245A1D1BD63C4700E7146F /* WithLatestFrom.swift in Sources */,
 				D2EBEAF81BB9B6B2003A27DC /* ScopedDisposable.swift in Sources */,
 				D2EBEAEA1BB9B697003A27DC /* SchedulerType.swift in Sources */,
 				D2EBEB031BB9B6C1003A27DC /* CombineLatest+CollectionType.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1836,7 +1836,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Krunoslav Zaher";
 				TargetAttributes = {
 					C8A56AD61AD7424700B4673B = {
@@ -2805,6 +2805,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2821,6 +2822,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2837,6 +2839,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2855,6 +2858,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2873,6 +2877,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2891,6 +2896,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2907,6 +2913,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2923,6 +2930,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2939,6 +2947,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2957,6 +2966,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2975,6 +2985,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -2993,6 +3004,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -3003,6 +3015,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -3056,6 +3069,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -3074,6 +3088,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -3092,6 +3107,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -3110,6 +3126,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -3120,6 +3137,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -3173,6 +3191,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -3224,6 +3243,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -3241,6 +3261,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -3258,6 +3279,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3276,6 +3298,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3294,6 +3317,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3312,6 +3336,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3330,6 +3355,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3348,6 +3374,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3366,6 +3393,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3384,6 +3412,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3402,6 +3431,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -3423,6 +3453,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -3441,6 +3472,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -3459,6 +3491,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -3482,7 +3515,7 @@
 				INFOPLIST_FILE = RxSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -3501,7 +3534,7 @@
 				INFOPLIST_FILE = RxSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -3520,7 +3553,7 @@
 				INFOPLIST_FILE = RxSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -3539,6 +3572,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -3557,6 +3591,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
@@ -3575,6 +3610,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = RxBlocking;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -292,6 +292,10 @@
 		C84B38EA1BA43380001B7D88 /* ScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84B38E71BA43380001B7D88 /* ScheduledItem.swift */; };
 		C84B38EE1BA433CD001B7D88 /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84B38ED1BA433CD001B7D88 /* Generate.swift */; };
 		C84B38EF1BA433CD001B7D88 /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84B38ED1BA433CD001B7D88 /* Generate.swift */; };
+		C84CC5401BDC3B3700E06A64 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC53F1BDC3B3700E06A64 /* ElementAt.swift */; };
+		C84CC5411BDC3B3E00E06A64 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC53F1BDC3B3700E06A64 /* ElementAt.swift */; };
+		C84CC5421BDC3B3E00E06A64 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC53F1BDC3B3700E06A64 /* ElementAt.swift */; };
+		C84CC5431BDC3B3E00E06A64 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC53F1BDC3B3700E06A64 /* ElementAt.swift */; };
 		C86409FC1BA593F500D3C4E8 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86409FB1BA593F500D3C4E8 /* Range.swift */; };
 		C86409FD1BA593F500D3C4E8 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86409FB1BA593F500D3C4E8 /* Range.swift */; };
 		C8640A031BA5B12A00D3C4E8 /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8640A021BA5B12A00D3C4E8 /* Repeat.swift */; };
@@ -531,10 +535,10 @@
 		C8F0C0441BBBFBB9001B112F /* _RXSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = C8093E881B8A732E0088E94D /* _RXSwizzling.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C8F0C0451BBBFBB9001B112F /* _RXKVOObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = C8093E861B8A732E0088E94D /* _RXKVOObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C8F0C04F1BBBFBCE001B112F /* ObservableConvertibleType+Blocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093F581B8A73A20088E94D /* ObservableConvertibleType+Blocking.swift */; };
-		CBEE771F1BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
-		CBEE77201BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
-		CBEE77211BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
-		CBEE77221BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
+		CBEE771F1BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; };
+		CBEE77201BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; };
+		CBEE77211BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; };
+		CBEE77221BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; };
 		D203C4F31BB9C4CA00D02D00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F11B8A752B00B02D69 /* RxCollectionViewReactiveArrayDataSource.swift */; };
 		D203C4F41BB9C52400D02D00 /* RxTableViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F21B8A752B00B02D69 /* RxTableViewReactiveArrayDataSource.swift */; };
 		D203C4F51BB9C52900D02D00 /* ItemEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F41B8A752B00B02D69 /* ItemEvents.swift */; };
@@ -931,6 +935,7 @@
 		C849BE2A1BAB5D070019AD27 /* ObservableConvertibleType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableConvertibleType.swift; sourceTree = "<group>"; };
 		C84B38E71BA43380001B7D88 /* ScheduledItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScheduledItem.swift; sourceTree = "<group>"; };
 		C84B38ED1BA433CD001B7D88 /* Generate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Generate.swift; sourceTree = "<group>"; };
+		C84CC53F1BDC3B3700E06A64 /* ElementAt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementAt.swift; sourceTree = "<group>"; };
 		C86409FB1BA593F500D3C4E8 /* Range.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Range.swift; sourceTree = "<group>"; };
 		C8640A021BA5B12A00D3C4E8 /* Repeat.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Repeat.swift; sourceTree = "<group>"; };
 		C88253F11B8A752B00B02D69 /* RxCollectionViewReactiveArrayDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxCollectionViewReactiveArrayDataSource.swift; sourceTree = "<group>"; };
@@ -1171,6 +1176,7 @@
 		C8093C6A1B8A72BE0088E94D /* Implementations */ = {
 			isa = PBXGroup;
 			children = (
+				C84CC53F1BDC3B3700E06A64 /* ElementAt.swift */,
 				D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */,
 				C8093C6B1B8A72BE0088E94D /* Amb.swift */,
 				C8C3DA111B93A3EA004D233E /* AnonymousObservable.swift */,
@@ -2150,6 +2156,7 @@
 				C8C3DA101B939767004D233E /* CurrentThreadScheduler.swift in Sources */,
 				C8093D861B8A72BE0088E94D /* Rx.swift in Sources */,
 				C80D342F1B9245A40014629D /* CombineLatest+CollectionType.swift in Sources */,
+				C84CC5411BDC3B3E00E06A64 /* ElementAt.swift in Sources */,
 				C8093DA61B8A72BE0088E94D /* SubjectType.swift in Sources */,
 				C8093D5C1B8A72BE0088E94D /* Observable+Debug.swift in Sources */,
 				C8093D581B8A72BE0088E94D /* Observable+Concurrency.swift in Sources */,
@@ -2271,6 +2278,7 @@
 				C8C3DA0F1B939767004D233E /* CurrentThreadScheduler.swift in Sources */,
 				C8093D851B8A72BE0088E94D /* Rx.swift in Sources */,
 				C80D342E1B9245A40014629D /* CombineLatest+CollectionType.swift in Sources */,
+				C84CC5401BDC3B3700E06A64 /* ElementAt.swift in Sources */,
 				C8093DA51B8A72BE0088E94D /* SubjectType.swift in Sources */,
 				C8093D5B1B8A72BE0088E94D /* Observable+Debug.swift in Sources */,
 				C8093D571B8A72BE0088E94D /* Observable+Concurrency.swift in Sources */,
@@ -2392,6 +2400,7 @@
 				C8F0BFBB1BBBFB8B001B112F /* CurrentThreadScheduler.swift in Sources */,
 				C8F0BFBC1BBBFB8B001B112F /* Rx.swift in Sources */,
 				C8F0BFBD1BBBFB8B001B112F /* CombineLatest+CollectionType.swift in Sources */,
+				C84CC5431BDC3B3E00E06A64 /* ElementAt.swift in Sources */,
 				C8F0BFBE1BBBFB8B001B112F /* SubjectType.swift in Sources */,
 				C8F0BFBF1BBBFB8B001B112F /* Observable+Debug.swift in Sources */,
 				C8F0BFC01BBBFB8B001B112F /* Observable+Concurrency.swift in Sources */,
@@ -2663,6 +2672,7 @@
 				D2EBEB1F1BB9B6C1003A27DC /* Skip.swift in Sources */,
 				D2EBEB321BB9B6CA003A27DC /* Observable+StandardSequenceOperators.swift in Sources */,
 				D2EBEB391BB9B6D8003A27DC /* DispatchQueueSchedulerPriority.swift in Sources */,
+				C84CC5421BDC3B3E00E06A64 /* ElementAt.swift in Sources */,
 				D2EBEB081BB9B6C1003A27DC /* DelaySubscription.swift in Sources */,
 				D2EBEADE1BB9B697003A27DC /* Disposable.swift in Sources */,
 				D2EBEB2F1BB9B6CA003A27DC /* Observable+Debug.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -531,6 +531,10 @@
 		C8F0C0441BBBFBB9001B112F /* _RXSwizzling.h in Headers */ = {isa = PBXBuildFile; fileRef = C8093E881B8A732E0088E94D /* _RXSwizzling.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C8F0C0451BBBFBB9001B112F /* _RXKVOObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = C8093E861B8A732E0088E94D /* _RXKVOObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C8F0C04F1BBBFBCE001B112F /* ObservableConvertibleType+Blocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093F581B8A73A20088E94D /* ObservableConvertibleType+Blocking.swift */; };
+		CBEE771F1BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
+		CBEE77201BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
+		CBEE77211BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
+		CBEE77221BD649A000AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE771E1BD649A000AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
 		D203C4F31BB9C4CA00D02D00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F11B8A752B00B02D69 /* RxCollectionViewReactiveArrayDataSource.swift */; };
 		D203C4F41BB9C52400D02D00 /* RxTableViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F21B8A752B00B02D69 /* RxTableViewReactiveArrayDataSource.swift */; };
 		D203C4F51BB9C52900D02D00 /* ItemEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F41B8A752B00B02D69 /* ItemEvents.swift */; };
@@ -978,6 +982,7 @@
 		C8F0C0021BBBFB8B001B112F /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8F0C04B1BBBFBB9001B112F /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8F0C0581BBBFBCE001B112F /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CBEE771E1BD649A000AD584C /* ToArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToArray.swift; sourceTree = "<group>"; };
 		D2138C751BB9BE9800339B5C /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithLatestFrom.swift; sourceTree = "<group>"; };
 		D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipWhile.swift; sourceTree = "<group>"; };
@@ -1214,6 +1219,7 @@
 				C8093C8F1B8A72BE0088E94D /* TakeWhile.swift */,
 				C8093C901B8A72BE0088E94D /* Throttle.swift */,
 				C8093C911B8A72BE0088E94D /* Timer.swift */,
+				CBEE771E1BD649A000AD584C /* ToArray.swift */,
 				C8093C941B8A72BE0088E94D /* Zip.swift */,
 				C8093C921B8A72BE0088E94D /* Zip+arity.swift */,
 				C8093C931B8A72BE0088E94D /* Zip+arity.tt */,
@@ -2199,6 +2205,7 @@
 				C8093CDC1B8A72BE0088E94D /* CompositeDisposable.swift in Sources */,
 				C8093D7E1B8A72BE0088E94D /* ObserverType.swift in Sources */,
 				C8093D401B8A72BE0088E94D /* SubscribeOn.swift in Sources */,
+				CBEE77201BD649A000AD584C /* ToArray.swift in Sources */,
 				C8093CFE1B8A72BE0088E94D /* Observable.swift in Sources */,
 				C8093CE21B8A72BE0088E94D /* NAryDisposable.swift in Sources */,
 				C8093CEC1B8A72BE0088E94D /* SerialDisposable.swift in Sources */,
@@ -2319,6 +2326,7 @@
 				C8093CDB1B8A72BE0088E94D /* CompositeDisposable.swift in Sources */,
 				C8093D7D1B8A72BE0088E94D /* ObserverType.swift in Sources */,
 				C8093D3F1B8A72BE0088E94D /* SubscribeOn.swift in Sources */,
+				CBEE771F1BD649A000AD584C /* ToArray.swift in Sources */,
 				C8093CFD1B8A72BE0088E94D /* Observable.swift in Sources */,
 				C8093CE11B8A72BE0088E94D /* NAryDisposable.swift in Sources */,
 				C8093CEB1B8A72BE0088E94D /* SerialDisposable.swift in Sources */,
@@ -2439,6 +2447,7 @@
 				C8F0BFF11BBBFB8B001B112F /* CompositeDisposable.swift in Sources */,
 				C8F0BFF21BBBFB8B001B112F /* ObserverType.swift in Sources */,
 				C8F0BFF31BBBFB8B001B112F /* SubscribeOn.swift in Sources */,
+				CBEE77221BD649A000AD584C /* ToArray.swift in Sources */,
 				C8F0BFF41BBBFB8B001B112F /* Observable.swift in Sources */,
 				C8F0BFF51BBBFB8B001B112F /* NAryDisposable.swift in Sources */,
 				C8F0BFF61BBBFB8B001B112F /* SerialDisposable.swift in Sources */,
@@ -2709,6 +2718,7 @@
 				D2EBEB431BB9B6DE003A27DC /* SubjectType.swift in Sources */,
 				D2EBEB201BB9B6C1003A27DC /* StartWith.swift in Sources */,
 				D2EBEAF41BB9B6AE003A27DC /* DisposeBase.swift in Sources */,
+				CBEE77211BD649A000AD584C /* ToArray.swift in Sources */,
 				D2EBEB3F1BB9B6D8003A27DC /* CurrentThreadScheduler.swift in Sources */,
 				D2EBEAF21BB9B6AE003A27DC /* CompositeDisposable.swift in Sources */,
 				D2EBEB0E1BB9B6C1003A27DC /* FlatMap.swift in Sources */,

--- a/RxBlocking/Info.plist
+++ b/RxBlocking/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/RxCocoa/Info.plist
+++ b/RxCocoa/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -144,7 +144,6 @@
 		C89464B91BC6C2B00055219D /* ObservableConvertibleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89464461BC6C2B00055219D /* ObservableConvertibleType.swift */; };
 		C89464BA1BC6C2B00055219D /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89464491BC6C2B00055219D /* Amb.swift */; };
 		C89464BB1BC6C2B00055219D /* AnonymousObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C894644A1BC6C2B00055219D /* AnonymousObservable.swift */; };
-		C89464BC1BC6C2B00055219D /* AsObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C894644B1BC6C2B00055219D /* AsObservable.swift */; };
 		C89464BD1BC6C2B00055219D /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C894644C1BC6C2B00055219D /* Buffer.swift */; };
 		C89464BE1BC6C2B00055219D /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C894644D1BC6C2B00055219D /* Catch.swift */; };
 		C89464BF1BC6C2B00055219D /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C894644E1BC6C2B00055219D /* CombineLatest+arity.swift */; };
@@ -524,7 +523,6 @@
 		C89464461BC6C2B00055219D /* ObservableConvertibleType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableConvertibleType.swift; sourceTree = "<group>"; };
 		C89464491BC6C2B00055219D /* Amb.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Amb.swift; sourceTree = "<group>"; };
 		C894644A1BC6C2B00055219D /* AnonymousObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = AnonymousObservable.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		C894644B1BC6C2B00055219D /* AsObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsObservable.swift; sourceTree = "<group>"; };
 		C894644C1BC6C2B00055219D /* Buffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Buffer.swift; sourceTree = "<group>"; };
 		C894644D1BC6C2B00055219D /* Catch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Catch.swift; sourceTree = "<group>"; };
 		C894644E1BC6C2B00055219D /* CombineLatest+arity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CombineLatest+arity.swift"; sourceTree = "<group>"; };
@@ -1091,7 +1089,6 @@
 				C84CC52D1BDC344100E06A64 /* ElementAt.swift */,
 				C89464491BC6C2B00055219D /* Amb.swift */,
 				C894644A1BC6C2B00055219D /* AnonymousObservable.swift */,
-				C894644B1BC6C2B00055219D /* AsObservable.swift */,
 				C894644C1BC6C2B00055219D /* Buffer.swift */,
 				C894644D1BC6C2B00055219D /* Catch.swift */,
 				C89464511BC6C2B00055219D /* CombineLatest.swift */,
@@ -1756,7 +1753,6 @@
 				C89465981BC6C2BC0055219D /* UISearchBar+Rx.swift in Sources */,
 				C89464E21BC6C2B00055219D /* Take.swift in Sources */,
 				C89465901BC6C2BC0055219D /* UIButton+Rx.swift in Sources */,
-				C89464BC1BC6C2B00055219D /* AsObservable.swift in Sources */,
 				C89464DD1BC6C2B00055219D /* Sink.swift in Sources */,
 				C89464FE1BC6C2B00055219D /* CurrentThreadScheduler.swift in Sources */,
 				C89464BE1BC6C2B00055219D /* Catch.swift in Sources */,

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -311,7 +311,8 @@
 		C8DF92EA1B0B38C0009BCF9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8DF92E91B0B38C0009BCF9A /* Images.xcassets */; };
 		C8DF92EB1B0B38C0009BCF9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8DF92E91B0B38C0009BCF9A /* Images.xcassets */; };
 		C8DF92F61B0B43A4009BCF9A /* IntroductionExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8DF92F51B0B43A4009BCF9A /* IntroductionExampleViewController.swift */; };
-		C8E9D2AF1BD3FD960079D0DB /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; settings = {ASSET_TAGS = (); }; };
+		C8E9D2AF1BD3FD960079D0DB /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
+		D2245A191BD5654C00E7146F /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2245A0B1BD564A700E7146F /* WithLatestFrom.swift */; };
 		D2AF91981BD3D95900A008C1 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AF91881BD2C51900A008C1 /* Using.swift */; };
 		EC91FB951BBA144400973245 /* GitHubSearchRepositoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC91FB941BBA144400973245 /* GitHubSearchRepositoriesViewController.swift */; };
 /* End PBXBuildFile section */
@@ -688,6 +689,7 @@
 		C8DF92F01B0B3E67009BCF9A /* Info-OSX.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-OSX.plist"; sourceTree = "<group>"; };
 		C8DF92F21B0B3E71009BCF9A /* Info-iOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
 		C8DF92F51B0B43A4009BCF9A /* IntroductionExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = IntroductionExampleViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D2245A0B1BD564A700E7146F /* WithLatestFrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithLatestFrom.swift; sourceTree = "<group>"; };
 		D2AF91881BD2C51900A008C1 /* Using.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Using.swift; sourceTree = "<group>"; };
 		EC91FB941BBA144400973245 /* GitHubSearchRepositoriesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSearchRepositoriesViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1135,6 +1137,7 @@
 				C89464761BC6C2B00055219D /* Zip+arity.swift */,
 				C89464771BC6C2B00055219D /* Zip+arity.tt */,
 				C89464781BC6C2B00055219D /* Zip+CollectionType.swift */,
+				D2245A0B1BD564A700E7146F /* WithLatestFrom.swift */,
 			);
 			path = Implementations;
 			sourceTree = "<group>";
@@ -1707,6 +1710,7 @@
 				C89464B11BC6C2B00055219D /* SingleAssignmentDisposable.swift in Sources */,
 				C89464AA1BC6C2B00055219D /* DisposeBase.swift in Sources */,
 				C89465871BC6C2BC0055219D /* RxCollectionViewDelegateProxy.swift in Sources */,
+				D2245A191BD5654C00E7146F /* WithLatestFrom.swift in Sources */,
 				C8297E3D1B6CF905000589EA /* SearchViewModel.swift in Sources */,
 				C89464E61BC6C2B00055219D /* Timer.swift in Sources */,
 				C8297E3E1B6CF905000589EA /* DetailViewController.swift in Sources */,

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		C84B913B1B8A282000C9CCCF /* RxCollectionViewSectionedReloadDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C859B9A51B45C80700D012D7 /* RxCollectionViewSectionedReloadDataSource.swift */; };
 		C84B913C1B8A282000C9CCCF /* RxCollectionViewSectionedDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C859B9A71B45C83700D012D7 /* RxCollectionViewSectionedDataSource.swift */; };
 		C84B913D1B8A282000C9CCCF /* RxCollectionViewSectionedAnimatedDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C859B9A91B45CB0900D012D7 /* RxCollectionViewSectionedAnimatedDataSource.swift */; };
+		C84CC52E1BDC344100E06A64 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC52D1BDC344100E06A64 /* ElementAt.swift */; };
 		C859B9A41B45C5D900D012D7 /* PartialUpdatesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C859B9A31B45C5D900D012D7 /* PartialUpdatesViewController.swift */; };
 		C859B9AC1B45CF9100D012D7 /* NumberCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C859B9AB1B45CF9100D012D7 /* NumberCell.swift */; };
 		C859B9AE1B45CFAB00D012D7 /* NumberSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C859B9AD1B45CFAB00D012D7 /* NumberSectionView.swift */; };
@@ -312,8 +313,8 @@
 		C8DF92EB1B0B38C0009BCF9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C8DF92E91B0B38C0009BCF9A /* Images.xcassets */; };
 		C8DF92F61B0B43A4009BCF9A /* IntroductionExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8DF92F51B0B43A4009BCF9A /* IntroductionExampleViewController.swift */; };
 		C8E9D2AF1BD3FD960079D0DB /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
+		CBEE77541BD8C7B700AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE77531BD8C7B700AD584C /* ToArray.swift */; };
 		D2245A191BD5654C00E7146F /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2245A0B1BD564A700E7146F /* WithLatestFrom.swift */; };
-		CBEE77541BD8C7B700AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE77531BD8C7B700AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
 		D2AF91981BD3D95900A008C1 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AF91881BD2C51900A008C1 /* Using.swift */; };
 		EC91FB951BBA144400973245 /* GitHubSearchRepositoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC91FB941BBA144400973245 /* GitHubSearchRepositoriesViewController.swift */; };
 /* End PBXBuildFile section */
@@ -469,6 +470,7 @@
 		C83367111AD029AE00C668A7 /* HtmlParsing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HtmlParsing.swift; sourceTree = "<group>"; };
 		C83367121AD029AE00C668A7 /* ImageService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		C83367211AD029AE00C668A7 /* Wireframe.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wireframe.swift; sourceTree = "<group>"; };
+		C84CC52D1BDC344100E06A64 /* ElementAt.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementAt.swift; sourceTree = "<group>"; };
 		C859B9A31B45C5D900D012D7 /* PartialUpdatesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartialUpdatesViewController.swift; sourceTree = "<group>"; };
 		C859B9A51B45C80700D012D7 /* RxCollectionViewSectionedReloadDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxCollectionViewSectionedReloadDataSource.swift; sourceTree = "<group>"; };
 		C859B9A71B45C83700D012D7 /* RxCollectionViewSectionedDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxCollectionViewSectionedDataSource.swift; sourceTree = "<group>"; };
@@ -1086,6 +1088,7 @@
 		C89464481BC6C2B00055219D /* Implementations */ = {
 			isa = PBXGroup;
 			children = (
+				C84CC52D1BDC344100E06A64 /* ElementAt.swift */,
 				C89464491BC6C2B00055219D /* Amb.swift */,
 				C894644A1BC6C2B00055219D /* AnonymousObservable.swift */,
 				C894644B1BC6C2B00055219D /* AsObservable.swift */,
@@ -1737,6 +1740,7 @@
 				C89464F51BC6C2B00055219D /* AnyObserver.swift in Sources */,
 				C89464D71BC6C2B00055219D /* Range.swift in Sources */,
 				C803974A1BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift in Sources */,
+				C84CC52E1BDC344100E06A64 /* ElementAt.swift in Sources */,
 				C8297E431B6CF905000589EA /* GitHubAPI.swift in Sources */,
 				C89464EB1BC6C2B00055219D /* Observable+Aggregate.swift in Sources */,
 				C8297E441B6CF905000589EA /* PseudoRandomGenerator.swift in Sources */,

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		07E300071B14995F00F00100 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E300061B14995F00F00100 /* TableViewController.swift */; };
 		07E300091B149A2A00F00100 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E300081B149A2A00F00100 /* User.swift */; };
 		07E3C2331B03605B0010338D /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07E3C2321B03605B0010338D /* Dependencies.swift */; };
+		B1B7C3D01BE006870076934E /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B7C3CF1BE006870076934E /* TakeLast.swift */; };
 		C803973A1BD3E17D009D8B26 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
 		C803973B1BD3E17D009D8B26 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
 		C80397491BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397481BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift */; };
@@ -451,6 +452,7 @@
 		07E300061B14995F00F00100 /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		07E300081B149A2A00F00100 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		07E3C2321B03605B0010338D /* Dependencies.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Dependencies.swift; path = Examples/Dependencies.swift; sourceTree = "<group>"; };
+		B1B7C3CF1BE006870076934E /* TakeLast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TakeLast.swift; sourceTree = "<group>"; };
 		C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
 		C80397481BD3E9A6009D8B26 /* GitHubSearchRepositoriesAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSearchRepositoriesAPI.swift; sourceTree = "<group>"; };
 		C80DDE7A1BCDA952006A1832 /* SkipWhile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipWhile.swift; sourceTree = "<group>"; };
@@ -1130,6 +1132,7 @@
 				C894646F1BC6C2B00055219D /* SubscribeOn.swift */,
 				C89464701BC6C2B00055219D /* Switch.swift */,
 				C89464711BC6C2B00055219D /* Take.swift */,
+				B1B7C3CF1BE006870076934E /* TakeLast.swift */,
 				C89464721BC6C2B00055219D /* TakeUntil.swift */,
 				C89464731BC6C2B00055219D /* TakeWhile.swift */,
 				C89464741BC6C2B00055219D /* Throttle.swift */,
@@ -1661,6 +1664,7 @@
 				C89464BB1BC6C2B00055219D /* AnonymousObservable.swift in Sources */,
 				C89465991BC6C2BC0055219D /* UISegmentedControl+Rx.swift in Sources */,
 				C8297E371B6CF905000589EA /* RxCollectionViewSectionedDataSource.swift in Sources */,
+				B1B7C3D01BE006870076934E /* TakeLast.swift in Sources */,
 				C89464CD1BC6C2B00055219D /* FlatMap.swift in Sources */,
 				C8297E381B6CF905000589EA /* Changeset.swift in Sources */,
 				C8297E391B6CF905000589EA /* CollectionViewImageCell.swift in Sources */,

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		C8DF92F61B0B43A4009BCF9A /* IntroductionExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8DF92F51B0B43A4009BCF9A /* IntroductionExampleViewController.swift */; };
 		C8E9D2AF1BD3FD960079D0DB /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
 		D2245A191BD5654C00E7146F /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2245A0B1BD564A700E7146F /* WithLatestFrom.swift */; };
+		CBEE77541BD8C7B700AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE77531BD8C7B700AD584C /* ToArray.swift */; settings = {ASSET_TAGS = (); }; };
 		D2AF91981BD3D95900A008C1 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AF91881BD2C51900A008C1 /* Using.swift */; };
 		EC91FB951BBA144400973245 /* GitHubSearchRepositoriesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC91FB941BBA144400973245 /* GitHubSearchRepositoriesViewController.swift */; };
 /* End PBXBuildFile section */
@@ -689,6 +690,7 @@
 		C8DF92F01B0B3E67009BCF9A /* Info-OSX.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-OSX.plist"; sourceTree = "<group>"; };
 		C8DF92F21B0B3E71009BCF9A /* Info-iOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
 		C8DF92F51B0B43A4009BCF9A /* IntroductionExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = IntroductionExampleViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		CBEE77531BD8C7B700AD584C /* ToArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToArray.swift; sourceTree = "<group>"; };
 		D2245A0B1BD564A700E7146F /* WithLatestFrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithLatestFrom.swift; sourceTree = "<group>"; };
 		D2AF91881BD2C51900A008C1 /* Using.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Using.swift; sourceTree = "<group>"; };
 		EC91FB941BBA144400973245 /* GitHubSearchRepositoriesViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSearchRepositoriesViewController.swift; sourceTree = "<group>"; };
@@ -1084,7 +1086,6 @@
 		C89464481BC6C2B00055219D /* Implementations */ = {
 			isa = PBXGroup;
 			children = (
-				D2AF91881BD2C51900A008C1 /* Using.swift */,
 				C89464491BC6C2B00055219D /* Amb.swift */,
 				C894644A1BC6C2B00055219D /* AnonymousObservable.swift */,
 				C894644B1BC6C2B00055219D /* AsObservable.swift */,
@@ -1133,6 +1134,8 @@
 				C89464731BC6C2B00055219D /* TakeWhile.swift */,
 				C89464741BC6C2B00055219D /* Throttle.swift */,
 				C89464751BC6C2B00055219D /* Timer.swift */,
+				CBEE77531BD8C7B700AD584C /* ToArray.swift */,
+				D2AF91881BD2C51900A008C1 /* Using.swift */,
 				C89464791BC6C2B00055219D /* Zip.swift */,
 				C89464761BC6C2B00055219D /* Zip+arity.swift */,
 				C89464771BC6C2B00055219D /* Zip+arity.tt */,
@@ -1717,6 +1720,7 @@
 				C8297E3F1B6CF905000589EA /* SectionModelType.swift in Sources */,
 				C8297E401B6CF905000589EA /* ImageService.swift in Sources */,
 				C89464AD1BC6C2B00055219D /* NopDisposable.swift in Sources */,
+				CBEE77541BD8C7B700AD584C /* ToArray.swift in Sources */,
 				C89465771BC6C2BC0055219D /* NSNotificationCenter+Rx.swift in Sources */,
 				C89465091BC6C2B00055219D /* ReplaySubject.swift in Sources */,
 				C8297E411B6CF905000589EA /* RxCollectionViewSectionedReloadDataSource.swift in Sources */,

--- a/RxExample/RxExample/Examples/Calculator/CalculatorViewController.swift
+++ b/RxExample/RxExample/Examples/Calculator/CalculatorViewController.swift
@@ -67,7 +67,7 @@ class CalculatorViewController: ViewController {
     
     let CLEAR_STATE = CalState(previousNumber: nil, action: .Clear, currentNumber: "0", inScreen: "0", replace: true)
     
-    let diposeBag = DisposeBag()
+    let disposeBag = DisposeBag()
     
     override func viewDidLoad() {
         let commands:[Observable<Action>] = [
@@ -122,7 +122,7 @@ class CalculatorViewController: ViewController {
                     self?.lastSignLabel.text = ""
                 }
             }
-            .addDisposableTo(diposeBag)
+            .addDisposableTo(disposeBag)
     }
     
     func tranformState(a: CalState, _ x: Action) -> CalState {

--- a/RxSwift/Concurrency/AsyncLock.swift
+++ b/RxSwift/Concurrency/AsyncLock.swift
@@ -21,26 +21,26 @@ That means that enqueued work could possibly be executed later on a different th
 class AsyncLock : Disposable {
     typealias Action = () -> Void
     
-    private let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
-    private var queue: Queue<Action> = Queue(capacity: 2)
+    private var _queue: Queue<Action> = Queue(capacity: 2)
 
-    private var isAcquired: Bool = false
-    private var hasFaulted: Bool = false
+    private var _isAcquired: Bool = false
+    private var _hasFaulted: Bool = false
     
     init() {
         
     }
     
     func wait(action: Action) {
-        let isOwner = lock.calculateLocked { () -> Bool in
-            if self.hasFaulted {
+        let isOwner = _lock.calculateLocked { () -> Bool in
+            if _hasFaulted {
                 return false
             }
             
-            self.queue.enqueue(action)
-            let isOwner = !self.isAcquired
-            self.isAcquired = true
+            _queue.enqueue(action)
+            let isOwner = !_isAcquired
+            _isAcquired = true
             
             return isOwner
         }
@@ -50,12 +50,12 @@ class AsyncLock : Disposable {
         }
         
         while true {
-            let nextAction = lock.calculateLocked { () -> Action? in
-                if self.queue.count > 0 {
-                    return self.queue.dequeue()
+            let nextAction = _lock.calculateLocked { () -> Action? in
+                if _queue.count > 0 {
+                    return _queue.dequeue()
                 }
                 else {
-                    self.isAcquired = false
+                    _isAcquired = false
                     return nil
                 }
             }
@@ -70,9 +70,9 @@ class AsyncLock : Disposable {
     }
     
     func dispose() {
-        lock.performLocked { oldState in
-            self.queue = Queue(capacity: 0)
-            self.hasFaulted = true
+        _lock.performLocked { oldState in
+            _queue = Queue(capacity: 0)
+            _hasFaulted = true
         }
     }
 }

--- a/RxSwift/DataStructures/Bag.swift
+++ b/RxSwift/DataStructures/Bag.swift
@@ -50,8 +50,8 @@ public struct Bag<T> : CustomStringConvertible {
     
     typealias Entry = (key: BagKey, value: T)
  
-    private var uniqueIdentity: Identity?
-    private var nextKey: ScopeUniqueTokenType = 0
+    private var _uniqueIdentity: Identity?
+    private var _nextKey: ScopeUniqueTokenType = 0
     
     var pairs = [Entry]()
 
@@ -77,17 +77,17 @@ public struct Bag<T> : CustomStringConvertible {
     - returns: Key that can be used to remove element from bag.
     */
     public mutating func insert(element: T) -> BagKey {
-        nextKey = nextKey &+ 1
+        _nextKey = _nextKey &+ 1
 
 #if DEBUG
-        nextKey = nextKey % 20
+        _nextKey = _nextKey % 20
 #endif
         
-        if nextKey == 0 {
-            uniqueIdentity = Identity()
+        if _nextKey == 0 {
+            _uniqueIdentity = Identity()
         }
         
-        let key = BagKey(uniqueIdentity: uniqueIdentity, key: nextKey)
+        let key = BagKey(uniqueIdentity: _uniqueIdentity, key: _nextKey)
         
         pairs.append(key: key, value: element)
         

--- a/RxSwift/DataStructures/InfiniteSequence.swift
+++ b/RxSwift/DataStructures/InfiniteSequence.swift
@@ -15,14 +15,14 @@ class InfiniteSequence<E> : SequenceType {
     typealias Element = E
     typealias Generator = AnyGenerator<E>
     
-    let repeatedValue: E
+    private let _repeatedValue: E
     
     init(repeatedValue: E) {
-        self.repeatedValue = repeatedValue
+        _repeatedValue = repeatedValue
     }
     
     func generate() -> Generator {
-        let repeatedValue = self.repeatedValue
+        let repeatedValue = _repeatedValue
         return anyGenerator {
             return repeatedValue
         }

--- a/RxSwift/DataStructures/Queue.swift
+++ b/RxSwift/DataStructures/Queue.swift
@@ -22,36 +22,36 @@ public struct Queue<T>: SequenceType {
     */
     public typealias Generator = AnyGenerator<T>
     
-    let resizeFactor = 2
+    private let _resizeFactor = 2
     
-    private var storage: [T?]
+    private var _storage: [T?]
     private var _count: Int
-    private var pushNextIndex: Int
-    private var initialCapacity: Int
-
+    private var _pushNextIndex: Int
+    private var _initialCapacity: Int
+    
     /**
     Creates new queue.
     
     - parameter capacity: Capacity of newly created queue.
     */
     public init(capacity: Int) {
-        initialCapacity = capacity
+        _initialCapacity = capacity
         
         _count = 0
-        pushNextIndex = 0
+        _pushNextIndex = 0
      
         if capacity > 0 {
-            storage = [T?](count: capacity, repeatedValue: nil)
+            _storage = [T?](count: capacity, repeatedValue: nil)
         }
         else {
-            storage = []
+            _storage = []
         }
     }
     
     private var dequeueIndex: Int {
         get {
-           let index = pushNextIndex - count
-            return index < 0 ? index + self.storage.count : index
+           let index = _pushNextIndex - count
+            return index < 0 ? index + _storage.count : index
         }
     }
     
@@ -79,7 +79,7 @@ public struct Queue<T>: SequenceType {
     public func peek() -> T {
         precondition(count > 0)
         
-        return storage[dequeueIndex]!
+        return _storage[dequeueIndex]!
     }
     
     mutating private func resizeTo(size: Int) {
@@ -88,19 +88,19 @@ public struct Queue<T>: SequenceType {
         let count = _count
         
         let dequeueIndex = self.dequeueIndex
-        let spaceToEndOfQueue = self.storage.count - dequeueIndex
+        let spaceToEndOfQueue = _storage.count - dequeueIndex
         
         // first batch is from dequeue index to end of array
         let countElementsInFirstBatch = min(count, spaceToEndOfQueue)
         // second batch is wrapped from start of array to end of queue
         let numberOfElementsInSecondBatch = count - countElementsInFirstBatch
         
-        newStorage[0 ..< countElementsInFirstBatch] = self.storage[dequeueIndex ..< (dequeueIndex + countElementsInFirstBatch)]
-        newStorage[countElementsInFirstBatch ..< (countElementsInFirstBatch + numberOfElementsInSecondBatch)] = self.storage[0 ..< numberOfElementsInSecondBatch]
+        newStorage[0 ..< countElementsInFirstBatch] = _storage[dequeueIndex ..< (dequeueIndex + countElementsInFirstBatch)]
+        newStorage[countElementsInFirstBatch ..< (countElementsInFirstBatch + numberOfElementsInSecondBatch)] = _storage[0 ..< numberOfElementsInSecondBatch]
         
         _count = count
-        pushNextIndex = count
-        storage = newStorage
+        _pushNextIndex = count
+        _storage = newStorage
     }
     
     /**
@@ -109,16 +109,16 @@ public struct Queue<T>: SequenceType {
     - parameter element: Element to enqueue.
     */
     public mutating func enqueue(element: T) {
-        if count == storage.count {
-            resizeTo(max(storage.count, 1) * resizeFactor)
+        if count == _storage.count {
+            resizeTo(max(_storage.count, 1) * _resizeFactor)
         }
         
-        storage[pushNextIndex] = element
-        pushNextIndex++
+        _storage[_pushNextIndex] = element
+        _pushNextIndex++
         _count = _count + 1
         
-        if pushNextIndex >= storage.count {
-            pushNextIndex -= storage.count
+        if _pushNextIndex >= _storage.count {
+            _pushNextIndex -= _storage.count
         }
     }
     
@@ -126,9 +126,9 @@ public struct Queue<T>: SequenceType {
         precondition(count > 0)
         
         let index = dequeueIndex
-        let value = storage[index]!
+        let value = _storage[index]!
         
-        storage[index] = nil
+        _storage[index] = nil
         
         _count = _count - 1
         
@@ -156,9 +156,9 @@ public struct Queue<T>: SequenceType {
     public mutating func dequeue() -> T {
         let value = dequeueElementOnly()
         
-        let downsizeLimit = storage.count / (resizeFactor * resizeFactor)
-        if _count < downsizeLimit && downsizeLimit >= initialCapacity {
-            resizeTo(storage.count / resizeFactor)
+        let downsizeLimit = _storage.count / (_resizeFactor * _resizeFactor)
+        if _count < downsizeLimit && downsizeLimit >= _initialCapacity {
+            resizeTo(_storage.count / _resizeFactor)
         }
         
         return value
@@ -177,11 +177,11 @@ public struct Queue<T>: SequenceType {
             }
             
             count--
-            if i >= self.storage.count {
-                i -= self.storage.count
+            if i >= self._storage.count {
+                i -= self._storage.count
             }
             
-            return self.storage[i++]
+            return self._storage[i++]
         }
     }
 }

--- a/RxSwift/Disposables/AnonymousDisposable.swift
+++ b/RxSwift/Disposables/AnonymousDisposable.swift
@@ -17,7 +17,7 @@ public final class AnonymousDisposable : DisposeBase, Cancelable {
     public typealias DisposeAction = () -> Void
     
     private var _disposed: Int32 = 0
-    private var disposeAction: DisposeAction?
+    private var _disposeAction: DisposeAction?
     
     /**
     - returns: Was resource disposed.
@@ -34,7 +34,7 @@ public final class AnonymousDisposable : DisposeBase, Cancelable {
     - parameter disposeAction: Disposal action which will be run upon calling `dispose`.
     */
     public init(_ disposeAction: DisposeAction) {
-        self.disposeAction = disposeAction
+        _disposeAction = disposeAction
         super.init()
     }
 
@@ -45,8 +45,8 @@ public final class AnonymousDisposable : DisposeBase, Cancelable {
     */
     public func dispose() {
         if OSAtomicCompareAndSwap32(0, 1, &_disposed) {
-            if let action = self.disposeAction {
-                self.disposeAction = nil
+            if let action = _disposeAction {
+                _disposeAction = nil
                 action()
             }
         }

--- a/RxSwift/Disposables/BinaryDisposable.swift
+++ b/RxSwift/Disposables/BinaryDisposable.swift
@@ -16,8 +16,8 @@ public final class BinaryDisposable : DisposeBase, Cancelable {
     private var _disposed: Int32 = 0
 
     // state
-    private var disposable1: Disposable?
-    private var disposable2: Disposable?
+    private var _disposable1: Disposable?
+    private var _disposable2: Disposable?
     
     /**
     - returns: Was resource disposed.
@@ -35,8 +35,8 @@ public final class BinaryDisposable : DisposeBase, Cancelable {
     - parameter disposable2: Second disposable
     */
     init(_ disposable1: Disposable, _ disposable2: Disposable) {
-        self.disposable1 = disposable1
-        self.disposable2 = disposable2
+        _disposable1 = disposable1
+        _disposable2 = disposable2
         super.init()
     }
     
@@ -47,10 +47,10 @@ public final class BinaryDisposable : DisposeBase, Cancelable {
     */
     public func dispose() {
         if OSAtomicCompareAndSwap32(0, 1, &_disposed) {
-            disposable1?.dispose()
-            disposable2?.dispose()
-            disposable1 = nil
-            disposable2 = nil
+            _disposable1?.dispose()
+            _disposable2?.dispose()
+            _disposable1 = nil
+            _disposable2 = nil
         }
     }
 }

--- a/RxSwift/Disposables/CompositeDisposable.swift
+++ b/RxSwift/Disposables/CompositeDisposable.swift
@@ -14,15 +14,15 @@ Represents a group of disposable resources that are disposed together.
 public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     public typealias DisposeKey = Bag<Disposable>.KeyType
     
-    private var lock = SpinLock()
+    private var _lock = SpinLock()
     
     // state
-    private var disposables: Bag<Disposable>? = Bag()
+    private var _disposables: Bag<Disposable>? = Bag()
 
     public var disposed: Bool {
         get {
-            return self.lock.calculateLocked {
-                return disposables == nil
+            return _lock.calculateLocked {
+                return _disposables == nil
             }
         }
     }
@@ -34,17 +34,17 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
      Initializes a new instance of composite disposable with the specified number of disposables.
     */
     public init(_ disposable1: Disposable, _ disposable2: Disposable) {
-        self.disposables!.insert(disposable1)
-        self.disposables!.insert(disposable2)
+        _disposables!.insert(disposable1)
+        _disposables!.insert(disposable2)
     }
     
     /**
      Initializes a new instance of composite disposable with the specified number of disposables.
     */
     public init(_ disposable1: Disposable, _ disposable2: Disposable, _ disposable3: Disposable) {
-        disposables!.insert(disposable1)
-        disposables!.insert(disposable2)
-        disposables!.insert(disposable3)
+        _disposables!.insert(disposable1)
+        _disposables!.insert(disposable2)
+        _disposables!.insert(disposable3)
     }
     
     /**
@@ -52,7 +52,7 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     */
     public init(disposables: [Disposable]) {
         for disposable in disposables {
-            self.disposables!.insert(disposable)
+            _disposables!.insert(disposable)
         }
     }
     
@@ -66,8 +66,8 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     public func addDisposable(disposable: Disposable) -> DisposeKey? {
         // this should be let
         // bucause of compiler bug it's var
-        let key  = self.lock.calculateLocked { () -> DisposeKey? in
-            return disposables?.insert(disposable)
+        let key  = _lock.calculateLocked { () -> DisposeKey? in
+            return _disposables?.insert(disposable)
         }
         
         if key == nil {
@@ -82,8 +82,8 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     */
     public var count: Int {
         get {
-            return self.lock.calculateLocked {
-                return disposables?.count ?? 0
+            return _lock.calculateLocked {
+                return _disposables?.count ?? 0
             }
         }
     }
@@ -94,8 +94,8 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     - parameter disposeKey: Key used to identify disposable to be removed.
     */
     public func removeDisposable(disposeKey: DisposeKey) {
-        let disposable = self.lock.calculateLocked { () -> Disposable? in
-            return disposables?.removeKey(disposeKey)
+        let disposable = _lock.calculateLocked { () -> Disposable? in
+            return _disposables?.removeKey(disposeKey)
         }
         
         if let disposable = disposable {
@@ -107,9 +107,9 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     Disposes all disposables in the group and removes them from the group.
     */
     public func dispose() {
-        let oldDisposables = self.lock.calculateLocked { () -> Bag<Disposable>? in
-            let disposeBag = disposables
-            self.disposables = nil
+        let oldDisposables = _lock.calculateLocked { () -> Bag<Disposable>? in
+            let disposeBag = _disposables
+            _disposables = nil
             
             return disposeBag
         }

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -33,11 +33,11 @@ In case explicit disposal is necessary, there is also `CompositeDisposable`.
 */
 public class DisposeBag: DisposeBase {
     
-    private var lock = SpinLock()
+    private var _lock = SpinLock()
     
     // state
-    private var disposables = [Disposable]()
-    private var disposed = false
+    private var _disposables = [Disposable]()
+    private var _disposed = false
     
     /**
     Constructs new empty dispose bag.
@@ -52,12 +52,12 @@ public class DisposeBag: DisposeBase {
     - parameter disposable: Disposable to add.
     */
     public func addDisposable(disposable: Disposable) {
-        let dispose = lock.calculateLocked { () -> Bool in
-            if disposed {
+        let dispose = _lock.calculateLocked { () -> Bool in
+            if _disposed {
                 return true
             }
             
-            disposables.append(disposable)
+            _disposables.append(disposable)
             
             return false
         }
@@ -71,11 +71,11 @@ public class DisposeBag: DisposeBase {
     This is internal on purpose, take a look at `CompositeDisposable` instead.
     */
     func dispose() {
-        let oldDisposables = lock.calculateLocked { () -> [Disposable] in
-            let disposables = self.disposables
+        let oldDisposables = _lock.calculateLocked { () -> [Disposable] in
+            let disposables = _disposables
             
-            self.disposables.removeAll(keepCapacity: false)
-            self.disposed = true
+            _disposables.removeAll(keepCapacity: false)
+            _disposed = true
             
             return disposables
         }

--- a/RxSwift/Disposables/ScheduledDisposable.swift
+++ b/RxSwift/Disposables/ScheduledDisposable.swift
@@ -36,7 +36,7 @@ public class ScheduledDisposable : Cancelable {
     */
     init(scheduler: ImmediateSchedulerType, disposable: Disposable) {
         self.scheduler = scheduler
-        self._disposable = disposable
+        _disposable = disposable
     }
     
     /**

--- a/RxSwift/Disposables/ScopedDisposable.swift
+++ b/RxSwift/Disposables/ScopedDisposable.swift
@@ -33,7 +33,7 @@ extension Disposable {
 This returns ARC (RAII) like resource management to `RxSwift`.
 */
 public class ScopedDisposable : DisposeBase {
-    private var disposable: Disposable?
+    private var _disposable: Disposable?
     
     /**
     Initializes new instance with a single disposable.
@@ -41,17 +41,17 @@ public class ScopedDisposable : DisposeBase {
     - parameter disposable: `Disposable` that will be disposed on scope exit.
     */
     public init(disposable: Disposable) {
-        self.disposable = disposable
+        _disposable = disposable
     }
     
     /**
     This is intentionally private.
     */
     func dispose() {
-        self.disposable?.dispose()
+        _disposable?.dispose()
     }
     
     deinit {
-        self.dispose()
+        dispose()
     }
 }

--- a/RxSwift/Disposables/SerialDisposable.swift
+++ b/RxSwift/Disposables/SerialDisposable.swift
@@ -12,7 +12,7 @@ import Foundation
 Represents a disposable resource whose underlying disposable resource can be replaced by another disposable resource, causing automatic disposal of the previous underlying disposable resource.
 */
 public class SerialDisposable : DisposeBase, Cancelable {
-    var lock = SpinLock()
+    private var _lock = SpinLock()
     
     // state
     private var _current = nil as Disposable?
@@ -43,12 +43,12 @@ public class SerialDisposable : DisposeBase, Cancelable {
     */
     public var disposable: Disposable {
         get {
-            return self.lock.calculateLocked {
+            return _lock.calculateLocked {
                 return self.disposable
             }
         }
         set (newDisposable) {
-            let disposable: Disposable? = self.lock.calculateLocked {
+            let disposable: Disposable? = _lock.calculateLocked {
                 if _disposed {
                     return newDisposable
                 }
@@ -69,7 +69,7 @@ public class SerialDisposable : DisposeBase, Cancelable {
     Disposes the underlying disposable as well as all future replacements.
     */
     public func dispose() {
-        let disposable: Disposable? = self.lock.calculateLocked {
+        let disposable: Disposable? = _lock.calculateLocked {
             if _disposed {
                 return nil
             }

--- a/RxSwift/Disposables/SingleAssignmentDisposable.swift
+++ b/RxSwift/Disposables/SingleAssignmentDisposable.swift
@@ -14,7 +14,7 @@ Represents a disposable resource which only allows a single assignment of its un
 If an underlying disposable resource has already been set, future attempts to set the underlying disposable resource will throw an exception.
 */
 public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
-    private var lock = SpinLock()
+    private var _lock = SpinLock()
     
     // state
     private var _disposed = false
@@ -26,7 +26,7 @@ public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
     */
     public var disposed: Bool {
         get {
-            return lock.calculateLocked {
+            return _lock.calculateLocked {
                 return _disposed
             }
         }
@@ -46,12 +46,12 @@ public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
     */
     public var disposable: Disposable {
         get {
-            return lock.calculateLocked {
+            return _lock.calculateLocked {
                 return _disposable ?? NopDisposable.instance
             }
         }
         set {
-            let disposable: Disposable? = lock.calculateLocked {
+            let disposable: Disposable? = _lock.calculateLocked {
                 if _disposableSet {
                     rxFatalError("oldState.disposable != nil")
                 }
@@ -77,7 +77,7 @@ public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
     Disposes the underlying disposable.
     */
     public func dispose() {
-        let disposable: Disposable? = lock.calculateLocked {
+        let disposable: Disposable? = _lock.calculateLocked {
             _disposed = true
             let dispose = _disposable
             _disposable = nil

--- a/RxSwift/Error.swift
+++ b/RxSwift/Error.swift
@@ -31,6 +31,10 @@ public enum RxErrorCode : Int {
     Aritmetic overflow error.
     */
     case Overflow  = 4
+    /**
+    Argument out of range error.
+    */
+    case ArgumentOutOfRange  = 5
 }
 
 /**
@@ -56,5 +60,10 @@ public struct RxError {
     Singleton instance of aritmetic overflow error.
     */
     public static let OverflowError = NSError(domain: RxErrorDomain, code: RxErrorCode.Overflow.rawValue, userInfo: nil)
+    
+    /**
+    Singleton instance of argument out of range error.
+    */
+    public static let ArgumentOutOfRange = NSError(domain: RxErrorDomain, code: RxErrorCode.ArgumentOutOfRange.rawValue, userInfo: nil)
 
 }

--- a/RxSwift/Info.plist
+++ b/RxSwift/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>Krunoslav-Zaher.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/RxSwift/Observable+Extensions.swift
+++ b/RxSwift/Observable+Extensions.swift
@@ -123,6 +123,6 @@ public extension ObservableType {
     */
     @warn_unused_result(message="http://git.io/rxs.ud")
     func subscribeSafe<O: ObserverType where O.E == E>(observer: O) -> Disposable {
-        return self.subscribe(observer)
+        return self.asObservable().subscribe(observer)
     }
 }

--- a/RxSwift/Observables/Implementations/Amb.swift
+++ b/RxSwift/Observables/Implementations/Amb.swift
@@ -98,8 +98,8 @@ class AmbSink<ElementType, O: ObserverType where O.E == ElementType> : Sink<O> {
             decide(o, e, .Right, subscription1)
         }
         
-        subscription1.disposable = _parent._left.subscribeSafe(sink1)
-        subscription2.disposable = _parent._right.subscribeSafe(sink2)
+        subscription1.disposable = _parent._left.subscribe(sink1)
+        subscription2.disposable = _parent._right.subscribe(sink2)
         
         return disposeAll
     }

--- a/RxSwift/Observables/Implementations/AsObservable.swift
+++ b/RxSwift/Observables/Implementations/AsObservable.swift
@@ -20,7 +20,7 @@ class AsObservableSink<O: ObserverType> : Sink<O>, ObserverType {
         
         switch event {
         case .Error, .Completed:
-            self.dispose()
+            dispose()
         default: break
         }
     }
@@ -28,15 +28,15 @@ class AsObservableSink<O: ObserverType> : Sink<O>, ObserverType {
 
 class AsObservable<Element> : Producer<Element> {
  
-    let source: Observable<Element>
+    private let _source: Observable<Element>
     
     init(source: Observable<Element>) {
-        self.source = source
+        _source = source
     }
     
     override func run<O: ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = AsObservableSink(observer: observer, cancel: cancel)
         setSink(sink)
-        return source.subscribeSafe(sink)
+        return _source.subscribeSafe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Buffer.swift
+++ b/RxSwift/Observables/Implementations/Buffer.swift
@@ -49,7 +49,7 @@ class BufferTimeCountSink<S: SchedulerType, Element, O: ObserverType where O.E =
  
     func run() -> Disposable {
         createTimer(_windowID)
-        return StableCompositeDisposable.create(_timerD, _parent._source.subscribeSafe(self))
+        return StableCompositeDisposable.create(_timerD, _parent._source.subscribe(self))
     }
     
     func startNewWindowAndSendCurrentOne() {

--- a/RxSwift/Observables/Implementations/Buffer.swift
+++ b/RxSwift/Observables/Implementations/Buffer.swift
@@ -9,16 +9,17 @@
 import Foundation
 
 class BufferTimeCount<Element, S: SchedulerType> : Producer<[Element]> {
-    let timeSpan: S.TimeInterval
-    let count: Int
-    let scheduler: S
-    let source: Observable<Element>
+    
+    private let _timeSpan: S.TimeInterval
+    private let _count: Int
+    private let _scheduler: S
+    private let _source: Observable<Element>
     
     init(source: Observable<Element>, timeSpan: S.TimeInterval, count: Int, scheduler: S) {
-        self.source = source
-        self.timeSpan = timeSpan
-        self.count = count
-        self.scheduler = scheduler
+        _source = source
+        _timeSpan = timeSpan
+        _count = count
+        _scheduler = scheduler
     }
     
     override func run<O : ObserverType where O.E == [Element]>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -32,70 +33,70 @@ class BufferTimeCountSink<S: SchedulerType, Element, O: ObserverType where O.E =
     typealias Parent = BufferTimeCount<Element, S>
     typealias E = Element
     
-    let parent: Parent
+    private let _parent: Parent
     
-    let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
-    let timerD = SerialDisposable()
-    var buffer = [Element]()
-    var windowID = 0
+    private let _timerD = SerialDisposable()
+    private var _buffer = [Element]()
+    private var _windowID = 0
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
  
     func run() -> Disposable {
-        createTimer(self.windowID)
-        return StableCompositeDisposable.create(timerD, self.parent.source.subscribeSafe(self))
+        createTimer(_windowID)
+        return StableCompositeDisposable.create(_timerD, _parent._source.subscribeSafe(self))
     }
     
     func startNewWindowAndSendCurrentOne() {
-        self.windowID = self.windowID &+ 1
-        let windowID = self.windowID
+        _windowID = _windowID &+ 1
+        let windowID = _windowID
         
-        let buffer = self.buffer
-        self.buffer = []
-        self.observer?.on(.Next(buffer))
+        let buffer = _buffer
+        _buffer = []
+        observer?.on(.Next(buffer))
         
         createTimer(windowID)
     }
     
     func on(event: Event<E>) {
-        self.lock.performLocked {
+        _lock.performLocked {
             switch event {
             case .Next(let element):
-                buffer.append(element)
+                _buffer.append(element)
                 
-                if buffer.count == parent.count {
+                if _buffer.count == _parent._count {
                     startNewWindowAndSendCurrentOne()
                 }
                 
             case .Error(let error):
-                self.buffer = []
-                self.observer?.on(.Error(error))
-                self.dispose()
+                _buffer = []
+                observer?.on(.Error(error))
+                dispose()
             case .Completed:
-                self.observer?.on(.Next(self.buffer))
-                self.observer?.on(.Completed)
-                self.dispose()
+                observer?.on(.Next(_buffer))
+                observer?.on(.Completed)
+                dispose()
             }
         }
     }
     
     func createTimer(windowID: Int) {
-        if timerD.disposed {
+        if _timerD.disposed {
             return
         }
         
-        if self.windowID != windowID {
+        if _windowID != windowID {
             return
         }
         
-        timerD.disposable = parent.scheduler.scheduleRelative(windowID, dueTime: self.parent.timeSpan) { previousWindowID in
-            self.lock.performLocked {
-                if previousWindowID != self.windowID {
+        _timerD.disposable = _parent._scheduler.scheduleRelative(windowID, dueTime: _parent._timeSpan) { previousWindowID in
+            self._lock.performLocked {
+                if previousWindowID != self._windowID {
                     return
                 }
              

--- a/RxSwift/Observables/Implementations/Catch.swift
+++ b/RxSwift/Observables/Implementations/Catch.swift
@@ -47,8 +47,8 @@ class CatchSink<O: ObserverType> : Sink<O>, ObserverType {
     func run() -> Disposable {
         let d1 = SingleAssignmentDisposable()
         _subscription.disposable = d1
-        d1.disposable = _parent._source.subscribeSafe(self)
-        
+        d1.disposable = _parent._source.subscribe(self)
+
         return _subscription
     }
     
@@ -65,7 +65,7 @@ class CatchSink<O: ObserverType> : Sink<O>, ObserverType {
 
                 let observer = CatchSinkProxy(parent: self)
                 
-                _subscription.disposable = catchSequence.subscribeSafe(observer)
+                _subscription.disposable = catchSequence.subscribe(observer)
             }
             catch let e {
                 observer?.on(.Error(e))

--- a/RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift
@@ -92,7 +92,7 @@ class CombineLatestCollectionTypeSink<C: CollectionType, R, O: ObserverType wher
         for i in parent.sources.startIndex ..< parent.sources.endIndex {
             let index = j
             let source = self.parent.sources[i].asObservable()
-            self.subscriptions[j].disposable = source.subscribeSafe(AnyObserver { event in
+            self.subscriptions[j].disposable = source.subscribe(AnyObserver { event in
                 self.on(event, atIndex: index)
             })
             

--- a/RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift
@@ -50,24 +50,24 @@ class CombineLatestCollectionTypeSink<C: CollectionType, R, O: ObserverType wher
                 if numberOfValues < parent.count {
                     let numberOfOthersThatAreDone = self.numberOfDone - (isDone[atIndex] ? 1 : 0)
                     if numberOfOthersThatAreDone == self.parent.count - 1 {
-                        self.observer?.on(.Completed)
-                        self.dispose()
+                        observer?.on(.Completed)
+                        dispose()
                     }
                     return
                 }
                 
                 do {
                     let result = try parent.resultSelector(values.map { $0! })
-                    self.observer?.on(.Next(result))
+                    observer?.on(.Next(result))
                 }
                 catch let error {
-                    self.observer?.on(.Error(error))
-                    self.dispose()
+                    observer?.on(.Error(error))
+                    dispose()
                 }
                 
             case .Error(let error):
-                self.observer?.on(.Error(error))
-                self.dispose()
+                observer?.on(.Error(error))
+                dispose()
             case .Completed:
                 if isDone[atIndex] {
                     return
@@ -77,11 +77,11 @@ class CombineLatestCollectionTypeSink<C: CollectionType, R, O: ObserverType wher
                 numberOfDone++
                 
                 if numberOfDone == self.parent.count {
-                    self.observer?.on(.Completed)
-                    self.dispose()
+                    observer?.on(.Completed)
+                    dispose()
                 }
                 else {
-                    self.subscriptions[atIndex].dispose()
+                    subscriptions[atIndex].dispose()
                 }
             }
         }

--- a/RxSwift/Observables/Implementations/CombineLatest+arity.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest+arity.swift
@@ -34,13 +34,13 @@ class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> {
     typealias R = O.E
     typealias Parent = CombineLatest2<E1, E2, R>
 
-    let parent: Parent
+    private let _parent: Parent
 
-    var latestElement1: E1! = nil
-    var latestElement2: E2! = nil
+    private var _latestElement1: E1! = nil
+    private var _latestElement2: E2! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 2, observer: observer, cancel: cancel)
     }
 
@@ -48,11 +48,11 @@ class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> {
         let subscription1 = SingleAssignmentDisposable()
         let subscription2 = SingleAssignmentDisposable()
 
-        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self.latestElement1 = e }, this: subscription1)
-        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self.latestElement2 = e }, this: subscription2)
+        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self._latestElement1 = e }, this: subscription1)
+        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
 
-         subscription1.disposable = parent.source1.subscribeSafe(observer1)
-         subscription2.disposable = parent.source2.subscribeSafe(observer2)
+         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
+         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -61,23 +61,23 @@ class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(latestElement1, latestElement2)
+        return try _parent._resultSelector(_latestElement1, _latestElement2)
     }
 }
 
 class CombineLatest2<E1, E2, R> : Producer<R> {
     typealias ResultSelector = (E1, E2) throws -> R
 
-    let source1: Observable<E1>
-    let source2: Observable<E2>
+    private let _source1: Observable<E1>
+    private let _source2: Observable<E2>
 
-    let resultSelector: ResultSelector
+    private let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, resultSelector: ResultSelector) {
-        self.source1 = source1
-        self.source2 = source2
+        _source1 = source1
+        _source2 = source2
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -111,14 +111,14 @@ class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink<O> {
     typealias R = O.E
     typealias Parent = CombineLatest3<E1, E2, E3, R>
 
-    let parent: Parent
+    private let _parent: Parent
 
-    var latestElement1: E1! = nil
-    var latestElement2: E2! = nil
-    var latestElement3: E3! = nil
+    private var _latestElement1: E1! = nil
+    private var _latestElement2: E2! = nil
+    private var _latestElement3: E3! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 3, observer: observer, cancel: cancel)
     }
 
@@ -127,13 +127,13 @@ class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink<O> {
         let subscription2 = SingleAssignmentDisposable()
         let subscription3 = SingleAssignmentDisposable()
 
-        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self.latestElement1 = e }, this: subscription1)
-        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self.latestElement2 = e }, this: subscription2)
-        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self.latestElement3 = e }, this: subscription3)
+        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self._latestElement1 = e }, this: subscription1)
+        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
+        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self._latestElement3 = e }, this: subscription3)
 
-         subscription1.disposable = parent.source1.subscribeSafe(observer1)
-         subscription2.disposable = parent.source2.subscribeSafe(observer2)
-         subscription3.disposable = parent.source3.subscribeSafe(observer3)
+         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
+         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
+         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -143,25 +143,25 @@ class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(latestElement1, latestElement2, latestElement3)
+        return try _parent._resultSelector(_latestElement1, _latestElement2, _latestElement3)
     }
 }
 
 class CombineLatest3<E1, E2, E3, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3) throws -> R
 
-    let source1: Observable<E1>
-    let source2: Observable<E2>
-    let source3: Observable<E3>
+    private let _source1: Observable<E1>
+    private let _source2: Observable<E2>
+    private let _source3: Observable<E3>
 
-    let resultSelector: ResultSelector
+    private let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, resultSelector: ResultSelector) {
-        self.source1 = source1
-        self.source2 = source2
-        self.source3 = source3
+        _source1 = source1
+        _source2 = source2
+        _source3 = source3
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -195,15 +195,15 @@ class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatestSink<O
     typealias R = O.E
     typealias Parent = CombineLatest4<E1, E2, E3, E4, R>
 
-    let parent: Parent
+    private let _parent: Parent
 
-    var latestElement1: E1! = nil
-    var latestElement2: E2! = nil
-    var latestElement3: E3! = nil
-    var latestElement4: E4! = nil
+    private var _latestElement1: E1! = nil
+    private var _latestElement2: E2! = nil
+    private var _latestElement3: E3! = nil
+    private var _latestElement4: E4! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 4, observer: observer, cancel: cancel)
     }
 
@@ -213,15 +213,15 @@ class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatestSink<O
         let subscription3 = SingleAssignmentDisposable()
         let subscription4 = SingleAssignmentDisposable()
 
-        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self.latestElement1 = e }, this: subscription1)
-        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self.latestElement2 = e }, this: subscription2)
-        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self.latestElement3 = e }, this: subscription3)
-        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self.latestElement4 = e }, this: subscription4)
+        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self._latestElement1 = e }, this: subscription1)
+        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
+        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self._latestElement3 = e }, this: subscription3)
+        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self._latestElement4 = e }, this: subscription4)
 
-         subscription1.disposable = parent.source1.subscribeSafe(observer1)
-         subscription2.disposable = parent.source2.subscribeSafe(observer2)
-         subscription3.disposable = parent.source3.subscribeSafe(observer3)
-         subscription4.disposable = parent.source4.subscribeSafe(observer4)
+         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
+         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
+         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
+         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -232,27 +232,27 @@ class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatestSink<O
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(latestElement1, latestElement2, latestElement3, latestElement4)
+        return try _parent._resultSelector(_latestElement1, _latestElement2, _latestElement3, _latestElement4)
     }
 }
 
 class CombineLatest4<E1, E2, E3, E4, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4) throws -> R
 
-    let source1: Observable<E1>
-    let source2: Observable<E2>
-    let source3: Observable<E3>
-    let source4: Observable<E4>
+    private let _source1: Observable<E1>
+    private let _source2: Observable<E2>
+    private let _source3: Observable<E3>
+    private let _source4: Observable<E4>
 
-    let resultSelector: ResultSelector
+    private let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, resultSelector: ResultSelector) {
-        self.source1 = source1
-        self.source2 = source2
-        self.source3 = source3
-        self.source4 = source4
+        _source1 = source1
+        _source2 = source2
+        _source3 = source3
+        _source4 = source4
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -286,16 +286,16 @@ class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLatestSi
     typealias R = O.E
     typealias Parent = CombineLatest5<E1, E2, E3, E4, E5, R>
 
-    let parent: Parent
+    private let _parent: Parent
 
-    var latestElement1: E1! = nil
-    var latestElement2: E2! = nil
-    var latestElement3: E3! = nil
-    var latestElement4: E4! = nil
-    var latestElement5: E5! = nil
+    private var _latestElement1: E1! = nil
+    private var _latestElement2: E2! = nil
+    private var _latestElement3: E3! = nil
+    private var _latestElement4: E4! = nil
+    private var _latestElement5: E5! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 5, observer: observer, cancel: cancel)
     }
 
@@ -306,17 +306,17 @@ class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLatestSi
         let subscription4 = SingleAssignmentDisposable()
         let subscription5 = SingleAssignmentDisposable()
 
-        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self.latestElement1 = e }, this: subscription1)
-        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self.latestElement2 = e }, this: subscription2)
-        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self.latestElement3 = e }, this: subscription3)
-        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self.latestElement4 = e }, this: subscription4)
-        let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self.latestElement5 = e }, this: subscription5)
+        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self._latestElement1 = e }, this: subscription1)
+        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
+        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self._latestElement3 = e }, this: subscription3)
+        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self._latestElement4 = e }, this: subscription4)
+        let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self._latestElement5 = e }, this: subscription5)
 
-         subscription1.disposable = parent.source1.subscribeSafe(observer1)
-         subscription2.disposable = parent.source2.subscribeSafe(observer2)
-         subscription3.disposable = parent.source3.subscribeSafe(observer3)
-         subscription4.disposable = parent.source4.subscribeSafe(observer4)
-         subscription5.disposable = parent.source5.subscribeSafe(observer5)
+         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
+         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
+         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
+         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
+         subscription5.disposable = _parent._source5.subscribeSafe(observer5)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -328,29 +328,29 @@ class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLatestSi
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(latestElement1, latestElement2, latestElement3, latestElement4, latestElement5)
+        return try _parent._resultSelector(_latestElement1, _latestElement2, _latestElement3, _latestElement4, _latestElement5)
     }
 }
 
 class CombineLatest5<E1, E2, E3, E4, E5, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4, E5) throws -> R
 
-    let source1: Observable<E1>
-    let source2: Observable<E2>
-    let source3: Observable<E3>
-    let source4: Observable<E4>
-    let source5: Observable<E5>
+    private let _source1: Observable<E1>
+    private let _source2: Observable<E2>
+    private let _source3: Observable<E3>
+    private let _source4: Observable<E4>
+    private let _source5: Observable<E5>
 
-    let resultSelector: ResultSelector
+    private let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, resultSelector: ResultSelector) {
-        self.source1 = source1
-        self.source2 = source2
-        self.source3 = source3
-        self.source4 = source4
-        self.source5 = source5
+        _source1 = source1
+        _source2 = source2
+        _source3 = source3
+        _source4 = source4
+        _source5 = source5
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -384,17 +384,17 @@ class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : CombineLate
     typealias R = O.E
     typealias Parent = CombineLatest6<E1, E2, E3, E4, E5, E6, R>
 
-    let parent: Parent
+    private let _parent: Parent
 
-    var latestElement1: E1! = nil
-    var latestElement2: E2! = nil
-    var latestElement3: E3! = nil
-    var latestElement4: E4! = nil
-    var latestElement5: E5! = nil
-    var latestElement6: E6! = nil
+    private var _latestElement1: E1! = nil
+    private var _latestElement2: E2! = nil
+    private var _latestElement3: E3! = nil
+    private var _latestElement4: E4! = nil
+    private var _latestElement5: E5! = nil
+    private var _latestElement6: E6! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 6, observer: observer, cancel: cancel)
     }
 
@@ -406,19 +406,19 @@ class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : CombineLate
         let subscription5 = SingleAssignmentDisposable()
         let subscription6 = SingleAssignmentDisposable()
 
-        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self.latestElement1 = e }, this: subscription1)
-        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self.latestElement2 = e }, this: subscription2)
-        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self.latestElement3 = e }, this: subscription3)
-        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self.latestElement4 = e }, this: subscription4)
-        let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self.latestElement5 = e }, this: subscription5)
-        let observer6 = CombineLatestObserver(lock: lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self.latestElement6 = e }, this: subscription6)
+        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self._latestElement1 = e }, this: subscription1)
+        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
+        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self._latestElement3 = e }, this: subscription3)
+        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self._latestElement4 = e }, this: subscription4)
+        let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self._latestElement5 = e }, this: subscription5)
+        let observer6 = CombineLatestObserver(lock: lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self._latestElement6 = e }, this: subscription6)
 
-         subscription1.disposable = parent.source1.subscribeSafe(observer1)
-         subscription2.disposable = parent.source2.subscribeSafe(observer2)
-         subscription3.disposable = parent.source3.subscribeSafe(observer3)
-         subscription4.disposable = parent.source4.subscribeSafe(observer4)
-         subscription5.disposable = parent.source5.subscribeSafe(observer5)
-         subscription6.disposable = parent.source6.subscribeSafe(observer6)
+         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
+         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
+         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
+         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
+         subscription5.disposable = _parent._source5.subscribeSafe(observer5)
+         subscription6.disposable = _parent._source6.subscribeSafe(observer6)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -431,31 +431,31 @@ class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : CombineLate
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(latestElement1, latestElement2, latestElement3, latestElement4, latestElement5, latestElement6)
+        return try _parent._resultSelector(_latestElement1, _latestElement2, _latestElement3, _latestElement4, _latestElement5, _latestElement6)
     }
 }
 
 class CombineLatest6<E1, E2, E3, E4, E5, E6, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4, E5, E6) throws -> R
 
-    let source1: Observable<E1>
-    let source2: Observable<E2>
-    let source3: Observable<E3>
-    let source4: Observable<E4>
-    let source5: Observable<E5>
-    let source6: Observable<E6>
+    private let _source1: Observable<E1>
+    private let _source2: Observable<E2>
+    private let _source3: Observable<E3>
+    private let _source4: Observable<E4>
+    private let _source5: Observable<E5>
+    private let _source6: Observable<E6>
 
-    let resultSelector: ResultSelector
+    private let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, resultSelector: ResultSelector) {
-        self.source1 = source1
-        self.source2 = source2
-        self.source3 = source3
-        self.source4 = source4
-        self.source5 = source5
-        self.source6 = source6
+        _source1 = source1
+        _source2 = source2
+        _source3 = source3
+        _source4 = source4
+        _source5 = source5
+        _source6 = source6
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -489,18 +489,18 @@ class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : Combine
     typealias R = O.E
     typealias Parent = CombineLatest7<E1, E2, E3, E4, E5, E6, E7, R>
 
-    let parent: Parent
+    private let _parent: Parent
 
-    var latestElement1: E1! = nil
-    var latestElement2: E2! = nil
-    var latestElement3: E3! = nil
-    var latestElement4: E4! = nil
-    var latestElement5: E5! = nil
-    var latestElement6: E6! = nil
-    var latestElement7: E7! = nil
+    private var _latestElement1: E1! = nil
+    private var _latestElement2: E2! = nil
+    private var _latestElement3: E3! = nil
+    private var _latestElement4: E4! = nil
+    private var _latestElement5: E5! = nil
+    private var _latestElement6: E6! = nil
+    private var _latestElement7: E7! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 7, observer: observer, cancel: cancel)
     }
 
@@ -513,21 +513,21 @@ class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : Combine
         let subscription6 = SingleAssignmentDisposable()
         let subscription7 = SingleAssignmentDisposable()
 
-        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self.latestElement1 = e }, this: subscription1)
-        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self.latestElement2 = e }, this: subscription2)
-        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self.latestElement3 = e }, this: subscription3)
-        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self.latestElement4 = e }, this: subscription4)
-        let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self.latestElement5 = e }, this: subscription5)
-        let observer6 = CombineLatestObserver(lock: lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self.latestElement6 = e }, this: subscription6)
-        let observer7 = CombineLatestObserver(lock: lock, parent: self, index: 6, setLatestValue: { (e: E7) -> Void in self.latestElement7 = e }, this: subscription7)
+        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self._latestElement1 = e }, this: subscription1)
+        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
+        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self._latestElement3 = e }, this: subscription3)
+        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self._latestElement4 = e }, this: subscription4)
+        let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self._latestElement5 = e }, this: subscription5)
+        let observer6 = CombineLatestObserver(lock: lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self._latestElement6 = e }, this: subscription6)
+        let observer7 = CombineLatestObserver(lock: lock, parent: self, index: 6, setLatestValue: { (e: E7) -> Void in self._latestElement7 = e }, this: subscription7)
 
-         subscription1.disposable = parent.source1.subscribeSafe(observer1)
-         subscription2.disposable = parent.source2.subscribeSafe(observer2)
-         subscription3.disposable = parent.source3.subscribeSafe(observer3)
-         subscription4.disposable = parent.source4.subscribeSafe(observer4)
-         subscription5.disposable = parent.source5.subscribeSafe(observer5)
-         subscription6.disposable = parent.source6.subscribeSafe(observer6)
-         subscription7.disposable = parent.source7.subscribeSafe(observer7)
+         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
+         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
+         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
+         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
+         subscription5.disposable = _parent._source5.subscribeSafe(observer5)
+         subscription6.disposable = _parent._source6.subscribeSafe(observer6)
+         subscription7.disposable = _parent._source7.subscribeSafe(observer7)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -541,33 +541,33 @@ class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : Combine
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(latestElement1, latestElement2, latestElement3, latestElement4, latestElement5, latestElement6, latestElement7)
+        return try _parent._resultSelector(_latestElement1, _latestElement2, _latestElement3, _latestElement4, _latestElement5, _latestElement6, _latestElement7)
     }
 }
 
 class CombineLatest7<E1, E2, E3, E4, E5, E6, E7, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7) throws -> R
 
-    let source1: Observable<E1>
-    let source2: Observable<E2>
-    let source3: Observable<E3>
-    let source4: Observable<E4>
-    let source5: Observable<E5>
-    let source6: Observable<E6>
-    let source7: Observable<E7>
+    private let _source1: Observable<E1>
+    private let _source2: Observable<E2>
+    private let _source3: Observable<E3>
+    private let _source4: Observable<E4>
+    private let _source5: Observable<E5>
+    private let _source6: Observable<E6>
+    private let _source7: Observable<E7>
 
-    let resultSelector: ResultSelector
+    private let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, source7: Observable<E7>, resultSelector: ResultSelector) {
-        self.source1 = source1
-        self.source2 = source2
-        self.source3 = source3
-        self.source4 = source4
-        self.source5 = source5
-        self.source6 = source6
-        self.source7 = source7
+        _source1 = source1
+        _source2 = source2
+        _source3 = source3
+        _source4 = source4
+        _source5 = source5
+        _source6 = source6
+        _source7 = source7
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -601,19 +601,19 @@ class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : Com
     typealias R = O.E
     typealias Parent = CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, R>
 
-    let parent: Parent
+    private let _parent: Parent
 
-    var latestElement1: E1! = nil
-    var latestElement2: E2! = nil
-    var latestElement3: E3! = nil
-    var latestElement4: E4! = nil
-    var latestElement5: E5! = nil
-    var latestElement6: E6! = nil
-    var latestElement7: E7! = nil
-    var latestElement8: E8! = nil
+    private var _latestElement1: E1! = nil
+    private var _latestElement2: E2! = nil
+    private var _latestElement3: E3! = nil
+    private var _latestElement4: E4! = nil
+    private var _latestElement5: E5! = nil
+    private var _latestElement6: E6! = nil
+    private var _latestElement7: E7! = nil
+    private var _latestElement8: E8! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 8, observer: observer, cancel: cancel)
     }
 
@@ -627,23 +627,23 @@ class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : Com
         let subscription7 = SingleAssignmentDisposable()
         let subscription8 = SingleAssignmentDisposable()
 
-        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self.latestElement1 = e }, this: subscription1)
-        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self.latestElement2 = e }, this: subscription2)
-        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self.latestElement3 = e }, this: subscription3)
-        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self.latestElement4 = e }, this: subscription4)
-        let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self.latestElement5 = e }, this: subscription5)
-        let observer6 = CombineLatestObserver(lock: lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self.latestElement6 = e }, this: subscription6)
-        let observer7 = CombineLatestObserver(lock: lock, parent: self, index: 6, setLatestValue: { (e: E7) -> Void in self.latestElement7 = e }, this: subscription7)
-        let observer8 = CombineLatestObserver(lock: lock, parent: self, index: 7, setLatestValue: { (e: E8) -> Void in self.latestElement8 = e }, this: subscription8)
+        let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self._latestElement1 = e }, this: subscription1)
+        let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
+        let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self._latestElement3 = e }, this: subscription3)
+        let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self._latestElement4 = e }, this: subscription4)
+        let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self._latestElement5 = e }, this: subscription5)
+        let observer6 = CombineLatestObserver(lock: lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self._latestElement6 = e }, this: subscription6)
+        let observer7 = CombineLatestObserver(lock: lock, parent: self, index: 6, setLatestValue: { (e: E7) -> Void in self._latestElement7 = e }, this: subscription7)
+        let observer8 = CombineLatestObserver(lock: lock, parent: self, index: 7, setLatestValue: { (e: E8) -> Void in self._latestElement8 = e }, this: subscription8)
 
-         subscription1.disposable = parent.source1.subscribeSafe(observer1)
-         subscription2.disposable = parent.source2.subscribeSafe(observer2)
-         subscription3.disposable = parent.source3.subscribeSafe(observer3)
-         subscription4.disposable = parent.source4.subscribeSafe(observer4)
-         subscription5.disposable = parent.source5.subscribeSafe(observer5)
-         subscription6.disposable = parent.source6.subscribeSafe(observer6)
-         subscription7.disposable = parent.source7.subscribeSafe(observer7)
-         subscription8.disposable = parent.source8.subscribeSafe(observer8)
+         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
+         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
+         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
+         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
+         subscription5.disposable = _parent._source5.subscribeSafe(observer5)
+         subscription6.disposable = _parent._source6.subscribeSafe(observer6)
+         subscription7.disposable = _parent._source7.subscribeSafe(observer7)
+         subscription8.disposable = _parent._source8.subscribeSafe(observer8)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -658,35 +658,35 @@ class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : Com
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(latestElement1, latestElement2, latestElement3, latestElement4, latestElement5, latestElement6, latestElement7, latestElement8)
+        return try _parent._resultSelector(_latestElement1, _latestElement2, _latestElement3, _latestElement4, _latestElement5, _latestElement6, _latestElement7, _latestElement8)
     }
 }
 
 class CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7, E8) throws -> R
 
-    let source1: Observable<E1>
-    let source2: Observable<E2>
-    let source3: Observable<E3>
-    let source4: Observable<E4>
-    let source5: Observable<E5>
-    let source6: Observable<E6>
-    let source7: Observable<E7>
-    let source8: Observable<E8>
+    private let _source1: Observable<E1>
+    private let _source2: Observable<E2>
+    private let _source3: Observable<E3>
+    private let _source4: Observable<E4>
+    private let _source5: Observable<E5>
+    private let _source6: Observable<E6>
+    private let _source7: Observable<E7>
+    private let _source8: Observable<E8>
 
-    let resultSelector: ResultSelector
+    private let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, source7: Observable<E7>, source8: Observable<E8>, resultSelector: ResultSelector) {
-        self.source1 = source1
-        self.source2 = source2
-        self.source3 = source3
-        self.source4 = source4
-        self.source5 = source5
-        self.source6 = source6
-        self.source7 = source7
-        self.source8 = source8
+        _source1 = source1
+        _source2 = source2
+        _source3 = source3
+        _source4 = source4
+        _source5 = source5
+        _source6 = source6
+        _source7 = source7
+        _source8 = source8
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {

--- a/RxSwift/Observables/Implementations/CombineLatest+arity.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest+arity.swift
@@ -34,10 +34,10 @@ class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> {
     typealias R = O.E
     typealias Parent = CombineLatest2<E1, E2, R>
 
-    private let _parent: Parent
+    let _parent: Parent
 
-    private var _latestElement1: E1! = nil
-    private var _latestElement2: E2! = nil
+    var _latestElement1: E1! = nil
+    var _latestElement2: E2! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
         _parent = parent
@@ -51,8 +51,8 @@ class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> {
         let observer1 = CombineLatestObserver(lock: lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self._latestElement1 = e }, this: subscription1)
         let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
 
-         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
-         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
+         subscription1.disposable = _parent._source1.subscribe(observer1)
+         subscription2.disposable = _parent._source2.subscribe(observer2)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -68,10 +68,10 @@ class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> {
 class CombineLatest2<E1, E2, R> : Producer<R> {
     typealias ResultSelector = (E1, E2) throws -> R
 
-    private let _source1: Observable<E1>
-    private let _source2: Observable<E2>
+    let _source1: Observable<E1>
+    let _source2: Observable<E2>
 
-    private let _resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, resultSelector: ResultSelector) {
         _source1 = source1
@@ -111,11 +111,11 @@ class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink<O> {
     typealias R = O.E
     typealias Parent = CombineLatest3<E1, E2, E3, R>
 
-    private let _parent: Parent
+    let _parent: Parent
 
-    private var _latestElement1: E1! = nil
-    private var _latestElement2: E2! = nil
-    private var _latestElement3: E3! = nil
+    var _latestElement1: E1! = nil
+    var _latestElement2: E2! = nil
+    var _latestElement3: E3! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
         _parent = parent
@@ -131,9 +131,9 @@ class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink<O> {
         let observer2 = CombineLatestObserver(lock: lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self._latestElement2 = e }, this: subscription2)
         let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self._latestElement3 = e }, this: subscription3)
 
-         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
-         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
-         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
+         subscription1.disposable = _parent._source1.subscribe(observer1)
+         subscription2.disposable = _parent._source2.subscribe(observer2)
+         subscription3.disposable = _parent._source3.subscribe(observer3)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -150,11 +150,11 @@ class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink<O> {
 class CombineLatest3<E1, E2, E3, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3) throws -> R
 
-    private let _source1: Observable<E1>
-    private let _source2: Observable<E2>
-    private let _source3: Observable<E3>
+    let _source1: Observable<E1>
+    let _source2: Observable<E2>
+    let _source3: Observable<E3>
 
-    private let _resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, resultSelector: ResultSelector) {
         _source1 = source1
@@ -195,12 +195,12 @@ class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatestSink<O
     typealias R = O.E
     typealias Parent = CombineLatest4<E1, E2, E3, E4, R>
 
-    private let _parent: Parent
+    let _parent: Parent
 
-    private var _latestElement1: E1! = nil
-    private var _latestElement2: E2! = nil
-    private var _latestElement3: E3! = nil
-    private var _latestElement4: E4! = nil
+    var _latestElement1: E1! = nil
+    var _latestElement2: E2! = nil
+    var _latestElement3: E3! = nil
+    var _latestElement4: E4! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
         _parent = parent
@@ -218,10 +218,10 @@ class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatestSink<O
         let observer3 = CombineLatestObserver(lock: lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self._latestElement3 = e }, this: subscription3)
         let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self._latestElement4 = e }, this: subscription4)
 
-         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
-         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
-         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
-         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
+         subscription1.disposable = _parent._source1.subscribe(observer1)
+         subscription2.disposable = _parent._source2.subscribe(observer2)
+         subscription3.disposable = _parent._source3.subscribe(observer3)
+         subscription4.disposable = _parent._source4.subscribe(observer4)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -239,12 +239,12 @@ class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatestSink<O
 class CombineLatest4<E1, E2, E3, E4, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4) throws -> R
 
-    private let _source1: Observable<E1>
-    private let _source2: Observable<E2>
-    private let _source3: Observable<E3>
-    private let _source4: Observable<E4>
+    let _source1: Observable<E1>
+    let _source2: Observable<E2>
+    let _source3: Observable<E3>
+    let _source4: Observable<E4>
 
-    private let _resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, resultSelector: ResultSelector) {
         _source1 = source1
@@ -286,13 +286,13 @@ class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLatestSi
     typealias R = O.E
     typealias Parent = CombineLatest5<E1, E2, E3, E4, E5, R>
 
-    private let _parent: Parent
+    let _parent: Parent
 
-    private var _latestElement1: E1! = nil
-    private var _latestElement2: E2! = nil
-    private var _latestElement3: E3! = nil
-    private var _latestElement4: E4! = nil
-    private var _latestElement5: E5! = nil
+    var _latestElement1: E1! = nil
+    var _latestElement2: E2! = nil
+    var _latestElement3: E3! = nil
+    var _latestElement4: E4! = nil
+    var _latestElement5: E5! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
         _parent = parent
@@ -312,11 +312,11 @@ class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLatestSi
         let observer4 = CombineLatestObserver(lock: lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self._latestElement4 = e }, this: subscription4)
         let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self._latestElement5 = e }, this: subscription5)
 
-         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
-         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
-         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
-         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
-         subscription5.disposable = _parent._source5.subscribeSafe(observer5)
+         subscription1.disposable = _parent._source1.subscribe(observer1)
+         subscription2.disposable = _parent._source2.subscribe(observer2)
+         subscription3.disposable = _parent._source3.subscribe(observer3)
+         subscription4.disposable = _parent._source4.subscribe(observer4)
+         subscription5.disposable = _parent._source5.subscribe(observer5)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -335,13 +335,13 @@ class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLatestSi
 class CombineLatest5<E1, E2, E3, E4, E5, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4, E5) throws -> R
 
-    private let _source1: Observable<E1>
-    private let _source2: Observable<E2>
-    private let _source3: Observable<E3>
-    private let _source4: Observable<E4>
-    private let _source5: Observable<E5>
+    let _source1: Observable<E1>
+    let _source2: Observable<E2>
+    let _source3: Observable<E3>
+    let _source4: Observable<E4>
+    let _source5: Observable<E5>
 
-    private let _resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, resultSelector: ResultSelector) {
         _source1 = source1
@@ -384,14 +384,14 @@ class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : CombineLate
     typealias R = O.E
     typealias Parent = CombineLatest6<E1, E2, E3, E4, E5, E6, R>
 
-    private let _parent: Parent
+    let _parent: Parent
 
-    private var _latestElement1: E1! = nil
-    private var _latestElement2: E2! = nil
-    private var _latestElement3: E3! = nil
-    private var _latestElement4: E4! = nil
-    private var _latestElement5: E5! = nil
-    private var _latestElement6: E6! = nil
+    var _latestElement1: E1! = nil
+    var _latestElement2: E2! = nil
+    var _latestElement3: E3! = nil
+    var _latestElement4: E4! = nil
+    var _latestElement5: E5! = nil
+    var _latestElement6: E6! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
         _parent = parent
@@ -413,12 +413,12 @@ class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : CombineLate
         let observer5 = CombineLatestObserver(lock: lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self._latestElement5 = e }, this: subscription5)
         let observer6 = CombineLatestObserver(lock: lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self._latestElement6 = e }, this: subscription6)
 
-         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
-         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
-         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
-         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
-         subscription5.disposable = _parent._source5.subscribeSafe(observer5)
-         subscription6.disposable = _parent._source6.subscribeSafe(observer6)
+         subscription1.disposable = _parent._source1.subscribe(observer1)
+         subscription2.disposable = _parent._source2.subscribe(observer2)
+         subscription3.disposable = _parent._source3.subscribe(observer3)
+         subscription4.disposable = _parent._source4.subscribe(observer4)
+         subscription5.disposable = _parent._source5.subscribe(observer5)
+         subscription6.disposable = _parent._source6.subscribe(observer6)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -438,14 +438,14 @@ class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : CombineLate
 class CombineLatest6<E1, E2, E3, E4, E5, E6, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4, E5, E6) throws -> R
 
-    private let _source1: Observable<E1>
-    private let _source2: Observable<E2>
-    private let _source3: Observable<E3>
-    private let _source4: Observable<E4>
-    private let _source5: Observable<E5>
-    private let _source6: Observable<E6>
+    let _source1: Observable<E1>
+    let _source2: Observable<E2>
+    let _source3: Observable<E3>
+    let _source4: Observable<E4>
+    let _source5: Observable<E5>
+    let _source6: Observable<E6>
 
-    private let _resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, resultSelector: ResultSelector) {
         _source1 = source1
@@ -489,15 +489,15 @@ class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : Combine
     typealias R = O.E
     typealias Parent = CombineLatest7<E1, E2, E3, E4, E5, E6, E7, R>
 
-    private let _parent: Parent
+    let _parent: Parent
 
-    private var _latestElement1: E1! = nil
-    private var _latestElement2: E2! = nil
-    private var _latestElement3: E3! = nil
-    private var _latestElement4: E4! = nil
-    private var _latestElement5: E5! = nil
-    private var _latestElement6: E6! = nil
-    private var _latestElement7: E7! = nil
+    var _latestElement1: E1! = nil
+    var _latestElement2: E2! = nil
+    var _latestElement3: E3! = nil
+    var _latestElement4: E4! = nil
+    var _latestElement5: E5! = nil
+    var _latestElement6: E6! = nil
+    var _latestElement7: E7! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
         _parent = parent
@@ -521,13 +521,13 @@ class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : Combine
         let observer6 = CombineLatestObserver(lock: lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self._latestElement6 = e }, this: subscription6)
         let observer7 = CombineLatestObserver(lock: lock, parent: self, index: 6, setLatestValue: { (e: E7) -> Void in self._latestElement7 = e }, this: subscription7)
 
-         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
-         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
-         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
-         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
-         subscription5.disposable = _parent._source5.subscribeSafe(observer5)
-         subscription6.disposable = _parent._source6.subscribeSafe(observer6)
-         subscription7.disposable = _parent._source7.subscribeSafe(observer7)
+         subscription1.disposable = _parent._source1.subscribe(observer1)
+         subscription2.disposable = _parent._source2.subscribe(observer2)
+         subscription3.disposable = _parent._source3.subscribe(observer3)
+         subscription4.disposable = _parent._source4.subscribe(observer4)
+         subscription5.disposable = _parent._source5.subscribe(observer5)
+         subscription6.disposable = _parent._source6.subscribe(observer6)
+         subscription7.disposable = _parent._source7.subscribe(observer7)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -548,15 +548,15 @@ class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : Combine
 class CombineLatest7<E1, E2, E3, E4, E5, E6, E7, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7) throws -> R
 
-    private let _source1: Observable<E1>
-    private let _source2: Observable<E2>
-    private let _source3: Observable<E3>
-    private let _source4: Observable<E4>
-    private let _source5: Observable<E5>
-    private let _source6: Observable<E6>
-    private let _source7: Observable<E7>
+    let _source1: Observable<E1>
+    let _source2: Observable<E2>
+    let _source3: Observable<E3>
+    let _source4: Observable<E4>
+    let _source5: Observable<E5>
+    let _source6: Observable<E6>
+    let _source7: Observable<E7>
 
-    private let _resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, source7: Observable<E7>, resultSelector: ResultSelector) {
         _source1 = source1
@@ -601,16 +601,16 @@ class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : Com
     typealias R = O.E
     typealias Parent = CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, R>
 
-    private let _parent: Parent
+    let _parent: Parent
 
-    private var _latestElement1: E1! = nil
-    private var _latestElement2: E2! = nil
-    private var _latestElement3: E3! = nil
-    private var _latestElement4: E4! = nil
-    private var _latestElement5: E5! = nil
-    private var _latestElement6: E6! = nil
-    private var _latestElement7: E7! = nil
-    private var _latestElement8: E8! = nil
+    var _latestElement1: E1! = nil
+    var _latestElement2: E2! = nil
+    var _latestElement3: E3! = nil
+    var _latestElement4: E4! = nil
+    var _latestElement5: E5! = nil
+    var _latestElement6: E6! = nil
+    var _latestElement7: E7! = nil
+    var _latestElement8: E8! = nil
 
     init(parent: Parent, observer: O, cancel: Disposable) {
         _parent = parent
@@ -636,14 +636,14 @@ class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : Com
         let observer7 = CombineLatestObserver(lock: lock, parent: self, index: 6, setLatestValue: { (e: E7) -> Void in self._latestElement7 = e }, this: subscription7)
         let observer8 = CombineLatestObserver(lock: lock, parent: self, index: 7, setLatestValue: { (e: E8) -> Void in self._latestElement8 = e }, this: subscription8)
 
-         subscription1.disposable = _parent._source1.subscribeSafe(observer1)
-         subscription2.disposable = _parent._source2.subscribeSafe(observer2)
-         subscription3.disposable = _parent._source3.subscribeSafe(observer3)
-         subscription4.disposable = _parent._source4.subscribeSafe(observer4)
-         subscription5.disposable = _parent._source5.subscribeSafe(observer5)
-         subscription6.disposable = _parent._source6.subscribeSafe(observer6)
-         subscription7.disposable = _parent._source7.subscribeSafe(observer7)
-         subscription8.disposable = _parent._source8.subscribeSafe(observer8)
+         subscription1.disposable = _parent._source1.subscribe(observer1)
+         subscription2.disposable = _parent._source2.subscribe(observer2)
+         subscription3.disposable = _parent._source3.subscribe(observer3)
+         subscription4.disposable = _parent._source4.subscribe(observer4)
+         subscription5.disposable = _parent._source5.subscribe(observer5)
+         subscription6.disposable = _parent._source6.subscribe(observer6)
+         subscription7.disposable = _parent._source7.subscribe(observer7)
+         subscription8.disposable = _parent._source8.subscribe(observer8)
 
         return CompositeDisposable(disposables: [
                 subscription1,
@@ -665,16 +665,16 @@ class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : Com
 class CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, R> : Producer<R> {
     typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7, E8) throws -> R
 
-    private let _source1: Observable<E1>
-    private let _source2: Observable<E2>
-    private let _source3: Observable<E3>
-    private let _source4: Observable<E4>
-    private let _source5: Observable<E5>
-    private let _source6: Observable<E6>
-    private let _source7: Observable<E7>
-    private let _source8: Observable<E8>
+    let _source1: Observable<E1>
+    let _source2: Observable<E2>
+    let _source3: Observable<E3>
+    let _source4: Observable<E4>
+    let _source5: Observable<E5>
+    let _source6: Observable<E6>
+    let _source7: Observable<E7>
+    let _source8: Observable<E8>
 
-    private let _resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, source7: Observable<E7>, source8: Observable<E8>, resultSelector: ResultSelector) {
         _source1 = source1

--- a/RxSwift/Observables/Implementations/CombineLatest+arity.tt
+++ b/RxSwift/Observables/Implementations/CombineLatest+arity.tt
@@ -32,14 +32,14 @@ class CombineLatestSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joinWithSep
     typealias R = O.E
     typealias Parent = CombineLatest<%= i %><<%= (Array(1...i).map { "E\($0)" }).joinWithSeparator(", ") %>, R>
 
-    let parent: Parent
+    let _parent: Parent
 
 <%= (Array(1...i).map {
-"    var latestElement\($0): E\($0)! = nil"
+"    var _latestElement\($0): E\($0)! = nil"
 }).joinWithSeparator("\n") %>
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: <%= i %>, observer: observer, cancel: cancel)
     }
 
@@ -49,11 +49,11 @@ class CombineLatestSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joinWithSep
 }).joinWithSeparator("\n") %>
 
 <%= (Array(1...i).map {
-"        let observer\($0) = CombineLatestObserver(lock: lock, parent: self, index: \($0 - 1), setLatestValue: { (e: E\($0)) -> Void in self.latestElement\($0) = e }, this: subscription\($0))"
+"        let observer\($0) = CombineLatestObserver(lock: lock, parent: self, index: \($0 - 1), setLatestValue: { (e: E\($0)) -> Void in self._latestElement\($0) = e }, this: subscription\($0))"
 }).joinWithSeparator("\n") %>
 
 <%= (Array(1...i).map {
-"         subscription\($0).disposable = parent.source\($0).subscribeSafe(observer\($0))"
+"         subscription\($0).disposable = _parent._source\($0).subscribe(observer\($0))"
 }).joinWithSeparator("\n") %>
 
         return CompositeDisposable(disposables: [
@@ -62,7 +62,7 @@ class CombineLatestSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joinWithSep
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(<%= (Array(1...i).map { "latestElement\($0)" }).joinWithSeparator(", ") %>)
+        return try _parent._resultSelector(<%= (Array(1...i).map { "_latestElement\($0)" }).joinWithSeparator(", ") %>)
     }
 }
 
@@ -70,17 +70,17 @@ class CombineLatest<%= i %><<%= (Array(1...i).map { "E\($0)" }).joinWithSeparato
     typealias ResultSelector = (<%= (Array(1...i).map { "E\($0)" }).joinWithSeparator(", ") %>) throws -> R
 
 <%= (Array(1...i).map {
-"    let source\($0): Observable<E\($0)>"
+"    let _source\($0): Observable<E\($0)>"
 }).joinWithSeparator("\n") %>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(<%= (Array(1...i).map { "source\($0): Observable<E\($0)>" }).joinWithSeparator(", ") %>, resultSelector: ResultSelector) {
 <%= (Array(1...i).map {
-"        self.source\($0) = source\($0)"
+"        _source\($0) = source\($0)"
 }).joinWithSeparator("\n")  %>
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {

--- a/RxSwift/Observables/Implementations/Concat.swift
+++ b/RxSwift/Observables/Implementations/Concat.swift
@@ -18,7 +18,7 @@ class ConcatSink<S: SequenceType, O: ObserverType where S.Generator.Element : Ob
     
     override func on(event: Event<Element>){
         switch event {
-        case .Next(_):
+        case .Next:
             observer?.on(event)
         case .Error:
             observer?.on(event)
@@ -30,7 +30,7 @@ class ConcatSink<S: SequenceType, O: ObserverType where S.Generator.Element : Ob
     
     override func extract(observable: Observable<E>) -> S.Generator? {
         if let source = observable as? Concat<S> {
-            return source.sources.generate()
+            return source._sources.generate()
         }
         else {
             return nil
@@ -41,10 +41,10 @@ class ConcatSink<S: SequenceType, O: ObserverType where S.Generator.Element : Ob
 class Concat<S: SequenceType where S.Generator.Element : ObservableConvertibleType> : Producer<S.Generator.Element.E> {
     typealias Element = S.Generator.Element.E
     
-    let sources: S
+    private let _sources: S
     
     init(sources: S) {
-        self.sources = sources
+        _sources = sources
     }
     
     override func run<O: ObserverType where O.E == Element>
@@ -52,6 +52,6 @@ class Concat<S: SequenceType where S.Generator.Element : ObservableConvertibleTy
         let sink = ConcatSink<S, O>(observer: observer, cancel: cancel)
         setSink(sink)
         
-        return sink.run(sources.generate())
+        return sink.run(_sources.generate())
     }
 }

--- a/RxSwift/Observables/Implementations/ConnectableObservable.swift
+++ b/RxSwift/Observables/Implementations/ConnectableObservable.swift
@@ -11,27 +11,27 @@ import Foundation
 class Connection<S: SubjectType> : Disposable {
     
     // state
-    weak var parent: ConnectableObservable<S>?
-    var subscription : Disposable?
+    private weak var _parent: ConnectableObservable<S>?
+    private var _subscription : Disposable?
     
     init(parent: ConnectableObservable<S>, subscription: Disposable) {
-        self.parent = parent
-        self.subscription = subscription
+        _parent = parent
+        _subscription = subscription
     }
     
     func dispose() {
-        guard let parent = self.parent else { return }
+        guard let parent = _parent else { return }
         
-        parent.lock.performLocked {
-            guard let oldSubscription = self.subscription else {
+        parent._lock.performLocked {
+            guard let oldSubscription = _subscription else {
                 return
             }
             
-            self.subscription = nil
-            if self.parent?.connection === self {
-                parent.connection = nil
+            _subscription = nil
+            if _parent?._connection === self {
+                parent._connection = nil
             }
-            self.parent = nil
+            _parent = nil
             
             oldSubscription.dispose()
         }
@@ -41,34 +41,34 @@ class Connection<S: SubjectType> : Disposable {
 public class ConnectableObservable<S: SubjectType> : Observable<S.E>, ConnectableObservableType {
     typealias ConnectionType = Connection<S>
     
-    let subject: S
-    let source: Observable<S.SubjectObserverType.E>
+    private let _subject: S
+    private let _source: Observable<S.SubjectObserverType.E>
     
-    let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
-    var connection: ConnectionType?
+    private var _connection: ConnectionType?
     
     public init(source: Observable<S.SubjectObserverType.E>, subject: S) {
-        self.source = AsObservable(source: source)
-        self.subject = subject
-        self.connection = nil
+        _source = AsObservable(source: source)
+        _subject = subject
+        _connection = nil
     }
     
     public func connect() -> Disposable {
-        return self.lock.calculateLocked {
-            if let connection = self.connection {
+        return _lock.calculateLocked {
+            if let connection = _connection {
                 return connection
             }
             
-            let disposable = self.source.subscribeSafe(self.subject.asObserver())
+            let disposable = _source.subscribeSafe(_subject.asObserver())
             let connection = Connection(parent: self, subscription: disposable)
-            self.connection = connection
+            _connection = connection
             return connection
         }
     }
     
     public override func subscribe<O : ObserverType where O.E == S.E>(observer: O) -> Disposable {
-        return subject.subscribeSafe(observer)
+        return _subject.subscribeSafe(observer)
     }
 }

--- a/RxSwift/Observables/Implementations/ConnectableObservable.swift
+++ b/RxSwift/Observables/Implementations/ConnectableObservable.swift
@@ -50,7 +50,7 @@ public class ConnectableObservable<S: SubjectType> : Observable<S.E>, Connectabl
     private var _connection: ConnectionType?
     
     public init(source: Observable<S.SubjectObserverType.E>, subject: S) {
-        _source = AsObservable(source: source)
+        _source = source
         _subject = subject
         _connection = nil
     }
@@ -61,7 +61,7 @@ public class ConnectableObservable<S: SubjectType> : Observable<S.E>, Connectabl
                 return connection
             }
             
-            let disposable = _source.subscribeSafe(_subject.asObserver())
+            let disposable = _source.subscribe(_subject.asObserver())
             let connection = Connection(parent: self, subscription: disposable)
             _connection = connection
             return connection
@@ -69,6 +69,6 @@ public class ConnectableObservable<S: SubjectType> : Observable<S.E>, Connectabl
     }
     
     public override func subscribe<O : ObserverType where O.E == S.E>(observer: O) -> Disposable {
-        return _subject.subscribeSafe(observer)
+        return _subject.subscribe(observer)
     }
 }

--- a/RxSwift/Observables/Implementations/Debug.swift
+++ b/RxSwift/Observables/Implementations/Debug.swift
@@ -49,6 +49,6 @@ class Debug<Element> : Producer<Element> {
         print("[\(_identifier)] subscribed")
         let sink = Debug_(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return _source.subscribeSafe(sink)
+        return _source.subscribe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Debug.swift
+++ b/RxSwift/Observables/Implementations/Debug.swift
@@ -12,10 +12,10 @@ class Debug_<O: ObserverType> : Sink<O>, ObserverType {
     typealias Element = O.E
     typealias Parent = Debug<Element>
     
-    let parent: Parent
+    private let _parent: Parent
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
@@ -25,30 +25,30 @@ class Debug_<O: ObserverType> : Sink<O>, ObserverType {
         let eventNormalized = eventText.characters.count > maxEventTextLength
             ? String(eventText.characters.prefix(maxEventTextLength / 2)) + "..." + String(eventText.characters.suffix(maxEventTextLength / 2))
             : eventText
-        print("[\(parent.identifier)] -> Event \(eventNormalized)")
+        print("[\(_parent._identifier)] -> Event \(eventNormalized)")
         observer?.on(event)
     }
     
     override func dispose() {
-        print("[\(parent.identifier)] dispose")
+        print("[\(_parent._identifier)] dispose")
         super.dispose()
     }
 }
 
 class Debug<Element> : Producer<Element> {
-    let identifier: String
+    private let _identifier: String
     
-    let source: Observable<Element>
+    private let _source: Observable<Element>
     
     init(source: Observable<Element>, identifier: String) {
-        self.identifier = identifier
-        self.source = source
+        _identifier = identifier
+        _source = source
     }
     
     override func run<O: ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
-        print("[\(identifier)] subscribed")
+        print("[\(_identifier)] subscribed")
         let sink = Debug_(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return self.source.subscribeSafe(sink)
+        return _source.subscribeSafe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Deferred.swift
+++ b/RxSwift/Observables/Implementations/Deferred.swift
@@ -22,7 +22,7 @@ class DeferredSink<O: ObserverType> : Sink<O>, ObserverType {
     func run() -> Disposable {
         do {
             let result = try _parent.eval()
-            return result.subscribeSafe(self)
+            return result.subscribe(self)
         }
         catch let e {
             observer?.on(.Error(e))

--- a/RxSwift/Observables/Implementations/Deferred.swift
+++ b/RxSwift/Observables/Implementations/Deferred.swift
@@ -12,21 +12,21 @@ class DeferredSink<O: ObserverType> : Sink<O>, ObserverType {
     typealias E = O.E
     typealias Parent = Deferred<E>
     
-    let parent: Parent
+    private let _parent: Parent
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
         do {
-            let result = try parent.eval()
+            let result = try _parent.eval()
             return result.subscribeSafe(self)
         }
         catch let e {
             observer?.on(.Error(e))
-            self.dispose()
+            dispose()
             return NopDisposable.instance
         }
     }
@@ -48,10 +48,10 @@ class DeferredSink<O: ObserverType> : Sink<O>, ObserverType {
 class Deferred<Element> : Producer<Element> {
     typealias Factory = () throws -> Observable<Element>
     
-    let observableFactory : Factory
+    private let _observableFactory : Factory
     
     init(observableFactory: Factory) {
-        self.observableFactory = observableFactory
+        _observableFactory = observableFactory
     }
     
     override func run<O: ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -61,6 +61,6 @@ class Deferred<Element> : Producer<Element> {
     }
     
     func eval() throws -> Observable<Element> {
-        return try observableFactory()
+        return try _observableFactory()
     }
 }

--- a/RxSwift/Observables/Implementations/DelaySubscription.swift
+++ b/RxSwift/Observables/Implementations/DelaySubscription.swift
@@ -45,7 +45,7 @@ class DelaySubscription<Element, S: SchedulerType>: Producer<Element> {
         let sink = DelaySubscriptionSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
         return _scheduler.scheduleRelative((), dueTime: _dueTime) { _ in
-            return self._source.subscribeSafe(sink)
+            return self._source.subscribe(sink)
         }
     }
 }

--- a/RxSwift/Observables/Implementations/DelaySubscription.swift
+++ b/RxSwift/Observables/Implementations/DelaySubscription.swift
@@ -12,17 +12,17 @@ class DelaySubscriptionSink<ElementType, O: ObserverType, S: SchedulerType where
     typealias Parent = DelaySubscription<ElementType, S>
     typealias E = O.E
     
-    let parent: Parent
+    private let _parent: Parent
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
     func on(event: Event<E>) {
         observer?.on(event)
         if event.isStopEvent {
-            self.dispose()
+            dispose()
         }
     }
     
@@ -31,21 +31,21 @@ class DelaySubscriptionSink<ElementType, O: ObserverType, S: SchedulerType where
 class DelaySubscription<Element, S: SchedulerType>: Producer<Element> {
     typealias TimeInterval = S.TimeInterval
     
-    let source: Observable<Element>
-    let dueTime: TimeInterval
-    let scheduler: S
+    private let _source: Observable<Element>
+    private let _dueTime: TimeInterval
+    private let _scheduler: S
     
     init(source: Observable<Element>, dueTime: TimeInterval, scheduler: S) {
-        self.source = source
-        self.dueTime = dueTime
-        self.scheduler = scheduler
+        _source = source
+        _dueTime = dueTime
+        _scheduler = scheduler
     }
     
     override func run<O : ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = DelaySubscriptionSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return scheduler.scheduleRelative((), dueTime: dueTime) { _ in
-            return self.source.subscribeSafe(sink)
+        return _scheduler.scheduleRelative((), dueTime: _dueTime) { _ in
+            return self._source.subscribeSafe(sink)
         }
     }
 }

--- a/RxSwift/Observables/Implementations/DistinctUntilChanged.swift
+++ b/RxSwift/Observables/Implementations/DistinctUntilChanged.swift
@@ -67,6 +67,6 @@ class DistinctUntilChanged<Element, Key>: Producer<Element> {
     override func run<O: ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = DistinctUntilChangedSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return _source.subscribeSafe(sink)
+        return _source.subscribe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Do.swift
+++ b/RxSwift/Observables/Implementations/Do.swift
@@ -12,24 +12,24 @@ class DoSink<O: ObserverType> : Sink<O>, ObserverType {
     typealias Element = O.E
     typealias Parent = Do<Element>
     
-    let parent: Parent
+    private let _parent: Parent
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
     func on(event: Event<Element>) {
         do {
-            try parent.eventHandler(event)
+            try _parent._eventHandler(event)
             observer?.on(event)
             if event.isStopEvent {
-                self.dispose()
+                dispose()
             }
         }
         catch let error {
             observer?.on(.Error(error))
-            self.dispose()
+            dispose()
         }
     }
 }
@@ -37,12 +37,12 @@ class DoSink<O: ObserverType> : Sink<O>, ObserverType {
 class Do<Element> : Producer<Element> {
     typealias EventHandler = Event<Element> throws -> Void
     
-    let source: Observable<Element>
-    let eventHandler: EventHandler
+    private let _source: Observable<Element>
+    private let _eventHandler: EventHandler
     
     init(source: Observable<Element>, eventHandler: EventHandler) {
-        self.source = source
-        self.eventHandler = eventHandler
+        _source = source
+        _eventHandler = eventHandler
     }
     
     override func run<O: ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -50,6 +50,6 @@ class Do<Element> : Producer<Element> {
         
         setSink(sink)
         
-        return self.source.subscribeSafe(sink)
+        return _source.subscribeSafe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Do.swift
+++ b/RxSwift/Observables/Implementations/Do.swift
@@ -50,6 +50,6 @@ class Do<Element> : Producer<Element> {
         
         setSink(sink)
         
-        return _source.subscribeSafe(sink)
+        return _source.subscribe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/ElementAt.swift
+++ b/RxSwift/Observables/Implementations/ElementAt.swift
@@ -1,0 +1,79 @@
+//
+//  ElementAt.swift
+//  Rx
+//
+//  Created by Junior B. on 21/10/15.
+//  Copyright © 2015 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+
+class ElementAtSink<SourceType, O: ObserverType where O.E == SourceType> : Sink<O>, ObserverType {
+    typealias Parent = ElementAt<SourceType>
+    
+    let parent: Parent
+    var i: Int
+    
+    init(parent: Parent, observer: O, cancel: Disposable) {
+        self.parent = parent
+        self.i = parent.index
+        
+        super.init(observer: observer, cancel: cancel)
+    }
+    
+    func on(event: Event<SourceType>) {
+        switch event {
+        case .Next(_):
+
+            if (i == 0) {
+                observer?.on(event)
+                observer?.on(.Completed)
+                self.dispose()
+            }
+            
+            do {
+                try decrementChecked(&i)
+            } catch(let e) {
+                observer?.onError(e)
+                dispose()
+                return
+            }
+            
+        case .Error(let e):
+            observer?.on(.Error(e))
+            self.dispose()
+        case .Completed:
+            if (parent.throwOnEmpty) {
+                observer?.onError(RxError.ArgumentOutOfRange)
+            } else {
+                observer?.on(.Completed)
+            }
+            
+            self.dispose()
+        }
+    }
+}
+
+class ElementAt<SourceType> : Producer<SourceType> {
+    
+    let source: Observable<SourceType>
+    let throwOnEmpty: Bool
+    let index: Int
+    
+    init(source: Observable<SourceType>, index: Int, throwOnEmpty: Bool) {
+        if index < 0 {
+            rxFatalError("index can't be negative")
+        }
+
+        self.source = source
+        self.index = index
+        self.throwOnEmpty = throwOnEmpty
+    }
+    
+    override func run<O: ObserverType where O.E == SourceType>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
+        let sink = ElementAtSink(parent: self, observer: observer, cancel: cancel)
+        setSink(sink)
+        return source.subscribeSafe(sink)
+    }
+}

--- a/RxSwift/Observables/Implementations/Empty.swift
+++ b/RxSwift/Observables/Implementations/Empty.swift
@@ -9,10 +9,6 @@
 import Foundation
 
 class Empty<Element> : Producer<Element> {
-    override init() {
-        
-    }
-    
     override func run<O : ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         observer.on(.Completed)
         return NopDisposable.instance

--- a/RxSwift/Observables/Implementations/FailWith.swift
+++ b/RxSwift/Observables/Implementations/FailWith.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 class FailWith<Element> : Producer<Element> {
-    let error: ErrorType
+    private let _error: ErrorType
     
     init(error: ErrorType) {
-        self.error = error
+        _error = error
     }
     
     override func run<O : ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
-        observer.on(.Error(error))
+        observer.on(.Error(_error))
         return NopDisposable.instance
     }
 }

--- a/RxSwift/Observables/Implementations/Filter.swift
+++ b/RxSwift/Observables/Implementations/Filter.swift
@@ -54,6 +54,6 @@ class Filter<Element> : Producer<Element> {
     override func run<O: ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = FilterSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return _source.subscribeSafe(sink)
+        return _source.subscribe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/FlatMap.swift
+++ b/RxSwift/Observables/Implementations/FlatMap.swift
@@ -118,7 +118,7 @@ class FlatMapSink<SourceType, S: ObservableConvertibleType, O: ObserverType wher
         let iterDisposable = SingleAssignmentDisposable()
         if let disposeKey = _group.addDisposable(iterDisposable) {
             let iter = FlatMapSinkIter(parent: self, disposeKey: disposeKey)
-            let subscription = source.subscribeSafe(iter)
+            let subscription = source.subscribe(iter)
             iterDisposable.disposable = subscription
         }
     }
@@ -126,7 +126,7 @@ class FlatMapSink<SourceType, S: ObservableConvertibleType, O: ObserverType wher
     func run() -> Disposable {
         _group.addDisposable(_sourceSubscription)
 
-        let subscription = _parent._source.subscribeSafe(self)
+        let subscription = _parent._source.subscribe(self)
         _sourceSubscription.disposable = subscription
         
         return _group

--- a/RxSwift/Observables/Implementations/FlatMap.swift
+++ b/RxSwift/Observables/Implementations/FlatMap.swift
@@ -16,36 +16,36 @@ class FlatMapSinkIter<SourceType, S: ObservableConvertibleType, O: ObserverType 
     typealias DisposeKey = CompositeDisposable.DisposeKey
     typealias E = O.E
     
-    let parent: Parent
-    let disposeKey: DisposeKey
+    private let _parent: Parent
+    private let _disposeKey: DisposeKey
     
     init(parent: Parent, disposeKey: DisposeKey) {
-        self.parent = parent
-        self.disposeKey = disposeKey
+        _parent = parent
+        _disposeKey = disposeKey
     }
     
     func on(event: Event<E>) {
         switch event {
         case .Next(let value):
-            parent.lock.performLocked {
-                parent.observer?.on(.Next(value))
+            _parent._lock.performLocked {
+                _parent.observer?.on(.Next(value))
             }
         case .Error(let error):
-            parent.lock.performLocked {
-                parent.observer?.on(.Error(error))
-                self.parent.dispose()
+            _parent._lock.performLocked {
+                _parent.observer?.on(.Error(error))
+                _parent.dispose()
             }
         case .Completed:
-            parent.group.removeDisposable(disposeKey)
+            _parent._group.removeDisposable(_disposeKey)
             // If this has returned true that means that `Completed` should be sent.
             // In case there is a race who will sent first completed,
             // lock will sort it out. When first Completed message is sent
             // it will set observer to nil, and thus prevent further complete messages
             // to be sent, and thus preserving the sequence grammar.
-            if parent.stopped && parent.group.count == FlatMapNoIterators {
-                parent.lock.performLocked {
-                    parent.observer?.on(.Completed)
-                    self.parent.dispose()
+            if _parent._stopped && _parent._group.count == FlatMapNoIterators {
+                _parent._lock.performLocked {
+                    _parent.observer?.on(.Completed)
+                    _parent.dispose()
                 }
             }
         }
@@ -57,18 +57,18 @@ class FlatMapSink<SourceType, S: ObservableConvertibleType, O: ObserverType wher
     typealias Element = SourceType
     typealias Parent = FlatMap<SourceType, S>
     
-    let parent: Parent
+    private let _parent: Parent
 
-    let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
-    let group = CompositeDisposable()
-    let sourceSubscription = SingleAssignmentDisposable()
+    private let _group = CompositeDisposable()
+    private let _sourceSubscription = SingleAssignmentDisposable()
 
-    var stopped = false
+    private var _stopped = false
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
@@ -87,36 +87,36 @@ class FlatMapSink<SourceType, S: ObservableConvertibleType, O: ObserverType wher
             }
             catch let e {
                 observer?.on(.Error(e))
-                self.dispose()
+                dispose()
             }
         case .Error(let error):
-            lock.performLocked {
+            _lock.performLocked {
                 observer?.on(.Error(error))
-                self.dispose()
+                dispose()
             }
         case .Completed:
-            lock.performLocked {
+            _lock.performLocked {
                 final()
             }
         }
     }
     
     func final() {
-        stopped = true
-        if group.count == FlatMapNoIterators {
-            lock.performLocked {
+        _stopped = true
+        if _group.count == FlatMapNoIterators {
+            _lock.performLocked {
                 observer?.on(.Completed)
                 dispose()
             }
         }
         else {
-            self.sourceSubscription.dispose()
+            _sourceSubscription.dispose()
         }
     }
     
     func subscribeInner(source: Observable<O.E>) {
         let iterDisposable = SingleAssignmentDisposable()
-        if let disposeKey = group.addDisposable(iterDisposable) {
+        if let disposeKey = _group.addDisposable(iterDisposable) {
             let iter = FlatMapSinkIter(parent: self, disposeKey: disposeKey)
             let subscription = source.subscribeSafe(iter)
             iterDisposable.disposable = subscription
@@ -124,12 +124,12 @@ class FlatMapSink<SourceType, S: ObservableConvertibleType, O: ObserverType wher
     }
     
     func run() -> Disposable {
-        group.addDisposable(sourceSubscription)
+        _group.addDisposable(_sourceSubscription)
 
-        let subscription = self.parent.source.subscribeSafe(self)
-        sourceSubscription.disposable = subscription
+        let subscription = _parent._source.subscribeSafe(self)
+        _sourceSubscription.disposable = subscription
         
-        return group
+        return _group
     }
 }
 
@@ -139,7 +139,7 @@ class FlatMapSink1<SourceType, S: ObservableConvertibleType, O : ObserverType wh
     }
     
     override func performMap(element: SourceType) throws -> S {
-        return try self.parent.selector1!(element)
+        return try _parent._selector1!(element)
     }
 }
 
@@ -151,7 +151,7 @@ class FlatMapSink2<SourceType, S: ObservableConvertibleType, O: ObserverType whe
     }
     
     override func performMap(element: SourceType) throws -> S {
-        return try parent.selector2!(element, try incrementChecked(&_index))
+        return try _parent._selector2!(element, try incrementChecked(&_index))
     }
 }
 
@@ -159,25 +159,25 @@ class FlatMap<SourceType, S: ObservableConvertibleType>: Producer<S.E> {
     typealias Selector1 = (SourceType) throws -> S
     typealias Selector2 = (SourceType, Int) throws -> S
     
-    let source: Observable<SourceType>
+    private let _source: Observable<SourceType>
     
-    let selector1: Selector1?
-    let selector2: Selector2?
+    private let _selector1: Selector1?
+    private let _selector2: Selector2?
     
     init(source: Observable<SourceType>, selector: Selector1) {
-        self.source = source
-        self.selector1 = selector
-        self.selector2 = nil
+        _source = source
+        _selector1 = selector
+        _selector2 = nil
     }
     
     init(source: Observable<SourceType>, selector: Selector2) {
-        self.source = source
-        self.selector2 = selector
-        self.selector1 = nil
+        _source = source
+        _selector2 = selector
+        _selector1 = nil
     }
     
     override func run<O: ObserverType where O.E == S.E>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
-        if let _ = self.selector1 {
+        if let _ = _selector1 {
             let sink = FlatMapSink1(parent: self, observer: observer, cancel: cancel)
             setSink(sink)
             return sink.run()

--- a/RxSwift/Observables/Implementations/Generate.swift
+++ b/RxSwift/Observables/Implementations/Generate.swift
@@ -11,25 +11,25 @@ import Foundation
 class GenerateSink<S, O: ObserverType> : Sink<O> {
     typealias Parent = Generate<S, O.E>
     
-    let parent: Parent
+    private let _parent: Parent
     
-    var state: S
+    private var _state: S
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
-        self.state = parent.initialState
+        _parent = parent
+        _state = parent._initialState
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
-        return parent.scheduler.scheduleRecursive(true) { (isFirst, recurse) -> Void in
+        return _parent._scheduler.scheduleRecursive(true) { (isFirst, recurse) -> Void in
             do {
                 if !isFirst {
-                    self.state = try self.parent.iterate(self.state)
+                    self._state = try self._parent._iterate(self._state)
                 }
                 
-                if try self.parent.condition(self.state) {
-                    let result = try self.parent.resultSelector(self.state)
+                if try self._parent._condition(self._state) {
+                    let result = try self._parent._resultSelector(self._state)
                     self.observer?.on(.Next(result))
                     
                     recurse(false)
@@ -48,18 +48,18 @@ class GenerateSink<S, O: ObserverType> : Sink<O> {
 }
 
 class Generate<S, E> : Producer<E> {
-    let initialState: S
-    let condition: S throws -> Bool
-    let iterate: S throws -> S
-    let resultSelector: S throws -> E
-    let scheduler: ImmediateSchedulerType
+    private let _initialState: S
+    private let _condition: S throws -> Bool
+    private let _iterate: S throws -> S
+    private let _resultSelector: S throws -> E
+    private let _scheduler: ImmediateSchedulerType
     
     init(initialState: S, condition: S throws -> Bool, iterate: S throws -> S, resultSelector: S throws -> E, scheduler: ImmediateSchedulerType) {
-        self.initialState = initialState
-        self.condition = condition
-        self.iterate = iterate
-        self.resultSelector = resultSelector
-        self.scheduler = scheduler
+        _initialState = initialState
+        _condition = condition
+        _iterate = iterate
+        _resultSelector = resultSelector
+        _scheduler = scheduler
         super.init()
     }
     

--- a/RxSwift/Observables/Implementations/Just.swift
+++ b/RxSwift/Observables/Implementations/Just.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 class Just<Element> : Producer<Element> {
-    let element: Element
+    private let _element: Element
     
     init(element: Element) {
-        self.element = element
+        _element = element
     }
     
     override func run<O : ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
-        observer.on(.Next(element))
+        observer.on(.Next(_element))
         observer.on(.Completed)
         return NopDisposable.instance
     }

--- a/RxSwift/Observables/Implementations/Map.swift
+++ b/RxSwift/Observables/Implementations/Map.swift
@@ -97,12 +97,12 @@ class Map<SourceType, ResultType>: Producer<ResultType> {
         if let _ = _selector1 {
             let sink = MapSink1(parent: self, observer: observer, cancel: cancel)
             setSink(sink)
-            return _source.subscribeSafe(sink)
+            return _source.subscribe(sink)
         }
         else {
             let sink = MapSink2(parent: self, observer: observer, cancel: cancel)
             setSink(sink)
-            return _source.subscribeSafe(sink)
+            return _source.subscribe(sink)
         }
         
     }

--- a/RxSwift/Observables/Implementations/Merge.swift
+++ b/RxSwift/Observables/Implementations/Merge.swift
@@ -66,9 +66,9 @@ class MergeSink<S: ObservableConvertibleType, O: ObserverType where O.E == S.E> 
     func run() -> Disposable {
         _group.addDisposable(_sourceSubscription)
         
-        let disposable = _parent._sources.subscribeSafe(self)
+        let disposable = _parent._sources.subscribe(self)
         _sourceSubscription.disposable = disposable
-        
+
         return _group
     }
     
@@ -80,7 +80,7 @@ class MergeSink<S: ObservableConvertibleType, O: ObserverType where O.E == S.E> 
             
             if let key = maybeKey {
                 let observer = MergeSinkIter(parent: self, disposeKey: key)
-                let disposable = value.asObservable().subscribeSafe(observer)
+                let disposable = value.asObservable().subscribe(observer)
                 innerSubscription.disposable = disposable
             }
         case .Error(let error):
@@ -174,7 +174,7 @@ class MergeConcurrentSink<S: ObservableConvertibleType, O: ObserverType where S.
     func run() -> Disposable {
         _group.addDisposable(_sourceSubscription)
         
-        let disposable = _parent._sources.subscribeSafe(self)
+        let disposable = _parent._sources.subscribe(self)
         _sourceSubscription.disposable = disposable
         return _group
     }
@@ -187,7 +187,7 @@ class MergeConcurrentSink<S: ObservableConvertibleType, O: ObserverType where S.
         if let key = key {
             let observer = MergeConcurrentSinkIter(parent: self, disposeKey: key)
             
-            let disposable = innerSource.asObservable().subscribeSafe(observer)
+            let disposable = innerSource.asObservable().subscribe(observer)
             subscription.disposable = disposable
         }
     }

--- a/RxSwift/Observables/Implementations/Merge.swift
+++ b/RxSwift/Observables/Implementations/Merge.swift
@@ -15,28 +15,28 @@ class MergeSinkIter<S: ObservableConvertibleType, O: ObserverType where O.E == S
     typealias DisposeKey = Bag<Disposable>.KeyType
     typealias Parent = MergeSink<S, O>
     
-    let parent: Parent
-    let disposeKey: DisposeKey
+    private let _parent: Parent
+    private let _disposeKey: DisposeKey
     
     init(parent: Parent, disposeKey: DisposeKey) {
-        self.parent = parent
-        self.disposeKey = disposeKey
+        _parent = parent
+        _disposeKey = disposeKey
     }
     
     func on(event: Event<E>) {
-        parent.lock.performLocked {
+        _parent._lock.performLocked {
             switch event {
             case .Next:
-                parent.observer?.on(event)
+                _parent.observer?.on(event)
             case .Error:
-                parent.observer?.on(event)
-                parent.dispose()
+                _parent.observer?.on(event)
+                _parent.dispose()
             case .Completed:
-                parent.group.removeDisposable(disposeKey)
+                _parent._group.removeDisposable(_disposeKey)
                 
-                if parent.stopped && parent.group.count == 1 {
-                    parent.observer?.on(.Completed)
-                    parent.dispose()
+                if _parent._stopped && _parent._group.count == 1 {
+                    _parent.observer?.on(.Completed)
+                    _parent.dispose()
                 }
             }
         }
@@ -47,36 +47,36 @@ class MergeSink<S: ObservableConvertibleType, O: ObserverType where O.E == S.E> 
     typealias E = S
     typealias Parent = Merge<S>
     
-    let parent: Parent
+    private let _parent: Parent
     
-    let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
-    var stopped = false
+    private var _stopped = false
     
-    let group = CompositeDisposable()
-    let sourceSubscription = SingleAssignmentDisposable()
+    private let _group = CompositeDisposable()
+    private let _sourceSubscription = SingleAssignmentDisposable()
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
-        group.addDisposable(sourceSubscription)
+        _group.addDisposable(_sourceSubscription)
         
-        let disposable = self.parent.sources.subscribeSafe(self)
-        sourceSubscription.disposable = disposable
+        let disposable = _parent._sources.subscribeSafe(self)
+        _sourceSubscription.disposable = disposable
         
-        return group
+        return _group
     }
     
     func on(event: Event<E>) {
         switch event {
         case .Next(let value):
             let innerSubscription = SingleAssignmentDisposable()
-            let maybeKey = group.addDisposable(innerSubscription)
+            let maybeKey = _group.addDisposable(innerSubscription)
             
             if let key = maybeKey {
                 let observer = MergeSinkIter(parent: self, disposeKey: key)
@@ -84,20 +84,20 @@ class MergeSink<S: ObservableConvertibleType, O: ObserverType where O.E == S.E> 
                 innerSubscription.disposable = disposable
             }
         case .Error(let error):
-            lock.performLocked {
+            _lock.performLocked {
                 observer?.on(.Error(error))
-                self.dispose()
+                dispose()
             }
         case .Completed:
-            lock.performLocked {
-                self.stopped = true
+            _lock.performLocked {
+                _stopped = true
                 
-                if group.count == 1 {
+                if _group.count == 1 {
                     observer?.on(.Completed)
-                    self.dispose()
+                    dispose()
                 }
                 else {
-                    sourceSubscription.dispose()
+                    _sourceSubscription.dispose()
                 }
             }
         }
@@ -111,35 +111,35 @@ class MergeConcurrentSinkIter<S: ObservableConvertibleType, O: ObserverType wher
     typealias DisposeKey = Bag<Disposable>.KeyType
     typealias Parent = MergeConcurrentSink<S, O>
     
-    let parent: Parent
-    let disposeKey: DisposeKey
+    private let _parent: Parent
+    private let _disposeKey: DisposeKey
     
     init(parent: Parent, disposeKey: DisposeKey) {
-        self.parent = parent
-        self.disposeKey = disposeKey
+        _parent = parent
+        _disposeKey = disposeKey
     }
     
     func on(event: Event<E>) {
-        parent.lock.performLocked {
+        _parent._lock.performLocked {
             switch event {
             case .Next:
-                parent.observer?.on(event)
+                _parent.observer?.on(event)
             case .Error:
-                parent.observer?.on(event)
-                self.parent.dispose()
+                _parent.observer?.on(event)
+                _parent.dispose()
             case .Completed:
-                parent.group.removeDisposable(disposeKey)
-                let queue = parent.queue
+                _parent._group.removeDisposable(_disposeKey)
+                let queue = _parent._queue
                 if queue.value.count > 0 {
                     let s = queue.value.dequeue()
-                    self.parent.subscribe(s, group: parent.group)
+                    _parent.subscribe(s, group: _parent._group)
                 }
                 else {
-                    parent.activeCount = parent.activeCount - 1
+                    _parent._activeCount = _parent._activeCount - 1
                     
-                    if parent.stopped && parent.activeCount == 0 {
-                        parent.observer?.on(.Completed)
-                        self.parent.dispose()
+                    if _parent._stopped && _parent._activeCount == 0 {
+                        _parent.observer?.on(.Completed)
+                        _parent.dispose()
                     }
                 }
             }
@@ -152,31 +152,31 @@ class MergeConcurrentSink<S: ObservableConvertibleType, O: ObserverType where S.
     typealias Parent = Merge<S>
     typealias QueueType = Queue<S>
     
-    let parent: Parent
+    private let _parent: Parent
     
-    let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
-    var stopped = false
-    var activeCount = 0
-    var queue = RxMutableBox(QueueType(capacity: 2))
+    private var _stopped = false
+    private var _activeCount = 0
+    private var _queue = RxMutableBox(QueueType(capacity: 2))
     
-    let sourceSubscription = SingleAssignmentDisposable()
-    let group = CompositeDisposable()
+    private let _sourceSubscription = SingleAssignmentDisposable()
+    private let _group = CompositeDisposable()
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         
-        group.addDisposable(sourceSubscription)
+        _group.addDisposable(_sourceSubscription)
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
-        group.addDisposable(sourceSubscription)
+        _group.addDisposable(_sourceSubscription)
         
-        let disposable = self.parent.sources.subscribeSafe(self)
-        sourceSubscription.disposable = disposable
-        return group
+        let disposable = _parent._sources.subscribeSafe(self)
+        _sourceSubscription.disposable = disposable
+        return _group
     }
     
     func subscribe(innerSource: E, group: CompositeDisposable) {
@@ -195,52 +195,52 @@ class MergeConcurrentSink<S: ObservableConvertibleType, O: ObserverType where S.
     func on(event: Event<E>) {
         switch event {
         case .Next(let value):
-            let subscribe = lock.calculateLocked { () -> Bool in
-                if activeCount < self.parent.maxConcurrent {
-                    self.activeCount += 1
+            let subscribe = _lock.calculateLocked { () -> Bool in
+                if _activeCount < _parent._maxConcurrent {
+                    _activeCount += 1
                     return true
                 }
                 else {
-                    queue.value.enqueue(value)
+                    _queue.value.enqueue(value)
                     return false
                 }
             }
             
             if subscribe {
-                self.subscribe(value, group: group)
+                self.subscribe(value, group: _group)
             }
         case .Error(let error):
-            lock.performLocked {
+            _lock.performLocked {
                 observer?.on(.Error(error))
-                self.dispose()
+                dispose()
             }
         case .Completed:
-            lock.performLocked {
-                if activeCount == 0 {
+            _lock.performLocked {
+                if _activeCount == 0 {
                     observer?.on(.Completed)
-                    self.dispose()
+                    dispose()
                 }
                 else {
-                    sourceSubscription.dispose()
+                    _sourceSubscription.dispose()
                 }
                     
-                stopped = true
+                _stopped = true
             }
         }
     }
 }
 
 class Merge<S: ObservableConvertibleType> : Producer<S.E> {
-    let sources: Observable<S>
-    let maxConcurrent: Int
+    private let _sources: Observable<S>
+    private let _maxConcurrent: Int
     
     init(sources: Observable<S>, maxConcurrent: Int) {
-        self.sources = sources
-        self.maxConcurrent = maxConcurrent
+        _sources = sources
+        _maxConcurrent = maxConcurrent
     }
     
     override func run<O: ObserverType where O.E == S.E>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
-        if maxConcurrent > 0 {
+        if _maxConcurrent > 0 {
             let sink = MergeConcurrentSink(parent: self, observer: observer, cancel: cancel)
             setSink(sink)
             return sink.run()

--- a/RxSwift/Observables/Implementations/Multicast.swift
+++ b/RxSwift/Observables/Implementations/Multicast.swift
@@ -13,19 +13,19 @@ class MulticastSink<S: SubjectType, O: ObserverType>: Sink<O>, ObserverType {
     typealias ResultType = Element
     typealias MutlicastType = Multicast<S, O.E>
     
-    let parent: MutlicastType
+    private let _parent: MutlicastType
     
     init(parent: MutlicastType, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
         do {
-            let subject = try parent.subjectSelector()
-            let connectable = ConnectableObservable(source: self.parent.source, subject: subject)
+            let subject = try _parent._subjectSelector()
+            let connectable = ConnectableObservable(source: _parent._source, subject: subject)
             
-            let observable = try self.parent.selector(connectable)
+            let observable = try _parent._selector(connectable)
             
             let subscription = observable.subscribeSafe(self)
             let connection = connectable.connect()
@@ -34,7 +34,7 @@ class MulticastSink<S: SubjectType, O: ObserverType>: Sink<O>, ObserverType {
         }
         catch let e {
             observer?.on(.Error(e))
-            self.dispose()
+            dispose()
             return NopDisposable.instance
         }
     }
@@ -44,7 +44,7 @@ class MulticastSink<S: SubjectType, O: ObserverType>: Sink<O>, ObserverType {
         switch event {
             case .Next: break
             case .Error, .Completed:
-                self.dispose()
+                dispose()
         }
     }
 }
@@ -53,14 +53,14 @@ class Multicast<S: SubjectType, R>: Producer<R> {
     typealias SubjectSelectorType = () throws -> S
     typealias SelectorType = (Observable<S.E>) throws -> Observable<R>
     
-    let source: Observable<S.SubjectObserverType.E>
-    let subjectSelector: SubjectSelectorType
-    let selector: SelectorType
+    private let _source: Observable<S.SubjectObserverType.E>
+    private let _subjectSelector: SubjectSelectorType
+    private let _selector: SelectorType
     
     init(source: Observable<S.SubjectObserverType.E>, subjectSelector: SubjectSelectorType, selector: SelectorType) {
-        self.source = source
-        self.subjectSelector = subjectSelector
-        self.selector = selector
+        _source = source
+        _subjectSelector = subjectSelector
+        _selector = selector
     }
     
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {

--- a/RxSwift/Observables/Implementations/Multicast.swift
+++ b/RxSwift/Observables/Implementations/Multicast.swift
@@ -27,7 +27,7 @@ class MulticastSink<S: SubjectType, O: ObserverType>: Sink<O>, ObserverType {
             
             let observable = try _parent._selector(connectable)
             
-            let subscription = observable.subscribeSafe(self)
+            let subscription = observable.subscribe(self)
             let connection = connectable.connect()
                 
             return BinaryDisposable(subscription, connection)

--- a/RxSwift/Observables/Implementations/ObserveOn.swift
+++ b/RxSwift/Observables/Implementations/ObserveOn.swift
@@ -24,7 +24,7 @@ class ObserveOn<E> : Producer<E> {
     override func run<O : ObserverType where O.E == E>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = ObserveOnSink(scheduler: scheduler, observer: observer, cancel: cancel)
         setSink(sink)
-        return source.subscribeSafe(sink)
+        return source.subscribe(sink)
     }
     
 #if TRACE_RESOURCES

--- a/RxSwift/Observables/Implementations/ObserveOn.swift
+++ b/RxSwift/Observables/Implementations/ObserveOn.swift
@@ -94,7 +94,7 @@ class ObserveOnSink<O: ObserverType> : ObserverBase<O.E> {
         if let nextEvent = nextEvent {
             observer?.on(nextEvent)
             if nextEvent.isStopEvent {
-                self.dispose()
+                dispose()
             }
         }
         else {

--- a/RxSwift/Observables/Implementations/ObserveOnSerialDispatchQueue.swift
+++ b/RxSwift/Observables/Implementations/ObserveOnSerialDispatchQueue.swift
@@ -75,7 +75,7 @@ class ObserveOnSerialDispatchQueue<E> : Producer<E> {
     override func run<O : ObserverType where O.E == E>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = ObserveOnSerialDispatchQueueSink(scheduler: scheduler, observer: observer, cancel: cancel)
         setSink(sink)
-        return source.subscribeSafe(sink)
+        return source.subscribe(sink)
     }
     
 #if TRACE_RESOURCES

--- a/RxSwift/Observables/Implementations/Range.swift
+++ b/RxSwift/Observables/Implementations/Range.swift
@@ -14,6 +14,14 @@ class RangeProducer<_CompilerWorkaround> : Producer<Int> {
     private let _scheduler: ImmediateSchedulerType
     
     init(start: Int, count: Int, scheduler: ImmediateSchedulerType) {
+        if count < 0 {
+            rxFatalError("count can't be negative")
+        }
+
+        if start &+ (count - 1) < start {
+            rxFatalError("overflow of count")
+        }
+
         _start = start
         _count = count
         _scheduler = scheduler

--- a/RxSwift/Observables/Implementations/Range.swift
+++ b/RxSwift/Observables/Implementations/Range.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 class RangeProducer<_CompilerWorkaround> : Producer<Int> {
-    let start: Int
-    let count: Int
-    let scheduler: ImmediateSchedulerType
+    private let _start: Int
+    private let _count: Int
+    private let _scheduler: ImmediateSchedulerType
     
     init(start: Int, count: Int, scheduler: ImmediateSchedulerType) {
-        self.start = start
-        self.count = count
-        self.scheduler = scheduler
+        _start = start
+        _count = count
+        _scheduler = scheduler
     }
     
     override func run<O : ObserverType where O.E == Int>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -29,17 +29,17 @@ class RangeProducer<_CompilerWorkaround> : Producer<Int> {
 class RangeSink<_CompilerWorkaround, O: ObserverType where O.E == Int> : Sink<O> {
     typealias Parent = RangeProducer<_CompilerWorkaround>
     
-    let parent: Parent
+    private let _parent: Parent
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
-        return self.parent.scheduler.scheduleRecursive(0) { i, recurse in
-            if i < self.parent.count {
-                self.observer?.on(.Next(self.parent.start + i))
+        return _parent._scheduler.scheduleRecursive(0) { i, recurse in
+            if i < self._parent._count {
+                self.observer?.on(.Next(self._parent._start + i))
                 recurse(i + 1)
             }
             else {

--- a/RxSwift/Observables/Implementations/Reduce.swift
+++ b/RxSwift/Observables/Implementations/Reduce.swift
@@ -69,6 +69,6 @@ class Reduce<SourceType, AccumulateType, ResultType> : Producer<ResultType> {
     override func run<O: ObserverType where O.E == ResultType>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = ReduceSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return _source.subscribeSafe(sink)
+        return _source.subscribe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Reduce.swift
+++ b/RxSwift/Observables/Implementations/Reduce.swift
@@ -12,13 +12,12 @@ class ReduceSink<SourceType, AccumulateType, O: ObserverType> : Sink<O>, Observe
     typealias ResultType = O.E
     typealias Parent = Reduce<SourceType, AccumulateType, ResultType>
     
-    let parent: Parent
-    var accumulation: AccumulateType
+    private let _parent: Parent
+    private var _accumulation: AccumulateType
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
-        
-        self.accumulation = parent.seed
+        _parent = parent
+        _accumulation = parent._seed
         
         super.init(observer: observer, cancel: cancel)
     }
@@ -27,25 +26,25 @@ class ReduceSink<SourceType, AccumulateType, O: ObserverType> : Sink<O>, Observe
         switch event {
         case .Next(let value):
             do {
-                self.accumulation = try parent.accumulator(accumulation, value)
+                _accumulation = try _parent._accumulator(_accumulation, value)
             }
             catch let e {
                 observer?.on(.Error(e))
-                self.dispose()
+                dispose()
             }
         case .Error(let e):
             observer?.on(.Error(e))
-            self.dispose()
+            dispose()
         case .Completed:
             do {
-                let result = try parent.mapResult(self.accumulation)
+                let result = try _parent._mapResult(_accumulation)
                 observer?.on(.Next(result))
                 observer?.on(.Completed)
-                self.dispose()
+                dispose()
             }
             catch let e {
                 observer?.on(.Error(e))
-                self.dispose()
+                dispose()
             }
         }
     }
@@ -55,21 +54,21 @@ class Reduce<SourceType, AccumulateType, ResultType> : Producer<ResultType> {
     typealias AccumulatorType = (AccumulateType, SourceType) throws -> AccumulateType
     typealias ResultSelectorType = (AccumulateType) throws -> ResultType
     
-    let source: Observable<SourceType>
-    let seed: AccumulateType
-    let accumulator: AccumulatorType
-    let mapResult: ResultSelectorType
+    private let _source: Observable<SourceType>
+    private let _seed: AccumulateType
+    private let _accumulator: AccumulatorType
+    private let _mapResult: ResultSelectorType
     
     init(source: Observable<SourceType>, seed: AccumulateType, accumulator: AccumulatorType, mapResult: ResultSelectorType) {
-        self.source = source
-        self.seed = seed
-        self.accumulator = accumulator
-        self.mapResult = mapResult
+        _source = source
+        _seed = seed
+        _accumulator = accumulator
+        _mapResult = mapResult
     }
     
     override func run<O: ObserverType where O.E == ResultType>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = ReduceSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return source.subscribeSafe(sink)
+        return _source.subscribeSafe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Repeat.swift
+++ b/RxSwift/Observables/Implementations/Repeat.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 class RepeatElement<Element> : Producer<Element> {
-    let element: Element
-    let scheduler: ImmediateSchedulerType
+    private let _element: Element
+    private let _scheduler: ImmediateSchedulerType
     
     init(element: Element, scheduler: ImmediateSchedulerType) {
-        self.element = element
-        self.scheduler = scheduler
+        _element = element
+        _scheduler = scheduler
     }
     
     override func run<O : ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -27,15 +27,15 @@ class RepeatElement<Element> : Producer<Element> {
 class RepeatElementSink<O: ObserverType> : Sink<O> {
     typealias Parent = RepeatElement<O.E>
     
-    let parent: Parent
+    private let _parent: Parent
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
-        return self.parent.scheduler.scheduleRecursive(self.parent.element) { e, recurse in
+        return _parent._scheduler.scheduleRecursive(_parent._element) { e, recurse in
             self.observer?.on(.Next(e))
             recurse(e)
         }

--- a/RxSwift/Observables/Implementations/Sample.swift
+++ b/RxSwift/Observables/Implementations/Sample.swift
@@ -13,39 +13,39 @@ class SamplerSink<O: ObserverType, ElementType, SampleType where O.E == ElementT
     
     typealias Parent = SampleSequenceSink<O, SampleType>
     
-    let parent: Parent
+    private let _parent: Parent
     
     init(parent: Parent) {
-        self.parent = parent
+        _parent = parent
     }
     
     func on(event: Event<E>) {
-        parent.lock.performLocked {
+        _parent._lock.performLocked {
             switch event {
             case .Next:
-                if let element = parent.element {
-                    if self.parent.parent.onlyNew {
-                        parent.element = nil
+                if let element = _parent._element {
+                    if _parent._parent._onlyNew {
+                        _parent._element = nil
                     }
                     
-                    parent.observer?.on(.Next(element))
+                    _parent.observer?.on(.Next(element))
                 }
 
-                if parent.atEnd {
-                    parent.observer?.on(.Completed)
-                    parent.dispose()
+                if _parent._atEnd {
+                    _parent.observer?.on(.Completed)
+                    _parent.dispose()
                 }
             case .Error(let e):
-                parent.observer?.on(.Error(e))
-                parent.dispose()
+                _parent.observer?.on(.Error(e))
+                _parent.dispose()
             case .Completed:
-                if let element = parent.element {
-                    parent.element = nil
-                    parent.observer?.on(.Next(element))
+                if let element = _parent._element {
+                    _parent._element = nil
+                    _parent.observer?.on(.Next(element))
                 }
-                if parent.atEnd {
-                    parent.observer?.on(.Completed)
-                    parent.dispose()
+                if _parent._atEnd {
+                    _parent.observer?.on(.Completed)
+                    _parent.dispose()
                 }
             }
         }
@@ -56,39 +56,39 @@ class SampleSequenceSink<O: ObserverType, SampleType> : Sink<O>, ObserverType {
     typealias Element = O.E
     typealias Parent = Sample<Element, SampleType>
     
-    let parent: Parent
+    private let _parent: Parent
 
-    let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
-    var element = nil as Element?
-    var atEnd = false
+    private var _element = nil as Element?
+    private var _atEnd = false
     
-    let sourceSubscription = SingleAssignmentDisposable()
+    private let _sourceSubscription = SingleAssignmentDisposable()
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
-        sourceSubscription.disposable = parent.source.subscribeSafe(self)
-        let samplerSubscription = parent.sampler.subscribeSafe(SamplerSink(parent: self))
+        _sourceSubscription.disposable = _parent._source.subscribeSafe(self)
+        let samplerSubscription = _parent._sampler.subscribeSafe(SamplerSink(parent: self))
         
-        return CompositeDisposable(sourceSubscription, samplerSubscription)
+        return CompositeDisposable(_sourceSubscription, samplerSubscription)
     }
     
     func on(event: Event<Element>) {
-        self.lock.performLocked {
+        _lock.performLocked {
             switch event {
             case .Next(let element):
-                self.element = element
+                _element = element
             case .Error:
                 observer?.on(event)
-                self.dispose()
+                dispose()
             case .Completed:
-                atEnd = true
-                sourceSubscription.dispose()
+                _atEnd = true
+                _sourceSubscription.dispose()
             }
         }
     }
@@ -96,14 +96,14 @@ class SampleSequenceSink<O: ObserverType, SampleType> : Sink<O>, ObserverType {
 }
 
 class Sample<Element, SampleType> : Producer<Element> {
-    let source: Observable<Element>
-    let sampler: Observable<SampleType>
-    let onlyNew: Bool
+    private let _source: Observable<Element>
+    private let _sampler: Observable<SampleType>
+    private let _onlyNew: Bool
 
     init(source: Observable<Element>, sampler: Observable<SampleType>, onlyNew: Bool) {
-        self.source = source
-        self.sampler = sampler
-        self.onlyNew = onlyNew
+        _source = source
+        _sampler = sampler
+        _onlyNew = onlyNew
     }
     
     override func run<O: ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {

--- a/RxSwift/Observables/Implementations/Sample.swift
+++ b/RxSwift/Observables/Implementations/Sample.swift
@@ -72,8 +72,8 @@ class SampleSequenceSink<O: ObserverType, SampleType> : Sink<O>, ObserverType {
     }
     
     func run() -> Disposable {
-        _sourceSubscription.disposable = _parent._source.subscribeSafe(self)
-        let samplerSubscription = _parent._sampler.subscribeSafe(SamplerSink(parent: self))
+        _sourceSubscription.disposable = _parent._source.subscribe(self)
+        let samplerSubscription = _parent._sampler.subscribe(SamplerSink(parent: self))
         
         return CompositeDisposable(_sourceSubscription, samplerSubscription)
     }

--- a/RxSwift/Observables/Implementations/Scan.swift
+++ b/RxSwift/Observables/Implementations/Scan.swift
@@ -12,12 +12,12 @@ class ScanSink<ElementType, Accumulate, O: ObserverType where O.E == Accumulate>
     typealias Parent = Scan<ElementType, Accumulate>
     typealias E = ElementType
     
-    let parent: Parent
-    var accumulate: Accumulate
+    private let _parent: Parent
+    private var _accumulate: Accumulate
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
-        self.accumulate = parent.seed
+        _parent = parent
+        _accumulate = parent._seed
         super.init(observer: observer, cancel: cancel)
     }
     
@@ -25,19 +25,19 @@ class ScanSink<ElementType, Accumulate, O: ObserverType where O.E == Accumulate>
         switch event {
         case .Next(let element):
             do {
-                self.accumulate = try self.parent.accumulator(self.accumulate, element)
-                observer?.on(.Next(self.accumulate))
+                _accumulate = try _parent._accumulator(_accumulate, element)
+                observer?.on(.Next(_accumulate))
             }
             catch let error {
-                self.observer?.on(.Error(error))
-                self.dispose()
+                observer?.on(.Error(error))
+                dispose()
             }
         case .Error(let error):
             observer?.on(.Error(error))
-            self.dispose()
+            dispose()
         case .Completed:
             observer?.on(.Completed)
-            self.dispose()
+            dispose()
         }
     }
     
@@ -46,19 +46,19 @@ class ScanSink<ElementType, Accumulate, O: ObserverType where O.E == Accumulate>
 class Scan<Element, Accumulate>: Producer<Accumulate> {
     typealias Accumulator = (Accumulate, Element) throws -> Accumulate
     
-    let source: Observable<Element>
-    let seed: Accumulate
-    let accumulator: Accumulator
+    private let _source: Observable<Element>
+    private let _seed: Accumulate
+    private let _accumulator: Accumulator
     
     init(source: Observable<Element>, seed: Accumulate, accumulator: Accumulator) {
-        self.source = source
-        self.seed = seed
-        self.accumulator = accumulator
+        _source = source
+        _seed = seed
+        _accumulator = accumulator
     }
     
     override func run<O : ObserverType where O.E == Accumulate>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = ScanSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return source.subscribeSafe(sink)
+        return _source.subscribeSafe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Scan.swift
+++ b/RxSwift/Observables/Implementations/Scan.swift
@@ -59,6 +59,6 @@ class Scan<Element, Accumulate>: Producer<Accumulate> {
     override func run<O : ObserverType where O.E == Accumulate>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = ScanSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return _source.subscribeSafe(sink)
+        return _source.subscribe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Skip.swift
+++ b/RxSwift/Observables/Implementations/Skip.swift
@@ -57,7 +57,7 @@ class SkipCount<Element>: Producer<Element> {
     override func run<O : ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = SkipCountSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return source.subscribeSafe(sink)
+        return source.subscribe(sink)
     }
 }
 
@@ -102,7 +102,7 @@ class SkipTimeSink<ElementType, S: SchedulerType, O: ObserverType where O.E == E
             return NopDisposable.instance
         }
         
-        let disposeSubscription = parent.source.subscribeSafe(self)
+        let disposeSubscription = parent.source.subscribe(self)
         
         return BinaryDisposable(disposeTimer, disposeSubscription)
     }

--- a/RxSwift/Observables/Implementations/SkipUntil.swift
+++ b/RxSwift/Observables/Implementations/SkipUntil.swift
@@ -102,9 +102,9 @@ class SkipUntilSink<ElementType, Other, O: ObserverType where O.E == ElementType
     }
     
     func run() -> Disposable {
-        let sourceSubscription = _parent._source.subscribeSafe(self)
+        let sourceSubscription = _parent._source.subscribe(self)
         let otherObserver = SkipUntilSinkOther(parent: self)
-        let otherSubscription = _parent._other.subscribeSafe(otherObserver)
+        let otherSubscription = _parent._other.subscribe(otherObserver)
         disposable = sourceSubscription
         otherObserver.disposable = otherSubscription
         

--- a/RxSwift/Observables/Implementations/SkipWhile.swift
+++ b/RxSwift/Observables/Implementations/SkipWhile.swift
@@ -104,12 +104,12 @@ class SkipWhile<Element>: Producer<Element> {
         if let _ = _predicate {
             let sink = SkipWhileSink(parent: self, observer: observer, cancel: cancel)
             setSink(sink)
-            return _source.subscribeSafe(sink)
+            return _source.subscribe(sink)
         }
         else {
             let sink = SkipWhileSinkWithIndex(parent: self, observer: observer, cancel: cancel)
             setSink(sink)
-            return _source.subscribeSafe(sink)
+            return _source.subscribe(sink)
         }
     }
 }

--- a/RxSwift/Observables/Implementations/StartWith.swift
+++ b/RxSwift/Observables/Implementations/StartWith.swift
@@ -23,6 +23,6 @@ class StartWith<Element>: Producer<Element> {
             observer.on(.Next(e))
         }
 
-        return source.subscribeSafe(observer)
+        return source.subscribe(observer)
     }
 }

--- a/RxSwift/Observables/Implementations/Switch.swift
+++ b/RxSwift/Observables/Implementations/Switch.swift
@@ -30,7 +30,7 @@ class SwitchSink<S: ObservableConvertibleType, O: ObserverType where S.E == O.E>
     }
     
     func run() -> Disposable {
-        let subscription = _parent._sources.subscribeSafe(self)
+        let subscription = _parent._sources.subscribe(self)
         _subscriptions.disposable = subscription
         return CompositeDisposable(_subscriptions, _innerSubscription)
     }
@@ -48,7 +48,7 @@ class SwitchSink<S: ObservableConvertibleType, O: ObserverType where S.E == O.E>
             _innerSubscription.disposable = d
                
             let observer = SwitchSinkIter(parent: self, id: latest, _self: d)
-            let disposable = observable.asObservable().subscribeSafe(observer)
+            let disposable = observable.asObservable().subscribe(observer)
             d.disposable = disposable
         case .Error(let error):
             _lock.performLocked {

--- a/RxSwift/Observables/Implementations/Take.swift
+++ b/RxSwift/Observables/Implementations/Take.swift
@@ -54,6 +54,9 @@ class TakeCount<Element>: Producer<Element> {
     private let _count: Int
     
     init(source: Observable<Element>, count: Int) {
+        if count < 0 {
+            rxFatalError("count can't be negative")
+        }
         _source = source
         _count = count
     }

--- a/RxSwift/Observables/Implementations/Take.swift
+++ b/RxSwift/Observables/Implementations/Take.swift
@@ -61,7 +61,7 @@ class TakeCount<Element>: Producer<Element> {
     override func run<O : ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = TakeCountSink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return _source.subscribeSafe(sink)
+        return _source.subscribe(sink)
     }
 }
 
@@ -108,7 +108,7 @@ class TakeTimeSink<ElementType, S: SchedulerType, O: ObserverType where O.E == E
             return NopDisposable.instance
         }
         
-        let disposeSubscription = _parent._source.subscribeSafe(self)
+        let disposeSubscription = _parent._source.subscribe(self)
         
         return BinaryDisposable(disposeTimer, disposeSubscription)
     }

--- a/RxSwift/Observables/Implementations/TakeLast.swift
+++ b/RxSwift/Observables/Implementations/TakeLast.swift
@@ -19,7 +19,7 @@ class TakeLastSink<ElementType, O: ObserverType where O.E == ElementType> : Sink
     
     init(parent: Parent, observer: O, cancel: Disposable) {
         _parent = parent
-        _elements = Queue<ElementType>(capacity: parent._count)
+        _elements = Queue<ElementType>(capacity: parent._count + 1)
         super.init(observer: observer, cancel: cancel)
     }
     

--- a/RxSwift/Observables/Implementations/TakeLast.swift
+++ b/RxSwift/Observables/Implementations/TakeLast.swift
@@ -1,0 +1,63 @@
+//
+//  TakeLast.swift
+//  Rx
+//
+//  Created by Tomi Koskinen on 25/10/15.
+//  Copyright © 2015 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+
+class TakeLastSink<ElementType, O: ObserverType where O.E == ElementType> : Sink<O>, ObserverType {
+    typealias Parent = TakeLast<ElementType>
+    typealias E = ElementType
+    
+    private let _parent: Parent
+    
+    private var _elements: Queue<ElementType>
+    
+    init(parent: Parent, observer: O, cancel: Disposable) {
+        _parent = parent
+        _elements = Queue<ElementType>(capacity: parent._count)
+        super.init(observer: observer, cancel: cancel)
+    }
+    
+    func on(event: Event<E>) {
+        switch event {
+        case .Next(let value):
+            _elements.enqueue(value)
+            if _elements.count > self._parent._count {
+                _elements.dequeue()
+            }
+        case .Error:
+            observer?.on(event)
+            dispose()
+        case .Completed:
+            for e in _elements {
+                observer?.on(.Next(e))
+            }
+            observer?.on(.Completed)
+            dispose()
+        }
+    }
+}
+
+class TakeLast<Element>: Producer<Element> {
+    private let _source: Observable<Element>
+    private let _count: Int
+    
+    init(source: Observable<Element>, count: Int) {
+        if count < 0 {
+            rxFatalError("count can't be negative")
+        }
+        _source = source
+        _count = count
+    }
+    
+    override func run<O : ObserverType where O.E == Element>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
+        let sink = TakeLastSink(parent: self, observer: observer, cancel: cancel)
+        setSink(sink)
+        return _source.subscribe(sink)
+    }
+}

--- a/RxSwift/Observables/Implementations/TakeUntil.swift
+++ b/RxSwift/Observables/Implementations/TakeUntil.swift
@@ -97,9 +97,9 @@ class TakeUntilSink<ElementType, Other, O: ObserverType where O.E == ElementType
     
     func run() -> Disposable {
         let otherObserver = TakeUntilSinkOther(parent: self)
-        let otherSubscription = _parent._other.subscribeSafe(otherObserver)
+        let otherSubscription = _parent._other.subscribe(otherObserver)
         otherObserver.disposable = otherSubscription
-        let sourceSubscription = _parent._source.subscribeSafe(self)
+        let sourceSubscription = _parent._source.subscribe(self)
         
         return CompositeDisposable(sourceSubscription, otherSubscription)
     }

--- a/RxSwift/Observables/Implementations/TakeWhile.swift
+++ b/RxSwift/Observables/Implementations/TakeWhile.swift
@@ -118,11 +118,11 @@ class TakeWhile<Element>: Producer<Element> {
         if let _ = _predicate {
             let sink = TakeWhileSink(parent: self, observer: observer, cancel: cancel)
             setSink(sink)
-            return _source.subscribeSafe(sink)
+            return _source.subscribe(sink)
         } else {
             let sink = TakeWhileSinkWithIndex(parent: self, observer: observer, cancel: cancel)
             setSink(sink)
-            return _source.subscribeSafe(sink)
+            return _source.subscribe(sink)
         }
     }
 }

--- a/RxSwift/Observables/Implementations/Throttle.swift
+++ b/RxSwift/Observables/Implementations/Throttle.swift
@@ -29,7 +29,7 @@ class ThrottleSink<O: ObserverType, Scheduler: SchedulerType> : Sink<O>, Observe
     }
     
     func run() -> Disposable {
-        let subscription = _parent._source.subscribeSafe(self)
+        let subscription = _parent._source.subscribe(self)
         
         return CompositeDisposable(subscription, cancellable)
     }

--- a/RxSwift/Observables/Implementations/ToArray.swift
+++ b/RxSwift/Observables/Implementations/ToArray.swift
@@ -45,6 +45,6 @@ class ToArray<SourceType> : Producer<[SourceType]> {
     override func run<O: ObserverType where O.E == [SourceType]>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = ToArraySink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return _source.subscribeSafe(sink)
+        return _source.subscribe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/ToArray.swift
+++ b/RxSwift/Observables/Implementations/ToArray.swift
@@ -1,0 +1,50 @@
+//
+//  ToArray.swift
+//  Rx
+//
+//  Created by Junior B. on 20/10/15.
+//  Copyright © 2015 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+class ToArraySink<SourceType, O: ObserverType where O.E == [SourceType]> : Sink<O>, ObserverType {
+    typealias Parent = ToArray<SourceType>
+    
+    let parent: Parent
+    var list = Array<SourceType>()
+    
+    init(parent: Parent, observer: O, cancel: Disposable) {
+        self.parent = parent
+        
+        super.init(observer: observer, cancel: cancel)
+    }
+    
+    func on(event: Event<SourceType>) {
+        switch event {
+        case .Next(let value):
+            self.list.append(value)
+        case .Error(let e):
+            observer?.on(.Error(e))
+            self.dispose()
+        case .Completed:
+            observer?.on(.Next(self.list))
+            observer?.on(.Completed)
+            self.dispose()
+        }
+    }
+}
+
+class ToArray<SourceType> : Producer<[SourceType]> {
+    let source: Observable<SourceType>
+    
+    init(source: Observable<SourceType>) {
+        self.source = source
+    }
+    
+    override func run<O: ObserverType where O.E == [SourceType]>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
+        let sink = ToArraySink(parent: self, observer: observer, cancel: cancel)
+        setSink(sink)
+        return source.subscribeSafe(sink)
+    }
+}

--- a/RxSwift/Observables/Implementations/ToArray.swift
+++ b/RxSwift/Observables/Implementations/ToArray.swift
@@ -11,11 +11,11 @@ import Foundation
 class ToArraySink<SourceType, O: ObserverType where O.E == [SourceType]> : Sink<O>, ObserverType {
     typealias Parent = ToArray<SourceType>
     
-    let parent: Parent
-    var list = Array<SourceType>()
+    let _parent: Parent
+    var _list = Array<SourceType>()
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        self._parent = parent
         
         super.init(observer: observer, cancel: cancel)
     }
@@ -23,12 +23,12 @@ class ToArraySink<SourceType, O: ObserverType where O.E == [SourceType]> : Sink<
     func on(event: Event<SourceType>) {
         switch event {
         case .Next(let value):
-            self.list.append(value)
+            self._list.append(value)
         case .Error(let e):
             observer?.on(.Error(e))
             self.dispose()
         case .Completed:
-            observer?.on(.Next(self.list))
+            observer?.on(.Next(_list))
             observer?.on(.Completed)
             self.dispose()
         }
@@ -36,15 +36,15 @@ class ToArraySink<SourceType, O: ObserverType where O.E == [SourceType]> : Sink<
 }
 
 class ToArray<SourceType> : Producer<[SourceType]> {
-    let source: Observable<SourceType>
-    
+    let _source: Observable<SourceType>
+
     init(source: Observable<SourceType>) {
-        self.source = source
+        _source = source
     }
     
     override func run<O: ObserverType where O.E == [SourceType]>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
         let sink = ToArraySink(parent: self, observer: observer, cancel: cancel)
         setSink(sink)
-        return source.subscribeSafe(sink)
+        return _source.subscribeSafe(sink)
     }
 }

--- a/RxSwift/Observables/Implementations/Using.swift
+++ b/RxSwift/Observables/Implementations/Using.swift
@@ -29,12 +29,12 @@ class UsingSink<SourceType, ResourceType: Disposable, O: ObserverType where O.E 
             let source = try _parent._observableFactory(resource)
             
             return StableCompositeDisposable.create(
-                source.subscribeSafe(self),
+                source.subscribe(self),
                 disposable
             )
         } catch let error {
             return StableCompositeDisposable.create(
-                failWith(error).subscribeSafe(self),
+                failWith(error).subscribe(self),
                 disposable
             )
         }

--- a/RxSwift/Observables/Implementations/WithLatestFrom.swift
+++ b/RxSwift/Observables/Implementations/WithLatestFrom.swift
@@ -30,8 +30,8 @@ class WithLatestFromSink<FirstO: ObservableType, SecondO: ObservableType, Result
         let sndSubscription = SingleAssignmentDisposable()
         let sndO = WithLatestFromSecond(parent: self, disposable: sndSubscription)
         
-        let fstSubscription = _parent._first.subscribeSafe(self)
-        sndSubscription.disposable = _parent._second.subscribeSafe(sndO)
+        let fstSubscription = _parent._first.subscribe(self)
+        sndSubscription.disposable = _parent._second.subscribe(sndO)
         
         return StableCompositeDisposable.create(fstSubscription, sndSubscription)
     }

--- a/RxSwift/Observables/Implementations/WithLatestFrom.swift
+++ b/RxSwift/Observables/Implementations/WithLatestFrom.swift
@@ -1,0 +1,116 @@
+//
+//  WithLatestFrom.swift
+//  RxExample
+//
+//  Created by Yury Korolev on 10/19/15.
+//  Copyright © 2015 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+class WithLatestFromSink<FirstO: ObservableType, SecondO: ObservableType, ResultType, O: ObserverType where O.E == ResultType > : Sink<O>, ObserverType {
+    
+    typealias Parent = WithLatestFrom<FirstO, SecondO, ResultType>
+    typealias SecondType = SecondO.E
+    typealias E = FirstO.E
+    
+    private let _parent: Parent
+    
+    private var _lock = NSRecursiveLock()
+    private var _latest: SecondO.E?
+    
+   
+    init(parent: Parent, observer: O, cancel: Disposable) {
+        _parent = parent
+        
+        super.init(observer: observer, cancel: cancel)
+    }
+    
+    func run() -> Disposable {
+        let sndSubscription = SingleAssignmentDisposable()
+        let sndO = WithLatestFromSecond(parent: self, disposable: sndSubscription)
+        
+        let fstSubscription = _parent._first.subscribeSafe(self)
+        sndSubscription.disposable = _parent._second.subscribeSafe(sndO)
+        
+        return StableCompositeDisposable.create(fstSubscription, sndSubscription)
+    }
+    
+    func on(event: Event<E>) {
+        _lock.performLocked {
+            switch event {
+            case let .Next(value):
+                guard let latest = _latest else { return }
+                do {
+                    let res = try _parent._resultSelector(value, latest)
+                    
+                    observer?.onNext(res)
+                } catch let e {
+                    observer?.onError(e)
+                    dispose()
+                }
+            case .Completed:
+                observer?.onComplete()
+                dispose()
+            case let .Error(error):
+                observer?.onError(error)
+                dispose()
+            }
+        }
+    }
+}
+
+class WithLatestFromSecond<FirstO: ObservableType, SecondO: ObservableType, ResultType, O: ObserverType where O.E == ResultType>: ObserverType {
+    
+    typealias Parent = WithLatestFromSink<FirstO, SecondO, ResultType, O>
+    typealias E = SecondO.E
+    
+    private let _parent: Parent
+    private let _disposable: Disposable
+    
+    init(parent: Parent, disposable: Disposable) {
+        _parent = parent
+        _disposable = disposable
+    }
+    
+    func on(event: Event<E>) {
+        switch event {
+        case let .Next(value):
+            _parent._lock.performLocked {
+                _parent._latest = value
+            }
+        case .Completed:
+            _disposable.dispose()
+        case let .Error(error):
+            _parent._lock.performLocked {
+                _parent.observer?.onError(error)
+                _parent.dispose()
+            }
+        }
+    }
+
+}
+
+class WithLatestFrom<FirstO: ObservableType, SecondO: ObservableType, ResultType>: Producer<ResultType> {
+   
+    typealias FirstType = FirstO.E
+    typealias SecondType = SecondO.E
+    typealias ResultSelector = (FirstType, SecondType) throws -> ResultType
+    
+    private let _first: FirstO
+    private let _second: SecondO
+    private let _resultSelector: ResultSelector
+
+    init(first: FirstO, second: SecondO, resultSelector: ResultSelector) {
+        _first = first
+        _second = second
+        _resultSelector = resultSelector
+    }
+    
+    override func run<O : ObserverType where O.E == ResultType>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
+        
+        let sink = WithLatestFromSink(parent: self, observer: observer, cancel: cancel)
+        setSink(sink)
+        return sink.run()
+    }
+}

--- a/RxSwift/Observables/Implementations/Zip+CollectionType.swift
+++ b/RxSwift/Observables/Implementations/Zip+CollectionType.swift
@@ -105,7 +105,7 @@ class ZipCollectionTypeSink<C: CollectionType, R, O: ObserverType where C.Genera
         for i in _parent.sources.startIndex ..< _parent.sources.endIndex {
             let index = j
             let source = _parent.sources[i].asObservable()
-            _subscriptions[j].disposable = source.subscribeSafe(AnyObserver { event in
+            _subscriptions[j].disposable = source.subscribe(AnyObserver { event in
                 self.on(event, atIndex: index)
                 })
             j++

--- a/RxSwift/Observables/Implementations/Zip+CollectionType.swift
+++ b/RxSwift/Observables/Implementations/Zip+CollectionType.swift
@@ -12,44 +12,44 @@ class ZipCollectionTypeSink<C: CollectionType, R, O: ObserverType where C.Genera
     typealias Parent = ZipCollectionType<C, R>
     typealias SourceElement = C.Generator.Element.E
     
-    let parent: Parent
+    private let _parent: Parent
     
-    let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
-    var numberOfValues = 0
-    var values: [Queue<SourceElement>]
-    var isDone: [Bool]
-    var numberOfDone = 0
-    var subscriptions: [SingleAssignmentDisposable]
+    private var _numberOfValues = 0
+    private var _values: [Queue<SourceElement>]
+    private var _isDone: [Bool]
+    private var _numberOfDone = 0
+    private var _subscriptions: [SingleAssignmentDisposable]
     
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
-        self.values = [Queue<SourceElement>](count: parent.count, repeatedValue: Queue(capacity: 4))
-        self.isDone = [Bool](count: parent.count, repeatedValue: false)
-        self.subscriptions = Array<SingleAssignmentDisposable>()
-        self.subscriptions.reserveCapacity(parent.count)
+        _parent = parent
+        _values = [Queue<SourceElement>](count: parent.count, repeatedValue: Queue(capacity: 4))
+        _isDone = [Bool](count: parent.count, repeatedValue: false)
+        _subscriptions = Array<SingleAssignmentDisposable>()
+        _subscriptions.reserveCapacity(parent.count)
         
         for _ in 0 ..< parent.count {
-            self.subscriptions.append(SingleAssignmentDisposable())
+            _subscriptions.append(SingleAssignmentDisposable())
         }
         
         super.init(observer: observer, cancel: cancel)
     }
     
     func on(event: Event<SourceElement>, atIndex: Int) {
-        lock.performLocked {
+        _lock.performLocked {
             switch event {
             case .Next(let element):
-                values[atIndex].enqueue(element)
+                _values[atIndex].enqueue(element)
                 
-                if values[atIndex].count == 1 {
-                    numberOfValues++
+                if _values[atIndex].count == 1 {
+                    _numberOfValues++
                 }
                 
-                if numberOfValues < parent.count {
-                    let numberOfOthersThatAreDone = self.numberOfDone - (isDone[atIndex] ? 1 : 0)
-                    if numberOfOthersThatAreDone == self.parent.count - 1 {
+                if _numberOfValues < _parent.count {
+                    let numberOfOthersThatAreDone = _numberOfDone - (_isDone[atIndex] ? 1 : 0)
+                    if numberOfOthersThatAreDone == _parent.count - 1 {
                         self.observer?.on(.Completed)
                         self.dispose()
                     }
@@ -58,19 +58,19 @@ class ZipCollectionTypeSink<C: CollectionType, R, O: ObserverType where C.Genera
                 
                 do {
                     var arguments = [SourceElement]()
-                    arguments.reserveCapacity(parent.count)
+                    arguments.reserveCapacity(_parent.count)
                     
                     // recalculate number of values
-                    numberOfValues = 0
+                    _numberOfValues = 0
                     
-                    for i in 0 ..< values.count {
-                        arguments.append(values[i].dequeue())
-                        if values[i].count > 0 {
-                            numberOfValues++
+                    for i in 0 ..< _values.count {
+                        arguments.append(_values[i].dequeue())
+                        if _values[i].count > 0 {
+                            _numberOfValues++
                         }
                     }
                     
-                    let result = try parent.resultSelector(arguments)
+                    let result = try _parent.resultSelector(arguments)
                     self.observer?.on(.Next(result))
                 }
                 catch let error {
@@ -82,19 +82,19 @@ class ZipCollectionTypeSink<C: CollectionType, R, O: ObserverType where C.Genera
                 self.observer?.on(.Error(error))
                 self.dispose()
             case .Completed:
-                if isDone[atIndex] {
+                if _isDone[atIndex] {
                     return
                 }
                 
-                isDone[atIndex] = true
-                numberOfDone++
+                _isDone[atIndex] = true
+                _numberOfDone++
                 
-                if numberOfDone == self.parent.count {
+                if _numberOfDone == _parent.count {
                     self.observer?.on(.Completed)
                     self.dispose()
                 }
                 else {
-                    self.subscriptions[atIndex].dispose()
+                    _subscriptions[atIndex].dispose()
                 }
             }
         }
@@ -102,16 +102,16 @@ class ZipCollectionTypeSink<C: CollectionType, R, O: ObserverType where C.Genera
     
     func run() -> Disposable {
         var j = 0
-        for i in parent.sources.startIndex ..< parent.sources.endIndex {
+        for i in _parent.sources.startIndex ..< _parent.sources.endIndex {
             let index = j
-            let source = self.parent.sources[i].asObservable()
-            self.subscriptions[j].disposable = source.subscribeSafe(AnyObserver { event in
+            let source = _parent.sources[i].asObservable()
+            _subscriptions[j].disposable = source.subscribeSafe(AnyObserver { event in
                 self.on(event, atIndex: index)
                 })
             j++
         }
         
-        return CompositeDisposable(disposables: self.subscriptions.map { $0 })
+        return CompositeDisposable(disposables: _subscriptions.map { $0 })
     }
 }
 

--- a/RxSwift/Observables/Implementations/Zip+arity.swift
+++ b/RxSwift/Observables/Implementations/Zip+arity.swift
@@ -21,7 +21,7 @@ Merges the specified observable sequences into one observable sequence by using 
 - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
-public func zip<O1: ObservableType, O2: ObservableType, R>
+public func zip<O1: ObservableConvertibleType, O2: ObservableConvertibleType, R>
     (source1: O1, _ source2: O2, resultSelector: (O1.E, O2.E) throws -> R)
     -> Observable<R> {
     return Zip2(
@@ -34,20 +34,20 @@ class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
     typealias R = O.E
     typealias Parent = Zip2<E1, E2, R>
 
-    let parent: Parent
+    let _parent: Parent
 
-    var values1: Queue<E1> = Queue(capacity: 2)
-    var values2: Queue<E2> = Queue(capacity: 2)
+    var _values1: Queue<E1> = Queue(capacity: 2)
+    var _values2: Queue<E2> = Queue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 2, observer: observer, cancel: cancel)
     }
 
     override func hasElements(index: Int) -> Bool {
         switch (index) {
-        case 0: return values1.count > 0
-        case 1: return values2.count > 0
+        case 0: return _values1.count > 0
+        case 1: return _values2.count > 0
 
         default:
             rxFatalError("Unhandled case (Function)")
@@ -60,11 +60,11 @@ class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
         let subscription1 = SingleAssignmentDisposable()
         let subscription2 = SingleAssignmentDisposable()
 
-        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self.values1.enqueue($0) }, this: subscription1)
-        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self.values2.enqueue($0) }, this: subscription2)
+        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self._values1.enqueue($0) }, this: subscription1)
+        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self._values2.enqueue($0) }, this: subscription2)
 
-        subscription1.disposable = parent.source1.subscribeSafe(observer1)
-        subscription2.disposable = parent.source2.subscribeSafe(observer2)
+        subscription1.disposable = _parent.source1.subscribe(observer1)
+        subscription2.disposable = _parent.source2.subscribe(observer2)
 
         return CompositeDisposable(disposables: [
            subscription1,
@@ -73,7 +73,7 @@ class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(values1.dequeue(), values2.dequeue())
+        return try _parent._resultSelector(_values1.dequeue(), _values2.dequeue())
     }
 }
 
@@ -83,13 +83,13 @@ class Zip2<E1, E2, R> : Producer<R> {
     let source1: Observable<E1>
     let source2: Observable<E2>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, resultSelector: ResultSelector) {
         self.source1 = source1
         self.source2 = source2
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -110,7 +110,7 @@ Merges the specified observable sequences into one observable sequence by using 
 - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
-public func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, R>
+public func zip<O1: ObservableConvertibleType, O2: ObservableConvertibleType, O3: ObservableConvertibleType, R>
     (source1: O1, _ source2: O2, _ source3: O3, resultSelector: (O1.E, O2.E, O3.E) throws -> R)
     -> Observable<R> {
     return Zip3(
@@ -123,22 +123,22 @@ class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
     typealias R = O.E
     typealias Parent = Zip3<E1, E2, E3, R>
 
-    let parent: Parent
+    let _parent: Parent
 
-    var values1: Queue<E1> = Queue(capacity: 2)
-    var values2: Queue<E2> = Queue(capacity: 2)
-    var values3: Queue<E3> = Queue(capacity: 2)
+    var _values1: Queue<E1> = Queue(capacity: 2)
+    var _values2: Queue<E2> = Queue(capacity: 2)
+    var _values3: Queue<E3> = Queue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 3, observer: observer, cancel: cancel)
     }
 
     override func hasElements(index: Int) -> Bool {
         switch (index) {
-        case 0: return values1.count > 0
-        case 1: return values2.count > 0
-        case 2: return values3.count > 0
+        case 0: return _values1.count > 0
+        case 1: return _values2.count > 0
+        case 2: return _values3.count > 0
 
         default:
             rxFatalError("Unhandled case (Function)")
@@ -152,13 +152,13 @@ class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
         let subscription2 = SingleAssignmentDisposable()
         let subscription3 = SingleAssignmentDisposable()
 
-        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self.values1.enqueue($0) }, this: subscription1)
-        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self.values2.enqueue($0) }, this: subscription2)
-        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self.values3.enqueue($0) }, this: subscription3)
+        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self._values1.enqueue($0) }, this: subscription1)
+        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self._values2.enqueue($0) }, this: subscription2)
+        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self._values3.enqueue($0) }, this: subscription3)
 
-        subscription1.disposable = parent.source1.subscribeSafe(observer1)
-        subscription2.disposable = parent.source2.subscribeSafe(observer2)
-        subscription3.disposable = parent.source3.subscribeSafe(observer3)
+        subscription1.disposable = _parent.source1.subscribe(observer1)
+        subscription2.disposable = _parent.source2.subscribe(observer2)
+        subscription3.disposable = _parent.source3.subscribe(observer3)
 
         return CompositeDisposable(disposables: [
            subscription1,
@@ -168,7 +168,7 @@ class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(values1.dequeue(), values2.dequeue(), values3.dequeue())
+        return try _parent._resultSelector(_values1.dequeue(), _values2.dequeue(), _values3.dequeue())
     }
 }
 
@@ -179,14 +179,14 @@ class Zip3<E1, E2, E3, R> : Producer<R> {
     let source2: Observable<E2>
     let source3: Observable<E3>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, resultSelector: ResultSelector) {
         self.source1 = source1
         self.source2 = source2
         self.source3 = source3
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -207,7 +207,7 @@ Merges the specified observable sequences into one observable sequence by using 
 - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
-public func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, R>
+public func zip<O1: ObservableConvertibleType, O2: ObservableConvertibleType, O3: ObservableConvertibleType, O4: ObservableConvertibleType, R>
     (source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: (O1.E, O2.E, O3.E, O4.E) throws -> R)
     -> Observable<R> {
     return Zip4(
@@ -220,24 +220,24 @@ class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
     typealias R = O.E
     typealias Parent = Zip4<E1, E2, E3, E4, R>
 
-    let parent: Parent
+    let _parent: Parent
 
-    var values1: Queue<E1> = Queue(capacity: 2)
-    var values2: Queue<E2> = Queue(capacity: 2)
-    var values3: Queue<E3> = Queue(capacity: 2)
-    var values4: Queue<E4> = Queue(capacity: 2)
+    var _values1: Queue<E1> = Queue(capacity: 2)
+    var _values2: Queue<E2> = Queue(capacity: 2)
+    var _values3: Queue<E3> = Queue(capacity: 2)
+    var _values4: Queue<E4> = Queue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 4, observer: observer, cancel: cancel)
     }
 
     override func hasElements(index: Int) -> Bool {
         switch (index) {
-        case 0: return values1.count > 0
-        case 1: return values2.count > 0
-        case 2: return values3.count > 0
-        case 3: return values4.count > 0
+        case 0: return _values1.count > 0
+        case 1: return _values2.count > 0
+        case 2: return _values3.count > 0
+        case 3: return _values4.count > 0
 
         default:
             rxFatalError("Unhandled case (Function)")
@@ -252,15 +252,15 @@ class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
         let subscription3 = SingleAssignmentDisposable()
         let subscription4 = SingleAssignmentDisposable()
 
-        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self.values1.enqueue($0) }, this: subscription1)
-        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self.values2.enqueue($0) }, this: subscription2)
-        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self.values3.enqueue($0) }, this: subscription3)
-        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self.values4.enqueue($0) }, this: subscription4)
+        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self._values1.enqueue($0) }, this: subscription1)
+        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self._values2.enqueue($0) }, this: subscription2)
+        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self._values3.enqueue($0) }, this: subscription3)
+        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self._values4.enqueue($0) }, this: subscription4)
 
-        subscription1.disposable = parent.source1.subscribeSafe(observer1)
-        subscription2.disposable = parent.source2.subscribeSafe(observer2)
-        subscription3.disposable = parent.source3.subscribeSafe(observer3)
-        subscription4.disposable = parent.source4.subscribeSafe(observer4)
+        subscription1.disposable = _parent.source1.subscribe(observer1)
+        subscription2.disposable = _parent.source2.subscribe(observer2)
+        subscription3.disposable = _parent.source3.subscribe(observer3)
+        subscription4.disposable = _parent.source4.subscribe(observer4)
 
         return CompositeDisposable(disposables: [
            subscription1,
@@ -271,7 +271,7 @@ class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(values1.dequeue(), values2.dequeue(), values3.dequeue(), values4.dequeue())
+        return try _parent._resultSelector(_values1.dequeue(), _values2.dequeue(), _values3.dequeue(), _values4.dequeue())
     }
 }
 
@@ -283,7 +283,7 @@ class Zip4<E1, E2, E3, E4, R> : Producer<R> {
     let source3: Observable<E3>
     let source4: Observable<E4>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, resultSelector: ResultSelector) {
         self.source1 = source1
@@ -291,7 +291,7 @@ class Zip4<E1, E2, E3, E4, R> : Producer<R> {
         self.source3 = source3
         self.source4 = source4
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -312,7 +312,7 @@ Merges the specified observable sequences into one observable sequence by using 
 - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
-public func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, R>
+public func zip<O1: ObservableConvertibleType, O2: ObservableConvertibleType, O3: ObservableConvertibleType, O4: ObservableConvertibleType, O5: ObservableConvertibleType, R>
     (source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: (O1.E, O2.E, O3.E, O4.E, O5.E) throws -> R)
     -> Observable<R> {
     return Zip5(
@@ -325,26 +325,26 @@ class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
     typealias R = O.E
     typealias Parent = Zip5<E1, E2, E3, E4, E5, R>
 
-    let parent: Parent
+    let _parent: Parent
 
-    var values1: Queue<E1> = Queue(capacity: 2)
-    var values2: Queue<E2> = Queue(capacity: 2)
-    var values3: Queue<E3> = Queue(capacity: 2)
-    var values4: Queue<E4> = Queue(capacity: 2)
-    var values5: Queue<E5> = Queue(capacity: 2)
+    var _values1: Queue<E1> = Queue(capacity: 2)
+    var _values2: Queue<E2> = Queue(capacity: 2)
+    var _values3: Queue<E3> = Queue(capacity: 2)
+    var _values4: Queue<E4> = Queue(capacity: 2)
+    var _values5: Queue<E5> = Queue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 5, observer: observer, cancel: cancel)
     }
 
     override func hasElements(index: Int) -> Bool {
         switch (index) {
-        case 0: return values1.count > 0
-        case 1: return values2.count > 0
-        case 2: return values3.count > 0
-        case 3: return values4.count > 0
-        case 4: return values5.count > 0
+        case 0: return _values1.count > 0
+        case 1: return _values2.count > 0
+        case 2: return _values3.count > 0
+        case 3: return _values4.count > 0
+        case 4: return _values5.count > 0
 
         default:
             rxFatalError("Unhandled case (Function)")
@@ -360,17 +360,17 @@ class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
         let subscription4 = SingleAssignmentDisposable()
         let subscription5 = SingleAssignmentDisposable()
 
-        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self.values1.enqueue($0) }, this: subscription1)
-        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self.values2.enqueue($0) }, this: subscription2)
-        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self.values3.enqueue($0) }, this: subscription3)
-        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self.values4.enqueue($0) }, this: subscription4)
-        let observer5 = ZipObserver(lock: lock, parent: self, index: 4, setNextValue: { self.values5.enqueue($0) }, this: subscription5)
+        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self._values1.enqueue($0) }, this: subscription1)
+        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self._values2.enqueue($0) }, this: subscription2)
+        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self._values3.enqueue($0) }, this: subscription3)
+        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self._values4.enqueue($0) }, this: subscription4)
+        let observer5 = ZipObserver(lock: lock, parent: self, index: 4, setNextValue: { self._values5.enqueue($0) }, this: subscription5)
 
-        subscription1.disposable = parent.source1.subscribeSafe(observer1)
-        subscription2.disposable = parent.source2.subscribeSafe(observer2)
-        subscription3.disposable = parent.source3.subscribeSafe(observer3)
-        subscription4.disposable = parent.source4.subscribeSafe(observer4)
-        subscription5.disposable = parent.source5.subscribeSafe(observer5)
+        subscription1.disposable = _parent.source1.subscribe(observer1)
+        subscription2.disposable = _parent.source2.subscribe(observer2)
+        subscription3.disposable = _parent.source3.subscribe(observer3)
+        subscription4.disposable = _parent.source4.subscribe(observer4)
+        subscription5.disposable = _parent.source5.subscribe(observer5)
 
         return CompositeDisposable(disposables: [
            subscription1,
@@ -382,7 +382,7 @@ class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(values1.dequeue(), values2.dequeue(), values3.dequeue(), values4.dequeue(), values5.dequeue())
+        return try _parent._resultSelector(_values1.dequeue(), _values2.dequeue(), _values3.dequeue(), _values4.dequeue(), _values5.dequeue())
     }
 }
 
@@ -395,7 +395,7 @@ class Zip5<E1, E2, E3, E4, E5, R> : Producer<R> {
     let source4: Observable<E4>
     let source5: Observable<E5>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, resultSelector: ResultSelector) {
         self.source1 = source1
@@ -404,7 +404,7 @@ class Zip5<E1, E2, E3, E4, E5, R> : Producer<R> {
         self.source4 = source4
         self.source5 = source5
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -425,7 +425,7 @@ Merges the specified observable sequences into one observable sequence by using 
 - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
-public func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, R>
+public func zip<O1: ObservableConvertibleType, O2: ObservableConvertibleType, O3: ObservableConvertibleType, O4: ObservableConvertibleType, O5: ObservableConvertibleType, O6: ObservableConvertibleType, R>
     (source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E) throws -> R)
     -> Observable<R> {
     return Zip6(
@@ -438,28 +438,28 @@ class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
     typealias R = O.E
     typealias Parent = Zip6<E1, E2, E3, E4, E5, E6, R>
 
-    let parent: Parent
+    let _parent: Parent
 
-    var values1: Queue<E1> = Queue(capacity: 2)
-    var values2: Queue<E2> = Queue(capacity: 2)
-    var values3: Queue<E3> = Queue(capacity: 2)
-    var values4: Queue<E4> = Queue(capacity: 2)
-    var values5: Queue<E5> = Queue(capacity: 2)
-    var values6: Queue<E6> = Queue(capacity: 2)
+    var _values1: Queue<E1> = Queue(capacity: 2)
+    var _values2: Queue<E2> = Queue(capacity: 2)
+    var _values3: Queue<E3> = Queue(capacity: 2)
+    var _values4: Queue<E4> = Queue(capacity: 2)
+    var _values5: Queue<E5> = Queue(capacity: 2)
+    var _values6: Queue<E6> = Queue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 6, observer: observer, cancel: cancel)
     }
 
     override func hasElements(index: Int) -> Bool {
         switch (index) {
-        case 0: return values1.count > 0
-        case 1: return values2.count > 0
-        case 2: return values3.count > 0
-        case 3: return values4.count > 0
-        case 4: return values5.count > 0
-        case 5: return values6.count > 0
+        case 0: return _values1.count > 0
+        case 1: return _values2.count > 0
+        case 2: return _values3.count > 0
+        case 3: return _values4.count > 0
+        case 4: return _values5.count > 0
+        case 5: return _values6.count > 0
 
         default:
             rxFatalError("Unhandled case (Function)")
@@ -476,19 +476,19 @@ class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
         let subscription5 = SingleAssignmentDisposable()
         let subscription6 = SingleAssignmentDisposable()
 
-        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self.values1.enqueue($0) }, this: subscription1)
-        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self.values2.enqueue($0) }, this: subscription2)
-        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self.values3.enqueue($0) }, this: subscription3)
-        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self.values4.enqueue($0) }, this: subscription4)
-        let observer5 = ZipObserver(lock: lock, parent: self, index: 4, setNextValue: { self.values5.enqueue($0) }, this: subscription5)
-        let observer6 = ZipObserver(lock: lock, parent: self, index: 5, setNextValue: { self.values6.enqueue($0) }, this: subscription6)
+        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self._values1.enqueue($0) }, this: subscription1)
+        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self._values2.enqueue($0) }, this: subscription2)
+        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self._values3.enqueue($0) }, this: subscription3)
+        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self._values4.enqueue($0) }, this: subscription4)
+        let observer5 = ZipObserver(lock: lock, parent: self, index: 4, setNextValue: { self._values5.enqueue($0) }, this: subscription5)
+        let observer6 = ZipObserver(lock: lock, parent: self, index: 5, setNextValue: { self._values6.enqueue($0) }, this: subscription6)
 
-        subscription1.disposable = parent.source1.subscribeSafe(observer1)
-        subscription2.disposable = parent.source2.subscribeSafe(observer2)
-        subscription3.disposable = parent.source3.subscribeSafe(observer3)
-        subscription4.disposable = parent.source4.subscribeSafe(observer4)
-        subscription5.disposable = parent.source5.subscribeSafe(observer5)
-        subscription6.disposable = parent.source6.subscribeSafe(observer6)
+        subscription1.disposable = _parent.source1.subscribe(observer1)
+        subscription2.disposable = _parent.source2.subscribe(observer2)
+        subscription3.disposable = _parent.source3.subscribe(observer3)
+        subscription4.disposable = _parent.source4.subscribe(observer4)
+        subscription5.disposable = _parent.source5.subscribe(observer5)
+        subscription6.disposable = _parent.source6.subscribe(observer6)
 
         return CompositeDisposable(disposables: [
            subscription1,
@@ -501,7 +501,7 @@ class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(values1.dequeue(), values2.dequeue(), values3.dequeue(), values4.dequeue(), values5.dequeue(), values6.dequeue())
+        return try _parent._resultSelector(_values1.dequeue(), _values2.dequeue(), _values3.dequeue(), _values4.dequeue(), _values5.dequeue(), _values6.dequeue())
     }
 }
 
@@ -515,7 +515,7 @@ class Zip6<E1, E2, E3, E4, E5, E6, R> : Producer<R> {
     let source5: Observable<E5>
     let source6: Observable<E6>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, resultSelector: ResultSelector) {
         self.source1 = source1
@@ -525,7 +525,7 @@ class Zip6<E1, E2, E3, E4, E5, E6, R> : Producer<R> {
         self.source5 = source5
         self.source6 = source6
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -546,7 +546,7 @@ Merges the specified observable sequences into one observable sequence by using 
 - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
-public func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, R>
+public func zip<O1: ObservableConvertibleType, O2: ObservableConvertibleType, O3: ObservableConvertibleType, O4: ObservableConvertibleType, O5: ObservableConvertibleType, O6: ObservableConvertibleType, O7: ObservableConvertibleType, R>
     (source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E) throws -> R)
     -> Observable<R> {
     return Zip7(
@@ -559,30 +559,30 @@ class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> {
     typealias R = O.E
     typealias Parent = Zip7<E1, E2, E3, E4, E5, E6, E7, R>
 
-    let parent: Parent
+    let _parent: Parent
 
-    var values1: Queue<E1> = Queue(capacity: 2)
-    var values2: Queue<E2> = Queue(capacity: 2)
-    var values3: Queue<E3> = Queue(capacity: 2)
-    var values4: Queue<E4> = Queue(capacity: 2)
-    var values5: Queue<E5> = Queue(capacity: 2)
-    var values6: Queue<E6> = Queue(capacity: 2)
-    var values7: Queue<E7> = Queue(capacity: 2)
+    var _values1: Queue<E1> = Queue(capacity: 2)
+    var _values2: Queue<E2> = Queue(capacity: 2)
+    var _values3: Queue<E3> = Queue(capacity: 2)
+    var _values4: Queue<E4> = Queue(capacity: 2)
+    var _values5: Queue<E5> = Queue(capacity: 2)
+    var _values6: Queue<E6> = Queue(capacity: 2)
+    var _values7: Queue<E7> = Queue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 7, observer: observer, cancel: cancel)
     }
 
     override func hasElements(index: Int) -> Bool {
         switch (index) {
-        case 0: return values1.count > 0
-        case 1: return values2.count > 0
-        case 2: return values3.count > 0
-        case 3: return values4.count > 0
-        case 4: return values5.count > 0
-        case 5: return values6.count > 0
-        case 6: return values7.count > 0
+        case 0: return _values1.count > 0
+        case 1: return _values2.count > 0
+        case 2: return _values3.count > 0
+        case 3: return _values4.count > 0
+        case 4: return _values5.count > 0
+        case 5: return _values6.count > 0
+        case 6: return _values7.count > 0
 
         default:
             rxFatalError("Unhandled case (Function)")
@@ -600,21 +600,21 @@ class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> {
         let subscription6 = SingleAssignmentDisposable()
         let subscription7 = SingleAssignmentDisposable()
 
-        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self.values1.enqueue($0) }, this: subscription1)
-        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self.values2.enqueue($0) }, this: subscription2)
-        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self.values3.enqueue($0) }, this: subscription3)
-        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self.values4.enqueue($0) }, this: subscription4)
-        let observer5 = ZipObserver(lock: lock, parent: self, index: 4, setNextValue: { self.values5.enqueue($0) }, this: subscription5)
-        let observer6 = ZipObserver(lock: lock, parent: self, index: 5, setNextValue: { self.values6.enqueue($0) }, this: subscription6)
-        let observer7 = ZipObserver(lock: lock, parent: self, index: 6, setNextValue: { self.values7.enqueue($0) }, this: subscription7)
+        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self._values1.enqueue($0) }, this: subscription1)
+        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self._values2.enqueue($0) }, this: subscription2)
+        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self._values3.enqueue($0) }, this: subscription3)
+        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self._values4.enqueue($0) }, this: subscription4)
+        let observer5 = ZipObserver(lock: lock, parent: self, index: 4, setNextValue: { self._values5.enqueue($0) }, this: subscription5)
+        let observer6 = ZipObserver(lock: lock, parent: self, index: 5, setNextValue: { self._values6.enqueue($0) }, this: subscription6)
+        let observer7 = ZipObserver(lock: lock, parent: self, index: 6, setNextValue: { self._values7.enqueue($0) }, this: subscription7)
 
-        subscription1.disposable = parent.source1.subscribeSafe(observer1)
-        subscription2.disposable = parent.source2.subscribeSafe(observer2)
-        subscription3.disposable = parent.source3.subscribeSafe(observer3)
-        subscription4.disposable = parent.source4.subscribeSafe(observer4)
-        subscription5.disposable = parent.source5.subscribeSafe(observer5)
-        subscription6.disposable = parent.source6.subscribeSafe(observer6)
-        subscription7.disposable = parent.source7.subscribeSafe(observer7)
+        subscription1.disposable = _parent.source1.subscribe(observer1)
+        subscription2.disposable = _parent.source2.subscribe(observer2)
+        subscription3.disposable = _parent.source3.subscribe(observer3)
+        subscription4.disposable = _parent.source4.subscribe(observer4)
+        subscription5.disposable = _parent.source5.subscribe(observer5)
+        subscription6.disposable = _parent.source6.subscribe(observer6)
+        subscription7.disposable = _parent.source7.subscribe(observer7)
 
         return CompositeDisposable(disposables: [
            subscription1,
@@ -628,7 +628,7 @@ class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(values1.dequeue(), values2.dequeue(), values3.dequeue(), values4.dequeue(), values5.dequeue(), values6.dequeue(), values7.dequeue())
+        return try _parent._resultSelector(_values1.dequeue(), _values2.dequeue(), _values3.dequeue(), _values4.dequeue(), _values5.dequeue(), _values6.dequeue(), _values7.dequeue())
     }
 }
 
@@ -643,7 +643,7 @@ class Zip7<E1, E2, E3, E4, E5, E6, E7, R> : Producer<R> {
     let source6: Observable<E6>
     let source7: Observable<E7>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, source7: Observable<E7>, resultSelector: ResultSelector) {
         self.source1 = source1
@@ -654,7 +654,7 @@ class Zip7<E1, E2, E3, E4, E5, E6, E7, R> : Producer<R> {
         self.source6 = source6
         self.source7 = source7
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {
@@ -675,7 +675,7 @@ Merges the specified observable sequences into one observable sequence by using 
 - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
-public func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType, R>
+public func zip<O1: ObservableConvertibleType, O2: ObservableConvertibleType, O3: ObservableConvertibleType, O4: ObservableConvertibleType, O5: ObservableConvertibleType, O6: ObservableConvertibleType, O7: ObservableConvertibleType, O8: ObservableConvertibleType, R>
     (source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E) throws -> R)
     -> Observable<R> {
     return Zip8(
@@ -688,32 +688,32 @@ class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink<O> {
     typealias R = O.E
     typealias Parent = Zip8<E1, E2, E3, E4, E5, E6, E7, E8, R>
 
-    let parent: Parent
+    let _parent: Parent
 
-    var values1: Queue<E1> = Queue(capacity: 2)
-    var values2: Queue<E2> = Queue(capacity: 2)
-    var values3: Queue<E3> = Queue(capacity: 2)
-    var values4: Queue<E4> = Queue(capacity: 2)
-    var values5: Queue<E5> = Queue(capacity: 2)
-    var values6: Queue<E6> = Queue(capacity: 2)
-    var values7: Queue<E7> = Queue(capacity: 2)
-    var values8: Queue<E8> = Queue(capacity: 2)
+    var _values1: Queue<E1> = Queue(capacity: 2)
+    var _values2: Queue<E2> = Queue(capacity: 2)
+    var _values3: Queue<E3> = Queue(capacity: 2)
+    var _values4: Queue<E4> = Queue(capacity: 2)
+    var _values5: Queue<E5> = Queue(capacity: 2)
+    var _values6: Queue<E6> = Queue(capacity: 2)
+    var _values7: Queue<E7> = Queue(capacity: 2)
+    var _values8: Queue<E8> = Queue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: 8, observer: observer, cancel: cancel)
     }
 
     override func hasElements(index: Int) -> Bool {
         switch (index) {
-        case 0: return values1.count > 0
-        case 1: return values2.count > 0
-        case 2: return values3.count > 0
-        case 3: return values4.count > 0
-        case 4: return values5.count > 0
-        case 5: return values6.count > 0
-        case 6: return values7.count > 0
-        case 7: return values8.count > 0
+        case 0: return _values1.count > 0
+        case 1: return _values2.count > 0
+        case 2: return _values3.count > 0
+        case 3: return _values4.count > 0
+        case 4: return _values5.count > 0
+        case 5: return _values6.count > 0
+        case 6: return _values7.count > 0
+        case 7: return _values8.count > 0
 
         default:
             rxFatalError("Unhandled case (Function)")
@@ -732,23 +732,23 @@ class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink<O> {
         let subscription7 = SingleAssignmentDisposable()
         let subscription8 = SingleAssignmentDisposable()
 
-        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self.values1.enqueue($0) }, this: subscription1)
-        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self.values2.enqueue($0) }, this: subscription2)
-        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self.values3.enqueue($0) }, this: subscription3)
-        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self.values4.enqueue($0) }, this: subscription4)
-        let observer5 = ZipObserver(lock: lock, parent: self, index: 4, setNextValue: { self.values5.enqueue($0) }, this: subscription5)
-        let observer6 = ZipObserver(lock: lock, parent: self, index: 5, setNextValue: { self.values6.enqueue($0) }, this: subscription6)
-        let observer7 = ZipObserver(lock: lock, parent: self, index: 6, setNextValue: { self.values7.enqueue($0) }, this: subscription7)
-        let observer8 = ZipObserver(lock: lock, parent: self, index: 7, setNextValue: { self.values8.enqueue($0) }, this: subscription8)
+        let observer1 = ZipObserver(lock: lock, parent: self, index: 0, setNextValue: { self._values1.enqueue($0) }, this: subscription1)
+        let observer2 = ZipObserver(lock: lock, parent: self, index: 1, setNextValue: { self._values2.enqueue($0) }, this: subscription2)
+        let observer3 = ZipObserver(lock: lock, parent: self, index: 2, setNextValue: { self._values3.enqueue($0) }, this: subscription3)
+        let observer4 = ZipObserver(lock: lock, parent: self, index: 3, setNextValue: { self._values4.enqueue($0) }, this: subscription4)
+        let observer5 = ZipObserver(lock: lock, parent: self, index: 4, setNextValue: { self._values5.enqueue($0) }, this: subscription5)
+        let observer6 = ZipObserver(lock: lock, parent: self, index: 5, setNextValue: { self._values6.enqueue($0) }, this: subscription6)
+        let observer7 = ZipObserver(lock: lock, parent: self, index: 6, setNextValue: { self._values7.enqueue($0) }, this: subscription7)
+        let observer8 = ZipObserver(lock: lock, parent: self, index: 7, setNextValue: { self._values8.enqueue($0) }, this: subscription8)
 
-        subscription1.disposable = parent.source1.subscribeSafe(observer1)
-        subscription2.disposable = parent.source2.subscribeSafe(observer2)
-        subscription3.disposable = parent.source3.subscribeSafe(observer3)
-        subscription4.disposable = parent.source4.subscribeSafe(observer4)
-        subscription5.disposable = parent.source5.subscribeSafe(observer5)
-        subscription6.disposable = parent.source6.subscribeSafe(observer6)
-        subscription7.disposable = parent.source7.subscribeSafe(observer7)
-        subscription8.disposable = parent.source8.subscribeSafe(observer8)
+        subscription1.disposable = _parent.source1.subscribe(observer1)
+        subscription2.disposable = _parent.source2.subscribe(observer2)
+        subscription3.disposable = _parent.source3.subscribe(observer3)
+        subscription4.disposable = _parent.source4.subscribe(observer4)
+        subscription5.disposable = _parent.source5.subscribe(observer5)
+        subscription6.disposable = _parent.source6.subscribe(observer6)
+        subscription7.disposable = _parent.source7.subscribe(observer7)
+        subscription8.disposable = _parent.source8.subscribe(observer8)
 
         return CompositeDisposable(disposables: [
            subscription1,
@@ -763,7 +763,7 @@ class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink<O> {
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(values1.dequeue(), values2.dequeue(), values3.dequeue(), values4.dequeue(), values5.dequeue(), values6.dequeue(), values7.dequeue(), values8.dequeue())
+        return try _parent._resultSelector(_values1.dequeue(), _values2.dequeue(), _values3.dequeue(), _values4.dequeue(), _values5.dequeue(), _values6.dequeue(), _values7.dequeue(), _values8.dequeue())
     }
 }
 
@@ -779,7 +779,7 @@ class Zip8<E1, E2, E3, E4, E5, E6, E7, E8, R> : Producer<R> {
     let source7: Observable<E7>
     let source8: Observable<E8>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, source7: Observable<E7>, source8: Observable<E8>, resultSelector: ResultSelector) {
         self.source1 = source1
@@ -791,7 +791,7 @@ class Zip8<E1, E2, E3, E4, E5, E6, E7, E8, R> : Producer<R> {
         self.source7 = source7
         self.source8 = source8
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {

--- a/RxSwift/Observables/Implementations/Zip+arity.tt
+++ b/RxSwift/Observables/Implementations/Zip+arity.tt
@@ -19,7 +19,7 @@ Merges the specified observable sequences into one observable sequence by using 
 - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
-public func zip<<%= (Array(1...i).map { "O\($0): ObservableType" }).joinWithSeparator(", ") %>, R>
+public func zip<<%= (Array(1...i).map { "O\($0): ObservableConvertibleType" }).joinWithSeparator(", ") %>, R>
     (<%= (Array(1...i).map { "source\($0): O\($0)" }).joinWithSeparator(", _ ") %>, resultSelector: (<%= (Array(1...i).map { "O\($0).E" }).joinWithSeparator(", ") %>) throws -> R)
     -> Observable<R> {
     return Zip<%= i %>(
@@ -32,21 +32,21 @@ class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joinWithSeparator(", 
     typealias R = O.E
     typealias Parent = Zip<%= i %><<%= (Array(1...i).map { "E\($0)" }).joinWithSeparator(", ") %>, R>
 
-    let parent: Parent
+    let _parent: Parent
 
 <%= (Array(1...i).map {
-"    var values\($0): Queue<E\($0)> = Queue(capacity: 2)"
+"    var _values\($0): Queue<E\($0)> = Queue(capacity: 2)"
 }).joinWithSeparator("\n") %>
 
     init(parent: Parent, observer: O, cancel: Disposable) {
-        self.parent = parent
+        _parent = parent
         super.init(arity: <%= i %>, observer: observer, cancel: cancel)
     }
 
     override func hasElements(index: Int) -> Bool {
         switch (index) {
 <%= (Array(0..<i).map {
-"        case \($0): return values\($0 + 1).count > 0\n"
+"        case \($0): return _values\($0 + 1).count > 0\n"
 }).joinWithSeparator("") %>
         default:
             rxFatalError("Unhandled case \(index)")
@@ -61,11 +61,11 @@ class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joinWithSeparator(", 
 }).joinWithSeparator("\n") %>
 
 <%= (Array(1...i).map {
-"        let observer\($0) = ZipObserver(lock: lock, parent: self, index: \($0 - 1), setNextValue: { self.values\($0).enqueue($0) }, this: subscription\($0))"
+"        let observer\($0) = ZipObserver(lock: lock, parent: self, index: \($0 - 1), setNextValue: { self._values\($0).enqueue($0) }, this: subscription\($0))"
 }).joinWithSeparator("\n") %>
 
 <%= (Array(1...i).map {
-"        subscription\($0).disposable = parent.source\($0).subscribeSafe(observer\($0))" }).joinWithSeparator("\n")
+"        subscription\($0).disposable = _parent.source\($0).subscribe(observer\($0))" }).joinWithSeparator("\n")
 %>
 
         return CompositeDisposable(disposables: [
@@ -74,7 +74,7 @@ class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joinWithSeparator(", 
     }
 
     override func getResult() throws -> R {
-        return try self.parent.resultSelector(<%= (Array(1...i).map { "values\($0).dequeue()" }).joinWithSeparator(", ") %>)
+        return try _parent._resultSelector(<%= (Array(1...i).map { "_values\($0).dequeue()" }).joinWithSeparator(", ") %>)
     }
 }
 
@@ -83,14 +83,14 @@ class Zip<%= i %><<%= (Array(1...i).map { "E\($0)" }).joinWithSeparator(", ") %>
 
 <%= (Array(1...i).map { "    let source\($0): Observable<E\($0)>" }).joinWithSeparator("\n") %>
 
-    let resultSelector: ResultSelector
+    let _resultSelector: ResultSelector
 
     init(<%= (Array(1...i).map { "source\($0): Observable<E\($0)>" }).joinWithSeparator(", ") %>, resultSelector: ResultSelector) {
 <%= (Array(1...i).map {
 "        self.source\($0) = source\($0)" }).joinWithSeparator("\n")
 %>
 
-        self.resultSelector = resultSelector
+        _resultSelector = resultSelector
     }
 
     override func run<O: ObserverType where O.E == R>(observer: O, cancel: Disposable, setSink: (Disposable) -> Void) -> Disposable {

--- a/RxSwift/Observables/Observable+Aggregate.swift
+++ b/RxSwift/Observables/Observable+Aggregate.swift
@@ -42,4 +42,17 @@ extension ObservableType {
         -> Observable<A> {
         return Reduce(source: self.asObservable(), seed: seed, accumulator: accumulator, mapResult: { $0 })
     }
+    
+    /**
+    Converts an Observable into another Observable that emits the whole sequence as a single array and then terminates.
+    
+    For aggregation behavior see `reduce`.
+    
+    - returns: An observable sequence containing all the emitted elements as array.
+    */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func toArray()
+        -> Observable<[E]> {
+            return ToArray(source: self.asObservable())
+    }
 }

--- a/RxSwift/Observables/Observable+Aggregate.swift
+++ b/RxSwift/Observables/Observable+Aggregate.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// reduce
+// MARK: reduce
 
 extension ObservableType {
     

--- a/RxSwift/Observables/Observable+Binding.swift
+++ b/RxSwift/Observables/Observable+Binding.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// multicast
+// MARK: multicast
 
 extension ObservableType {
     
@@ -50,7 +50,7 @@ extension ObservableType {
     }
 }
 
-// publish
+// MARK: publish
 
 extension ObservableType {
     
@@ -67,7 +67,7 @@ extension ObservableType {
     }
 }
 
-// replay
+// MARK: replay
 
 extension ObservableType {
     
@@ -86,7 +86,7 @@ extension ObservableType {
     }
 }
 
-// refcount
+// MARK: refcount
 
 extension ConnectableObservableType {
     
@@ -101,7 +101,7 @@ extension ConnectableObservableType {
     }
 }
 
-// share 
+// MARK: share
 
 extension ObservableType {
     
@@ -118,7 +118,7 @@ extension ObservableType {
     }
 }
 
-// shareReplay
+// MARK: shareReplay
 
 extension ObservableType {
     

--- a/RxSwift/Observables/Observable+Concurrency.swift
+++ b/RxSwift/Observables/Observable+Concurrency.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// observeOn
+// MARK: observeOn
 
 extension ObservableType {
     
@@ -33,7 +33,7 @@ extension ObservableType {
     }
 }
 
-// subscribeOn
+// MARK: subscribeOn
 
 extension ObservableType {
     

--- a/RxSwift/Observables/Observable+Creation.swift
+++ b/RxSwift/Observables/Observable+Creation.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// create
+// MARK: create
 
 /**
 Creates an observable sequence from a specified subscribe method implementation.
@@ -21,7 +21,7 @@ public func create<E>(subscribe: (AnyObserver<E>) -> Disposable) -> Observable<E
     return AnonymousObservable(subscribe)
 }
 
-// empty
+// MARK: empty
 
 /**
 Returns an empty observable sequence, using the specified scheduler to send out the single `Completed` message.
@@ -33,7 +33,7 @@ public func empty<E>() -> Observable<E> {
     return Empty<E>()
 }
 
-// never
+// MARK: never
 
 /**
 Returns a non-terminating observable sequence, which can be used to denote an infinite duration.
@@ -45,7 +45,7 @@ public func never<E>() -> Observable<E> {
     return Never()
 }
 
-// just
+// MARK: just
 
 /**
 Returns an observable sequence that contains a single element.
@@ -58,7 +58,7 @@ public func just<E>(element: E) -> Observable<E> {
     return Just(element: element)
 }
 
-// of
+// MARK: of
 
 /**
 This method creates a new Observable instance with a variable number of elements.
@@ -97,7 +97,7 @@ extension SequenceType {
     }
 }
 
-// fail
+// MARK: fail
 
 /**
 Returns an observable sequence that terminates with an `error`.
@@ -109,7 +109,7 @@ public func failWith<E>(error: ErrorType) -> Observable<E> {
     return FailWith(error: error)
 }
 
-// defer
+// MARK: defer
 
 /**
 Returns an observable sequence that invokes the specified factory function whenever a new observer subscribes.

--- a/RxSwift/Observables/Observable+Creation.swift
+++ b/RxSwift/Observables/Observable+Creation.swift
@@ -148,14 +148,6 @@ Generates an observable sequence of integral numbers within a specified range, u
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
 public func range(start: Int, _ count: Int, _ scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<Int> {
-    if count < 0 {
-        rxFatalError("count can't be negative")
-    }
-
-    if start &+ (count - 1) < start {
-        rxFatalError("overflow of count")
-    }
-    
     return RangeProducer<Int>(start: start, count: count, scheduler: scheduler)
 }
 

--- a/RxSwift/Observables/Observable+Debug.swift
+++ b/RxSwift/Observables/Observable+Debug.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// debug
+// MARK: debug
 
 extension ObservableType {
     

--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -239,3 +239,19 @@ extension SequenceType where Generator.Element : ObservableConvertibleType {
         }
     }
 }
+
+// withLatestFrom
+
+extension ObservableType {
+    
+    /**
+    Merges two observable sequences into one observable sequence by combining each element from self with the latest element from the second source, if any.
+     
+    - parameter second: Second observable source.
+    - parameter resultSelector: Function to invoke for each element from the self combined with the latest element from the second source, if any.
+    - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
+    */
+    public func withLatestFrom<SecondO: ObservableType, ResultType>(second: SecondO, resultSelector: (E, SecondO.E) throws -> ResultType) -> Observable<ResultType> {
+        return WithLatestFrom(first: self, second: second, resultSelector: resultSelector)
+    }
+}

--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// combineLatest
+// MARK: combineLatest
 
 extension CollectionType where Generator.Element : ObservableConvertibleType {
     
@@ -24,7 +24,7 @@ extension CollectionType where Generator.Element : ObservableConvertibleType {
     }
 }
 
-// zip
+// MARK: zip
 
 extension CollectionType where Generator.Element : ObservableConvertibleType {
     
@@ -40,7 +40,7 @@ extension CollectionType where Generator.Element : ObservableConvertibleType {
     }
 }
 
-// switch
+// MARK: switch
 
 extension ObservableType where E : ObservableConvertibleType {
     
@@ -59,7 +59,7 @@ extension ObservableType where E : ObservableConvertibleType {
     }
 }
 
-// concat
+// MARK: concat
 
 extension ObservableType {
 
@@ -102,7 +102,7 @@ extension ObservableType where E : ObservableConvertibleType {
     }
 }
 
-// merge
+// MARK: merge
 
 extension ObservableType where E : ObservableConvertibleType {
     
@@ -129,7 +129,7 @@ extension ObservableType where E : ObservableConvertibleType {
     }
 }
 
-// catch
+// MARK: catch
 
 extension ObservableType {
     
@@ -172,7 +172,7 @@ extension SequenceType where Generator.Element : ObservableConvertibleType {
     }
 }
 
-// takeUntil
+// MARK: takeUntil
 
 extension ObservableType {
     
@@ -189,7 +189,7 @@ extension ObservableType {
     }
 }
 
-// skipUntil
+// MARK: skipUntil
 
 extension ObservableType {
     
@@ -206,7 +206,7 @@ extension ObservableType {
     }
 }
 
-// amb
+// MARK: amb
 
 extension ObservableType {
     

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// distinct until changed
+// MARK: distinct until changed
 
 extension ObservableType where E: Equatable {
     
@@ -63,7 +63,7 @@ extension ObservableType {
     }
 }
 
-// do
+// MARK: do
 
 extension ObservableType {
     
@@ -103,7 +103,7 @@ extension ObservableType {
     }
 }
 
-// startWith
+// MARK: startWith
 
 extension ObservableType {
     
@@ -120,7 +120,7 @@ extension ObservableType {
     }
 }
 
-// retry
+// MARK: retry
 
 extension ObservableType {
     
@@ -151,7 +151,7 @@ extension ObservableType {
     }
 }
 
-// scan
+// MARK: scan
 
 extension ObservableType {
     

--- a/RxSwift/Observables/Observable+StandardSequenceOperators.swift
+++ b/RxSwift/Observables/Observable+StandardSequenceOperators.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// filter aka where
+// MARK: filter aka where
 
 extension ObservableType {
     
@@ -25,7 +25,7 @@ extension ObservableType {
     }
 }
 
-// takeWhile
+// MARK: takeWhile
 
 extension ObservableType {
     
@@ -56,7 +56,7 @@ extension ObservableType {
     }
 }
 
-// take
+// MARK: take
 
 extension ObservableType {
     
@@ -78,7 +78,7 @@ extension ObservableType {
     }
 }
     
-// skip
+// MARK: skip
 
 extension ObservableType {
     
@@ -95,7 +95,7 @@ extension ObservableType {
     }
 }
 
-// SkipWhile
+// MARK: SkipWhile
 
 extension ObservableType {
    
@@ -123,7 +123,7 @@ extension ObservableType {
     }
 }
 
-// map aka select
+// MARK: map aka select
 
 extension ObservableType {
     
@@ -152,7 +152,7 @@ extension ObservableType {
     }
 }
     
-// flatMap
+// MARK: flatMap
 
 extension ObservableType {
 

--- a/RxSwift/Observables/Observable+StandardSequenceOperators.swift
+++ b/RxSwift/Observables/Observable+StandardSequenceOperators.swift
@@ -77,7 +77,27 @@ extension ObservableType {
         }
     }
 }
+
+// MARK: takeLast
+
+extension ObservableType {
     
+    /**
+    Returns a specified number of contiguous elements from the end of an observable sequence.
+     
+     This operator accumulates a buffer with a length enough to store elements count elements. Upon completion of the source sequence, this buffer is drained on the result sequence. This causes the elements to be delayed.
+     
+     - parameter count: Number of elements to take from the end of the source sequence.
+     - returns: An observable sequence containing the specified number of elements from the end of the source sequence.
+     */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func takeLast(count: Int)
+        -> Observable<E> {
+        return TakeLast(source: self.asObservable(), count: count)
+    }
+}
+
+
 // MARK: skip
 
 extension ObservableType {

--- a/RxSwift/Observables/Observable+StandardSequenceOperators.swift
+++ b/RxSwift/Observables/Observable+StandardSequenceOperators.swift
@@ -180,3 +180,20 @@ extension ObservableType {
         return FlatMap(source: self.asObservable(), selector: selector)
     }
 }
+
+// elementAt
+
+extension ObservableType {
+    
+    /**
+    Returns a sequence emitting only item _n_ emitted by an Observable
+    
+    - parameter index: The index of the required item (starting from 0).
+    - returns: An observable sequence that emits the desired item as its own sole emission.
+    */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func elementAt(index: Int)
+        -> Observable<E> {
+            return ElementAt(source: self.asObservable(), index: index, throwOnEmpty: true)
+    }
+}

--- a/RxSwift/Observables/Observable+Time.swift
+++ b/RxSwift/Observables/Observable+Time.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-// throttle
+// MARK: throttle
 extension ObservableType {
     
     /**
@@ -42,7 +42,7 @@ extension ObservableType {
     }
 }
 
-// sample
+// MARK: sample
 
 extension ObservableType {
    
@@ -79,7 +79,7 @@ extension ObservableType {
     }
 }
 
-// interval
+// MARK: interval
 
 /**
 Returns an observable sequence that produces a value after each period, using the specified scheduler to run timers and to send out observer messages.
@@ -97,7 +97,7 @@ public func interval<S: SchedulerType>(period: S.TimeInterval, _ scheduler: S)
     )
 }
 
-// timer
+// MARK: timer
 
 /**
 Returns an observable sequence that periodically produces a value after the specified initial relative due time has elapsed, using the specified scheduler to run timers.
@@ -134,7 +134,7 @@ public func timer<S: SchedulerType>(dueTime: S.TimeInterval, _ scheduler: S)
     )
 }
 
-// take
+// MARK: take
 
 extension ObservableType {
 
@@ -152,7 +152,7 @@ extension ObservableType {
     }
 }
 
-// skip
+// MARK: skip
 
 extension ObservableType {
     
@@ -171,7 +171,7 @@ extension ObservableType {
 }
 
 
-// delaySubscription
+// MARK: delaySubscription
 
 extension ObservableType {
     
@@ -189,7 +189,7 @@ extension ObservableType {
     }
 }
 
-// buffer 
+// MARK: buffer
 
 extension ObservableType {
 

--- a/RxSwift/Observers/AnonymousObserver.swift
+++ b/RxSwift/Observers/AnonymousObserver.swift
@@ -13,17 +13,17 @@ class AnonymousObserver<ElementType> : ObserverBase<ElementType> {
     
     typealias EventHandler = Event<Element> -> Void
     
-    private let eventHandler : EventHandler
+    private let _eventHandler : EventHandler
     
     init(_ eventHandler: EventHandler) {
 #if TRACE_RESOURCES
         OSAtomicIncrement32(&resourceCount)
 #endif
-        self.eventHandler = eventHandler
+        _eventHandler = eventHandler
     }
 
     override func onCore(event: Event<Element>) {
-        return self.eventHandler(event)
+        return _eventHandler(event)
     }
     
 #if TRACE_RESOURCES

--- a/RxSwift/Observers/ObserverBase.swift
+++ b/RxSwift/Observers/ObserverBase.swift
@@ -11,20 +11,17 @@ import Foundation
 class ObserverBase<ElementType> : Disposable, ObserverType {
     typealias E = ElementType
     
-    var isStopped: Int32 = 0
-    
-    init() {
-    }
+    private var _isStopped: Int32 = 0
     
     func on(event: Event<E>) {
         switch event {
         case .Next:
-            if isStopped == 0 {
+            if _isStopped == 0 {
                 onCore(event)
             }
         case .Error, .Completed:
            
-            if !OSAtomicCompareAndSwap32(0, 1, &isStopped) {
+            if !OSAtomicCompareAndSwap32(0, 1, &_isStopped) {
                 return
             }
             
@@ -37,6 +34,6 @@ class ObserverBase<ElementType> : Disposable, ObserverType {
     }
     
     func dispose() {
-        isStopped = 1
+        _isStopped = 1
     }
 }

--- a/RxSwift/Observers/TailRecursiveSink.swift
+++ b/RxSwift/Observers/TailRecursiveSink.swift
@@ -101,7 +101,7 @@ class TailRecursiveSink<S: SequenceType, O: ObserverType where S.Generator.Eleme
             return
         }
         
-        let subscription2 = next!.subscribeSafe(self)
+        let subscription2 = next!.subscribe(self)
         _subscription.disposable = subscription2
     }
     

--- a/RxSwift/Observers/TailRecursiveSink.swift
+++ b/RxSwift/Observers/TailRecursiveSink.swift
@@ -12,19 +12,19 @@ import Foundation
 class TailRecursiveSink<S: SequenceType, O: ObserverType where S.Generator.Element: ObservableConvertibleType, S.Generator.Element.E == O.E> : Sink<O>, ObserverType {
     typealias E = O.E
     
-    var generators: [S.Generator] = []
-    var disposed = false
-    var subscription = SerialDisposable()
+    var _generators:[S.Generator] = []
+    var _disposed = false
+    var _subscription = SerialDisposable()
     
     // this is thread safe object
-    var gate = AsyncLock()
+    var _gate = AsyncLock()
     
     override init(observer: O, cancel: Disposable) {
         super.init(observer: observer, cancel: cancel)
     }
     
     func run(sources: S.Generator) -> Disposable {
-        self.generators.append(sources)
+        _generators.append(sources)
         
         scheduleMoveNext()
         
@@ -34,7 +34,7 @@ class TailRecursiveSink<S: SequenceType, O: ObserverType where S.Generator.Eleme
             }
         }
         
-        return StableCompositeDisposable.create(self.subscription, disposeSinkStack)
+        return StableCompositeDisposable.create(_subscription, disposeSinkStack)
     }
     
     func scheduleMoveNext() {
@@ -45,12 +45,12 @@ class TailRecursiveSink<S: SequenceType, O: ObserverType where S.Generator.Eleme
     
     // simple implementation for now
     func schedule(action: () -> Void) {
-        self.gate.wait(action)
+        _gate.wait(action)
     }
 
     func done() {
         observer?.on(.Completed)
-        self.dispose()
+        dispose()
     }
     
     func extract(observable: Observable<E>) -> S.Generator? {
@@ -64,32 +64,32 @@ class TailRecursiveSink<S: SequenceType, O: ObserverType where S.Generator.Eleme
     // should be done on gate locked
 
     private func moveNext() {
-        var next: Observable<E>? = nil;
+        var next: Observable<E>? = nil
         
         repeat {
-            if self.generators.count == 0 {
+            if _generators.count == 0 {
                 break
             }
             
-            if disposed {
+            if _disposed {
                 return
             }
             
-            var e = generators.last!
+            var e = _generators.last!
             
             let nextCandidate = e.next()?.asObservable()
-            generators.removeLast()
-            generators.append(e)
+            _generators.removeLast()
+            _generators.append(e)
 
             if nextCandidate == nil {
-                generators.removeLast()
+                _generators.removeLast()
                 continue;
             }
        
             let nextGenerator = extract(nextCandidate!)
         
             if let nextGenerator = nextGenerator {
-                self.generators.append(nextGenerator)
+                self._generators.append(nextGenerator)
             }
             else {
                 next = nextCandidate
@@ -102,12 +102,12 @@ class TailRecursiveSink<S: SequenceType, O: ObserverType where S.Generator.Eleme
         }
         
         let subscription2 = next!.subscribeSafe(self)
-        subscription.disposable = subscription2
+        _subscription.disposable = subscription2
     }
     
     private func disposePrivate() {
-        disposed = true
-        generators.removeAll(keepCapacity: false)
+        _disposed = true
+        _generators.removeAll(keepCapacity: false)
     }
     
 }

--- a/RxSwift/Rx.swift
+++ b/RxSwift/Rx.swift
@@ -37,6 +37,15 @@ func incrementChecked(inout i: Int) throws -> Int {
     return result
 }
 
+func decrementChecked(inout i: Int) throws -> Int {
+    if i == Int.min {
+        throw RxError.OverflowError
+    }
+    let result = i
+    i -= 1
+    return result
+}
+
 extension NSObject {
     func rx_synchronized<T>(@noescape action: () -> T) -> T {
         objc_sync_enter(self)

--- a/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
@@ -17,7 +17,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     public typealias TimeInterval = NSTimeInterval
     public typealias Time = NSDate
     
-    private let queue : dispatch_queue_t
+    private let _queue : dispatch_queue_t
     
     public var now : NSDate {
         get {
@@ -26,7 +26,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     }
     
     // leeway for scheduling timers
-    var leeway: Int64 = 0
+    private var _leeway: Int64 = 0
     
     /**
     Constructs new `ConcurrentDispatchQueueScheduler` that wraps `queue`.
@@ -34,7 +34,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - parameter queue: Target dispatch queue.
     */
     public init(queue: dispatch_queue_t) {
-        self.queue = queue
+        _queue = queue
     }
     
     /**
@@ -77,7 +77,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     func scheduleInternal<StateType>(state: StateType, action: StateType -> Disposable) -> Disposable {
         let cancel = SingleAssignmentDisposable()
         
-        dispatch_async(self.queue) {
+        dispatch_async(_queue) {
             if cancel.disposed {
                 return
             }
@@ -97,7 +97,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public final func scheduleRelative<StateType>(state: StateType, dueTime: NSTimeInterval, action: (StateType) -> Disposable) -> Disposable {
-        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.queue)
+        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _queue)
         
         let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchTime(dueTime)
         
@@ -129,7 +129,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public func schedulePeriodic<StateType>(state: StateType, startAfter: TimeInterval, period: TimeInterval, action: (StateType) -> StateType) -> Disposable {
-        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.queue)
+        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _queue)
         
         let initial = MainScheduler.convertTimeIntervalToDispatchTime(startAfter)
         let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchInterval(period)

--- a/RxSwift/Schedulers/SchedulerServices+Emulation.swift
+++ b/RxSwift/Schedulers/SchedulerServices+Emulation.swift
@@ -18,24 +18,24 @@ class SchedulePeriodicRecursive<State, S: SchedulerType> {
     typealias TimeInterval = S.TimeInterval
     typealias RecursiveScheduler = AnyRecursiveScheduler<SchedulePeriodicRecursiveCommand, S.TimeInterval>
     
-    let scheduler: S
-    let startAfter: TimeInterval
-    let period: TimeInterval
-    let action: RecursiveAction
+    private let _scheduler: S
+    private let _startAfter: TimeInterval
+    private let _period: TimeInterval
+    private let _action: RecursiveAction
     
-    var state: State
-    var pendingTickCount: Int32 = 0
+    private var _state: State
+    private var _pendingTickCount: Int32 = 0
     
     init(scheduler: S, startAfter: TimeInterval, period: TimeInterval, action: RecursiveAction, state: State) {
-        self.scheduler = scheduler
-        self.startAfter = startAfter
-        self.period = period
-        self.action = action
-        self.state = state
+        _scheduler = scheduler
+        _startAfter = startAfter
+        _period = period
+        _action = action
+        _state = state
     }
     
     func start() -> Disposable {
-        return scheduler.scheduleRecursive(SchedulePeriodicRecursiveCommand.Tick, dueTime: self.startAfter, action: self.tick)
+        return _scheduler.scheduleRecursive(SchedulePeriodicRecursiveCommand.Tick, dueTime: _startAfter, action: self.tick)
     }
     
     func tick(command: SchedulePeriodicRecursiveCommand, scheduler: RecursiveScheduler) -> Void {
@@ -44,18 +44,18 @@ class SchedulePeriodicRecursive<State, S: SchedulerType> {
         // tick interval is short.
         switch command {
         case .Tick:
-            scheduler.schedule(.Tick, dueTime: self.period)
-
+            scheduler.schedule(.Tick, dueTime: _period)
+            
             // The idea is that if on tick there wasn't any item enqueued, schedule to perform work immediatelly.
             // Else work will be scheduled after previous enqueued work completes.
-            if OSAtomicIncrement32(&pendingTickCount) == 1 {
+            if OSAtomicIncrement32(&_pendingTickCount) == 1 {
                 self.tick(.DispatchStart, scheduler: scheduler)
             }
-
+            
         case .DispatchStart:
-            self.state = action(state)
+            _state = _action(_state)
             // Start work and schedule check is this last batch of work
-            if OSAtomicDecrement32(&pendingTickCount) > 0 {
+            if OSAtomicDecrement32(&_pendingTickCount) > 0 {
                 // This gives priority to scheduler emulation, it's not perfect, but helps
                 scheduler.schedule(SchedulePeriodicRecursiveCommand.DispatchStart)
             }

--- a/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
@@ -29,7 +29,7 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     public typealias TimeInterval = NSTimeInterval
     public typealias Time = NSDate
     
-    private let serialQueue : dispatch_queue_t
+    private let _serialQueue : dispatch_queue_t
 
     /**
     - returns: Current time.
@@ -41,10 +41,10 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     }
     
     // leeway for scheduling timers
-    var leeway: Int64 = 0
+    private var _leeway: Int64 = 0
     
     init(serialQueue: dispatch_queue_t) {
-        self.serialQueue = serialQueue
+        _serialQueue = serialQueue
     }
 
     /**
@@ -132,7 +132,7 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     func scheduleInternal<StateType>(state: StateType, action: (StateType) -> Disposable) -> Disposable {
         let cancel = SingleAssignmentDisposable()
         
-        dispatch_async(self.serialQueue) {
+        dispatch_async(_serialQueue) {
             if cancel.disposed {
                 return
             }
@@ -153,7 +153,7 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public final func scheduleRelative<StateType>(state: StateType, dueTime: NSTimeInterval, action: (StateType) -> Disposable) -> Disposable {
-        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.serialQueue)
+        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _serialQueue)
         
         let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchTime(dueTime)
         
@@ -185,7 +185,7 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public func schedulePeriodic<StateType>(state: StateType, startAfter: TimeInterval, period: TimeInterval, action: (StateType) -> StateType) -> Disposable {
-        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, self.serialQueue)
+        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _serialQueue)
         
         let initial = MainScheduler.convertTimeIntervalToDispatchTime(startAfter)
         let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchInterval(period)

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -12,19 +12,19 @@ private class BehaviorSubjectSubscription<Element> : Disposable {
     typealias Parent = BehaviorSubject<Element>
     typealias DisposeKey = Bag<AnyObserver<Element>>.KeyType
     
-    let parent: Parent
-    var disposeKey: DisposeKey?
+    private let _parent: Parent
+    private var _disposeKey: DisposeKey?
     
     init(parent: BehaviorSubject<Element>, disposeKey: DisposeKey) {
-        self.parent = parent
-        self.disposeKey = disposeKey
+        _parent = parent
+        _disposeKey = disposeKey
     }
     
     func dispose() {
-        self.parent.lock.performLocked {
-            if let disposeKey = disposeKey {
-                self.parent.observers.removeKey(disposeKey)
-                self.disposeKey = nil
+        _parent._lock.performLocked {
+            if let disposeKey = _disposeKey {
+                _parent._observers.removeKey(disposeKey)
+                _disposeKey = nil
             }
         }
     }
@@ -38,19 +38,19 @@ Observers can subscribe to the subject to receive the last (or initial) value an
 public final class BehaviorSubject<Element> : Observable<Element>, SubjectType, ObserverType, Disposable {
     public typealias SubjectObserverType = BehaviorSubject<Element>
     
-    let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
     private var _disposed = false
     private var _value: Element
-    private var observers = Bag<AnyObserver<Element>>()
-    private var stoppedEvent: Event<Element>?
+    private var _observers = Bag<AnyObserver<Element>>()
+    private var _stoppedEvent: Event<Element>?
 
     /**
     Indicates whether the subject has been disposed.
     */
     public var disposed: Bool {
-        return lock.calculateLocked {
+        return _lock.calculateLocked {
             return _disposed
         }
     }
@@ -61,7 +61,7 @@ public final class BehaviorSubject<Element> : Observable<Element>, SubjectType, 
     - parameter value: Initial value sent to observers when no other value has been received by the subject yet.
     */
     public init(value: Element) {
-        self._value = value
+        _value = value
     }
     
     /**
@@ -70,12 +70,12 @@ public final class BehaviorSubject<Element> : Observable<Element>, SubjectType, 
     - returns: Latest value.
     */
     public func value() throws -> Element {
-        return try lock.calculateLockedOrFail {
+        return try _lock.calculateLockedOrFail {
             if _disposed {
                 throw RxError.DisposedError
             }
             
-            if let error = stoppedEvent?.error {
+            if let error = _stoppedEvent?.error {
                 // intentionally throw exception
                 throw error
             }
@@ -91,21 +91,19 @@ public final class BehaviorSubject<Element> : Observable<Element>, SubjectType, 
     - parameter event: Event to send to the observers.
     */
     public func on(event: Event<E>) {
-        lock.performLocked {
-            if self.stoppedEvent != nil || _disposed {
+        _lock.performLocked {
+            if _stoppedEvent != nil || _disposed {
                 return
             }
             
             switch event {
             case .Next(let value):
-                self._value = value
-            case .Error:
-                self.stoppedEvent = event
-            case .Completed:
-                self.stoppedEvent = event
+                _value = value
+            case .Error, .Completed:
+                _stoppedEvent = event
             }
             
-            self.observers.forEach { $0.on(event) }
+            _observers.forEach { $0.on(event) }
         }
     }
     
@@ -116,18 +114,18 @@ public final class BehaviorSubject<Element> : Observable<Element>, SubjectType, 
     - returns: Disposable object that can be used to unsubscribe the observer from the subject.
     */
     public override func subscribe<O : ObserverType where O.E == Element>(observer: O) -> Disposable {
-        return lock.calculateLocked {
+        return _lock.calculateLocked {
             if _disposed {
                 observer.on(.Error(RxError.DisposedError))
                 return NopDisposable.instance
             }
             
-            if let stoppedEvent = stoppedEvent {
+            if let stoppedEvent = _stoppedEvent {
                 observer.on(stoppedEvent)
                 return NopDisposable.instance
             }
             
-            let key = observers.insert(observer.asObserver())
+            let key = _observers.insert(observer.asObserver())
             observer.on(.Next(_value))
         
             return BehaviorSubjectSubscription(parent: self, disposeKey: key)
@@ -145,10 +143,10 @@ public final class BehaviorSubject<Element> : Observable<Element>, SubjectType, 
     Unsubscribe all observers and release resources.
     */
     public func dispose() {
-        lock.performLocked {
+        _lock.performLocked {
             _disposed = true
-            observers.removeAll()
-            stoppedEvent = nil
+            _observers.removeAll()
+            _stoppedEvent = nil
         }
     }
 }

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -11,29 +11,26 @@ import Foundation
 class Subscription<Element> : Disposable {
     typealias KeyType = Bag<AnyObserver<Element>>.KeyType
     
-    private var lock = SpinLock()
+    private var _lock = SpinLock()
 
     // state
-    private var subject: PublishSubject<Element>?
-    private var key: KeyType?
+    private var _subject: PublishSubject<Element>?
+    private var _key: KeyType?
     
     init(subject: PublishSubject<Element>, key: KeyType) {
-        self.key = key
-        self.subject = subject
+        _key = key
+        _subject = subject
     }
     
     func dispose() {
-        lock.performLocked {
-            guard let subject = subject else {
-                return
+        _lock.performLocked {
+            guard let subject = _subject,
+                let key = _key else {
+                    return
             }
             
-            guard let key = key else {
-                return
-            }
-            
-            self.subject = nil
-            self.key = nil
+            _subject = nil
+            _key = nil
             
             subject.unsubscribe(key)
         }
@@ -50,19 +47,19 @@ public class PublishSubject<Element> : Observable<Element>, SubjectType, Cancela
     
     typealias DisposeKey = Bag<AnyObserver<Element>>.KeyType
     
-    private let lock = NSRecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
-    var _disposed = false
-    var observers = Bag<AnyObserver<Element>>()
-    var stoppedEvent = nil as Event<Element>?
+    private var _disposed = false
+    private var _observers = Bag<AnyObserver<Element>>()
+    private var _stoppedEvent = nil as Event<Element>?
     
     /**
     Indicates whether the subject has been disposed.
     */
     public var disposed: Bool {
         get {
-            return self.lock.calculateLocked {
+            return _lock.calculateLocked {
                 return _disposed
             }
         }
@@ -81,19 +78,19 @@ public class PublishSubject<Element> : Observable<Element>, SubjectType, Cancela
     - parameter event: Event to send to the observers.
     */
     public func on(event: Event<Element>) {
-        lock.performLocked {
+        _lock.performLocked {
             switch event {
             case .Next(_):
-                if disposed || stoppedEvent != nil {
+                if disposed || _stoppedEvent != nil {
                     return
                 }
                 
-                observers.forEach { $0.on(event) }
+                _observers.forEach { $0.on(event) }
             case .Completed, .Error:
-                if stoppedEvent == nil {
-                    self.stoppedEvent = event
-                    observers.forEach { $0.on(event) }
-                    self.observers.removeAll()
+                if _stoppedEvent == nil {
+                    _stoppedEvent = event
+                    _observers.forEach { $0.on(event) }
+                    _observers.removeAll()
                 }
             }
         }
@@ -106,8 +103,8 @@ public class PublishSubject<Element> : Observable<Element>, SubjectType, Cancela
     - returns: Disposable object that can be used to unsubscribe the observer from the subject.
     */
     public override func subscribe<O : ObserverType where O.E == Element>(observer: O) -> Disposable {
-        return lock.calculateLocked {
-            if let stoppedEvent = stoppedEvent {
+        return _lock.calculateLocked {
+            if let stoppedEvent = _stoppedEvent {
                 observer.on(stoppedEvent)
                 return NopDisposable.instance
             }
@@ -117,14 +114,14 @@ public class PublishSubject<Element> : Observable<Element>, SubjectType, Cancela
                 return NopDisposable.instance
             }
             
-            let key = observers.insert(observer.asObserver())
+            let key = _observers.insert(observer.asObserver())
             return Subscription(subject: self, key: key)
         }
     }
 
     func unsubscribe(key: DisposeKey) {
-        self.lock.performLocked {
-            _ = observers.removeKey(key)
+        _lock.performLocked {
+            _ = _observers.removeKey(key)
         }
     }
     
@@ -139,10 +136,10 @@ public class PublishSubject<Element> : Observable<Element>, SubjectType, Cancela
     Unsubscribe all observers and release resources.
     */
     public func dispose() {
-        self.lock.performLocked {
+        _lock.performLocked {
             _disposed = true
-            self.observers.removeAll()
-            self.stoppedEvent = nil
+            _observers.removeAll()
+            _stoppedEvent = nil
         }
     }
 }

--- a/RxSwift/Subjects/Variable.swift
+++ b/RxSwift/Subjects/Variable.swift
@@ -16,9 +16,9 @@ Unlike `BehaviorSubject` it can't terminate with error.
 public class Variable<Element> : ObservableType {
     public typealias E = Element
     
-    let subject: BehaviorSubject<Element>
+    private let _subject: BehaviorSubject<Element>
     
-    private var lock = SpinLock()
+    private var _lock = SpinLock()
  
     // state
     private var _value: E
@@ -32,15 +32,15 @@ public class Variable<Element> : ObservableType {
     */
     public var value: E {
         get {
-            return lock.calculateLocked {
+            return _lock.calculateLocked {
                 return _value
             }
         }
         set(newValue) {
-            lock.performLocked {
+            _lock.performLocked {
                 _value = newValue
             }
-            self.subject.on(.Next(newValue))
+            _subject.on(.Next(newValue))
         }
     }
     
@@ -50,8 +50,8 @@ public class Variable<Element> : ObservableType {
     - parameter value: Initial variable value.
     */
     public init(_ value: Element) {
-        self._value = value
-        self.subject = BehaviorSubject(value: value)
+        _value = value
+        _subject = BehaviorSubject(value: value)
     }
     
     /**
@@ -63,13 +63,13 @@ public class Variable<Element> : ObservableType {
     - returns: Disposable object that can be used to unsubscribe the observer from the variable.
     */
     public func subscribe<O: ObserverType where O.E == E>(observer: O) -> Disposable {
-        return self.subject.subscribe(observer)
+        return _subject.subscribe(observer)
     }
     
     /**
     - returns: Canonical interface for push style sequence
     */
     public func asObservable() -> Observable<E> {
-        return self.subject
+        return _subject
     }
 }

--- a/RxTests/PerformanceTests/main.swift
+++ b/RxTests/PerformanceTests/main.swift
@@ -9,6 +9,8 @@
 import Foundation
 import RxSwift
 import RxCocoa
+import AppKit
+import CoreLocation
 
 let NumberOfIterations = 1000
 
@@ -45,13 +47,24 @@ func measureMemoryUsage(@noescape work: () -> ()) -> (bytesAllocated: UInt64, al
     return (approxValuePerIteration(bytesAfter - bytes), approxValuePerIteration(allocationsAfter - allocations))
 }
 
+let bechmarkTime = true
+
 func compareTwoImplementations(@noescape first first: () -> (), @noescape second: () -> ()) {
     // first warm up to keep it fair
     first()
     second()
 
-    let time1 = measureTime(first)
-    let time2 = measureTime(second)
+    let time1: UInt64
+    let time2: UInt64
+
+    if bechmarkTime {
+        time1 = measureTime(first)
+        time2 = measureTime(second)
+    }
+    else {
+        time1 = 0
+        time2 = 0
+    }
 
     registerMallocHooks()
 
@@ -72,6 +85,18 @@ func compareTwoImplementations(@noescape first first: () -> (), @noescape second
 }
 
 compareTwoImplementations(first: {
+    let publishSubject = PublishSubject<Int>()
+
+    publishSubject
+        .shareReplay(1)
+        .subscribeNext { _ in
+            
+        }
+
+
+    for i in 0..<100 {
+        publishSubject.on(.Next(i))
+    }
 
 }, second: {
     

--- a/RxTests/RxSwiftTests/Tests/Observable+AggregateTest.swift
+++ b/RxTests/RxSwiftTests/Tests/Observable+AggregateTest.swift
@@ -346,3 +346,157 @@ extension ObservableAggregateTest {
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
 }
+
+
+// MARK: toArray
+extension ObservableAggregateTest {
+    
+    func test_ToArrayWithSingleItem_Return() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs: ColdObservable<Int> = scheduler.createColdObservable([
+            next(10, 1),
+            completed(20)
+            ])
+
+        let res = scheduler.start {
+            return xs.toArray().map { EquatableArray($0) }
+        }
+
+        let correctMessages = [
+            next(220, EquatableArray([1])),
+            completed(220)
+        ]
+        
+        let correctSubscriptions = [
+            Subscription(200, 220)
+        ]
+        
+        XCTAssertEqual(res.messages, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func test_ToArrayWithMultipleItems_Return() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs: ColdObservable<Int> = scheduler.createColdObservable([
+            next(10, 1),
+            next(20, 2),
+            next(30, 3),
+            next(40, 4),
+            completed(50)
+            ])
+        
+        let res = scheduler.start {
+            return xs.toArray().map { EquatableArray($0) }
+        }
+        
+        let correctMessages = [
+            next(250, EquatableArray([1,2,3,4])),
+            completed(250)
+        ]
+        
+        let correctSubscriptions = [
+            Subscription(200, 250)
+        ]
+        
+        XCTAssertEqual(res.messages, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func test_ToArrayWithNoItems_Empty() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs: ColdObservable<Int> = scheduler.createColdObservable([
+            completed(50)
+            ])
+        
+        let res = scheduler.start {
+            return xs.toArray().map { EquatableArray($0) }
+        }
+        
+        let correctMessages: [Recorded<EquatableArray<Int>>] = [
+            next(250, EquatableArray([])),
+            completed(250)
+        ]
+        
+        let correctSubscriptions = [
+            Subscription(200, 250)
+        ]
+        
+        XCTAssertEqual(res.messages, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func test_ToArrayWithSingleItem_Never() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(150, 1)
+            ])
+        
+        let res = scheduler.start {
+            return xs.toArray().map { EquatableArray($0) }
+        }
+        
+        let correctMessages: [Recorded<EquatableArray<Int>>] = [
+        ]
+        
+        let correctSubscriptions = [
+            Subscription(200, 1000)
+        ]
+        
+        XCTAssertEqual(res.messages, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func test_ToArrayWithImmediateError_Throw() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs: ColdObservable<Int> = scheduler.createColdObservable([
+            error(10, testError)
+            ])
+        
+        let res = scheduler.start {
+            return xs.toArray().map { EquatableArray($0) }
+        }
+        
+        let correctMessages: [Recorded<EquatableArray<Int>>] = [
+            error(210, testError)
+        ]
+        
+        let correctSubscriptions = [
+            Subscription(200, 210)
+        ]
+        
+        XCTAssertEqual(res.messages, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func test_ToArrayWithMultipleItems_Throw() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs: ColdObservable<Int> = scheduler.createColdObservable([
+            next(10, 1),
+            next(20, 2),
+            next(30, 3),
+            next(40, 4),
+            error(50, testError)
+            ])
+        
+        let res = scheduler.start {
+            return xs.toArray().map { EquatableArray($0) }
+        }
+        
+        let correctMessages: [Recorded<EquatableArray<Int>>] = [
+            error(250, testError)
+        ]
+        
+        let correctSubscriptions = [
+            Subscription(200, 250)
+        ]
+        
+        XCTAssertEqual(res.messages, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+}

--- a/RxTests/RxSwiftTests/Tests/Observable+MultipleTest.swift
+++ b/RxTests/RxSwiftTests/Tests/Observable+MultipleTest.swift
@@ -3949,3 +3949,272 @@ extension ObservableMultipleTest {
         XCTAssert(disposed, "disposed")
     }
 }
+
+
+// MARK: withLatestFrom
+
+extension ObservableMultipleTest {
+    
+    func testWithLatestFrom_Simple1() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(90, 1),
+            next(180, 2),
+            next(250, 3),
+            next(260, 4),
+            next(310, 5),
+            next(340, 6),
+            next(410, 7),
+            next(420, 8),
+            next(470, 9),
+            next(550, 10),
+            completed(590)
+        ])
+        
+        let ys = scheduler.createHotObservable([
+            next(255, "bar"),
+            next(330, "foo"),
+            next(350, "qux"),
+            completed(400)
+        ])
+        
+        let res = scheduler.start {
+            xs.withLatestFrom(ys) { x, y in "\(x)\(y)" }
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(260, "4bar"),
+            next(310, "5bar"),
+            next(340, "6foo"),
+            next(410, "7qux"),
+            next(420, "8qux"),
+            next(470, "9qux"),
+            next(550, "10qux"),
+            completed(590)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 590)
+        ])
+        
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 400)
+        ])
+    }
+    
+    func testWithLatestFrom_Simple2() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(90, 1),
+            next(180, 2),
+            next(250, 3),
+            next(260, 4),
+            next(310, 5),
+            next(340, 6),
+            completed(390)
+        ])
+        
+        let ys = scheduler.createHotObservable([
+            next(255, "bar"),
+            next(330, "foo"),
+            next(350, "qux"),
+            next(370, "baz"),
+            completed(400)
+        ])
+        
+        let res = scheduler.start {
+            xs.withLatestFrom(ys) { x, y in "\(x)\(y)" }
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(260, "4bar"),
+            next(310, "5bar"),
+            next(340, "6foo"),
+            completed(390)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 390)
+        ])
+        
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 390)
+        ])
+    }
+    
+    func testWithLatestFrom_Simple3() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(90, 1),
+            next(180, 2),
+            next(250, 3),
+            next(260, 4),
+            next(310, 5),
+            next(340, 6),
+            completed(390)
+        ])
+        
+        let ys = scheduler.createHotObservable([
+            next(245, "bar"),
+            next(330, "foo"),
+            next(350, "qux"),
+            next(370, "baz"),
+            completed(400)
+        ])
+        
+        let res = scheduler.start {
+            xs.withLatestFrom(ys) { x, y in "\(x)\(y)" }
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(250, "3bar"),
+            next(260, "4bar"),
+            next(310, "5bar"),
+            next(340, "6foo"),
+            completed(390)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 390)
+        ])
+        
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 390)
+        ])
+    }
+    
+    func testWithLatestFrom_Error1() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(90, 1),
+            next(180, 2),
+            next(250, 3),
+            next(260, 4),
+            next(310, 5),
+            next(340, 6),
+            next(410, 7),
+            next(420, 8),
+            next(470, 9),
+            next(550, 10),
+            error(590, testError)
+        ])
+        
+        let ys = scheduler.createHotObservable([
+            next(255, "bar"),
+            next(330, "foo"),
+            next(350, "qux"),
+            completed(400)
+        ])
+        
+        let res = scheduler.start {
+            xs.withLatestFrom(ys) { x, y in "\(x)\(y)" }
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(260, "4bar"),
+            next(310, "5bar"),
+            next(340, "6foo"),
+            next(410, "7qux"),
+            next(420, "8qux"),
+            next(470, "9qux"),
+            next(550, "10qux"),
+            error(590, testError)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 590)
+        ])
+        
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 400)
+        ])
+    }
+    
+    func testWithLatestFrom_Error2() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(90, 1),
+            next(180, 2),
+            next(250, 3),
+            next(260, 4),
+            next(310, 5),
+            next(340, 6),
+            completed(390)
+        ])
+        
+        let ys = scheduler.createHotObservable([
+            next(255, "bar"),
+            next(330, "foo"),
+            next(350, "qux"),
+            error(370, testError)
+        ])
+        
+        let res = scheduler.start {
+            xs.withLatestFrom(ys) { x, y in "\(x)\(y)" }
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(260, "4bar"),
+            next(310, "5bar"),
+            next(340, "6foo"),
+            error(370, testError)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 370)
+        ])
+        
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 370)
+        ])
+    }
+    
+    func testWithLatestFrom_Error3() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(90, 1),
+            next(180, 2),
+            next(250, 3),
+            next(260, 4),
+            next(310, 5),
+            next(340, 6),
+            completed(390)
+        ])
+        
+        let ys = scheduler.createHotObservable([
+            next(255, "bar"),
+            next(330, "foo"),
+            next(350, "qux"),
+            completed(400)
+        ])
+        
+        let res = scheduler.start {
+            xs.withLatestFrom(ys) {
+                (x, y) throws -> String in
+                if x == 5 {
+                    throw testError
+                }
+                return "\(x)\(y)"
+            }
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(260, "4bar"),
+            error(310, testError)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 310)
+        ])
+        
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 310)
+        ])
+    }
+}

--- a/RxTests/RxSwiftTests/Tests/Observable+StandardSequenceOperatorsTest.swift
+++ b/RxTests/RxSwiftTests/Tests/Observable+StandardSequenceOperatorsTest.swift
@@ -2816,6 +2816,254 @@ extension ObservableStandardSequenceOperators {
     }
 }
 
+// MARK: takeLast
+
+extension ObservableStandardSequenceOperators {
+    func testTakeLast_Complete_Less() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            completed(300)
+            ])
+        
+        let res = scheduler.start {
+            xs.takeLast(7)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(300, 9),
+            next(300, 13),
+            next(300, 7),
+            next(300, 1),
+            next(300, -1),
+            completed(300)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 300)
+            ])
+    }
+    
+    func testTakeLast_Complete_Same() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            completed(310)
+            ])
+        
+        let res = scheduler.start {
+            xs.takeLast(5)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(310, 9),
+            next(310, 13),
+            next(310, 7),
+            next(310, 1),
+            next(310, -1),
+            completed(310)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 310)
+            ])
+    }
+    
+    func testTakeLast_Complete_More() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            next(310, 3),
+            next(340, 8),
+            completed(350)
+            ])
+        
+        let res = scheduler.start {
+            xs.takeLast(5)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(350, 7),
+            next(350, 1),
+            next(350, -1),
+            next(350, 3),
+            next(350, 8),
+            completed(350)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 350)
+            ])
+    }
+    
+    func testTakeLast_Error_Less() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(290, 64),
+            error(300, testError)
+            ])
+        
+        let res = scheduler.start {
+            xs.takeLast(7)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            error(300, testError)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 300)
+            ])
+    }
+    
+    func testTakeLast_Error_Same() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            error(310, testError)
+            ])
+        
+        let res = scheduler.start {
+            xs.takeLast(5)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            error(310, testError)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 310)
+            ])
+    }
+    
+    func testTakeLast_Error_More() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            next(310, 3),
+            next(340, 64),
+            error(360, testError)
+            ])
+        
+        let res = scheduler.start {
+            xs.takeLast(5)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            error(360, testError)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 360)
+            ])
+    }
+    
+    func testTakeLast_0_DefaultScheduler() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13)
+            ])
+        
+        let res = scheduler.start {
+            xs.takeLast(0)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 1000)
+            ])
+    }
+    
+    func testTakeLast_TakeLast1() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            next(310, 3),
+            next(340, 8),
+            next(370, 11),
+            completed(400)
+            ])
+        
+        let res = scheduler.start {
+            xs.takeLast(3)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(400, 3),
+            next(400, 8),
+            next(400, 11),
+            completed(400)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 400)
+            ])
+    }
+    
+    func testTakeLast_DecrementCountsFirst() {
+        let k = BehaviorSubject(value: false)
+        
+        _ = k.takeLast(1).subscribeNext { n in
+            k.on(.Next(!n))
+        }
+    }
+}
+
 // MARK: skip
 extension ObservableStandardSequenceOperators {
     func testSkip_Complete_After() {

--- a/RxTests/RxSwiftTests/Tests/Observable+StandardSequenceOperatorsTest.swift
+++ b/RxTests/RxSwiftTests/Tests/Observable+StandardSequenceOperatorsTest.swift
@@ -36,8 +36,7 @@ func isPrime(i: Int) -> Bool {
     return true
 }
 
-// where
-
+// MARK: where
 extension ObservableStandardSequenceOperators  {
     func test_filterComplete() {
         let scheduler = TestScheduler(initialClock: 0)
@@ -210,7 +209,7 @@ extension ObservableStandardSequenceOperators  {
     }
 }
 
-// takeWhile
+// MARK: takeWhile
 extension ObservableStandardSequenceOperators {
     func testTakeWhile_Complete_Before() {
         let scheduler = TestScheduler(initialClock: 0)
@@ -701,7 +700,7 @@ extension ObservableStandardSequenceOperators {
     
 }
 
-// map
+// MARK: map
 // these test are not port from Rx
 extension ObservableStandardSequenceOperators {
     func testMap_Never() {
@@ -1043,7 +1042,7 @@ extension ObservableStandardSequenceOperators {
     }
 }
 
-// flatMap
+// MARK: flatMap
 extension ObservableStandardSequenceOperators {
     
     func testFlatMap_Complete() {
@@ -2353,7 +2352,7 @@ extension ObservableStandardSequenceOperators {
     
 }
 
-// take
+// MARK: take
 
 extension ObservableStandardSequenceOperators {
     func testTake_Complete_After() {
@@ -2817,7 +2816,7 @@ extension ObservableStandardSequenceOperators {
     }
 }
 
-// skip
+// MARK: skip
 extension ObservableStandardSequenceOperators {
     func testSkip_Complete_After() {
         let scheduler = TestScheduler(initialClock: 0)
@@ -3642,6 +3641,253 @@ extension ObservableStandardSequenceOperators {
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 350)
+            ])
+    }
+}
+
+// MARK: elementAt
+extension ObservableStandardSequenceOperators {
+    
+    func testElementAt_Complete_After() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            next(310, 3),
+            next(340, 8),
+            next(370, 11),
+            next(410, 15),
+            next(415, 16),
+            next(460, 72),
+            next(510, 76),
+            next(560, 32),
+            next(570, -100),
+            next(580, -3),
+            next(590, 5),
+            next(630, 10),
+            completed(690)
+            ])
+        
+        let res = scheduler.start {
+            xs.elementAt(10)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(460, 72),
+            completed(460)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 460)
+            ])
+    }
+    
+    
+    func testElementAt_Complete_Before() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            completed(320)
+            ])
+        
+        let res = scheduler.start {
+            xs.elementAt(10)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            error(320, RxError.ArgumentOutOfRange)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 320)
+            ])
+    }
+    
+    func testElementAt_Error_After() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            next(310, 3),
+            next(340, 8),
+            next(370, 11),
+            next(410, 15),
+            next(415, 16),
+            next(460, 72),
+            next(510, 76),
+            next(560, 32),
+            next(570, -100),
+            next(580, -3),
+            next(590, 5),
+            next(630, 10),
+            error(690, testError)
+            ])
+        
+        let res = scheduler.start {
+            xs.elementAt(10)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(460, 72),
+            completed(460)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 460)
+            ])
+    }
+    
+    func testElementAt_Error_Before() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            error(310, testError)
+            ])
+        
+        let res = scheduler.start {
+            xs.elementAt(10)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            error(310, testError)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 310)
+            ])
+    }
+    
+    func testElementAt_Dispose_Before() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            next(310, 3),
+            next(340, 8),
+            next(370, 11),
+            next(410, 15),
+            next(415, 16),
+            next(460, 72),
+            next(510, 76),
+            next(560, 32),
+            next(570, -100),
+            next(580, -3),
+            next(590, 5),
+            next(630, 10),
+            error(690, testError)
+            ])
+        
+        let res = scheduler.start(250) {
+            xs.elementAt(3)
+        }
+        
+        XCTAssertEqual(res.messages, [])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+            ])
+    }
+    
+    func testElementAt_Dispose_After() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            next(310, 3),
+            next(340, 8),
+            next(370, 11),
+            next(410, 15),
+            next(415, 16),
+            next(460, 72),
+            next(510, 76),
+            next(560, 32),
+            next(570, -100),
+            next(580, -3),
+            next(590, 5),
+            next(630, 10),
+            error(690, testError)
+            ])
+        
+        let res = scheduler.start(400) {
+            xs.elementAt(3)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(280, 1),
+            completed(280)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 280)
+            ])
+    }
+    
+    func testElementAt_First() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(70, 6),
+            next(150, 4),
+            next(210, 9),
+            next(230, 13),
+            next(270, 7),
+            next(280, 1),
+            next(300, -1),
+            next(310, 3),
+            next(340, 8),
+            next(370, 11),
+            completed(400)
+            ])
+        
+        let res = scheduler.start {
+            xs.elementAt(0)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(210, 9),
+            completed(210)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 210)
             ])
     }
 }

--- a/RxTests/RxTests.xcodeproj/project.pbxproj
+++ b/RxTests/RxTests.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 		C836EA081B8A76CD00AB941D /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C836EA001B8A76A900AB941D /* RxSwift.framework */; };
 		C84B8FC21B89D0D500C9CCCF /* BagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84B8FC11B89D0D500C9CCCF /* BagTest.swift */; };
 		C84B8FC31B89D0D500C9CCCF /* BagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84B8FC11B89D0D500C9CCCF /* BagTest.swift */; };
+		C84CC4E91BDADA0B00E06A64 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C836EA001B8A76A900AB941D /* RxSwift.framework */; };
+		C84CC4EB1BDAEDF700E06A64 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C84CC4EA1BDAEDF700E06A64 /* RxCocoa.framework */; };
 		C85F4E431B7F70EA00A866C7 /* CompositeObserverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85F4E421B7F70EA00A866C7 /* CompositeObserverTest.swift */; };
 		C85F4E441B7F70EA00A866C7 /* CompositeObserverTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85F4E421B7F70EA00A866C7 /* CompositeObserverTest.swift */; };
 		C8633AE51B0A9FF300375D60 /* KVOObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8633AE41B0A9FF300375D60 /* KVOObservableTests.swift */; };
@@ -217,6 +219,8 @@
 		C81CC92A1B513FD400915606 /* NSObject+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+RxTests.swift"; sourceTree = "<group>"; };
 		C836EA001B8A76A900AB941D /* RxSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C84B8FC11B89D0D500C9CCCF /* BagTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BagTest.swift; sourceTree = "<group>"; };
+		C84CC4E71BDAD9FF00E06A64 /* RxBlocking.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxBlocking.framework; path = ../build/Debug/RxBlocking.framework; sourceTree = "<group>"; };
+		C84CC4EA1BDAEDF700E06A64 /* RxCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RxCocoa.framework; path = ../build/Debug/RxCocoa.framework; sourceTree = "<group>"; };
 		C85F4E421B7F70EA00A866C7 /* CompositeObserverTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompositeObserverTest.swift; sourceTree = "<group>"; };
 		C8633AE41B0A9FF300375D60 /* KVOObservableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KVOObservableTests.swift; sourceTree = "<group>"; };
 		C868D0F81BB76A29003D1474 /* PerformanceTools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTools.swift; sourceTree = "<group>"; };
@@ -262,6 +266,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C84CC4EB1BDAEDF700E06A64 /* RxCocoa.framework in Frameworks */,
+				C84CC4E91BDADA0B00E06A64 /* RxSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -291,6 +297,8 @@
 		C81108151AF50DDA001C13E4 = {
 			isa = PBXGroup;
 			children = (
+				C84CC4EA1BDAEDF700E06A64 /* RxCocoa.framework */,
+				C84CC4E71BDAD9FF00E06A64 /* RxBlocking.framework */,
 				C8A468CE1B8A897D00BF917B /* RxBlocking.framework */,
 				C8A468CC1B8A897800BF917B /* RxCocoa.framework */,
 				C836EA001B8A76A900AB941D /* RxSwift.framework */,

--- a/scripts/playgrounds.sh
+++ b/scripts/playgrounds.sh
@@ -1,0 +1,16 @@
+. scripts/common.sh
+
+CONFIGURATIONS=(Release)
+
+# make sure osx builds
+for scheme in "RxSwift-OSX"
+do
+  for configuration in ${CONFIGURATIONS[@]}
+  do
+    PAGES_PATH=${BUILD_DIRECTORY}/Build/Products/${configuration}/all-playground-pages.swift
+    rx ${scheme} ${configuration} "" build
+    cat Rx.playground/Sources/*.swift Rx.playground/Pages/**/*.swift > ${PAGES_PATH}
+    swift -v -D NOT_IN_PLAYGROUND -F ${BUILD_DIRECTORY}/Build/Products/${configuration} ${PAGES_PATH}
+  done
+done
+

--- a/scripts/pre-release-tests.sh
+++ b/scripts/pre-release-tests.sh
@@ -113,6 +113,10 @@ do
 	done
 done
 
+# compile and run playgrounds
+
+. scripts/playgrounds.sh
+
 if [ "${RELEASE_TEST}" -eq 1 ]; then
 	mdast -u mdast-slug -u mdast-validate-links ./*.md
 	mdast -u mdast-slug -u mdast-validate-links ./**/*.md


### PR DESCRIPTION
### PLEASE IGNORE THIS PULL REQUEST
*I intended to make a pull request into develop, not master.  I've submitted a separate pull request.*

Fix warnings due to use in app extensions and to Xcode updates.

Xcode gives two warnings when including the Rx project and building in an app.

1. The first is due to use in a component that will be used in an extension. Xcode displays the message “linking against dylib not safe for use in application extensions”. To configure an app extension target to use an embedded framework, set the target’s “Require Only App-Extension-Safe API” build setting to Yes.

    https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html

2. The second is due to changes in Xcode that want to update the project file to comply with the latest guidelines. Clicking the warning brings up a prompt to modify the project.