### PR TITLE
fix example `map`

### DIFF
--- a/Rx.playground/Pages/Transforming_Observables.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Transforming_Observables.xcplaygroundpage/Contents.swift
@@ -19,11 +19,11 @@ Transform the items emitted by an Observable by applying a function to each item
 */
 
 example("map") {
-    let originalSequence = Observable.of(Character("A"), Character("B"), Character("C"))
+    let originalSequence = Observable.of(1, 2, 3)
 
     _ = originalSequence
-        .map { char in
-            char.hashValue
+        .map { number in
+            number * 2
         }
         .subscribe { print($0) }
 }


### PR DESCRIPTION
Before output:

```
--- map example ---
Next(4799450059485597671)
Next(4799450059485597672)
Next(4799450059485597677)
Completed
```

after:

```
--- map example ---
Next(A)
Next(B)
Next(C)
Completed
```