### PR TITLE
removed unnecessary `break`

### DIFF
--- a/RxCocoa/Common/CocoaUnits/UIBindingObserver.swift
+++ b/RxCocoa/Common/CocoaUnits/UIBindingObserver.swift
@@ -46,7 +46,6 @@ public class UIBindingObserver<UIElementType, Value where UIElementType: AnyObje
             }
         case .Error(let error):
             bindingErrorToInterface(error)
-            break
         case .Completed:
             break
         }


### PR DESCRIPTION
Sorry to bother about something so trivial, but I found unnecessary `break` keyword.