### PR TITLE
Make ControlProperty initializer public

### DIFF
--- a/RxCocoa/Common/CocoaUnits/ControlProperty.swift
+++ b/RxCocoa/Common/CocoaUnits/ControlProperty.swift
@@ -40,7 +40,7 @@ public struct ControlProperty<PropertyType> : ControlPropertyType {
     let source: Observable<PropertyType>
     let observer: AnyObserver<PropertyType>
     
-    init(source: Observable<PropertyType>, observer: AnyObserver<PropertyType>) {
+    public init(source: Observable<PropertyType>, observer: AnyObserver<PropertyType>) {
         self.source = source.subscribeOn(ConcurrentMainScheduler.sharedInstance)
         self.observer = observer
     }


### PR DESCRIPTION
When conforming to `ControlPropertyType` you are not able to create a `ControlProperty` to return in `asControlProperty()`.