### PR TITLE
Reflect infinite sequences in the regex example

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -65,7 +65,7 @@ These diagrams are called marble diagrams.
 
 If we were to specify sequence grammar as regular expression it would look something like this
 
-**Next* (Error | Completed)**
+**Next* (Error | Completed)?**
 
 This describes the following:
 


### PR DESCRIPTION
The text gives an example of an infinite sequence here "Some sequences are finite, and some are infinite, like sequence of button taps" and just few lines below tries to explain sequences with a regex (which is great). However the regex was always having a terminating element (error or completion) and that contradicts the idea of an infinite sequence (which never terminates). 

What I did was to add a "?" to the terminating element in the regex example