### PR TITLE
Making withLatestFrom subscribe to the right hand side first

### DIFF
--- a/RxSwift/Observables/Implementations/WithLatestFrom.swift
+++ b/RxSwift/Observables/Implementations/WithLatestFrom.swift
@@ -32,8 +32,8 @@ class WithLatestFromSink<FirstType, SecondType, ResultType, O: ObserverType wher
         let sndSubscription = SingleAssignmentDisposable()
         let sndO = WithLatestFromSecond(parent: self, disposable: sndSubscription)
         
-        let fstSubscription = _parent._first.subscribe(self)
         sndSubscription.disposable = _parent._second.subscribe(sndO)
+        let fstSubscription = _parent._first.subscribe(self)
         
         return StableCompositeDisposable.create(fstSubscription, sndSubscription)
     }

--- a/RxTests/RxSwiftTests/Tests/Observable+MultipleTest.swift
+++ b/RxTests/RxSwiftTests/Tests/Observable+MultipleTest.swift
@@ -4293,6 +4293,24 @@ extension ObservableMultipleTest {
         ])
     }
     
+    func testWithLatestFrom_TwoObservablesWithImmediateValues() {
+        let xs = BehaviorSubject<Int>(value: 3)
+        let ys = BehaviorSubject<Int>(value: 5)
+        
+        let scheduler = TestScheduler(initialClock: 0)
+
+        
+        let res = scheduler.start {
+            xs.withLatestFrom(ys) { x, y in "\(x)\(y)" }
+                .take(1)
+        }
+        
+        XCTAssertEqual(res.messages, [
+            next(200, "35"),
+            completed(200)
+        ])
+    }
+    
     func testWithLatestFrom_Simple2() {
         let scheduler = TestScheduler(initialClock: 0)
         


### PR DESCRIPTION
This resolves an issue where you have two observables that yield values
immediately and it wasn't yielding a result