### PR TITLE
Simplify computed properties

### DIFF
--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -112,9 +112,7 @@ extension UICollectionView {
     For more information take a look at `DelegateProxyType` protocol documentation.
     */
     public var rx_dataSource: DelegateProxy {
-        get {
-            return proxyForObject(RxCollectionViewDataSourceProxy.self, self)
-        }
+        return proxyForObject(RxCollectionViewDataSourceProxy.self, self)
     }
     
     /**

--- a/RxExample/RxDataSourceStarterKit/Changeset.swift
+++ b/RxExample/RxDataSourceStarterKit/Changeset.swift
@@ -18,9 +18,7 @@ struct ItemPath : CustomDebugStringConvertible {
     let itemIndex: Int
 
     var debugDescription : String {
-        get {
-            return "(\(sectionIndex), \(itemIndex))"
-        }
+        return "(\(sectionIndex), \(itemIndex))"
     }
 }
 
@@ -51,20 +49,18 @@ public struct Changeset<S: SectionModelType> : CustomDebugStringConvertible {
     }
 
     public var debugDescription : String {
-        get {
-            let serializedSections = "[\n" + finalSections.map { "\($0)" }.joinWithSeparator(",\n") + "\n]\n"
-            return " >> Final sections"
+        let serializedSections = "[\n" + finalSections.map { "\($0)" }.joinWithSeparator(",\n") + "\n]\n"
+        return " >> Final sections"
             + "   \n\(serializedSections)"
             + (insertedSections.count > 0 || deletedSections.count > 0 || movedSections.count > 0 || updatedSections.count > 0 ? "\nSections:" : "")
             + (insertedSections.count > 0 ? "\ninsertedSections:\n\t\(insertedSections)" : "")
             + (deletedSections.count > 0 ?  "\ndeletedSections:\n\t\(deletedSections)" : "")
             + (movedSections.count > 0 ? "\nmovedSections:\n\t\(movedSections)" : "")
             + (updatedSections.count > 0 ? "\nupdatesSections:\n\t\(updatedSections)" : "")
-                + (insertedItems.count > 0 || deletedItems.count > 0 || movedItems.count > 0 || updatedItems.count > 0 ? "\nItems:" : "")
+            + (insertedItems.count > 0 || deletedItems.count > 0 || movedItems.count > 0 || updatedItems.count > 0 ? "\nItems:" : "")
             + (insertedItems.count > 0 ? "\ninsertedItems:\n\t\(insertedItems)" : "")
             + (deletedItems.count > 0 ? "\ndeletedItems:\n\t\(deletedItems)" : "")
             + (movedItems.count > 0 ? "\nmovedItems:\n\t\(movedItems)" : "")
             + (updatedItems.count > 0 ? "\nupdatedItems:\n\t\(updatedItems)" : "")
-        }
     }
 }

--- a/RxExample/RxDataSourceStarterKit/Differentiator.swift
+++ b/RxExample/RxDataSourceStarterKit/Differentiator.swift
@@ -33,19 +33,17 @@ enum EditEvent : CustomDebugStringConvertible {
 
 extension EditEvent {
     var debugDescription: String {
-        get {
-            switch self {
-            case .Inserted:
-                return "Inserted"
-            case .Deleted:
-                return "Deleted"
-            case .Moved:
-                return "Moved"
-            case .MovedAutomatically:
-                return "MovedAutomatically"
-            case .Untouched:
-                return "Untouched"
-            }
+        switch self {
+        case .Inserted:
+            return "Inserted"
+        case .Deleted:
+            return "Deleted"
+        case .Moved:
+            return "Moved"
+        case .MovedAutomatically:
+            return "MovedAutomatically"
+        case .Untouched:
+            return "Untouched"
         }
     }
 }
@@ -57,9 +55,7 @@ struct SectionAdditionalInfo : CustomDebugStringConvertible {
 
 extension SectionAdditionalInfo {
     var debugDescription: String {
-        get {
-            return "\(event), \(indexAfterDelete)"
-        }
+        return "\(event), \(indexAfterDelete)"
     }
 }
 
@@ -70,9 +66,7 @@ struct ItemAdditionalInfo : CustomDebugStringConvertible {
 
 extension ItemAdditionalInfo {
     var debugDescription: String {
-        get {
-            return "\(event) \(indexAfterDelete)"
-        }
+        return "\(event) \(indexAfterDelete)"
     }
 }
 

--- a/RxExample/RxDataSourceStarterKit/SectionModel.swift
+++ b/RxExample/RxDataSourceStarterKit/SectionModel.swift
@@ -25,9 +25,7 @@ public struct SectionModel<Section, ItemType> : SectionModelType, CustomStringCo
     }
     
     public var description: String {
-        get {
-            return "\(self.model) > \(items)"
-        }
+        return "\(self.model) > \(items)"
     }
 }
 
@@ -48,15 +46,11 @@ public struct HashableSectionModel<Section: Hashable, ItemType: Hashable> : Hash
     }
     
     public var description: String {
-        get {
-            return "HashableSectionModel(model: \"\(self.model)\", items: \(items))"
-        }
+        return "HashableSectionModel(model: \"\(self.model)\", items: \(items))"
     }
     
     public var hashValue: Int {
-        get {
-            return self.model.hashValue
-        }
+        return self.model.hashValue
     }
 
 }

--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/User.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/User.swift
@@ -23,9 +23,7 @@ struct User: Equatable, CustomDebugStringConvertible {
 
 extension User {
     var debugDescription: String {
-        get {
-            return firstName + " " + lastName
-        }
+        return firstName + " " + lastName
     }
 }
 

--- a/RxExample/RxExample/Services/ReachabilityService.swift
+++ b/RxExample/RxExample/Services/ReachabilityService.swift
@@ -20,9 +20,7 @@ class ReachabilityService {
 
     private let _reachabilityChangedSubject = PublishSubject<ReachabilityStatus>()
     private var reachabilityChanged: Observable<ReachabilityStatus> {
-        get {
-            return _reachabilityChangedSubject.asObservable()
-        }
+        return _reachabilityChangedSubject.asObservable()
     }
 
     // singleton

--- a/RxSwift/DataStructures/Bag.swift
+++ b/RxSwift/DataStructures/Bag.swift
@@ -35,13 +35,11 @@ public struct BagKey : Hashable {
     let key: Int
 
     public var hashValue: Int {
-        get {
-            if let uniqueIdentity = uniqueIdentity {
-                return hash(key) ^ (unsafeAddressOf(uniqueIdentity).hashValue)
-            }
-            else {
-                return hash(key)
-            }
+        if let uniqueIdentity = uniqueIdentity {
+            return hash(key) ^ (unsafeAddressOf(uniqueIdentity).hashValue)
+        }
+        else {
+            return hash(key)
         }
     }
 }
@@ -212,9 +210,7 @@ extension Bag {
     A textual representation of `self`, suitable for debugging.
     */
     public var debugDescription : String {
-        get {
-            return "\(self.count) elements in Bag"
-        }
+        return "\(self.count) elements in Bag"
     }
 }
 

