### PR TITLE
Workaround for segmentation fault in Xcode 7.3

### DIFF
--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -139,6 +139,11 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
 
         let scheduledItem = ScheduledItem(action: action, state: state)
         queue.value.enqueue(scheduledItem)
-        return scheduledItem
+        
+        // In Xcode 7.3, `return scheduledItem` causes segmentation fault 11 on release build.
+        // To workaround this compiler issue, returns AnonymousDisposable that disposes scheduledItem.
+        return AnonymousDisposable {
+            scheduledItem.dispose()
+        }
     }
 }


### PR DESCRIPTION
Unfortunately, the compiler issue mentioned in #472 is not fixed in Swift 2.2.
This patch is just a workaround for the issue :pray: 