### PR TITLE
Update UIApplication+Rx.swift to fix mismatch #if statement

### DIFF
--- a/RxCocoa/iOS/UIApplication+Rx.swift
+++ b/RxCocoa/iOS/UIApplication+Rx.swift
@@ -10,6 +10,7 @@ import Foundation
 
 #if os(iOS)
     import UIKit
+#endif
     
 #if !RX_NO_MODULE
     import RxSwift
@@ -26,4 +27,3 @@ import Foundation
             }.asObserver()
         }
     }
-#endif


### PR DESCRIPTION
Carthage build failed due to this issue.

`MyProject/Carthage/Checkouts/RxSwift/RxCocoa/iOS/UIApplication+Rx.swift:29:1: error: expected expression
MyProject/Carthage/Checkouts/RxSwift/RxCocoa/iOS/UIApplication+Rx.swift:29:7: error: expected #else or #endif at end of configuration block
A shell task failed with exit code 65:
** BUILD FAILED **`