### PR TITLE
Fix http body logging of NSURLSession

### DIFF
--- a/RxCocoa/Common/Observables/NSURLSession+Rx.swift
+++ b/RxCocoa/Common/Observables/NSURLSession+Rx.swift
@@ -64,7 +64,7 @@ func convertURLRequestToCurlCommand(request: NSURLRequest) -> String {
     if  request.HTTPMethod == "POST" && request.HTTPBody != nil {
         let maybeBody = NSString(data: request.HTTPBody!, encoding: NSUTF8StringEncoding) as? String
         if let body = maybeBody {
-            returnValue += "-d \"\(body)\""
+            returnValue += "-d \"\(escapeTerminalString(body))\" "
         }
     }
 


### PR DESCRIPTION
It is a log of when I POST body as json using NSURLSession+Rx.

```
curl -i -v -X POST -d "{"foo":true}"-H"Content-Type: application/json" "https://example.com/"
```

I found this small problems.
* There is no space after the `-d value`
* Value of `-d` is does not seem to be escaped