### PR TITLE
Add rx_scopeIndex property in UISearchBar

### DIFF
--- a/RxCocoa/iOS/UISearchBar+Rx.swift
+++ b/RxCocoa/iOS/UISearchBar+Rx.swift
@@ -47,6 +47,27 @@ extension UISearchBar {
         
         return ControlProperty(values: source, valueSink: bindingObserver)
     }
+    
+    /**
+    Reactive wrapper for `selectedScopeButtonIndex` property.
+    */
+    public var rx_scopeIndex: ControlProperty<Int> {
+        let source: Observable<Int> = Observable.deferred { [weak self] () -> Observable<Int> in
+            let scope = self?.selectedScopeButtonIndex ?? 0
+
+            return (self?.rx_delegate.observe("searchBar:selectedScopeButtonIndexDidChange:") ?? Observable.empty())
+                .map() { a in
+                    return a[1] as! Int
+                }
+                .startWith(scope)
+        }
+
+        let bindingObserver = UIBindingObserver(UIElement: self) { (searchBar, index: Int) in
+            searchBar.selectedScopeButtonIndex = index
+        }
+
+        return ControlProperty(values: source, valueSink: bindingObserver)
+    }
 }
 
 #endif


### PR DESCRIPTION
Add `rx_scopeIndex` property for `UISearchBar`, a reactive wrapper for its `selectedScopeButtonInde` property.