### PR TITLE
Fix Demo Mistake

### DIFF
--- a/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
@@ -56,14 +56,11 @@ example("concat") {
         .subscribe { print($0) }
         .addDisposableTo(disposeBag)
     
+    subject2.onNext("🐱")
     subject1.onNext("🍐")
     subject1.onNext("🍊")
     
     variable.value = subject2
-    
-    subject2.onNext("🐱")
-    
-    subject1.onCompleted()
     
     subject2.onNext("🐭")
 }


### PR DESCRIPTION
This example of `concat()` cannot show users the effect of `concat()` which the document mentions:
'waiting for each sequence to terminate successfully before emitting elements from the next sequence'
So I fixed it.