### PR TITLE
Fix Blurred demonstration of 'concat demo'. 

### DIFF
--- a/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
@@ -61,6 +61,7 @@ example("concat") {
     
     variable.value = subject2
     
+    subject2.onNext("I would be ignored")
     subject2.onNext("🐱")
     
     subject1.onCompleted()


### PR DESCRIPTION
changed target to develop branch 
replacement of PR#692

The output is of "concat example" is :  

Next(🍎)
Next(🍐)
Next(🍊)
Next(🐱)
Next(🐭)

If people do not use 'concat()', the result is the same, the demo cannot show the effect of 'concat()', which is "waiting for each sequence to terminate successfully before emitting elements from the next sequence"

so I add one line code for better demonstration.