### PR TITLE
Add doOn shortcut operators

### DIFF
--- a/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
+++ b/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
@@ -156,7 +156,7 @@ extension DriverConvertibleType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     @warn_unused_result(message="http://git.io/rxs.uo")
-    public func doOnComplete(onCompleted: (() -> Void))
+    public func doOnCompleted(onCompleted: (() -> Void))
         -> Driver<E> {
         return self.doOn(onCompleted: onCompleted)
     }

--- a/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
+++ b/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
@@ -136,6 +136,30 @@ extension DriverConvertibleType {
             
         return Driver(source)
     }
+
+    /**
+     Invokes an action for each Next event in the observable sequence, and propagates all observer messages through the result sequence.
+
+     - parameter onNext: Action to invoke for each element in the observable sequence.
+     - returns: The source sequence with the side-effecting behavior applied.
+     */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func doOnNext(onNext: (E -> Void))
+        -> Driver<E> {
+        return self.doOn(onNext: onNext)
+    }
+
+    /**
+     Invokes an action for the Completed event in the observable sequence, and propagates all observer messages through the result sequence.
+
+     - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+     - returns: The source sequence with the side-effecting behavior applied.
+     */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func doOnComplete(onCompleted: (() -> Void))
+        -> Driver<E> {
+        return self.doOn(onCompleted: onCompleted)
+    }
 }
 
 extension DriverConvertibleType {

--- a/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
+++ b/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
@@ -129,10 +129,10 @@ extension DriverConvertibleType {
     - returns: The source sequence with the side-effecting behavior applied.
     */
     @warn_unused_result(message="http://git.io/rxs.uo")
-    public func doOn(onNext onNext: (E -> Void)? = nil, onError: (ErrorType -> Void)? = nil, onCompleted: (() -> Void)? = nil)
+    public func doOn(onNext onNext: (E -> Void)? = nil, onCompleted: (() -> Void)? = nil)
         -> Driver<E> {
         let source = self.asObservable()
-            .doOn(onNext: onNext, onError: onError, onCompleted: onCompleted)
+            .doOn(onNext: onNext, onCompleted: onCompleted)
             
         return Driver(source)
     }

--- a/RxExample/RxExample/Services/ImageService.swift
+++ b/RxExample/RxExample/Services/ImageService.swift
@@ -75,17 +75,17 @@ class DefaultImageService: ImageService {
                     else {
                         // fetch from network
                         decodedImage = self.$.URLSession.rx_data(NSURLRequest(URL: URL))
-                            .doOn(onNext: { data in
+                            .doOnNext { data in
                                 self._imageDataCache.setObject(data, forKey: URL)
-                            })
+                            }
                             .flatMap(self.decodeImage)
                             .trackActivity(self.loadingImage)
                     }
                 }
                 
-                return decodedImage.doOn(onNext: { image in
+                return decodedImage.doOnNext { image in
                     self._imageCache.setObject(image, forKey: URL)
-                })
+                }
             }
     }
 

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -113,6 +113,42 @@ extension ObservableType {
             }
         }
     }
+
+    /**
+     Invokes an action for each Next event in the observable sequence, and propagates all observer messages through the result sequence.
+
+     - parameter onNext: Action to invoke for each element in the observable sequence.
+     - returns: The source sequence with the side-effecting behavior applied.
+     */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func doOnNext(onNext: (E throws -> Void))
+        -> Observable<E> {
+        return self.doOn(onNext: onNext)
+    }
+
+    /**
+     Invokes an action for the Error event in the observable sequence, and propagates all observer messages through the result sequence.
+
+     - parameter onError: Action to invoke upon errored termination of the observable sequence.
+     - returns: The source sequence with the side-effecting behavior applied.
+     */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func doOnError(onError: (ErrorType throws -> Void))
+        -> Observable<E> {
+        return self.doOn(onError: onError)
+    }
+
+    /**
+     Invokes an action for the Completed event in the observable sequence, and propagates all observer messages through the result sequence.
+
+     - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+     - returns: The source sequence with the side-effecting behavior applied.
+     */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func doOnComplete(onCompleted: (() throws -> Void))
+        -> Observable<E> {
+        return self.doOn(onCompleted: onCompleted)
+    }
 }
 
 // MARK: startWith

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -145,7 +145,7 @@ extension ObservableType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     @warn_unused_result(message="http://git.io/rxs.uo")
-    public func doOnComplete(onCompleted: (() throws -> Void))
+    public func doOnCompleted(onCompleted: (() throws -> Void))
         -> Observable<E> {
         return self.doOn(onCompleted: onCompleted)
     }

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -71,7 +71,7 @@ extension ObservableType {
     }
 }
 
