### PR TITLE
Replace `rand` with `arc4random`

### DIFF
--- a/RxCocoa/Common/CocoaUnits/Driver/Driver.swift
+++ b/RxCocoa/Common/CocoaUnits/Driver/Driver.swift
@@ -211,7 +211,7 @@ public func driveOnScheduler(scheduler: SchedulerType, action: () -> ()) {
 
 func _forceCompilerToStopDoingInsaneOptimizationsThatBreakCode(scheduler: SchedulerType) {
     let a: Int32 = 1
-    let b = 314 + Int32(rand() & 1)
+    let b = 314 + Int32(arc4random() & 1)
     if a == b {
         print(scheduler)
     }


### PR DESCRIPTION
Swift 2.3 won't compile with `rand`.

Is `_forceCompilerToStopDoingInsaneOptimizationsThatBreakCode` even needed anymore? If not, maybe it can be removed in a separate PR.