### PR TITLE
Make UIBarButtonItem.rx_tap to shareable.

### DIFF
--- a/RxCocoa/Common/Observables/NSObject+Rx.swift
+++ b/RxCocoa/Common/Observables/NSObject+Rx.swift
@@ -220,3 +220,21 @@ extension NSObject {
         return result
     }
 }
+
+extension NSObject {
+    /**
+     Helper to make sure that `Observable` returned from `createCachedObservable` is only created once.
+     This is important because there is only one `target` and `action` properties on `NSControl` or `UIBarButtonItem`.
+     */
+    func rx_lazyInstanceObservable<T: AnyObject>(key: UnsafePointer<Void>, createCachedObservable: () -> T) -> T {
+        if let value = objc_getAssociatedObject(self, key) {
+            return value as! T
+        }
+        
+        let observable = createCachedObservable()
+        
+        objc_setAssociatedObject(self, key, observable, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        
+        return observable
+    }
+}

--- a/RxCocoa/OSX/NSControl+Rx.swift
+++ b/RxCocoa/OSX/NSControl+Rx.swift
@@ -43,22 +43,6 @@ extension NSControl {
         return ControlEvent(events: source)
     }
 
-    /**
-    Helper to make sure that `Observable` returned from `createCachedObservable` is only created once.
-    This is important because on OSX there is only one `target` and `action` properties on `NSControl`.
-    */
-    func rx_lazyInstanceObservable<T: AnyObject>(key: UnsafePointer<Void>, createCachedObservable: () -> T) -> T {
-        if let value = objc_getAssociatedObject(self, key) {
-            return value as! T
-        }
-
-        let observable = createCachedObservable()
-
-        objc_setAssociatedObject(self, key, observable, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-
-        return observable
-    }
-
     func rx_value<T: Equatable>(getter getter: () -> T, setter: T -> Void) -> ControlProperty<T> {
         MainScheduler.ensureExecutingOnScheduler()
 


### PR DESCRIPTION
UIBarButtonItem has only one target, so UIBarButtonItem.rx_tap cannot share now.
```swift
let barButton = UIBarButtonItem()
barButton.rx_tap
  .subscribeNext { [weak self] _ in
    // Never not be called.
  }
  .addDisposable(disposeBag)
barButton.rx_tap
  .subscribeNext { [weak self] _ in
    ...
  }
  .addDisposable(disposeBag)
```

I move ControlEvent initializer to BarButtonItemTarget, and reuse it.
Then, UIBarButtonItem.rx_tap can share.

Please check this pr :3