### PR TITLE
Rewrite Bag.count implementation to reduce compilation time

### DIFF
--- a/RxSwift/DataStructures/Bag.swift
+++ b/RxSwift/DataStructures/Bag.swift
@@ -152,7 +152,11 @@ public struct Bag<T> : CustomDebugStringConvertible {
     - returns: Number of elements in bag.
     */
     public var count: Int {
-        return _pairs.count + (_value0 != nil ? 1 : 0) + (_value1 != nil ? 1 : 0) + (_dictionary?.count ?? 0)
+        var dictionaryCount = 0
+        if let dc = _dictionary?.count {
+            dictionaryCount = dc
+        }
+        return _pairs.count + (_value0 != nil ? 1 : 0) + (_value1 != nil ? 1 : 0) + dictionaryCount
     }
     
     /**


### PR DESCRIPTION
I've observed that there is some code that results in super long compilation times. 

I'm using the following build environment:
```
$ xcodebuild -version
Xcode 7.3.1
Build version 7D1014

$ swift -version
Apple Swift version 2.2 (swiftlang-703.0.18.8 clang-703.0.31)
Target: x86_64-apple-macosx10.9
```

And this is the script I used to profile the compiler:

```
xcodebuild\
		 -workspace Rx.xcworkspace\
		 -scheme RxSwift-iOS\
		 -configuration Release CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO OTHER_SWIFT_FLAGS="-Xfrontend -debug-time-function-bodies"\
		 clean build | grep [1-9].[0-9]ms | sort -nr | head -3 | cat
```

The worst performing line of code is in `Bag.swift`
```
public var count: Int {
    return _pairs.count + (_value0 != nil ? 1 : 0) + (_value1 != nil ? 1 : 0) + (_dictionary?.count ?? 0)
}
```

Which takes around **1005 ms** on my machine to compile
```
1005.0ms	/RxSwift/RxSwift/DataStructures/Bag.swift:154:27	get {}
```

Just by replacing the coalescing operator the same function takes around **13 ms** to compile

```
public var count: Int {
    var dictionaryCount = 0
    if let dc = _dictionary?.count {
        dictionaryCount = dc
    }
    return _pairs.count + (_value0 != nil ? 1 : 0) + (_value1 != nil ? 1 : 0) + dictionaryCount
}
```

```
12.8ms	/RxSwift/RxSwift/DataStructures/Bag.swift:154:27	get {}
```
