### PR TITLE
Add rx_editing property in UITextField

### DIFF
--- a/Documentation/API.md
+++ b/Documentation/API.md
@@ -229,6 +229,7 @@ extension UIButton {
 extension UITextField {
 
     public var rx_text: ControlProperty<String> {}
+    public var rx_editing: ControlProperty<Bool> {}
 
 }
 ```

--- a/RxCocoa/iOS/UITextField+Rx.swift
+++ b/RxCocoa/iOS/UITextField+Rx.swift
@@ -30,6 +30,23 @@ extension UITextField {
         )
     }
     
+    /**
+    Reactive wrapper for `editing` property.
+    */
+    public var rx_editing: ControlProperty<Bool> {
+        return UIControl.rx_value(
+            self,
+            getter: { textField in
+                textField.editing
+            }, setter: { textField, value in
+                if value {
+                    textField.becomeFirstResponder()
+                } else {
+                    textField.resignFirstResponder()
+                }
+            }
+        )
+    }
 }
 
 #endif


### PR DESCRIPTION
Add `rx_editing` property for `UITextField`, a reactive wrapper for its `editing` property.