### PR TITLE
Resolve minor static analysis issues

### DIFF
--- a/RxCocoa/Common/_RXDelegateProxy.m
+++ b/RxCocoa/Common/_RXDelegateProxy.m
@@ -58,7 +58,7 @@ static NSMutableDictionary *forwardableSelectorsPerClass = nil;
 #define CLASS_HIERARCHY_MAX_DEPTH 100
 
         NSInteger  classHierarchyDepth = 0;
-        Class      targetClass         = self;
+        Class      targetClass         = NULL;
 
         for (classHierarchyDepth = 0, targetClass = self;
              classHierarchyDepth < CLASS_HIERARCHY_MAX_DEPTH && targetClass != nil;


### PR DESCRIPTION
Not a major issue by any definition of the word, but we're seeing static analysis issues come through in our build logs when including RxSwift as a subproject. 

I could use some guidance here on your project's style and approach: there are 11 additional static analysis warnings as follows:

```
RxSwift/RxCocoa/Common/_RXObjCRuntime.m:599:16: warning: Potential null dereference.  According to coding standards in 'Creating and Returning NSError Objects' the parameter may be null
        *error = [NSError errorWithDomain:RXObjCRuntimeErrorDomain
        ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I see that you've annotated the `NSError *__autoreleasing *__nonnull`, however if you [read Apple's blog post on nullability](https://developer.apple.com/swift/blog/?id=25), they specifically say:

> The particular type NSError ** is so often used to return errors via method parameters that it is always assumed to be a nullable pointer to a nullable NSError reference.

So these issues are only going to go away if the code is changed to treat them as nullable. I'm happy to make this change (something as simple as an early return, or a parameter assertion), but I wasn't sure which approach you'd prefer. 

It's also worth noting that [people have filed radars against this issue](http://www.openradar.me/21766176), however I'd like to see this resolved sooner rather than later.