### PR TITLE
Change anyGenerator to AnyGenerator for Swift 2.2 (Xcode 7.3)

### DIFF
--- a/RxSwift/DataStructures/InfiniteSequence.swift
+++ b/RxSwift/DataStructures/InfiniteSequence.swift
@@ -23,7 +23,7 @@ struct InfiniteSequence<E> : SequenceType {
     
     func generate() -> Generator {
         let repeatedValue = _repeatedValue
-        return anyGenerator {
+        return AnyGenerator {
             return repeatedValue
         }
     }

--- a/RxSwift/DataStructures/Queue.swift
+++ b/RxSwift/DataStructures/Queue.swift
@@ -162,7 +162,7 @@ public struct Queue<T>: SequenceType {
         var i = dequeueIndex
         var count = _count
 
-        return anyGenerator {
+        return AnyGenerator {
             if count == 0 {
                 return nil
             }


### PR DESCRIPTION
Fixes a warning.