### PR TITLE
Fix Blurred demonstration of 'concat demo'. 

### DIFF
--- a/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
@@ -61,6 +61,7 @@ example("concat") {
     
     variable.value = subject2
     
+    subject2.onNext("I would be ignored")
     subject2.onNext("🐱")
     
     subject1.onCompleted()


### PR DESCRIPTION
This example of `concat()` cannot show users the effect of `concat()` which the document mentions:
'waiting for each sequence to terminate successfully before emitting elements from the next sequence'
So I fixed it.