### PR TITLE
Replace failWith with error in examples

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -1099,12 +1099,12 @@ NSURLSession.sharedSession().rx_response(myNSURLRequest)
                 return just(transform(data))
             }
             else {
-                return failWith(yourNSError)
+                return Observable.error(yourNSError)
             }
         }
         else {
             rxFatalError("response = nil")
-            return failWith(yourNSError)
+            return Observable.error(yourNSError)
         }
     }
     .subscribe { event in

--- a/Rx.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
@@ -139,11 +139,11 @@ example("generate") {
 }
 
 /*:
-### failWith
+### error
 create an Observable that emits no items and terminates with an error
 */
 
-example("failWith") {
+example("error") {
     let error = NSError(domain: "Test", code: -1, userInfo: nil)
     
     let erroredSequence = Observable<Int>.error(error)


### PR DESCRIPTION
Replace `failWith` examples with `error`.