### PR TITLE
Make name parameter of rx_notification optional.

### DIFF
--- a/RxCocoa/Common/Observables/NSNotificationCenter+Rx.swift
+++ b/RxCocoa/Common/Observables/NSNotificationCenter+Rx.swift
@@ -20,7 +20,7 @@ extension NSNotificationCenter {
     - returns: Observable sequence of posted notifications.
     */
     @warn_unused_result(message="http://git.io/rxs.uo")
-    public func rx_notification(name: String, object: AnyObject? = nil) -> Observable<NSNotification> {
+    public func rx_notification(name: String?, object: AnyObject? = nil) -> Observable<NSNotification> {
         return Observable.create { [weak object] observer in
             let nsObserver = self.addObserverForName(name, object: object, queue: nil) { notification in
                 observer.on(.Next(notification))


### PR DESCRIPTION
`NSNotificationCenter` allows observation without specifying a notification name via `addObserverForName`; this PR just promotes that optionality up to `rx_notification` as well. 