### PR TITLE
Fix RxCocoa compilation error with swift 2.3 (Xcode 8-beta)

### DIFF
--- a/RxCocoa/Common/CocoaUnits/Driver/Driver.swift
+++ b/RxCocoa/Common/CocoaUnits/Driver/Driver.swift
@@ -211,7 +211,7 @@ public func driveOnScheduler(scheduler: SchedulerType, action: () -> ()) {
 
 func _forceCompilerToStopDoingInsaneOptimizationsThatBreakCode(scheduler: SchedulerType) {
     let a: Int32 = 1
-    let b = 314 + Int32(rand() & 1)
+    let b = 314 + Int32(arc4random() & 1)
     if a == b {
         print(scheduler)
     }


### PR DESCRIPTION
Hi,

Apparently `rand()` is off limits to swift code as of Xcode 8.0 beta 1, so RxCocoa fails to compile thanks to the delightfully named `_forceCompilerToStopDoingInsaneOptimizationsThatBreakCode` function :)

This just replaces `rand()` with `arc4random()`, as suggested by the compiler's error message. 

 I didn't include the changes to `Rx.xcodeproj/project.pbxproj` which set the language version to swift 2.3, so this should still build fine on the release version of Xcode.  The first time you open the project in the beta it will ask you to migrate to the new syntax, but no changes will be needed (assuming you choose swift 2.3 and not 3.0 of course)