### PR TITLE
Updated CocoaPods instructions for latest CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,13 +460,15 @@ Open Rx.xcworkspace, choose `RxExample` and hit run. This method will build ever
 # Podfile
 use_frameworks!
 
-pod 'RxSwift',    '~> 2.0'
-pod 'RxCocoa',    '~> 2.0'
-pod 'RxBlocking', '~> 2.0'
-pod 'RxTests',    '~> 2.0'
+target 'YOUR_TARGET_NAME' do
+    pod 'RxSwift',    '~> 2.0'
+    pod 'RxCocoa',    '~> 2.0'
+    pod 'RxBlocking', '~> 2.0'
+    pod 'RxTests',    '~> 2.0'
+end
 ```
 
-type in `Podfile` directory
+replace `YOUR_TARGET_NAME`, then type in the `Podfile` directory:
 
 ```
 $ pod install


### PR DESCRIPTION
In CocoaPods 1.0.0.beta.3, the Podfile now needs to specify the target name, otherwise `pod install` fails with the following:

```[!] The dependency `RxSwift (~> 2.0)` is not used in any concrete target.
The dependency `RxCocoa (~> 2.0)` is not used in any concrete target.```

I added an extra step to the instructions to make it work again. The above format of course still works on the pre-1.0.0 cocoapods as well, so I believe it's safe to update the instructions already.