### PR TITLE
flatMap example needed print statement added in order to see what was coming from se…

### DIFF
--- a/Rx.playground/Pages/Transforming_Observables.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Transforming_Observables.xcplaygroundpage/Contents.swift
@@ -44,8 +44,9 @@ example("flatMap") {
     let sequenceString = Observable.of("A", "B", "C", "D", "E", "F", "--")
 
     _ = sequenceInt
-        .flatMap { int in
-            sequenceString
+        .flatMap { (x:Int) -> Observable<String> in
+            print("from sequenceInt \(x)")
+            return sequenceString
         }
         .subscribe {
             print($0)


### PR DESCRIPTION
…quenceInt. Without adding the print statement and "(x:Int) -> Observable<String> in", it can be quite hard to see what is going on if not already familiar with the concept, IMHO.