### PR TITLE
ForwardIf operator

### DIFF
--- a/Rx.playground/Pages/Combining_Observables.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Combining_Observables.xcplaygroundpage/Contents.swift
@@ -236,6 +236,28 @@ example("merge 2") {
     subject1.on(.Next(80))
     subject1.on(.Next(100))
     subject2.on(.Next(1))
+
+}
+
+example("forwardIf") {
+    let subject1 = PublishSubject<Int>()
+    let subject2 = PublishSubject<Bool>()
+
+    _ = subject1
+        .forwardIf(subject2)
+        .subscribe {
+            print($0)
+        }
+
+    subject1.on(.Next(20))
+    subject1.on(.Next(40))
+    subject2.on(.Next(true))
+    subject1.on(.Next(60))
+    subject1.on(.Next(80))
+    subject2.on(.Next(false))
+    subject1.on(.Next(100))
+    subject2.on(.Next(true))
+    subject1.on(.Next(120))
 }
 
 

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1102,6 +1102,10 @@
 		D2FC15B31BCB95E5007361FF /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */; };
 		D2FC15B41BCB95E7007361FF /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */; };
 		D2FC15B51BCB95E8007361FF /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */; };
+		E126CB4E1C4F082100647DCC /* ForwardIf.swift in Sources */ = {isa = PBXBuildFile; fileRef = E126CB4D1C4F082100647DCC /* ForwardIf.swift */; };
+		E126CB4F1C4F164E00647DCC /* ForwardIf.swift in Sources */ = {isa = PBXBuildFile; fileRef = E126CB4D1C4F082100647DCC /* ForwardIf.swift */; };
+		E126CB501C4F165700647DCC /* ForwardIf.swift in Sources */ = {isa = PBXBuildFile; fileRef = E126CB4D1C4F082100647DCC /* ForwardIf.swift */; };
+		E126CB511C4F165800647DCC /* ForwardIf.swift in Sources */ = {isa = PBXBuildFile; fileRef = E126CB4D1C4F082100647DCC /* ForwardIf.swift */; };
 		F31F35B01BB4FED800961002 /* UIStepper+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */; };
 /* End PBXBuildFile section */
 
@@ -1646,6 +1650,7 @@
 		D285BAC31BC0231000B3F602 /* SkipUntil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipUntil.swift; sourceTree = "<group>"; };
 		D2EA280C1BB9B5A200880ED3 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2EBEB811BB9B99D003A27DC /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E126CB4D1C4F082100647DCC /* ForwardIf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForwardIf.swift; sourceTree = "<group>"; };
 		F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStepper+Rx.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1915,6 +1920,7 @@
 				C8C3DA051B9393AC004D233E /* Empty.swift */,
 				C8C3DA081B93941E004D233E /* Error.swift */,
 				C8093C7A1B8A72BE0088E94D /* Filter.swift */,
+				E126CB4D1C4F082100647DCC /* ForwardIf.swift */,
 				C84B38ED1BA433CD001B7D88 /* Generate.swift */,
 				C8C3DA021B9390C4004D233E /* Just.swift */,
 				C8093C7C1B8A72BE0088E94D /* Map.swift */,
@@ -3606,6 +3612,7 @@
 				C8093D5E1B8A72BE0088E94D /* Observable+Multiple.swift in Sources */,
 				C83D73C11C1DBAEE003DC470 /* InvocableType.swift in Sources */,
 				C8093D741B8A72BE0088E94D /* ObserverBase.swift in Sources */,
+				E126CB4F1C4F164E00647DCC /* ForwardIf.swift in Sources */,
 				C85106891C2D550E0075150C /* String+Rx.swift in Sources */,
 				C8093D121B8A72BE0088E94D /* ConnectableObservable.swift in Sources */,
 				C8BF34D01C2E426800416CAE /* Platform.Linux.swift in Sources */,
@@ -3828,6 +3835,7 @@
 				C83D73C01C1DBAEE003DC470 /* InvocableType.swift in Sources */,
 				C8093D731B8A72BE0088E94D /* ObserverBase.swift in Sources */,
 				C85106881C2D550E0075150C /* String+Rx.swift in Sources */,