--- a/RxSwift/DataStructures/Queue.swift
+++ b/RxSwift/DataStructures/Queue.swift
@@ -49,28 +49,22 @@ public struct Queue<T>: SequenceType {
     }
     
     private var dequeueIndex: Int {
-        get {
-           let index = _pushNextIndex - count
-            return index < 0 ? index + _storage.count : index
-        }
+        let index = _pushNextIndex - count
+        return index < 0 ? index + _storage.count : index
     }
     
     /**
     - returns: Is queue empty.
     */
     public var isEmpty: Bool {
-        get {
-            return count == 0
-        }
+        return count == 0
     }
     
     /**
     - returns: Number of elements inside queue.
     */
     public var count: Int {
-        get {
-            return _count
-        }
+        return _count
     }
     
     /**

--- a/RxSwift/Disposables/AnonymousDisposable.swift
+++ b/RxSwift/Disposables/AnonymousDisposable.swift
@@ -23,9 +23,7 @@ public final class AnonymousDisposable : DisposeBase, Cancelable {
     - returns: Was resource disposed.
     */
     public var disposed: Bool {
-        get {
-            return _disposed == 1
-        }
+        return _disposed == 1
     }
 
     /**

--- a/RxSwift/Disposables/BinaryDisposable.swift
+++ b/RxSwift/Disposables/BinaryDisposable.swift
@@ -23,9 +23,7 @@ public final class BinaryDisposable : DisposeBase, Cancelable {
     - returns: Was resource disposed.
     */
     public var disposed: Bool {
-        get {
-            return _disposed > 0
-        }
+        return _disposed > 0
     }
 
     /**

--- a/RxSwift/Disposables/BooleanDisposable.swift
+++ b/RxSwift/Disposables/BooleanDisposable.swift
@@ -33,9 +33,7 @@ public class BooleanDisposable : Disposable, Cancelable {
         - returns: Was resource disposed.
      */
     public var disposed: Bool {
-        get {
-            return _disposed
-        }
+        return _disposed
     }
     
     /**

--- a/RxSwift/Disposables/CompositeDisposable.swift
+++ b/RxSwift/Disposables/CompositeDisposable.swift
@@ -20,10 +20,8 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     private var _disposables: Bag<Disposable>? = Bag()
 
     public var disposed: Bool {
-        get {
-            _lock.lock(); defer { _lock.unlock() }
-            return _disposables == nil
-        }
+        _lock.lock(); defer { _lock.unlock() }
+        return _disposables == nil
     }
     
     public override init() {
@@ -82,10 +80,8 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     - returns: Gets the number of disposables contained in the `CompositeDisposable`.
     */
     public var count: Int {
-        get {
-            _lock.lock(); defer { _lock.unlock() }
-            return _disposables?.count ?? 0
-        }
+        _lock.lock(); defer { _lock.unlock() }
+        return _disposables?.count ?? 0
     }
     
     /**

--- a/RxSwift/Disposables/RefCountDisposable.swift
+++ b/RxSwift/Disposables/RefCountDisposable.swift
@@ -21,10 +21,8 @@ public class RefCountDisposable : DisposeBase, Cancelable {
      - returns: Was resource disposed.
      */
     public var disposed: Bool {
-        get {
-            _lock.lock(); defer { _lock.unlock() }
-            return _disposable == nil
-        }
+        _lock.lock(); defer { _lock.unlock() }
+        return _disposable == nil
     }
 
     /**

--- a/RxSwift/Disposables/ScheduledDisposable.swift
+++ b/RxSwift/Disposables/ScheduledDisposable.swift
@@ -28,9 +28,7 @@ public class ScheduledDisposable : Cancelable {
     - returns: Was resource disposed.
     */
     public var disposed: Bool {
-        get {
-            return _disposed == 1
-        }
+        return _disposed == 1
     }
 
     /**

--- a/RxSwift/Disposables/SerialDisposable.swift
+++ b/RxSwift/Disposables/SerialDisposable.swift
@@ -22,9 +22,7 @@ public class SerialDisposable : DisposeBase, Cancelable {
     - returns: Was resource disposed.
     */
     public var disposed: Bool {
-        get {
-            return _disposed
-        }
+        return _disposed
     }
     
     /**

--- a/RxSwift/Disposables/SingleAssignmentDisposable.swift
+++ b/RxSwift/Disposables/SingleAssignmentDisposable.swift
@@ -25,9 +25,7 @@ public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
     - returns: A value that indicates whether the object is disposed.
     */
     public var disposed: Bool {
-        get {
-            return _disposed
-        }
+        return _disposed
     }
 
     /**

--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -37,15 +37,13 @@ extension Event {
     - returns: Description of event
     */
     public var debugDescription: String {
-        get {
-            switch self {
-            case .Next(let value):
-                return "Next(\(value))"
-            case .Error(let error):
-                return "Error(\(error))"
-            case .Completed:
-                return "Completed"
-            }
+        switch self {
+        case .Next(let value):
+            return "Next(\(value))"
+        case .Error(let error):
+            return "Error(\(error))"
+        case .Completed:
+            return "Completed"
         }
     }
 }
