### PR TITLE
remove redundant state property of the PublishSubject

### DIFF
--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -28,7 +28,6 @@ final public class PublishSubject<Element>
     // state
     private var _disposed = false
     private var _observers = Bag<AnyObserver<Element>>()
-    private var _stopped = false
     private var _stoppedEvent = nil as Event<Element>?
     
     /**
@@ -58,7 +57,7 @@ final public class PublishSubject<Element>
     func _synchronized_on(event: Event<E>) {
         switch event {
         case .Next(_):
-            if _disposed || _stopped {
+            if _disposed || _stoppedEvent != nil {
                 return
             }
             
@@ -66,7 +65,6 @@ final public class PublishSubject<Element>
         case .Completed, .Error:
             if _stoppedEvent == nil {
                 _stoppedEvent = event
-                _stopped = true
                 _observers.on(event)
                 _observers.removeAll()
             }


### PR DESCRIPTION
As near as I can tell, the state property `_stopped` of the `PublishSubject` class is redundant.
https://github.com/ReactiveX/RxSwift/pull/596/files#diff-53af0ab0a90f54260431a581ecb1822fL31

So I remove that property and modified `PublishSubject` implementation (like `BehaviorSubject`).
cf.) https://github.com/ReactiveX/RxSwift/blob/master/RxSwift/Subjects/BehaviorSubject.swift#L81