+				E126CB4E1C4F082100647DCC /* ForwardIf.swift in Sources */,
 				C8093D111B8A72BE0088E94D /* ConnectableObservable.swift in Sources */,
 				C8BF34CF1C2E426800416CAE /* Platform.Linux.swift in Sources */,
 				C8093D611B8A72BE0088E94D /* Observable+StandardSequenceOperators.swift in Sources */,
@@ -3974,6 +3982,7 @@
 				C8F0BFAE1BBBFB8B001B112F /* Observable+Multiple.swift in Sources */,
 				C83D73C31C1DBAEE003DC470 /* InvocableType.swift in Sources */,
 				C8F0BFAF1BBBFB8B001B112F /* ObserverBase.swift in Sources */,
+				E126CB511C4F165800647DCC /* ForwardIf.swift in Sources */,
 				C851068B1C2D550E0075150C /* String+Rx.swift in Sources */,
 				C8F0BFB01BBBFB8B001B112F /* ConnectableObservable.swift in Sources */,
 				C8BF34D21C2E426800416CAE /* Platform.Linux.swift in Sources */,
@@ -4289,6 +4298,7 @@
 				C83D73C21C1DBAEE003DC470 /* InvocableType.swift in Sources */,
 				D2EBEB071BB9B6C1003A27DC /* Deferred.swift in Sources */,
 				C851068A1C2D550E0075150C /* String+Rx.swift in Sources */,
+				E126CB501C4F165700647DCC /* ForwardIf.swift in Sources */,
 				D2EBEB2C1BB9B6CA003A27DC /* Observable+Binding.swift in Sources */,
 				C8BF34D11C2E426800416CAE /* Platform.Linux.swift in Sources */,
 				D2EBEB041BB9B6C1003A27DC /* Concat.swift in Sources */,

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		CBEE77541BD8C7B700AD584C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBEE77531BD8C7B700AD584C /* ToArray.swift */; };
 		D2245A191BD5654C00E7146F /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2245A0B1BD564A700E7146F /* WithLatestFrom.swift */; };
 		D2AF91981BD3D95900A008C1 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2AF91881BD2C51900A008C1 /* Using.swift */; };
+		E1AFE5C71C50CC560015087B /* ForwardIf.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AFE5B11C50CC200015087B /* ForwardIf.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -927,6 +928,7 @@
 		CBEE77531BD8C7B700AD584C /* ToArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToArray.swift; sourceTree = "<group>"; };
 		D2245A0B1BD564A700E7146F /* WithLatestFrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithLatestFrom.swift; sourceTree = "<group>"; };
 		D2AF91881BD2C51900A008C1 /* Using.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Using.swift; sourceTree = "<group>"; };
+		E1AFE5B11C50CC200015087B /* ForwardIf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForwardIf.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1395,6 +1397,7 @@
 				C89464591BC6C2B00055219D /* Empty.swift */,
 				C894645A1BC6C2B00055219D /* Error.swift */,
 				C894645B1BC6C2B00055219D /* Filter.swift */,
+				E1AFE5B11C50CC200015087B /* ForwardIf.swift */,
 				C894645D1BC6C2B00055219D /* Generate.swift */,
 				C894645E1BC6C2B00055219D /* Just.swift */,
 				C894645F1BC6C2B00055219D /* Map.swift */,
@@ -2255,6 +2258,7 @@
 				C89465811BC6C2BC0055219D /* ItemEvents.swift in Sources */,
 				C89465861BC6C2BC0055219D /* RxCollectionViewDataSourceProxy.swift in Sources */,
 				C89465981BC6C2BC0055219D /* UISearchBar+Rx.swift in Sources */,
+				E1AFE5C71C50CC560015087B /* ForwardIf.swift in Sources */,
 				C89464E21BC6C2B00055219D /* Take.swift in Sources */,
 				C80DA3551C30B48300C588B9 /* PriorityQueue.swift in Sources */,
 				B18F3BC11BD93E00000AAC79 /* Reachability.swift in Sources */,

