### PR TITLE
Use unbounded replay subject in the Playground

### DIFF
--- a/Rx.playground/Pages/Subjects.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Subjects.xcplaygroundpage/Contents.swift
@@ -58,7 +58,7 @@ example("PublishSubject") {
 */
 example("ReplaySubject") {
     let disposeBag = DisposeBag()
-    let subject = ReplaySubject<String>.create(bufferSize: 1)
+    let subject = ReplaySubject<String>.createUnbounded()
 
     writeSequenceToConsole("1", sequence: subject).addDisposableTo(disposeBag)
     subject.on(.Next("a"))


### PR DESCRIPTION
Before this change the output was as follows:

```
--- ReplaySubject example ---
Subscription: 1, event: Next(a)
Subscription: 1, event: Next(b)
Subscription: 2, event: Next(b)
Subscription: 1, event: Next(c)
Subscription: 2, event: Next(c)
Subscription: 1, event: Next(d)
Subscription: 2, event: Next(d)
```

It didn't match the description of `ReplaySubject`. `Subscription: 2, event: Next(a)` was missing since `bufferSize` was equal to 1. I think that an unbounded replay subject fits better here.

If we don't want to use an unbounded replay subject here, we should change the buffer size to `2`.