### PR TITLE
Support creating unbounded ReplaySubject

### DIFF
--- a/RxSwift/Observables/Observable+Binding.swift
+++ b/RxSwift/Observables/Observable+Binding.swift
@@ -73,7 +73,7 @@ extension ObservableType {
     
     /**
     Returns a connectable observable sequence that shares a single subscription to the underlying sequence replaying bufferSize elements.
-    /Volumes/Work/Projects/opensource/RxSwift-fpillet/Rx.xcodeproj
+
     This operator is a specialization of `multicast` using a `ReplaySubject`.
     
     - parameter bufferSize: Maximum element count of the replay buffer.

--- a/RxSwift/Observables/Observable+Binding.swift
+++ b/RxSwift/Observables/Observable+Binding.swift
@@ -73,7 +73,7 @@ extension ObservableType {
     
     /**
     Returns a connectable observable sequence that shares a single subscription to the underlying sequence replaying bufferSize elements.
-    
+    /Volumes/Work/Projects/opensource/RxSwift-fpillet/Rx.xcodeproj
     This operator is a specialization of `multicast` using a `ReplaySubject`.
     
     - parameter bufferSize: Maximum element count of the replay buffer.
@@ -84,6 +84,19 @@ extension ObservableType {
         -> ConnectableObservable<ReplaySubject<E>> {
         return self.multicast(ReplaySubject.create(bufferSize: bufferSize))
     }
+	
+	/**
+	Returns a connectable observable sequence that shares a single subscription to the underlying sequence replaying all elements.
+	
+	This operator is a specialization of `multicast` using a `ReplaySubject`.
+	
+	- returns: A connectable observable sequence that shares a single subscription to the underlying sequence.
+	*/
+	@warn_unused_result(message="http://git.io/rxs.uo")
+	public func replayAll()
+		-> ConnectableObservable<ReplaySubject<E>> {
+			return self.multicast(ReplaySubject.createUnbounded())
+	}
 }
 
 // MARK: refcount

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -51,19 +51,26 @@ public class ReplaySubject<Element>
     /**
     Creates new instance of `ReplaySubject` that replays at most `bufferSize` last elements of sequence.
     
-    - parameter bufferSize: Maximal number of elements to replay to observer after subscription. Use `0` or `Int.max` for unlimited storage.
+    - parameter bufferSize: Maximal number of elements to replay to observer after subscription.
     - returns: New instance of replay subject.
     */
     public static func create(bufferSize bufferSize: Int) -> ReplaySubject<Element> {
-		switch bufferSize {
-		case 0, Int.max:
-			return ReplayAll()
-		case 1:
-			return ReplayOne()
-		default:
-			return ReplayMany(bufferSize: bufferSize)
-		}
+        if bufferSize == 1 {
+            return ReplayOne()
+        }
+        else {
+            return ReplayMany(bufferSize: bufferSize)
+        }
     }
+	
+	/**
+	Creates a new instance of `ReplaySubject` that buffers all the elements of a sequence.
+	To avoid filling up memory, developer needs to make sure that the use case will only ever store a 'reasonable'
+	number of elements.
+	*/
+	public static func createUnbounded() -> ReplaySubject<Element> {
+		return ReplayAll()
+	}
 }
 
 class ReplayBufferBase<Element>

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -51,16 +51,18 @@ public class ReplaySubject<Element>
     /**
     Creates new instance of `ReplaySubject` that replays at most `bufferSize` last elements of sequence.
     
-    - parameter bufferSize: Maximal number of elements to replay to observer after subscription.
+    - parameter bufferSize: Maximal number of elements to replay to observer after subscription. Use `0` or `Int.max` for unlimited storage.
     - returns: New instance of replay subject.
     */
     public static func create(bufferSize bufferSize: Int) -> ReplaySubject<Element> {
-        if bufferSize == 1 {
-            return ReplayOne()
-        }
-        else {
-            return ReplayMany(bufferSize: bufferSize)
-        }
+		switch bufferSize {
+		case 0, Int.max:
+			return ReplayAll()
+		case 1:
+			return ReplayOne()
+		default:
+			return ReplayMany(bufferSize: bufferSize)
+		}
     }
 }
 

--- a/RxTests/RxSwiftTests/Tests/Observable+BindingTest.swift
+++ b/RxTests/RxSwiftTests/Tests/Observable+BindingTest.swift
@@ -675,6 +675,227 @@ extension ObservableBindingTest {
             Subscription(650, 800),
             ])
     }