--- a/RxSwift/Observables/Implementations/ForwardIf.swift
+++ b/RxSwift/Observables/Implementations/ForwardIf.swift
@@ -1,0 +1,129 @@
+//
+//  ForwardIf.swift
+//  Rx
+//
+//  Created by Jorge Bernal Ordovas on 20/01/16.
+//  Copyright © 2016 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+class ForwardIfSinkIter<S: ObservableType, O: ObserverType where O.E == S.E> : ObserverType {
+    typealias Parent = ForwardIfSink<S, O>
+    typealias DisposeKey = CompositeDisposable.DisposeKey
+    typealias E = O.E
+
+    private let _parent: Parent
+    private let _disposeKey: DisposeKey
+
+    init(parent: Parent, disposeKey: DisposeKey) {
+        _parent = parent
+        _disposeKey = disposeKey
+    }
+
+    func on(event: Event<E>) {
+        switch event {
+        case .Next(let value):
+            _parent._lock.lock(); defer { _parent._lock.unlock() } // lock {
+                _parent.forwardOn(.Next(value))
+            // }
+        case .Error(let error):
+            _parent._lock.lock(); defer { _parent._lock.unlock() } // lock {
+                _parent.forwardOn(.Error(error))
+                _parent.dispose()
+            // }
+        case .Completed:
+            _parent._group.removeDisposable(_disposeKey)
+            _parent._lock.lock(); defer { _parent._lock.unlock() } // lock {
+                _parent.forwardOn(.Completed)
+                _parent.dispose()
+            // }
+        }
+    }
+
+}
+
+class ForwardIfSink<S: ObservableType, O: ObserverType where O.E == S.E>: Sink<O>, ObserverType {
+    typealias E = Bool
+    typealias SourceType = S.E
+    typealias DisposeKey = CompositeDisposable.DisposeKey
+
+    private let _lock = NSRecursiveLock()
+
+    private let _source: S
+    private let _group = CompositeDisposable()
+    private let _conditionSubscription = SingleAssignmentDisposable()
+    private var _sourceDisposeKey: DisposeKey? = nil
+
+    init(observer: O, source: S) {
+        _source = source
+        super.init(observer: observer)
+    }
+
+    func on(event: Event<E>) {
+        switch event {
+        case .Next(let element):
+            if element {
+                subscribeInner(_source)
+            } else {
+                unsubscribeInner()
+            }
+        case .Completed:
+            _lock.lock(); defer { _lock.unlock() } // lock {
+                forwardOn(.Completed)
+                dispose()
+            // }
+        case .Error(let error):
+            _lock.lock(); defer { _lock.unlock() } // lock {
+                forwardOn(.Error(error))
+                dispose()
+            // }
+        }
+    }
+
+    func subscribeInner(source: S) {
+        print("subscribeInner")
+        if _sourceDisposeKey != nil {
+            return
+        }
+        let iterDisposable = SingleAssignmentDisposable()
+        if let disposeKey = _group.addDisposable(iterDisposable) {
+            _sourceDisposeKey = disposeKey
+            let iter = ForwardIfSinkIter(parent: self, disposeKey: disposeKey)
+            let subscription = source.subscribe(iter)
+            iterDisposable.disposable = subscription
+        }
+    }
+
+    func unsubscribeInner() {
+        if let disposeKey = _sourceDisposeKey {
+            _group.removeDisposable(disposeKey)
+            _sourceDisposeKey = nil
+        }
+    }
+
+    func run(condition: Observable<Bool>) -> Disposable {
+        _group.addDisposable(_conditionSubscription)
+
+        let subscription = condition.subscribe(self)
+        _conditionSubscription.disposable = subscription
+
+        return _group
+    }
+}
+
+class ForwardIf<S: ObservableType>: Producer<S.E> {
+    private let _source: S
+    private let _condition: Observable<Bool>
+
+    init(source: S, condition: Observable<Bool>) {
+        _source = source
+        _condition = condition
+    }
+
+    override func run<O: ObserverType where O.E == S.E>(observer: O) -> Disposable {
+        let sink = ForwardIfSink<S, O>(observer: observer, source: _source)
+        sink.disposable = sink.run(_condition)
+        return sink
+    }
+}

--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -328,3 +328,20 @@ extension ObservableType {
         return WithLatestFrom(first: asObservable(), second: second.asObservable(), resultSelector: { $1 })
     }
 }
+
+// MARK: forwardIf
+
+extension ObservableType {
+
+    /**
+     Propagates the source observable sequence while the condition observable sequence last value is true.
+     
+     - parameter source: Source observable sequence to propagate
+     - parameter condition: Boolean observable sequence that dictates if the source propagates.
+     - returns: An observable sequence that subscribes and emits the values of the source observable as long as the last emitted value of the condition observable is true.
+     */
+    public func forwardIf<ConditionO: ObservableConvertibleType where ConditionO.E == Bool>(condition: ConditionO) -> Observable<E> {
+        return ForwardIf(source: self, condition: condition.asObservable())
+    }
+}
+