-// MARK: do
+// MARK: doOn
 
 extension ObservableType {
     

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -564,11 +564,11 @@ extension DriverTest {
         XCTAssertEqual(events, expectedEvents)
     }
 
-    func testAsDriver_doOnComplete() {
+    func testAsDriver_doOnCompleted() {
         let hotObservable = BackgroundThreadPrimitiveHotObservable<Int>()
 
         var completed = false
-        let driver = hotObservable.asDriver(onErrorJustReturn: -1).doOnComplete { e in
+        let driver = hotObservable.asDriver(onErrorJustReturn: -1).doOnCompleted { e in
             XCTAssertTrue(isMainThread())
             completed = true
         }

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -537,6 +537,55 @@ extension DriverTest {
         let expectedEvents = [.Next(1), .Next(2), .Next(-1), .Completed] as [Event<Int>]
         XCTAssertEqual(events, expectedEvents)
     }
+
+
+    func testAsDriver_doOnNext() {
+        let hotObservable = BackgroundThreadPrimitiveHotObservable<Int>()
+
+        var events = [Int]()
+
+        let driver = hotObservable.asDriver(onErrorJustReturn: -1).doOnNext { e in
+            XCTAssertTrue(isMainThread())
+            events.append(e)
+        }
+
+        let results = subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription(driver) {
+            XCTAssertTrue(hotObservable.subscriptions == [SubscribedToHotObservable])
+
+            hotObservable.on(.Next(1))
+            hotObservable.on(.Next(2))
+            hotObservable.on(.Error(testError))
+
+            XCTAssertTrue(hotObservable.subscriptions == [UnsunscribedFromHotObservable])
+        }
+
+        XCTAssertEqual(results, [1, 2, -1])
+        let expectedEvents = [1, 2, -1]
+        XCTAssertEqual(events, expectedEvents)
+    }
+
+    func testAsDriver_doOnComplete() {
+        let hotObservable = BackgroundThreadPrimitiveHotObservable<Int>()
+
+        var completed = false
+        let driver = hotObservable.asDriver(onErrorJustReturn: -1).doOnComplete { e in
+            XCTAssertTrue(isMainThread())
+            completed = true
+        }
+
+        let results = subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription(driver) {
+            XCTAssertTrue(hotObservable.subscriptions == [SubscribedToHotObservable])
+
+            hotObservable.on(.Next(1))
+            hotObservable.on(.Next(2))
+            hotObservable.on(.Error(testError))
+
+            XCTAssertTrue(hotObservable.subscriptions == [UnsunscribedFromHotObservable])
+        }
+
+        XCTAssertEqual(results, [1, 2, -1])
+        XCTAssertEqual(completed, true)
+    }
 }
 
 // MARK: distinct until change

--- a/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
@@ -271,9 +271,9 @@ extension ObservableSingleTest {
     }
 }
 
-// Do 
+// doOn
 extension ObservableSingleTest {
-    func testDo_shouldSeeAllValues() {
+    func testDoOn_shouldSeeAllValues() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let xs = scheduler.createHotObservable([
@@ -317,7 +317,7 @@ extension ObservableSingleTest {
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
 
-    func testDo_plainAction() {
+    func testDoOn_plainAction() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let xs = scheduler.createHotObservable([
@@ -356,8 +356,8 @@ extension ObservableSingleTest {
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
-    
-    func testDo_nextCompleted() {
+
+    func testDoOn_nextCompleted() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let xs = scheduler.createHotObservable([
@@ -404,7 +404,7 @@ extension ObservableSingleTest {
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
     
-    func testDo_completedNever() {
+    func testDoOn_completedNever() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let recordedEvents: [Recorded<Event<Int>>] = [
@@ -439,7 +439,7 @@ extension ObservableSingleTest {
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
     
-    func testDo_nextError() {
+    func testDoOn_nextError() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let xs = scheduler.createHotObservable([
@@ -486,7 +486,7 @@ extension ObservableSingleTest {
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
     
-    func testDo_nextErrorNot() {
+    func testDoOn_nextErrorNot() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let xs = scheduler.createHotObservable([
@@ -533,7 +533,7 @@ extension ObservableSingleTest {
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
     
-    func testDo_Throws() {
+    func testDoOn_Throws() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let xs = scheduler.createHotObservable([

--- a/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
@@ -679,13 +679,13 @@ extension ObservableSingleTest {
             ])
 
         let res = scheduler.start { xs.doOnError { _ in
-                throw testError
+                throw testError1
             }
         }
 
         let correctMessages = [
             next(210, 2),
-            error(250, testError)
+            error(250, testError1)
         ]
 
         let correctSubscriptions = [

--- a/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
@@ -696,7 +696,7 @@ extension ObservableSingleTest {
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
 
-    func testDoOnComplete_normal() {
+    func testDoOnCompleted_normal() {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createHotObservable([
@@ -710,7 +710,7 @@ extension ObservableSingleTest {
 
         var didComplete = false
 
-        let res = scheduler.start { xs.doOnComplete { error in
+        let res = scheduler.start { xs.doOnCompleted { error in
                 didComplete = true
             }
         }
@@ -733,7 +733,7 @@ extension ObservableSingleTest {
         XCTAssertEqual(didComplete, true)
     }
 
-    func testDoOnComplete_throws() {
+    func testDoOnCompleted_throws() {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createHotObservable([
@@ -745,7 +745,7 @@ extension ObservableSingleTest {
             completed(250)
             ])
 
-        let res = scheduler.start { xs.doOnComplete { error in
+        let res = scheduler.start { xs.doOnCompleted { error in
                 throw testError
             }
         }


### PR DESCRIPTION
Adds three operators that are shortcuts for `doOn`. I use these commonly and have seem them in [other projects](https://github.com/artsy/eidolon/blob/04a0c8488525be4b918e212e92a29f143e0f5838/Kiosk/Observable%2BOperators.swift#L64-L94) as well.