### PR TITLE
Documentation for skipUntil corrected

### DIFF
--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -247,12 +247,12 @@ extension ObservableType {
 extension ObservableType {
     
     /**
-    Returns the elements from the source observable sequence until the other observable sequence produces an element.
+    Returns the elements from the source observable sequence that are emitted after the other observable sequence produces an element.
 
     - seealso: [skipUntil operator on reactivex.io](http://reactivex.io/documentation/operators/skipuntil.html)
     
-    - parameter other: Observable sequence that terminates propagation of elements of the source sequence.
-    - returns: An observable sequence containing the elements of the source sequence up to the point the other sequence interrupted further propagation.
+    - parameter other: Observable sequence that starts propagation of elements of the source sequence.
+    - returns: An observable sequence containing the elements of the source sequence that are emitted after the other sequence emits an item.
     */
     @warn_unused_result(message="http://git.io/rxs.uo")
     public func skipUntil<O: ObservableType>(other: O)


### PR DESCRIPTION
It seems a copy paste error as documentation for both `skipUntil` and `takeUntil` was same.
I have corrected the documentation for `skipUntil` keeping `takeUntil` intact.