--- a/Sources/AllTests/main.swift
+++ b/Sources/AllTests/main.swift
@@ -326,6 +326,8 @@ _ObservableMultipleTest.allTests = [
     //("testWithLatestFrom_Error2", { _ObservableMultipleTest.setUp(); _ObservableMultipleTest.testWithLatestFrom_Error2(); _ObservableMultipleTest.tearDown(); }),
     //("testWithLatestFrom_Error3", { _ObservableMultipleTest.setUp(); _ObservableMultipleTest.testWithLatestFrom_Error3(); _ObservableMultipleTest.tearDown(); }),
     ("testWithLatestFrom_MakeSureDefaultOverloadTakesSecondSequenceValues", { _ObservableMultipleTest.setUp(); _ObservableMultipleTest.testWithLatestFrom_MakeSureDefaultOverloadTakesSecondSequenceValues(); _ObservableMultipleTest.tearDown(); }),
+    ("testForwardIf_simple1", { _ObservableMultipleTest.setUp(); _ObservableMultipleTest.testForwardIf_simple1(); _ObservableMultipleTest.tearDown(); }),
+    ("testForwardIf_ConditionCompletedCausesDisposal", { _ObservableMultipleTest.setUp(); _ObservableMultipleTest.testForwardIf_ConditionCompletedCausesDisposal(); _ObservableMultipleTest.tearDown(); }),
 ]
 
 

--- a/Sources/RxSwift/ForwardIf.swift
+++ b/Sources/RxSwift/ForwardIf.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/Implementations/ForwardIf.swift

--- a/Tests/RxSwiftTests/Tests/Observable+MultipleTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+MultipleTest.swift
@@ -4622,3 +4622,84 @@ extension ObservableMultipleTest {
             ])
     }
 }
+
+// MARK: forwardIf
+extension ObservableMultipleTest {
+    func testForwardIf_simple1() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(90, 1),
+            next(180, 2),
+            next(250, 3),
+            next(260, 4),
+            next(310, 5),
+            next(360, 6),
+            completed(390)
+        ])
+        
+        let ys = scheduler.createHotObservable([
+            next(210, true),
+            next(300, false),
+            next(350, true),
+            completed(400)
+        ])
+
+        let res = scheduler.start {
+            xs.forwardIf(ys)
+        }
+
+        XCTAssertEqual(res.events, [
+            next(250, 3),
+            next(260, 4),
+            next(360, 6),
+            completed(390)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(210, 300),
+            Subscription(350, 390)
+            ])
+
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 390)
+            ])
+
+    }
+
+    func testForwardIf_ConditionCompletedCausesDisposal() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(90, 1),
+            next(180, 2),
+            next(250, 3),
+            next(260, 4),
+            next(310, 5),
+            next(360, 6),
+            completed(390)
+        ])
+        
+        let ys = scheduler.createHotObservable([
+            next(290, true),
+            completed(300)
+        ])
+
+        let res = scheduler.start {
+            xs.forwardIf(ys)
+        }
+
+        XCTAssertEqual(res.events, [
+            completed(300)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(290, 300)
+            ])
+
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 300)
+            ])
+
+    }
+}


### PR DESCRIPTION
ForwardIf propagates the source observable sequence while the condition
observable sequence last value is true.

This is useful when an Observable performs side effects on subscription, so we
only want to subscribe when another observable is true.

An example case for this would be an Observable that performs network requests.
We only want it to hit the network if the subscribing view controller is
visible.

This example would look something like this:

```swift
service.refreshModel
  .forwardIf(visible)
  .subscribeNext(bindModel)
  .addDisposableTo(disposeBag)
```

Notes:

- `ForwardIf` is mostly a suggestion. I've thought about how to name this and I'm not 100% sold on any name. Other options: `subscribeWhen`, `subscribeWhile`, `forwardWhile`.
- It looks like RxJS [pausable](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/pausable.md) does a similar thing. Looking at the implementation I understand it does the same thing, but the documentation doesn't guarantee that the source observable would only get subscribed when the condition is true.
- Even if you decide not to include this as a part of RxSwift, I'd really appreciate a code review or any comments about the implementation, specially around locking and threading. It's my first approach to RxSwift code, and I'm not too sure if I did things right.