### PR TITLE
Move parameter line to correct function

### DIFF
--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -109,7 +109,6 @@ extension ObservableType where E : ObservableConvertibleType {
     /**
     Merges elements from all observable sequences in the given enumerable sequence into a single observable sequence.
     
-    - parameter maxConcurrent: Maximum number of inner observable sequences being subscribed to concurrently.
     - returns: The observable sequence that merges the elements of the observable sequences.
     */
     @warn_unused_result(message="http://git.io/rxs.uo")
@@ -120,6 +119,7 @@ extension ObservableType where E : ObservableConvertibleType {
     /**
     Merges elements from all inner observable sequences into a single observable sequence, limiting the number of concurrent subscriptions to inner sequences.
     
+    - parameter maxConcurrent: Maximum number of inner observable sequences being subscribed to concurrently.
     - returns: The observable sequence that merges the elements of the inner sequences.
     */
     @warn_unused_result(message="http://git.io/rxs.uo")


### PR DESCRIPTION
The `maxConcurrent` parameter line was in the wrong function, documenting the parameter-less function.

Closes #257 and #259.