### PR TITLE
Add Swift 3 swift-DEVELOPMENT-SNAPSHOT-2016-05-09 compatibility.

### DIFF
--- a/RxBlocking/RunLoopLock.swift
+++ b/RxBlocking/RunLoopLock.swift
@@ -29,7 +29,7 @@ typealias AtomicInt = Int32
 #endif
 
 class RunLoopLock {
-    let currentRunLoop: CFRunLoopRef
+    let currentRunLoop: CFRunLoop
 
     var calledRun: AtomicInt = 0
     var calledStop: AtomicInt = 0
@@ -41,7 +41,7 @@ class RunLoopLock {
     func dispatch(action: () -> ()) {
         CFRunLoopPerformBlock(currentRunLoop, kCFRunLoopDefaultMode) {
             if CurrentThreadScheduler.isScheduleRequired {
-                CurrentThreadScheduler.instance.schedule(()) { _ in
+                CurrentThreadScheduler.instance.schedule(state: ()) { _ in
                     action()
                     return NopDisposable.instance
                 }

--- a/RxSwift/Concurrency/Lock.swift
+++ b/RxSwift/Concurrency/Lock.swift
@@ -69,20 +69,20 @@ protocol Lock {
 #endif
 
 extension NSRecursiveLock : Lock {
-    func performLocked(@noescape action: () -> Void) {
+    func performLocked(action: @noescape () -> Void) {
         self.lock()
         action()
         self.unlock()
     }
 
-    func calculateLocked<T>(@noescape action: () -> T) -> T {
+    func calculateLocked<T>(action: @noescape () -> T) -> T {
         self.lock()
         let result = action()
         self.unlock()
         return result
     }
 
-    func calculateLockedOrFail<T>(@noescape action: () throws -> T) throws -> T {
+    func calculateLockedOrFail<T>(action: @noescape () throws -> T) throws -> T {
         self.lock()
         defer {
             self.unlock()

--- a/RxSwift/DataStructures/Bag.swift
+++ b/RxSwift/DataStructures/Bag.swift
@@ -223,7 +223,7 @@ extension Bag {
     
     - parameter action: Enumeration closure.
     */
-    public func forEach(@noescape action: (T) -> Void) {
+    public func forEach(action: @noescape (T) -> Void) {
         if _onlyFastPath {
             if let value0 = _value0 {
                 action(value0)

--- a/RxSwift/DataStructures/PriorityQueue.swift
+++ b/RxSwift/DataStructures/PriorityQueue.swift
@@ -54,7 +54,7 @@ struct PriorityQueue<Element: AnyObject> {
             swap(&_elements[index], &_elements[_elements.count - 1])
         }
 
-        _elements.popLast()
+        _ = _elements.popLast()
 
         if !removingLast {
             bubbleToHigherPriority(initialUnbalancedIndex: index)

--- a/RxSwift/Disposables/ScheduledDisposable.swift
+++ b/RxSwift/Disposables/ScheduledDisposable.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-private let disposeScheduledDisposable: ScheduledDisposable -> Disposable = { sd in
+private let disposeScheduledDisposable: (ScheduledDisposable) -> Disposable = { sd in
     sd.disposeInner()
     return NopDisposable.instance
 }

--- a/RxSwift/Extensions/String+Rx.swift
+++ b/RxSwift/Extensions/String+Rx.swift
@@ -14,7 +14,7 @@ extension String {
     */
     func lastIndexOf(character: Character) -> Index? {
         var last: Index?
-        for i in startIndex ..< endIndex {
+        for i in characters.indices.indices {
             if self[i] == character {
                 last = i
             }

--- a/RxSwift/Observable+Extensions.swift
+++ b/RxSwift/Observable+Extensions.swift
@@ -35,7 +35,7 @@ extension ObservableType {
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
     @warn_unused_result(message: "http://git.io/rxs.ud")
-    public func subscribe(onNext onNext: (E -> Void)? = nil, onError: (ErrorProtocol -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
+    public func subscribe(onNext: ((E) -> Void)? = nil, onError: ((ErrorProtocol) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
         -> Disposable {
 
         let disposable: Disposable

--- a/RxSwift/Observable.swift
+++ b/RxSwift/Observable.swift
@@ -45,7 +45,7 @@ public class Observable<Element> : ObservableType {
     /**
     Optimizations for map operator
     */
-    internal func composeMap<R>(selector: Element throws -> R) -> Observable<R> {
+    internal func composeMap<R>(selector: (Element) throws -> R) -> Observable<R> {
         return Map(source: self, selector: selector)
     }
 }

--- a/RxSwift/Observables/Implementations/AddRef.swift
+++ b/RxSwift/Observables/Implementations/AddRef.swift
@@ -27,7 +27,7 @@ class AddRefSink<O: ObserverType> : Sink<O>, ObserverType {
 }
 
 class AddRef<Element> : Producer<Element> {
-    typealias EventHandler = Event<Element> throws -> Void
+    typealias EventHandler = (Event<Element>) throws -> Void
     
     private let _source: Observable<Element>
     private let _refCount: RefCountDisposable

--- a/RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift
@@ -90,9 +90,9 @@ class CombineLatestCollectionTypeSink<C: Collection, R, O: ObserverType where C.
     
     func run() -> Disposable {
         var j = 0
-        for i in _parent._sources.startIndex ..< _parent._sources.endIndex {
+        for i in _parent._sources {
             let index = j
-            let source = _parent._sources[i].asObservable()
+            let source = i.asObservable()
             _subscriptions[j].disposable = source.subscribe(observer: AnyObserver { event in
                 self.on(event: event, atIndex: index)
             })
@@ -105,7 +105,7 @@ class CombineLatestCollectionTypeSink<C: Collection, R, O: ObserverType where C.
 }
 
 class CombineLatestCollectionType<C: Collection, R where C.Iterator.Element : ObservableConvertibleType> : Producer<R> {
-    typealias ResultSelector = [C.Iterator.Element.E] throws -> R
+    typealias ResultSelector = ([C.Iterator.Element.E]) throws -> R
     
     let _sources: C
     let _resultSelector: ResultSelector

--- a/RxSwift/Observables/Implementations/Debug.swift
+++ b/RxSwift/Observables/Implementations/Debug.swift
@@ -59,7 +59,7 @@ class Debug<Element> : Producer<Element> {
         else {
             let trimmedFile: String
             if let lastIndex = file.lastIndexOf(character: "/") {
-                trimmedFile = file[lastIndex.successor() ..< file.endIndex]
+                trimmedFile = file[file.index(after: lastIndex) ..< file.endIndex]
             }
             else {
                 trimmedFile = file

--- a/RxSwift/Observables/Implementations/Do.swift
+++ b/RxSwift/Observables/Implementations/Do.swift
@@ -35,7 +35,7 @@ class DoSink<O: ObserverType> : Sink<O>, ObserverType {
 }
 
 class Do<Element> : Producer<Element> {
-    typealias EventHandler = Event<Element> throws -> Void
+    typealias EventHandler = (Event<Element>) throws -> Void
     
     private let _source: Observable<Element>
     private let _eventHandler: EventHandler

--- a/RxSwift/Observables/Implementations/Generate.swift
+++ b/RxSwift/Observables/Implementations/Generate.swift
@@ -49,12 +49,12 @@ class GenerateSink<S, O: ObserverType> : Sink<O> {
 
 class Generate<S, E> : Producer<E> {
     private let _initialState: S
-    private let _condition: S throws -> Bool
-    private let _iterate: S throws -> S
-    private let _resultSelector: S throws -> E
+    private let _condition: (S) throws -> Bool
+    private let _iterate: (S) throws -> S
+    private let _resultSelector: (S) throws -> E
     private let _scheduler: ImmediateSchedulerType
     
-    init(initialState: S, condition: S throws -> Bool, iterate: S throws -> S, resultSelector: S throws -> E, scheduler: ImmediateSchedulerType) {
+    init(initialState: S, condition: (S) throws -> Bool, iterate: (S) throws -> S, resultSelector: (S) throws -> E, scheduler: ImmediateSchedulerType) {
         _initialState = initialState
         _condition = condition
         _iterate = iterate

--- a/RxSwift/Observables/Implementations/Map.swift
+++ b/RxSwift/Observables/Implementations/Map.swift
@@ -118,7 +118,7 @@ class Map<SourceType, ResultType>: Producer<ResultType> {
 #endif
     }
 
-    override func composeMap<R>(selector: ResultType throws -> R) -> Observable<R> {
+    override func composeMap<R>(selector: (ResultType) throws -> R) -> Observable<R> {
         let originalSelector = _selector
         return Map<SourceType, R>(source: _source, selector: { (s: SourceType) throws -> R in
             let r: ResultType = try originalSelector(s)

--- a/RxSwift/Observables/Implementations/ObserveOn.swift
+++ b/RxSwift/Observables/Implementations/ObserveOn.swift
@@ -79,7 +79,7 @@ class ObserveOnSink<O: ObserverType> : ObserverBase<O.E> {
         }
     }
     
-    func run(state: Void, recurse: Void -> Void) {
+    func run(state: Void, recurse: (Void) -> Void) {
         let (nextEvent, observer) = self._lock.calculateLocked { () -> (Event<E>?, O?) in
             if self._queue.count > 0 {
                 return (self._queue.dequeue(), self._observer)

--- a/RxSwift/Observables/Implementations/RetryWhen.swift
+++ b/RxSwift/Observables/Implementations/RetryWhen.swift
@@ -135,9 +135,9 @@ class RetryWhenSequence<S: Sequence, TriggerObservable: ObservableType, Error wh
     typealias Element = S.Iterator.Element.E
     
     private let _sources: S
-    private let _notificationHandler: Observable<Error> -> TriggerObservable
+    private let _notificationHandler: (Observable<Error>) -> TriggerObservable
     
-    init(sources: S, notificationHandler: Observable<Error> -> TriggerObservable) {
+    init(sources: S, notificationHandler: (Observable<Error>) -> TriggerObservable) {
         _sources = sources
         _notificationHandler = notificationHandler
     }

--- a/RxSwift/Observables/Implementations/Switch.swift
+++ b/RxSwift/Observables/Implementations/Switch.swift
@@ -144,7 +144,7 @@ final class SwitchIdentitySink<S: ObservableConvertibleType, O: ObserverType whe
 }
 
 final class MapSwitchSink<SourceType, S: ObservableConvertibleType, O: ObserverType where O.E == S.E> : SwitchSink<SourceType, S, O> {
-    typealias Selector = SourceType throws -> S
+    typealias Selector = (SourceType) throws -> S
 
     private let _selector: Selector
 
@@ -175,7 +175,7 @@ final class Switch<S: ObservableConvertibleType> : Producer<S.E> {
 }
 
 final class FlatMapLatest<SourceType, S: ObservableConvertibleType> : Producer<S.E> {
-    typealias Selector = SourceType throws -> S
+    typealias Selector = (SourceType) throws -> S
 
     private let _source: Observable<SourceType>
     private let _selector: Selector

--- a/RxSwift/Observables/Implementations/Using.swift
+++ b/RxSwift/Observables/Implementations/Using.swift
@@ -59,7 +59,7 @@ class Using<SourceType, ResourceType: Disposable>: Producer<SourceType> {
     typealias E = SourceType
     
     typealias ResourceFactory = () throws -> ResourceType
-    typealias ObservableFactory = ResourceType throws -> Observable<SourceType>
+    typealias ObservableFactory = (ResourceType) throws -> Observable<SourceType>
     
     private let _resourceFactory: ResourceFactory
     private let _observableFactory: ObservableFactory

--- a/RxSwift/Observables/Implementations/Zip+CollectionType.swift
+++ b/RxSwift/Observables/Implementations/Zip+CollectionType.swift
@@ -103,9 +103,9 @@ class ZipCollectionTypeSink<C: Collection, R, O: ObserverType where C.Iterator.E
     
     func run() -> Disposable {
         var j = 0
-        for i in _parent.sources.startIndex ..< _parent.sources.endIndex {
+        for i in _parent.sources {
             let index = j
-            let source = _parent.sources[i].asObservable()
+            let source = i.asObservable()
             _subscriptions[j].disposable = source.subscribe(observer: AnyObserver { event in
                 self.on(event: event, atIndex: index)
                 })
@@ -117,7 +117,7 @@ class ZipCollectionTypeSink<C: Collection, R, O: ObserverType where C.Iterator.E
 }
 
 class ZipCollectionType<C: Collection, R where C.Iterator.Element : ObservableConvertibleType> : Producer<R> {
-    typealias ResultSelector = [C.Iterator.Element.E] throws -> R
+    typealias ResultSelector = ([C.Iterator.Element.E]) throws -> R
     
     let sources: C
     let resultSelector: ResultSelector

--- a/RxSwift/Observables/Observable+Creation.swift
+++ b/RxSwift/Observables/Observable+Creation.swift
@@ -132,7 +132,7 @@ extension Observable {
     - returns: The generated sequence.
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public static func generate(initialState: E, condition: E throws -> Bool, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance, iterate: E throws -> E) -> Observable<E> {
+    public static func generate(initialState: E, condition: (E) throws -> Bool, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance, iterate: (E) throws -> E) -> Observable<E> {
         return Generate(initialState: initialState, condition: condition, iterate: iterate, resultSelector: { $0 }, scheduler: scheduler)
     }
 
@@ -160,7 +160,7 @@ extension Observable {
     - returns: An observable sequence whose lifetime controls the lifetime of the dependent resource object.
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public static func using<R: Disposable>(resourceFactory: () throws -> R, observableFactory: R throws -> Observable<E>) -> Observable<E> {
+    public static func using<R: Disposable>(resourceFactory: () throws -> R, observableFactory: (R) throws -> Observable<E>) -> Observable<E> {
         return Using(resourceFactory: resourceFactory, observableFactory: observableFactory)
     }
 }

--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -21,7 +21,7 @@ extension Collection where Iterator.Element : ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func combineLatest<R>(resultSelector: [Generator.Element.E] throws -> R) -> Observable<R> {
+    public func combineLatest<R>(resultSelector: ([Generator.Element.E]) throws -> R) -> Observable<R> {
         return CombineLatestCollectionType(sources: self, resultSelector: resultSelector)
     }
 }
@@ -39,7 +39,7 @@ extension Collection where Iterator.Element : ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func zip<R>(resultSelector: [Generator.Element.E] throws -> R) -> Observable<R> {
+    public func zip<R>(resultSelector: ([Generator.Element.E]) throws -> R) -> Observable<R> {
         return ZipCollectionType(sources: self, resultSelector: resultSelector)
     }
 }
@@ -168,7 +168,7 @@ extension ObservableType where E : ObservableConvertibleType {
     - returns: The observable sequence that merges the elements of the inner sequences.
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func merge(maxConcurrent maxConcurrent: Int)
+    public func merge(maxConcurrent: Int)
         -> Observable<E.E> {
         return MergeLimited(source: asObservable(), maxConcurrent: maxConcurrent)
     }

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -100,7 +100,7 @@ extension ObservableType {
     - returns: The source sequence with the side-effecting behavior applied.
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func doOn(onNext: (E throws -> Void)? = nil, onError: (ErrorProtocol throws -> Void)? = nil, onCompleted: (() throws -> Void)? = nil)
+    public func doOn(onNext: ((E) throws -> Void)? = nil, onError: ((ErrorProtocol) throws -> Void)? = nil, onCompleted: (() throws -> Void)? = nil)
         -> Observable<E> {
         return Do(source: self.asObservable()) { e in
             switch e {
@@ -121,7 +121,7 @@ extension ObservableType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func doOnNext(onNext: (E throws -> Void))
+    public func doOnNext(onNext: ((E) throws -> Void))
         -> Observable<E> {
         return self.doOn(onNext: onNext)
     }
@@ -133,7 +133,7 @@ extension ObservableType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func doOnError(onError: (ErrorProtocol throws -> Void))
+    public func doOnError(onError: ((ErrorProtocol) throws -> Void))
         -> Observable<E> {
         return self.doOn(onError: onError)
     }
@@ -214,7 +214,7 @@ extension ObservableType {
     - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func retryWhen<TriggerObservable: ObservableType, Error: ErrorProtocol>(notificationHandler: Observable<Error> -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType, Error: ErrorProtocol>(notificationHandler: (Observable<Error>) -> TriggerObservable)
         -> Observable<E> {
             return RetryWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
     }
@@ -229,7 +229,7 @@ extension ObservableType {
     - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func retryWhen<TriggerObservable: ObservableType>(notificationHandler: Observable<ErrorProtocol> -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType>(notificationHandler: (Observable<ErrorProtocol>) -> TriggerObservable)
         -> Observable<E> {
             return RetryWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
     }

--- a/RxSwift/Observables/Observable+StandardSequenceOperators.swift
+++ b/RxSwift/Observables/Observable+StandardSequenceOperators.swift
@@ -173,7 +173,7 @@ extension ObservableType {
      
     */
     @warn_unused_result(message: "http://git.io/rxs.uo")
-    public func map<R>(selector: E throws -> R)
+    public func map<R>(selector: (E) throws -> R)
         -> Observable<R> {
         return self.asObservable().composeMap(selector: selector)
     }

--- a/RxSwift/Observers/AnonymousObserver.swift
+++ b/RxSwift/Observers/AnonymousObserver.swift
@@ -11,7 +11,7 @@ import Foundation
 class AnonymousObserver<ElementType> : ObserverBase<ElementType> {
     typealias Element = ElementType
     
-    typealias EventHandler = Event<Element> -> Void
+    typealias EventHandler = (Event<Element>) -> Void
     
     private let _eventHandler : EventHandler
     

--- a/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
@@ -62,11 +62,11 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public final func schedule<StateType>(state: StateType, action: StateType -> Disposable) -> Disposable {
+    public final func schedule<StateType>(state: StateType, action: (StateType) -> Disposable) -> Disposable {
         return self.scheduleInternal(state: state, action: action)
     }
     
-    func scheduleInternal<StateType>(state: StateType, action: StateType -> Disposable) -> Disposable {
+    func scheduleInternal<StateType>(state: StateType, action: (StateType) -> Disposable) -> Disposable {
         let cancel = SingleAssignmentDisposable()
         
         dispatch_async(_queue) {
@@ -89,7 +89,9 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public final func scheduleRelative<StateType>(state: StateType, dueTime: NSTimeInterval, action: (StateType) -> Disposable) -> Disposable {
-        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _queue)
+        
+        // Swift 3.0 IUO
+        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _queue)!
         
         let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchTime(timeInterval: dueTime)
         
@@ -121,7 +123,9 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public func schedulePeriodic<StateType>(state: StateType, startAfter: TimeInterval, period: TimeInterval, action: (StateType) -> StateType) -> Disposable {
-        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _queue)
+        
+        // Swift 3.0 IUO
+        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _queue)!
         
         let initial = MainScheduler.convertTimeIntervalToDispatchTime(timeInterval: startAfter)
         let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchInterval(timeInterval: period)

--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -74,10 +74,10 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
 
     static var queue : ScheduleQueue? {
         get {
-            return NSThread.getThreadLocalStorageValueForKey(key: CurrentThreadSchedulerQueueKeyInstance)
+            return NSThread.getThreadLocalStorageValueForKey(key: CurrentThreadSchedulerQueueKeyInstance as NSString)
         }
         set {
-            NSThread.setThreadLocalStorageValue(value: newValue, forKey: CurrentThreadSchedulerQueueKeyInstance)
+            NSThread.setThreadLocalStorageValue(value: newValue, forKey: CurrentThreadSchedulerQueueKeyInstance as NSString)
         }
     }
 
@@ -86,11 +86,11 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
     */
     public static private(set) var isScheduleRequired: Bool {
         get {
-            let value: CurrentThreadSchedulerValue? = NSThread.getThreadLocalStorageValueForKey(key: CurrentThreadSchedulerKeyInstance)
+            let value: CurrentThreadSchedulerValue? = NSThread.getThreadLocalStorageValueForKey(key: CurrentThreadSchedulerKeyInstance as NSString)
             return value == nil
         }
         set(isScheduleRequired) {
-            NSThread.setThreadLocalStorageValue(value: isScheduleRequired ? nil : CurrentThreadSchedulerValueInstance, forKey: CurrentThreadSchedulerKeyInstance)
+            NSThread.setThreadLocalStorageValue(value: isScheduleRequired ? nil : CurrentThreadSchedulerValueInstance, forKey: CurrentThreadSchedulerKeyInstance as NSString)
         }
     }
 

--- a/RxSwift/Schedulers/HistoricalSchedulerTimeConverter.swift
+++ b/RxSwift/Schedulers/HistoricalSchedulerTimeConverter.swift
@@ -63,7 +63,7 @@ public struct HistoricalSchedulerTimeConverter : VirtualTimeConverterType {
      - parameter timeInterval: Time interval offset.
      - returns: Time offsetted by time interval.
     */
-    public func offsetVirtualTime(time time: VirtualTimeUnit, offset: VirtualTimeIntervalUnit) -> VirtualTimeUnit {
+    public func offsetVirtualTime(time: VirtualTimeUnit, offset: VirtualTimeIntervalUnit) -> VirtualTimeUnit {
         return time.addingTimeInterval(offset)
     }
 

--- a/RxSwift/Schedulers/Internal/ScheduledItem.swift
+++ b/RxSwift/Schedulers/Internal/ScheduledItem.swift
@@ -11,7 +11,7 @@ import Foundation
 struct ScheduledItem<T>
     : ScheduledItemType
     , InvocableType {
-    typealias Action = T -> Disposable
+    typealias Action = (T) -> Disposable
     
     private let _action: Action
     private let _state: T

--- a/RxSwift/Schedulers/MainScheduler.swift
+++ b/RxSwift/Schedulers/MainScheduler.swift
@@ -49,7 +49,7 @@ public final class MainScheduler : SerialDispatchQueueScheduler {
         }
     }
 
-    override func scheduleInternal<StateType>(state: StateType, action: StateType -> Disposable) -> Disposable {
+    override func scheduleInternal<StateType>(state: StateType, action: (StateType) -> Disposable) -> Disposable {
         let currentNumberEnqueued = AtomicIncrement(&numberEnqueued)
 
         if NSThread.current().isMainThread && currentNumberEnqueued == 1 {

--- a/RxSwift/Schedulers/RecursiveScheduler.swift
+++ b/RxSwift/Schedulers/RecursiveScheduler.swift
@@ -126,7 +126,7 @@ class AnyRecursiveScheduler<State> {
 Type erased recursive scheduler.
 */
 class RecursiveImmediateScheduler<State> {
-    typealias Action =  (state: State, recurse: State -> Void) -> Void
+    typealias Action =  (state: State, recurse: (State) -> Void) -> Void
     
     private var _lock = SpinLock()
     private let _group = CompositeDisposable()

--- a/RxSwift/Schedulers/SchedulerServices+Emulation.swift
+++ b/RxSwift/Schedulers/SchedulerServices+Emulation.swift
@@ -14,7 +14,7 @@ enum SchedulePeriodicRecursiveCommand {
 }
 
 class SchedulePeriodicRecursive<State> {
-    typealias RecursiveAction = State -> State
+    typealias RecursiveAction = (State) -> State
     typealias RecursiveScheduler = AnyRecursiveScheduler<SchedulePeriodicRecursiveCommand>
 
     private let _scheduler: SchedulerType

--- a/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
@@ -54,7 +54,8 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     - parameter serialQueueConfiguration: Additional configuration of internal serial dispatch queue.
     */
     public convenience init(internalSerialQueueName: String, serialQueueConfiguration: ((dispatch_queue_t) -> Void)? = nil) {
-        let queue = dispatch_queue_create(internalSerialQueueName, DISPATCH_QUEUE_SERIAL)
+        // Swift 3.0 IUO
+        let queue = dispatch_queue_create(internalSerialQueueName, DISPATCH_QUEUE_SERIAL)!
         serialQueueConfiguration?(queue)
         self.init(serialQueue: queue)
     }
@@ -66,7 +67,8 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     - parameter internalSerialQueueName: Name of internal serial dispatch queue proxy.
     */
     public convenience init(queue: dispatch_queue_t, internalSerialQueueName: String) {
-        let serialQueue = dispatch_queue_create(internalSerialQueueName, DISPATCH_QUEUE_SERIAL)
+        // Swift 3.0 IUO
+        let serialQueue = dispatch_queue_create(internalSerialQueueName, DISPATCH_QUEUE_SERIAL)!
         dispatch_set_target_queue(serialQueue, queue)
         self.init(serialQueue: serialQueue)
     }
@@ -126,7 +128,8 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public final func scheduleRelative<StateType>(state: StateType, dueTime: NSTimeInterval, action: (StateType) -> Disposable) -> Disposable {
-        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _serialQueue)
+        // Swift 3.0 IUO
+        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _serialQueue)!
         
         let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchTime(timeInterval: dueTime)
         
@@ -158,7 +161,9 @@ public class SerialDispatchQueueScheduler: SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public func schedulePeriodic<StateType>(state: StateType, startAfter: TimeInterval, period: TimeInterval, action: (StateType) -> StateType) -> Disposable {
-        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _serialQueue)
+        
+        // Swift 3.0 IUO
+        let timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _serialQueue)!
         
         let initial = MainScheduler.convertTimeIntervalToDispatchTime(timeInterval: startAfter)
         let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchInterval(timeInterval: period)

--- a/RxSwift/Schedulers/VirtualTimeConverterType.swift
+++ b/RxSwift/Schedulers/VirtualTimeConverterType.swift
@@ -61,7 +61,7 @@ public protocol VirtualTimeConverterType {
      - parameter offset: Virtual time interval.
      - returns: Time corresponding to time offsetted by virtual time interval.
     */
-    func offsetVirtualTime(time time: VirtualTimeUnit, offset: VirtualTimeIntervalUnit) -> VirtualTimeUnit
+    func offsetVirtualTime(time: VirtualTimeUnit, offset: VirtualTimeIntervalUnit) -> VirtualTimeUnit
 
     /**
      This is aditional abstraction because `NSDate` is unfortunately not comparable.

--- a/RxSwift/Schedulers/VirtualTimeScheduler.swift
+++ b/RxSwift/Schedulers/VirtualTimeScheduler.swift
@@ -72,7 +72,7 @@ public class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func schedule<StateType>(state: StateType, action: StateType -> Disposable) -> Disposable {
+    public func schedule<StateType>(state: StateType, action: (StateType) -> Disposable) -> Disposable {
         return self.scheduleRelative(state: state, dueTime: 0.0) { a in
             return action(a)
         }
@@ -86,7 +86,7 @@ public class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleRelative<StateType>(state: StateType, dueTime: RxTimeInterval, action: StateType -> Disposable) -> Disposable {
+    public func scheduleRelative<StateType>(state: StateType, dueTime: RxTimeInterval, action: (StateType) -> Disposable) -> Disposable {
         let time = self.now.addingTimeInterval(dueTime)
         let absoluteTime = _converter.convertToVirtualTime(time: time)
         let adjustedTime = self.adjustScheduledTime(time: absoluteTime)
@@ -101,7 +101,7 @@ public class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleRelativeVirtual<StateType>(state: StateType, dueTime: VirtualTimeInterval, action: StateType -> Disposable) -> Disposable {
+    public func scheduleRelativeVirtual<StateType>(state: StateType, dueTime: VirtualTimeInterval, action: (StateType) -> Disposable) -> Disposable {
         let time = _converter.offsetVirtualTime(time: self.clock, offset: dueTime)
         return scheduleAbsoluteVirtual(state: state, time: time, action: action)
     }
@@ -114,7 +114,7 @@ public class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleAbsoluteVirtual<StateType>(state: StateType, time: Converter.VirtualTimeUnit, action: StateType -> Disposable) -> Disposable {
+    public func scheduleAbsoluteVirtual<StateType>(state: StateType, time: Converter.VirtualTimeUnit, action: (StateType) -> Disposable) -> Disposable {
         MainScheduler.ensureExecutingOnScheduler()
 
         let compositeDisposable = CompositeDisposable()

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -54,7 +54,7 @@ public class ReplaySubject<Element>
     - parameter bufferSize: Maximal number of elements to replay to observer after subscription.
     - returns: New instance of replay subject.
     */
-    public static func create(bufferSize bufferSize: Int) -> ReplaySubject<Element> {
+    public static func create(bufferSize: Int) -> ReplaySubject<Element> {
         if bufferSize == 1 {
             return ReplayOne()
         }


### PR DESCRIPTION
Added swift-DEVELOPMENT-SNAPSHOT-2016-05-09 compatibility. These changes included reordering @noescape, wrapping the parameter of single parameter function types with parentheses, conforming to the new index APIs, and implicitly unwrapping newly annotated libdispatch functions.

All additions of IUOs have been marked with // Swift 3.0 IUO.