+	
+	func testReplayAll_Basic() {
+		let scheduler = TestScheduler(initialClock: 0)
+		
+		let xs = scheduler.createHotObservable([
+			next(110, 7),
+			next(220, 3),
+			next(280, 4),
+			next(290, 1),
+			next(340, 8),
+			next(360, 5),
+			next(370, 6),
+			next(390, 7),
+			next(410, 13),
+			next(430, 2),
+			next(450, 9),
+			next(520, 11),
+			next(560, 20),
+			error(600, testError)
+			])
+		
+		var ys: ConnectableObservable<ReplaySubject<Int>>! = nil
+		var subscription: Disposable! = nil
+		var connection: Disposable! = nil
+		let res: MockObserver<Int> = scheduler.createObserver()
+		
+		scheduler.scheduleAt(Defaults.created) { ys = xs.replayAll() }
+		scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
+		scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
+		
+		scheduler.scheduleAt(200) { connection = ys.connect() }
+		scheduler.scheduleAt(400) { connection.dispose() }
+		
+		scheduler.scheduleAt(500) { connection = ys.connect() }
+		scheduler.scheduleAt(550) { connection.dispose() }
+		
+		scheduler.scheduleAt(650) { connection = ys.connect() }
+		scheduler.scheduleAt(800) { connection.dispose() }
+		
+		scheduler.start();
+		
+		XCTAssertEqual(res.messages, [
+			next(450, 3),
+			next(450, 4),
+			next(450, 1),
+			next(450, 8),
+			next(450, 5),
+			next(450, 6),
+			next(450, 7),
+			next(520, 11),
+			])
+		
+		XCTAssertEqual(xs.subscriptions, [
+			Subscription(200, 400),
+			Subscription(500, 550),
+			Subscription(650, 800)
+			])
+	}
+
+	
+	func testReplayAll_Error() {
+		let scheduler = TestScheduler(initialClock: 0)
+		
+		let xs = scheduler.createHotObservable([
+			next(110, 7),
+			next(220, 3),
+			next(280, 4),
+			next(290, 1),
+			next(340, 8),
+			next(360, 5),
+			next(370, 6),
+			next(390, 7),
+			next(410, 13),
+			next(430, 2),
+			next(450, 9),
+			next(520, 11),
+			next(560, 20),
+			error(600, testError)
+			])
+		
+		var ys: ConnectableObservable<ReplaySubject<Int>>! = nil
+		var subscription: Disposable! = nil
+		var connection: Disposable! = nil
+		let res: MockObserver<Int> = scheduler.createObserver()
+		
+		scheduler.scheduleAt(Defaults.created) { ys = xs.replayAll() }
+		scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
+		scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
+		
+		scheduler.scheduleAt(300) { connection = ys.connect() }
+		scheduler.scheduleAt(400) { connection.dispose() }
+		
+		scheduler.scheduleAt(500) { connection = ys.connect() }
+		scheduler.scheduleAt(800) { connection.dispose() }
+		
+		scheduler.start();
+		
+		XCTAssertEqual(res.messages, [
+			next(450, 8),
+			next(450, 5),
+			next(450, 6),
+			next(450, 7),
+			next(520, 11),
+			next(560, 20),
+			error(600, testError),
+			])
+		
+		XCTAssertEqual(xs.subscriptions, [
+			Subscription(300, 400),
+			Subscription(500, 600),
+			])
+	}
+	
+	func testReplayAll_Complete() {
+		let scheduler = TestScheduler(initialClock: 0)
+		
+		let xs = scheduler.createHotObservable([
+			next(110, 7),
+			next(220, 3),
+			next(280, 4),
+			next(290, 1),
+			next(340, 8),
+			next(360, 5),
+			next(370, 6),
+			next(390, 7),
+			next(410, 13),
+			next(430, 2),
+			next(450, 9),
+			next(520, 11),
+			next(560, 20),
+			completed(600)
+			])
+		
+		var ys: ConnectableObservable<ReplaySubject<Int>>! = nil
+		var subscription: Disposable! = nil
+		var connection: Disposable! = nil
+		let res: MockObserver<Int> = scheduler.createObserver()
+		
+		scheduler.scheduleAt(Defaults.created) { ys = xs.replayAll() }
+		scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
+		scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
+		
+		scheduler.scheduleAt(300) { connection = ys.connect() }
+		scheduler.scheduleAt(400) { connection.dispose() }
+		
+		scheduler.scheduleAt(500) { connection = ys.connect() }
+		scheduler.scheduleAt(800) { connection.dispose() }
+		
+		scheduler.start();
+		
+		XCTAssertEqual(res.messages, [
+			next(450, 8),
+			next(450, 5),
+			next(450, 6),
+			next(450, 7),
+			next(520, 11),
+			next(560, 20),
+			completed(600)
+			])
+		
+		XCTAssertEqual(xs.subscriptions, [
+			Subscription(300, 400),
+			Subscription(500, 600),
+			])
+	}
+	
+	func testReplayAll_Dispose() {
+		let scheduler = TestScheduler(initialClock: 0)
+		
+		let xs = scheduler.createHotObservable([
+			next(110, 7),
+			next(220, 3),
+			next(280, 4),
+			next(290, 1),
+			next(340, 8),
+			next(360, 5),
+			next(370, 6),
+			next(390, 7),
+			next(410, 13),
+			next(430, 2),
+			next(450, 9),
+			next(520, 11),
+			next(560, 20),
+			completed(600)
+			])
+		
+		var ys: ConnectableObservable<ReplaySubject<Int>>! = nil
+		var subscription: Disposable! = nil
+		var connection: Disposable! = nil
+		let res: MockObserver<Int> = scheduler.createObserver()
+		
+		scheduler.scheduleAt(Defaults.created) { ys = xs.replayAll() }
+		scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
+		scheduler.scheduleAt(475) { subscription.dispose() }
+		
+		scheduler.scheduleAt(250) { connection = ys.connect() }
+		scheduler.scheduleAt(400) { connection.dispose() }
+		
+		scheduler.scheduleAt(500) { connection = ys.connect() }
+		scheduler.scheduleAt(550) { connection.dispose() }
+		
+		scheduler.scheduleAt(650) { connection = ys.connect() }
+		scheduler.scheduleAt(800) { connection.dispose() }
+		
+		scheduler.start();
+		
+		XCTAssertEqual(res.messages, [
+			next(450, 4),
+			next(450, 1),
+			next(450, 8),
+			next(450, 5),
+			next(450, 6),
+			next(450, 7),
+			])
+		
+		XCTAssertEqual(xs.subscriptions, [
+			Subscription(250, 400),
+			Subscription(500, 550),
+			Subscription(650, 800),
+			])
+	}
 }
 
 


### PR DESCRIPTION
There was previously no way to externally instantiate the `ReplayAll` concrete class