### PR TITLE
UILabel rx_text as `String?`

### DIFF
--- a/RxCocoa/iOS/UILabel+Rx.swift
+++ b/RxCocoa/iOS/UILabel+Rx.swift
@@ -19,7 +19,7 @@ extension UILabel {
     /**
     Bindable sink for `text` property.
     */
-    public var rx_text: AnyObserver<String> {
+    public var rx_text: AnyObserver<String?> {
         return UIBindingObserver(UIElement: self) { label, text in
             label.text = text
         }.asObserver()

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchCell.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchCell.swift
@@ -33,7 +33,8 @@ public class WikipediaSearchCell: UITableViewCell {
         didSet {
             let disposeBag = DisposeBag()
 
-            (viewModel?.title ?? Driver.just(""))
+            viewModel.title
+                .map(Optional.init)
                 .drive(self.titleOutlet.rx_text)
                 .addDisposableTo(disposeBag)
 


### PR DESCRIPTION
UILabels text attribute is a Optional String. With `rx_text` reflecting that you can now set a UILabels text back to `nil`, which is the default value. 😋