### PR TITLE
Simplify Queue.swift's init logic

### DIFF
--- a/RxSwift/DataStructures/Queue.swift
+++ b/RxSwift/DataStructures/Queue.swift
@@ -25,8 +25,8 @@ public struct Queue<T>: SequenceType {
     private let _resizeFactor = 2
     
     private var _storage: ContiguousArray<T?>
-    private var _count: Int
-    private var _pushNextIndex: Int
+    private var _count = 0
+    private var _pushNextIndex = 0
     private var _initialCapacity: Int
     
     /**
@@ -36,16 +36,8 @@ public struct Queue<T>: SequenceType {
     */
     public init(capacity: Int) {
         _initialCapacity = capacity
-        
-        _count = 0
-        _pushNextIndex = 0
-     
-        if capacity > 0 {
-            _storage = ContiguousArray<T?>(count: capacity, repeatedValue: nil)
-        }
-        else {
-            _storage = ContiguousArray<T?>()
-        }
+
+        _storage = ContiguousArray<T?>(count: capacity, repeatedValue: nil)
     }
     
     private var dequeueIndex: Int {


### PR DESCRIPTION
Just a little simplification of `init(capacity: Int)`.

I gave `_count` and `_pushNextIndex` default values of 0 outside the `init` method like `_resizeFactor ` does and since this method must be called with a capacity value it makes sense to just initialize `_storage` with `ContiguousArray<T?>(count: capacity, repeatedValue: nil)` even when the value is 0. 

How does it look?


