### PR TITLE
Add a script that updates RxSwift jazzy docs

### DIFF
--- a/scripts/update-jazzy-docs.sh
+++ b/scripts/update-jazzy-docs.sh
@@ -1,0 +1,22 @@
+. scripts/common.sh
+
+function updateDocs() {
+  WORKSPACE=$1
+  SCHEME=$2
+  CONFIGURATION=$3
+  SIMULATOR=$4
+  MODULE=$5
+
+  ensure_simulator_available "${SIMULATOR}"
+  SIMULATOR_GUID=`simulator_ids "${SIMULATOR}"`
+  DESTINATION='id='$SIMULATOR_GUID''
+
+  set -x
+  killall Simulator || true
+  jazzy --config .jazzy.yml -m "${MODULE}" -x -workspace,"${WORKSPACE}",-scheme,"${SCHEME}",-configuration,"${CONFIGURATION}",-derivedDataPath,"${BUILD_DIRECTORY}",-destination,"$DESTINATION"
+  set +x
+}
+
+./scripts/update-jazzy-config.rb
+
+updateDocs Rx.xcworkspace "RxExample-iOS" "Release" $DEFAULT_IOS9_SIMULATOR "RxSwift"


### PR DESCRIPTION
#730 added scripts that updated `.jazzy.yml`, whereas this PR adds a script that uses `.jazzy.yml` to actually generate the docs.

This is a first pass.  It shouldn't be considered a finished feature, since it only generates the docs for `RxSwift` and not `RxCocoa`.  The destination would need to be different for each, since it still saves to the default `docs/`.  Also, it only generates docs for `iOS` and not the other platforms.  It's also not very DRY, since it repeats some logic from `common.sh` in `action()` which gets the simulator ID and also compiles the arguments for `xcodebuild`.