### PR TITLE
Adding 'rx_searchTapped' and 'rx_cancelTapped' ControlEvents to UISearchBar

### DIFF
--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -250,6 +250,10 @@ extension UISearchBar {
 
     public var rx_searchText: ControlProperty<String> {}
 
+    public var rx_searchTapped: ControlEvent<UISearchBar> {}
+
+    public var rx_cancelTapped: ControlEvent<UISearchBar> {}
+
 }
 ```
 

--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -250,9 +250,9 @@ extension UISearchBar {
 
     public var rx_searchText: ControlProperty<String> {}
 
-    public var rx_searchTapped: ControlEvent<UISearchBar> {}
+    public var rx_searchButtonClicked: ControlEvent<Void> {}
 
-    public var rx_cancelTapped: ControlEvent<UISearchBar> {}
+    public var rx_cancelButtonClicked: ControlEvent<Void> {}
 
 }
 ```

--- a/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
@@ -14,19 +14,30 @@ import UIKit
 import RxSwift
 #endif
 
-class RxSearchBarDelegateProxy : DelegateProxy
+public class RxSearchBarDelegateProxy : DelegateProxy
                                , UISearchBarDelegate
                                , DelegateProxyType {
     
-    class func currentDelegateFor(object: AnyObject) -> AnyObject? {
+    public class func currentDelegateFor(object: AnyObject) -> AnyObject? {
         let searchBar: UISearchBar = castOrFatalError(object)
         return searchBar.delegate
     }
     
-    class func setCurrentDelegate(delegate: AnyObject?, toObject object: AnyObject) {
+    public class func setCurrentDelegate(delegate: AnyObject?, toObject object: AnyObject) {
         let searchBar: UISearchBar = castOrFatalError(object)
         searchBar.delegate = castOptionalOrFatalError(delegate)
-    }
+  }
+  
+  // MARK: delegate proxy
+  
+  /**
+  For more information take a look at `DelegateProxyType`.
+  */
+  public override class func createProxyForObject(object: AnyObject) -> AnyObject {
+    let searchBar = (object as! UISearchBar)
+    
+    return castOrFatalError(searchBar.rx_createDelegateProxy())
+  }
 }
 
 #endif

--- a/RxCocoa/iOS/UISearchBar+Rx.swift
+++ b/RxCocoa/iOS/UISearchBar+Rx.swift
@@ -16,7 +16,16 @@ import UIKit
 
 
 
-extension UISearchBar {
+  extension UISearchBar {
+    
+    /**
+     Factory method that enables subclasses to implement their own `rx_delegate`.
+     
+     - returns: Instance of delegate proxy that wraps `delegate`.
+     */
+    public func rx_createDelegateProxy() -> RxSearchBarDelegateProxy {
+      return RxSearchBarDelegateProxy(parentObject: self)
+    }
     
     /**
     Reactive wrapper for `delegate`.
@@ -51,7 +60,7 @@ extension UISearchBar {
     /**
      Reactive wrapper for `searchBarSearchButtonClicked:` delegate event.
      */
-    public var rx_searchTapped: ControlEvent<UISearchBar> {
+    public var rx_searchButtonClicked: ControlEvent<UISearchBar> {
         let source: Observable<UISearchBar> = Observable.deferred { [weak self] () -> Observable<UISearchBar> in
             return (self?.rx_delegate.observe("searchBarSearchButtonClicked:") ?? Observable.empty())
                 .flatMap { a -> Observable<UISearchBar> in
@@ -66,7 +75,7 @@ extension UISearchBar {
     /**
      Reactive wrapper for `searchBarCancelButtonClicked:` delegate event.
      */
-    public var rx_cancelTapped: ControlEvent<UISearchBar> {
+    public var rx_cancelButtonClicked: ControlEvent<UISearchBar> {
         let source: Observable<UISearchBar> = Observable.deferred { [weak self] () -> Observable<UISearchBar> in
             return (self?.rx_delegate.observe("searchBarCancelButtonClicked:") ?? Observable.empty())
                 .flatMap { a -> Observable<UISearchBar> in

--- a/RxCocoa/iOS/UISearchBar+Rx.swift
+++ b/RxCocoa/iOS/UISearchBar+Rx.swift
@@ -60,13 +60,10 @@ import UIKit
     /**
      Reactive wrapper for `searchBarSearchButtonClicked:` delegate event.
      */
-    public var rx_searchButtonClicked: ControlEvent<UISearchBar> {
-        let source: Observable<UISearchBar> = Observable.deferred { [weak self] () -> Observable<UISearchBar> in
+    public var rx_searchButtonClicked: ControlEvent<Void> {
+        let source: Observable<Void> = Observable.deferred { [weak self] () -> Observable<Void> in
             return (self?.rx_delegate.observe("searchBarSearchButtonClicked:") ?? Observable.empty())
-                .flatMap { a -> Observable<UISearchBar> in
-                    let result = a.first.flatMap { $0 as? UISearchBar }.flatMap { Observable.just($0) }
-                    return result ?? Observable.empty()
-            }
+                .map { _ in () }
         }
         
         return ControlEvent(events: source)
@@ -75,13 +72,10 @@ import UIKit
     /**
      Reactive wrapper for `searchBarCancelButtonClicked:` delegate event.
      */
-    public var rx_cancelButtonClicked: ControlEvent<UISearchBar> {
-        let source: Observable<UISearchBar> = Observable.deferred { [weak self] () -> Observable<UISearchBar> in
+    public var rx_cancelButtonClicked: ControlEvent<Void> {
+        let source: Observable<Void> = Observable.deferred { [weak self] () -> Observable<Void> in
             return (self?.rx_delegate.observe("searchBarCancelButtonClicked:") ?? Observable.empty())
-                .flatMap { a -> Observable<UISearchBar> in
-                    let result = a.first.flatMap { $0 as? UISearchBar }.flatMap { Observable.just($0) }
-                    return result ?? Observable.empty()
-            }
+                .map { _ in () }
         }
       
         return ControlEvent(events: source)

--- a/RxCocoa/iOS/UISearchBar+Rx.swift
+++ b/RxCocoa/iOS/UISearchBar+Rx.swift
@@ -47,6 +47,36 @@ extension UISearchBar {
         
         return ControlProperty(values: source, valueSink: bindingObserver)
     }
-}
-
+    
+    /**
+     Reactive wrapper for `searchBarSearchButtonClicked:` delegate event.
+     */
+    public var rx_searchTapped: ControlEvent<UISearchBar> {
+        let source: Observable<UISearchBar> = Observable.deferred { [weak self] () -> Observable<UISearchBar> in
+            return (self?.rx_delegate.observe("searchBarSearchButtonClicked:") ?? Observable.empty())
+                .flatMap { a -> Observable<UISearchBar> in
+                    let result = a.first.flatMap { $0 as? UISearchBar }.flatMap { Observable.just($0) }
+                    return result ?? Observable.empty()
+            }
+        }
+        
+        return ControlEvent(events: source)
+    }
+    
+    /**
+     Reactive wrapper for `searchBarCancelButtonClicked:` delegate event.
+     */
+    public var rx_cancelTapped: ControlEvent<UISearchBar> {
+        let source: Observable<UISearchBar> = Observable.deferred { [weak self] () -> Observable<UISearchBar> in
+            return (self?.rx_delegate.observe("searchBarCancelButtonClicked:") ?? Observable.empty())
+                .flatMap { a -> Observable<UISearchBar> in
+                    let result = a.first.flatMap { $0 as? UISearchBar }.flatMap { Observable.just($0) }
+                    return result ?? Observable.empty()
+            }
+        }
+      
+        return ControlEvent(events: source)
+    }
+  }
+  
 #endif

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
@@ -50,8 +50,15 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
                     : Observable.empty()
             }
 
-        let searchResult = searchBar.rx_text.asDriver()
+        let searchText = searchBar.rx_text.asDriver()
             .throttle(0.3)
+        let searchTapped = searchBar.rx_searchTapped.asDriver()
+            .flatMap { $0.text.flatMap { Driver.just($0) } ?? Driver.empty() }
+        let cancelTapped = searchBar.rx_cancelTapped.asDriver()
+            .map { _ in "" }
+      
+        let searchResult = Driver.of(searchText, searchTapped, cancelTapped)
+            .merge()
             .distinctUntilChanged()
             .flatMapLatest { query -> Driver<RepositoriesState> in
                 if query.isEmpty {

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
@@ -52,12 +52,10 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
 
         let searchText = searchBar.rx_text.asDriver()
             .throttle(0.3)
-        let searchTapped = searchBar.rx_searchTapped.asDriver()
-            .flatMap { $0.text.flatMap { Driver.just($0) } ?? Driver.empty() }
-        let cancelTapped = searchBar.rx_cancelTapped.asDriver()
+        let cancelTapped = searchBar.rx_cancelButtonClicked.asDriver()
             .map { _ in "" }
       
-        let searchResult = Driver.of(searchText, searchTapped, cancelTapped)
+        let searchResult = Driver.of(searchText, cancelTapped)
             .merge()
             .distinctUntilChanged()
             .flatMapLatest { query -> Driver<RepositoriesState> in

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
@@ -44,13 +44,8 @@ class WikipediaSearchViewController: ViewController {
 
         let API = DefaultWikipediaAPI.sharedAPI
 
-        let searchText = searchBar.rx_text.asDriver()
+        searchBar.rx_text.asDriver()
             .throttle(0.3)
-        let searchTapped = searchBar.rx_searchButtonClicked.asDriver()
-            .flatMap { $0.text.flatMap { Driver.just($0) } ?? Driver.empty() }
-      
-          Driver.of(searchText, searchTapped)
-            .merge()
             .distinctUntilChanged()
             .flatMapLatest { query in
                 API.getSearchResults(query)

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
@@ -44,9 +44,13 @@ class WikipediaSearchViewController: ViewController {
 
         let API = DefaultWikipediaAPI.sharedAPI
 
-        searchBar.rx_text
-            .asDriver()
+        let searchText = searchBar.rx_text.asDriver()
             .throttle(0.3)
+        let searchTapped = searchBar.rx_searchTapped.asDriver()
+            .flatMap { $0.text.flatMap { Driver.just($0) } ?? Driver.empty() }
+      
+          Driver.of(searchText, searchTapped)
+            .merge()
             .distinctUntilChanged()
             .flatMapLatest { query in
                 API.getSearchResults(query)

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
@@ -46,7 +46,7 @@ class WikipediaSearchViewController: ViewController {
 
         let searchText = searchBar.rx_text.asDriver()
             .throttle(0.3)
-        let searchTapped = searchBar.rx_searchTapped.asDriver()
+        let searchTapped = searchBar.rx_searchButtonClicked.asDriver()
             .flatMap { $0.text.flatMap { Driver.just($0) } ?? Driver.empty() }
       
           Driver.of(searchText, searchTapped)

--- a/RxExample/RxExample/iOS/Main.storyboard
+++ b/RxExample/RxExample/iOS/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9531" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="E5v-jn-n2n">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="E5v-jn-n2n">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
@@ -129,7 +129,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <searchBar key="tableHeaderView" contentMode="redraw" text="" placeholder="Repository search" id="zFx-qa-Lve">
+                        <searchBar key="tableHeaderView" contentMode="redraw" text="" placeholder="Repository search" showsCancelButton="YES" id="zFx-qa-Lve">
                             <rect key="frame" x="0.0" y="64" width="320" height="44"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <textInputTraits key="textInputTraits"/>

--- a/Tests/RxCocoaTests/Control+RxTests+UIKit.swift
+++ b/Tests/RxCocoaTests/Control+RxTests+UIKit.swift
@@ -650,14 +650,13 @@ extension ControlTests {
   func testSearchBar_SearchBar_rx_searchButtonClicked() {
     let searchBar = UISearchBar(frame: CGRectMake(0, 0, 1, 1))
     
-    var detectedSearchBar: UISearchBar? = nil
-    
+    var didClickSearchButton = false
     let disposable = searchBar.rx_searchButtonClicked
-      .subscribeNext { detectedSearchBar = $0 }
+        .subscribeNext { didClickSearchButton = true }
     
     searchBar.delegate!.searchBarSearchButtonClicked!(searchBar)
     
-    XCTAssertEqual(searchBar, detectedSearchBar)
+    XCTAssertTrue(didClickSearchButton)
     
     disposable.dispose()
   }
@@ -665,14 +664,13 @@ extension ControlTests {
   func testSearchBar_SearchBar_rx_cancelButtonClicked() {
     let searchBar = UISearchBar(frame: CGRectMake(0, 0, 1, 1))
     
-    var detectedSearchBar: UISearchBar? = nil
-    
+    var didClickCancelButton = false
     let disposable = searchBar.rx_cancelButtonClicked
-      .subscribeNext { detectedSearchBar = $0 }
+      .subscribeNext { didClickCancelButton = true }
     
     searchBar.delegate!.searchBarCancelButtonClicked!(searchBar)
     
-    XCTAssertEqual(searchBar, detectedSearchBar)
+    XCTAssertTrue(didClickCancelButton)
     
     disposable.dispose()
   }

--- a/Tests/RxCocoaTests/Control+RxTests+UIKit.swift
+++ b/Tests/RxCocoaTests/Control+RxTests+UIKit.swift
@@ -616,10 +616,20 @@ extension ControlTests {
 
 // UISearchBar
 extension ControlTests {
-    func testSearchBar_DelegateEventCompletesOnDealloc() {
-        let createView: () -> UISearchBar = { UISearchBar(frame: CGRectMake(0, 0, 1, 1)) }
-        ensurePropertyDeallocated(createView, "a") { (view: UISearchBar) in view.rx_text }
-    }
+  func testSearchBar_DelegateEventTextCompletesOnDealloc() {
+      let createView: () -> UISearchBar = { UISearchBar(frame: CGRectMake(0, 0, 1, 1)) }
+      ensurePropertyDeallocated(createView, "a") { (view: UISearchBar) in view.rx_text }
+  }
+  
+  func testSearchBar_DelegateEventSearchCompletesOnDealloc() {
+    let createView: () -> UISearchBar = { UISearchBar(frame: CGRectMake(0, 0, 1, 1)) }
+    ensureEventDeallocated(createView) { (view: UISearchBar) in view.rx_searchTapped }
+  }
+  
+  func testSearchBar_DelegateEventCancelCompletesOnDealloc() {
+    let createView: () -> UISearchBar = { UISearchBar(frame: CGRectMake(0, 0, 1, 1)) }
+    ensureEventDeallocated(createView) { (view: UISearchBar) in view.rx_cancelTapped }
+  }
 }
 
 

--- a/Tests/RxCocoaTests/Control+RxTests+UIKit.swift
+++ b/Tests/RxCocoaTests/Control+RxTests+UIKit.swift
@@ -623,12 +623,58 @@ extension ControlTests {
   
   func testSearchBar_DelegateEventSearchCompletesOnDealloc() {
     let createView: () -> UISearchBar = { UISearchBar(frame: CGRectMake(0, 0, 1, 1)) }
-    ensureEventDeallocated(createView) { (view: UISearchBar) in view.rx_searchTapped }
+    ensureEventDeallocated(createView) { (view: UISearchBar) in view.rx_searchButtonClicked }
   }
   
   func testSearchBar_DelegateEventCancelCompletesOnDealloc() {
     let createView: () -> UISearchBar = { UISearchBar(frame: CGRectMake(0, 0, 1, 1)) }
-    ensureEventDeallocated(createView) { (view: UISearchBar) in view.rx_cancelTapped }
+    ensureEventDeallocated(createView) { (view: UISearchBar) in view.rx_cancelButtonClicked }
+  }
+  
+  func testSearchBar_Text_rx_text() {
+    let baseText = "someText"
+    let searchBar = UISearchBar(frame: CGRectMake(0, 0, 1, 1))
+    
+    var detectedText: String? = nil
+    
+    let disposable = searchBar.rx_text
+      .subscribeNext { detectedText = $0 }
+    
+    searchBar.delegate!.searchBar!(searchBar, textDidChange: baseText)
+    
+    XCTAssertEqual(baseText, detectedText)
+    
+    disposable.dispose()
+  }
+  
+  func testSearchBar_SearchBar_rx_searchButtonClicked() {
+    let searchBar = UISearchBar(frame: CGRectMake(0, 0, 1, 1))
+    
+    var detectedSearchBar: UISearchBar? = nil
+    
+    let disposable = searchBar.rx_searchButtonClicked
+      .subscribeNext { detectedSearchBar = $0 }
+    
+    searchBar.delegate!.searchBarSearchButtonClicked!(searchBar)
+    
+    XCTAssertEqual(searchBar, detectedSearchBar)
+    
+    disposable.dispose()
+  }
+  
+  func testSearchBar_SearchBar_rx_cancelButtonClicked() {
+    let searchBar = UISearchBar(frame: CGRectMake(0, 0, 1, 1))
+    
+    var detectedSearchBar: UISearchBar? = nil
+    
+    let disposable = searchBar.rx_cancelButtonClicked
+      .subscribeNext { detectedSearchBar = $0 }
+    
+    searchBar.delegate!.searchBarCancelButtonClicked!(searchBar)
+    
+    XCTAssertEqual(searchBar, detectedSearchBar)
+    
+    disposable.dispose()
   }
 }
 


### PR DESCRIPTION
I've created two ControlEvents that listens to UISearchBarDelegate methods `searchBarSearchButtonClicked:` and `searchBarCancelButtonClicked:`.

I also updated the API.md, the example project. I hope that's ok.