@@ -55,35 +53,29 @@ extension Event {
     - returns: Is `Completed` or `Error` event
     */
     public var isStopEvent: Bool {
-        get {
-            switch self {
-            case .Next: return false
-            case .Error, .Completed: return true
-            }
+        switch self {
+        case .Next: return false
+        case .Error, .Completed: return true
         }
     }
-    
+
     /**
     - returns: If `Next` event, returns element value.
     */
     public var element: Element? {
-        get {
-            if case .Next(let value) = self {
-                return value
-            }
-            return nil
+        if case .Next(let value) = self {
+            return value
         }
+        return nil
     }
-    
+
     /**
     - returns: If `Error` event, returns error.
     */
     public var error: ErrorType? {
-        get {
-            if case .Error(let error) = self {
-                return error
-            }
-            return nil
+        if case .Error(let error) = self {
+            return error
         }
+        return nil
     }
 }

--- a/RxSwift/Observables/Implementations/WithLatestFrom.swift
+++ b/RxSwift/Observables/Implementations/WithLatestFrom.swift
@@ -76,9 +76,7 @@ class WithLatestFromSecond<FirstType, SecondType, ResultType, O: ObserverType wh
     private let _disposable: Disposable
 
     var _lock: NSRecursiveLock {
-        get {
-            return _parent._lock
-        }
+        return _parent._lock
     }
 
     init(parent: Parent, disposable: Disposable) {

--- a/RxSwift/RxMutableBox.swift
+++ b/RxSwift/RxMutableBox.swift
@@ -32,8 +32,6 @@ extension RxMutableBox {
     - returns: Box description.
     */
     var debugDescription: String {
-        get {
-            return "MutatingBox(\(self.value))"
-        }
+        return "MutatingBox(\(self.value))"
     }
 }

--- a/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
@@ -20,9 +20,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     private let _queue : dispatch_queue_t
     
     public var now : NSDate {
-        get {
-            return NSDate()
-        }
+        return NSDate()
     }
     
     // leeway for scheduling timers

--- a/RxSwift/Schedulers/ConcurrentMainScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentMainScheduler.swift
@@ -25,9 +25,7 @@ public final class ConcurrentMainScheduler : SchedulerType {
     - returns: Current time.
     */
     public var now : NSDate {
-        get {
-            return _mainScheduler.now
-        }
+        return _mainScheduler.now
     }
 
     private init(mainScheduler: MainScheduler) {

--- a/RxSwift/Schedulers/Internal/ScheduledItem.swift
+++ b/RxSwift/Schedulers/Internal/ScheduledItem.swift
@@ -19,9 +19,7 @@ struct ScheduledItem<T>
     private let _disposable = SingleAssignmentDisposable()
 
     var disposed: Bool {
-        get {
-            return _disposable.disposed
-        }
+        return _disposable.disposed
     }
     
     init(action: Action, state: T) {

--- a/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
@@ -35,9 +35,7 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     - returns: Current time.
     */
     public var now : NSDate {
-        get {
-            return NSDate()
-        }
+        return NSDate()
     }
     
     // leeway for scheduling timers

--- a/RxSwift/Schedulers/VirtualTimeScheduler.swift
+++ b/RxSwift/Schedulers/VirtualTimeScheduler.swift
@@ -251,9 +251,7 @@ extension VirtualTimeScheduler {
     A textual representation of `self`, suitable for debugging.
     */
     public var debugDescription: String {
-        get {
-            return self._schedulerQueue.debugDescription
-        }
+        return self._schedulerQueue.debugDescription
     }
 }
 
@@ -266,9 +264,7 @@ class VirtualSchedulerItem<Time>
     let id: Int
 
     var disposed: Bool {
-        get {
-            return disposable.disposed
-        }
+        return disposable.disposed
     }
     
     var disposable = SingleAssignmentDisposable()

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -35,9 +35,7 @@ final public class PublishSubject<Element>
     Indicates whether the subject has been disposed.
     */
     public var disposed: Bool {
-        get {
-            return _disposed
-        }
+        return _disposed
     }
     
     /**

--- a/RxTests/Recorded.swift
+++ b/RxTests/Recorded.swift
@@ -37,9 +37,7 @@ extension Recorded {
     A textual representation of `self`, suitable for debugging.
     */
     public var debugDescription: String {
-        get {
-            return "\(value) @ \(time)"
-        }
+        return "\(value) @ \(time)"
     }
 }
 

--- a/RxTests/Subscription.swift
+++ b/RxTests/Subscription.swift
@@ -50,9 +50,7 @@ public struct Subscription
      The hash value.
     */
     public var hashValue : Int {
-        get {
-            return subscribe.hashValue ^ unsubscribe.hashValue
-        }
+        return subscribe.hashValue ^ unsubscribe.hashValue
     }
 }
 
@@ -61,10 +59,8 @@ extension Subscription {
     A textual representation of `self`, suitable for debugging.
     */
     public var debugDescription : String {
-        get {
-            let infiniteText = "Infinity"
-            return "(\(subscribe) : \(unsubscribe != Int.max ? String(unsubscribe) : infiniteText))"
-        }
+        let infiniteText = "Infinity"
+        return "(\(subscribe) : \(unsubscribe != Int.max ? String(unsubscribe) : infiniteText))"
     }
 }
 

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -280,9 +280,7 @@ class ThreeDSectionedViewDelegateProxy : DelegateProxy
 
 extension ThreeDSectionedView {
     var rx_proxy: DelegateProxy {
-        get {
-            return proxyForObject(ThreeDSectionedViewDelegateProxy.self, self)
-        }
+        return proxyForObject(ThreeDSectionedViewDelegateProxy.self, self)
     }
 }
 

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
@@ -19,15 +19,11 @@ class MySubject<Element where Element : Hashable> : SubjectType, ObserverType {
     var _disposed: Bool = false
     
     var subscribeCount: Int {
-        get {
-            return _subscribeCount
-        }
+        return _subscribeCount
     }
     
     var diposed: Bool {
-        get {
-            return _disposed
-        }
+        return _disposed
     }
     
     func disposeOn(value: Element, disposable: Disposable) {

--- a/Tests/RxTest.swift
+++ b/Tests/RxTest.swift
@@ -36,9 +36,7 @@ class RxTest
     private var startResourceCount: Int32 = 0
 
     var accumulateStatistics: Bool {
-        get {
-            return true
-        }
+        return true
     }
 
     #if TRACE_RESOURCES


### PR DESCRIPTION
According to various guidelines (e.g. [Github](https://github.com/github/swift-style-guide)):

```Prefer implicit getters on read-only properties and subscripts```

Which reduces indents (always good thing) and improves readability IMHO