### PR TITLE
Markdown typo on Why.md

### DIFF
--- a/Documentation/Why.md
+++ b/Documentation/Why.md
@@ -22,7 +22,7 @@ viewModel
   .addDisposableTo(disposeBag)
 ```
 
-** Official suggestion is to always use `.addDisposableTo(disposeBag)` even though that's not necessary for simple bindings.**
+**Official suggestion is to always use `.addDisposableTo(disposeBag)` even though that's not necessary for simple bindings.**
 
 ### Retries
 


### PR DESCRIPTION
Sentence was not bold because of space after the two stars