### PR TITLE
Add a convenient method for data source

### DIFF
--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -64,6 +64,22 @@ extension UITableView {
     }
     
     /**
+     Binds sequences of elements to table view rows. The method uses the same cell identifier as cell type.
+     
+     - parameter source: Observable sequence of items.
+     - parameter configureCell: Transform between sequence elements and view cells.
+     - parameter cellType: Type of table view cell.
+     - returns: Disposable object that can be used to unbind.
+     */
+    public func rx_itemsWithCellType<S: SequenceType, Cell: UITableViewCell, O: ObservableType where O.E == S>
+        (cellType: Cell.Type = Cell.self)
+        -> (source: O)
+        -> (configureCell: (Int, S.Generator.Element, Cell) -> Void)
+        -> Disposable {
+            return rx_itemsWithCellIdentifier(String(cellType), cellType: cellType)
+    }
+    
+    /**
     Binds sequences of elements to table view rows using a custom reactive data used to perform the transformation.
     
     - parameter dataSource: Data source used to transform elements to view cells.

--- a/Tests/RxCocoaTests/UITableView+RxTests.swift
+++ b/Tests/RxCocoaTests/UITableView+RxTests.swift
@@ -219,6 +219,22 @@ class UITableViewTests : RxTest {
         }
         ensureEventDeallocated(createView) { (view: UITableView) in view.rx_modelSelected(Int.self) }
     }
+    
+    func testTableView_DelegateEventCompletesOnDealloc3_inferredCellReuseIdentifier() {
+        let items: Observable<[Int]> = Observable.just([1, 2, 3])
+        
+        let createView: () -> (UITableView, Disposable) = {
+            let tableView = UITableView(frame: CGRectMake(0, 0, 1, 1))
+            let cellType = "UITableViewCell"
+            tableView.registerClass(NSClassFromString(cellType), forCellReuseIdentifier: cellType)
+            let dataSourceSubscription = items.bindTo(tableView.rx_itemsWithCellType(UITableViewCell.self)) { (index: Int, item: Int, cell) in
+                
+            }
+            
+            return (tableView, dataSourceSubscription)
+        }
+        ensureEventDeallocated(createView) { (view: UITableView) in view.rx_modelSelected(Int.self) }
+    }
 
     func testTableView_ModelSelected_rx_itemsWithCellFactory() {
         let items: Observable<[Int]> = Observable.just([1, 2, 3])


### PR DESCRIPTION
I prefer to use the same reuse identifiers for cells to avoid hard coded values in the code. So I've add a convenient method to the UITableView extension. 