### PR TITLE
Update new Playground API

### DIFF
--- a/Rx.playground/Sources/SupportCode.swift
+++ b/Rx.playground/Sources/SupportCode.swift
@@ -25,7 +25,7 @@ public func playgroundShouldContinueIndefinitely() {
 import XCPlayground
 
 public func playgroundShouldContinueIndefinitely() {
-    XCPSetExecutionShouldContinueIndefinitely(true)
+    XCPlaygroundPage.currentPage.needsIndefiniteExecution = true
 }
 
 #endif


### PR DESCRIPTION
Use `XCPlaygroundPage.currentPage.needsIndefiniteExecution = true` instead of  `XCPSetExecutionShouldContinueIndefinitely(true)` that was deprecated.