### PR TITLE
Adds ignoreElements() operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+* Adds `ignoreElements` operator.
+
 ---
 
 ## [2.0.0-beta.3](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-beta.3)

--- a/RxSwift/Observables/Observable+Time.swift
+++ b/RxSwift/Observables/Observable+Time.swift
@@ -170,6 +170,23 @@ extension ObservableType {
     }
 }
 
+// MARK: ignoreElements
+
+extension ObservableType {
+
+    /**
+     Skips elements and completes (or errors) when the receiver completes (or errors). Equivalent to filter that always returns false.
+
+     - returns: An observable sequence that skips all elements of the source sequence.
+     */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func ignoreElements()
+        -> Observable<E> {
+            return filter { _ -> Bool in
+                return false
+            }
+    }
+}
 
 // MARK: delaySubscription
 

--- a/RxTests/RxSwiftTests/Tests/Observable+TimeTest.swift
+++ b/RxTests/RxSwiftTests/Tests/Observable+TimeTest.swift
@@ -1178,6 +1178,32 @@ extension ObservableTimeTest {
     }
 }
 
+// MARK: IgnoreElements
+
+extension ObservableTimeTest {
+    func testIgnoreElements_DoesNotSendValues() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(210, 1),
+            next(220, 2),
+            completed(230)
+            ])
+
+        let res = scheduler.start {
+            xs.ignoreElements()
+        }
+
+        XCTAssertEqual(res.messages, [
+            completed(230)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 230)
+            ])
+    }
+}
+
 // MARK: Buffer
 extension ObservableTimeTest {
     func testBufferWithTimeOrCount_Basic() {


### PR DESCRIPTION
Hey there! Here's an implementation of `ignoreElements()` – had a difficult time figuring out the test harness setup, but I really like it :heart_eyes_cat: Is there any documentation around it? 

Edit: Just for clarification, this is a small operator, but one that I needed in [this app](https://github.com/artsy/eidolon) for abstracting network request _completion_ from network response data.