### PR TITLE
Change _forwardToDelegate to weak reference

### DIFF
--- a/RxCocoa/Common/_RXDelegateProxy.h
+++ b/RxCocoa/Common/_RXDelegateProxy.h
@@ -10,7 +10,7 @@
 
 @interface _RXDelegateProxy : NSObject
 
-@property (nonatomic, assign, readonly) id _forwardToDelegate;
+@property (nonatomic, weak, readonly) id _forwardToDelegate;
 
 -(void)_setForwardToDelegate:(id)forwardToDelegate retainDelegate:(BOOL)retainDelegate;
 


### PR DESCRIPTION
It causes EXC_BAD_ACCESS in `RxScrollViewDelegateProxy.scrollViewDidScroll` when deallocating object.