### PR TITLE
Added Observable for View animation completion that enables chaining

### DIFF
--- a/RxCocoa/iOS/UIView+Rx.swift
+++ b/RxCocoa/iOS/UIView+Rx.swift
@@ -32,6 +32,28 @@ extension UIView {
             view.alpha = alpha
         }.asObserver()
     }
+    
+    static func rx_animation(duration: NSTimeInterval, animations: () -> Void) -> Observable<Bool> {
+        return Observable.create { observer in
+            UIView.animateWithDuration(duration, animations: animations) {
+                observer.on(.Next($0))
+                observer.on(.Completed)
+            }
+            return AnonymousDisposable {}
+        }
+        .observeOn(MainScheduler.instance)
+    }
+}
+    
+extension ObservableType {
+    /**
+     Chaining view animations from Observable.
+     */
+    func animate(duration: NSTimeInterval, animations: () -> Void) -> Observable<E> {
+        return self.flatMap { (element: E) -> Observable<E> in
+            return UIView.rx_animation(duration, animations: animations).map { _ in return element }
+        }
+    }
 }
 
 #endif


### PR DESCRIPTION
Added Observable for View animation completion that enables chaining them.

- Simple Animation:
``` Swift
        UIView.rx_animation(1) { [weak self] in self?.summaryView.alpha = 0 }
            .subscribeNext { [weak self] in self?.showSomething() }
            .addDisposableTo(disposeBag)
```

- Animation Chaining:
``` Swift
    button.rx_tap.asObservable()
        .animate(1) { [weak self] in self?.imageView.alpha = 0 }
        .animate(1) { [weak self] in self?.imageView.alpha = 1 }
        .animate(1) { [weak self] in self?.imageView.alpha = 0 }
        .animate(1) { [weak self] in self?.imageView.alpha = 1 }
        .subscribeNext { [weak self] model in self?.showDetail(model) }
        .addDisposableTo(disposeBag)
```