### PR TITLE
Work around to an error with preprocessors in swift

### DIFF
--- a/RxCocoa/iOS/UIApplication+Rx.swift
+++ b/RxCocoa/iOS/UIApplication+Rx.swift
@@ -10,11 +10,11 @@ import Foundation
 
 #if os(iOS)
     import UIKit
-    
+
 #if !RX_NO_MODULE
     import RxSwift
 #endif
-    
+
     extension UIApplication {
         
         /**
@@ -27,3 +27,4 @@ import Foundation
         }
     }
 #endif
+


### PR DESCRIPTION
Compilation of RxCocoa-iOS fails expecting an #endif at the end of UIApplication+Rx.swift, despite the #endif, in fact, being present.

Adding white space after the last #endif works around the problem.

See Open Radar here

http://www.openradar.appspot.com/18594933