### PR TITLE
Return generic SignedIntegerType Observable for timer instead of Int64

### DIFF
--- a/RxSwift/Observables/Observable+Time.swift
+++ b/RxSwift/Observables/Observable+Time.swift
@@ -125,7 +125,7 @@ extension Observable where Element: SignedIntegerType {
     */
     @warn_unused_result(message="http://git.io/rxs.uo")
     public static func timer(dueTime: RxTimeInterval, scheduler: SchedulerType)
-        -> Observable<Int64> {
+        -> Observable<E> {
         return Timer(
             dueTime: dueTime,
             period: nil,

--- a/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
@@ -1307,7 +1307,7 @@ extension ObservableSingleTest {
                 errors.scan((0, nil)) { (a: (Int, NSError!), e) in
                     (a.0 + 1, e)
                 }
-                .flatMap { (a, e) -> Observable<Int64> in
+                .flatMap { (a, e) -> Observable<Int> in
                     if a >= 4 {
                         return Observable.error(e)
                     }


### PR DESCRIPTION
Seems to have been left out when the time creators where converted to contained extensions.