### PR TITLE
Accept array of signals to sequenceOf()

### DIFF
--- a/RxSwift/Observables/Observable+Creation.swift
+++ b/RxSwift/Observables/Observable+Creation.swift
@@ -83,9 +83,13 @@ This method creates a new Observable instance with a variable number of elements
 */
 @warn_unused_result(message="http://git.io/rxs.uo")
 public func sequenceOf<E>(elements: E ..., scheduler: ImmediateSchedulerType? = nil) -> Observable<E> {
-    return Sequence(elements: elements, scheduler: scheduler)
+    return sequenceOfElements(elements, scheduler: scheduler)
 }
 
+@warn_unused_result(message="http://git.io/rxs.uo")
+public func sequenceOfElements<E>(elements: [E], scheduler: ImmediateSchedulerType? = nil) -> Observable<E> {
+    return Sequence(elements: elements, scheduler: scheduler)
+}
 
 extension SequenceType {
     /**


### PR DESCRIPTION
Hi all,

First of all - great framework!

Here's a little one I noticed; since Swift does not (yet) have a splat operator or similar (https://devforums.apple.com/message/970958#970958), there is no convenient way to pass an array to a variadic function. This makes something like `sequenceOf()` pretty inconvenient if you don't know the number of signals at compile time.

In order to "fix" this, make the primary method take an array argument, and delegate the variadic version to this. *Only hitch* is that using an overloaded function currently crashes the compiler, so here I've had to rename it. AFAIK I'm not doing something horribly wrong to cause this? If I am, can certainly change it since overloading is The Right Way.

Anyway, thanks!