### PR TITLE
Use StaticString for file in XCTest helpers

### DIFF
--- a/RxTests/XCTest+Rx.swift
+++ b/RxTests/XCTest+Rx.swift
@@ -58,7 +58,7 @@ Event is considered equal if:
 - parameter lhs: first set of events.
 - parameter lhs: second set of events.
 */
-public func XCTAssertEqual<T: Equatable>(lhs: [Event<T>], _ rhs: [Event<T>], file: String = __FILE__, line: UInt = __LINE__) {
+public func XCTAssertEqual<T: Equatable>(lhs: [Event<T>], _ rhs: [Event<T>], file: StaticString = __FILE__, line: UInt = __LINE__) {
     let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }
     let rightEquatable = rhs.map { AnyEquatable(target: $0, comparer: ==) }
     #if os(Linux)
@@ -86,7 +86,7 @@ Event is considered equal if:
 - parameter lhs: first set of events.
 - parameter lhs: second set of events.
 */
-public func XCTAssertEqual<T: Equatable>(lhs: [Recorded<Event<T>>], _ rhs: [Recorded<Event<T>>], file: String = __FILE__, line: UInt = __LINE__) {
+public func XCTAssertEqual<T: Equatable>(lhs: [Recorded<Event<T>>], _ rhs: [Recorded<Event<T>>], file: StaticString = __FILE__, line: UInt = __LINE__) {
     let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }
     let rightEquatable = rhs.map { AnyEquatable(target: $0, comparer: ==) }
     #if os(Linux)


### PR DESCRIPTION
As mentioned on #472, submitting a fix for the `StaticString` changes in Xcode 7.3-beta2