### PR TITLE
Added hasObservers on each of the Subject classes

### DIFF
--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -22,6 +22,9 @@ public final class BehaviorSubject<Element>
     public typealias SubjectObserverType = BehaviorSubject<Element>
     typealias DisposeKey = Bag<AnyObserver<Element>>.KeyType
     
+    /**
+     Indicates whether the subject has any observers
+     */
     public var hasObservers: Bool {
         return _observers.count > 0
     }

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -22,6 +22,10 @@ public final class BehaviorSubject<Element>
     public typealias SubjectObserverType = BehaviorSubject<Element>
     typealias DisposeKey = Bag<AnyObserver<Element>>.KeyType
     
+    public var hasObservers: Bool {
+        return _observers.count > 0
+    }
+    
     let _lock = NSRecursiveLock()
     
     // state

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -26,6 +26,7 @@ public final class BehaviorSubject<Element>
      Indicates whether the subject has any observers
      */
     public var hasObservers: Bool {
+        _lock.lock(); defer { _lock.unlock() }
         return _observers.count > 0
     }
     

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -23,6 +23,9 @@ final public class PublishSubject<Element>
     
     typealias DisposeKey = Bag<AnyObserver<Element>>.KeyType
     
+    /**
+     Indicates whether the subject has any observers
+     */
     public var hasObservers: Bool {
         return _observers.count > 0
     }

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -23,6 +23,10 @@ final public class PublishSubject<Element>
     
     typealias DisposeKey = Bag<AnyObserver<Element>>.KeyType
     
+    public var hasObservers: Bool {
+        return _observers.count > 0
+    }
+    
     private var _lock = NSRecursiveLock()
     
     // state

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -27,6 +27,7 @@ final public class PublishSubject<Element>
      Indicates whether the subject has any observers
      */
     public var hasObservers: Bool {
+        _lock.lock(); defer { _lock.unlock() }
         return _observers.count > 0
     }
     

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -20,6 +20,9 @@ public class ReplaySubject<Element>
     , Disposable {
     public typealias SubjectObserverType = ReplaySubject<Element>
     
+    /**
+     Indicates whether the subject has any observers
+     */
     public var hasObservers: Bool {
         return _observers.count > 0
     }

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -20,6 +20,15 @@ public class ReplaySubject<Element>
     , Disposable {
     public typealias SubjectObserverType = ReplaySubject<Element>
     
+    public var hasObservers: Bool {
+        return _observers.count > 0
+    }
+    
+    // state
+    private var _disposed = false
+    private var _stoppedEvent = nil as Event<Element>?
+    private var _observers = Bag<AnyObserver<Element>>()
+    
     typealias DisposeKey = Bag<AnyObserver<Element>>.KeyType
     
     func unsubscribe(key: DisposeKey) {
@@ -78,11 +87,6 @@ class ReplayBufferBase<Element>
     , SynchronizedUnsubscribeType {
     
     private var _lock = NSRecursiveLock()
-
-    // state
-    private var _disposed = false
-    private var _stoppedEvent = nil as Event<Element>?
-    private var _observers = Bag<AnyObserver<Element>>()
     
     func trim() {
         abstractMethod()

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -24,8 +24,11 @@ public class ReplaySubject<Element>
      Indicates whether the subject has any observers
      */
     public var hasObservers: Bool {
+        _lock.lock(); defer { _lock.unlock() }
         return _observers.count > 0
     }
+    
+    private var _lock = NSRecursiveLock()
     
     // state
     private var _disposed = false
@@ -88,8 +91,6 @@ public class ReplaySubject<Element>
 class ReplayBufferBase<Element>
     : ReplaySubject<Element>
     , SynchronizedUnsubscribeType {
-    
-    private var _lock = NSRecursiveLock()
     
     func trim() {
         abstractMethod()

--- a/RxSwift/Subjects/SubjectType.swift
+++ b/RxSwift/Subjects/SubjectType.swift
@@ -20,9 +20,15 @@ public protocol SubjectType : ObservableType {
     associatedtype SubjectObserverType : ObserverType
     
     /**
+     Check whether the subject has any observers
+     */
+    var hasObservers: Bool { get }
+    
+    /**
     Returns observer interface for subject.
     
     - returns: Observer interface for subject.
     */
     func asObserver() -> SubjectObserverType
+    
 }


### PR DESCRIPTION
The reason that I need hasObservers property on Subject type is the following:

Here at my company we need to implement hash table whose key is a String and value is BehaviorSubject<Something>. In order to keep memory usage in check, we need to clean up the hash table by periodically removing BehaviorSubjects that do not have any subscriptions. Therefore, we need a way to determine whether a BehaviorSubject has subscribers or not.

I noticed in RxJava we do have hasObservers at our disposal. So I basically ported this feature to RxSwift.

Details:

Added var hasObservers: Bool { get } to the SubjectType protocol.

Then made all the Subject classes conform to the protocol by providing
hasObservers as a computed property.