### PR TITLE
Resolve minor static analysis issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 * Adds `rx_title` to `UIViewController`.
 * Adds `rx_scrollEnabled` to `UIScrollView`.
+* Resolve static analysis issues relating to non-use of an assigned value, and potential null dereferences in RxCocoa's Objective-C classes.
 
 
 ## [2.5.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.5.0)

--- a/RxCocoa/Common/_RX.h
+++ b/RxCocoa/Common/_RX.h
@@ -32,6 +32,12 @@
 #define CLASS_VALUE(x)    [NSValue valueWithNonretainedObject:(x)]
 #define IMP_VALUE(x)      [NSValue valueWithPointer:(x)]
 
+/**
+ Checks that the local `error` instance exists before assigning it's value by reference.
+ This macro exists to work around static analysis warnings — `NSError` is always assumed to be `nullable`, even though we explictly define the method parameter as `nonnull`. See http://www.openradar.me/21766176 for more details.
+ */
+#define RX_SAFE_ERROR(errorValue) if (error != nil) { *error = (errorValue); }
+
 // Inspired by http://p99.gforge.inria.fr
 
 // https://gcc.gnu.org/onlinedocs/gcc-2.95.3/cpp_1.html#SEC26

--- a/RxCocoa/Common/_RXDelegateProxy.m
+++ b/RxCocoa/Common/_RXDelegateProxy.m
@@ -58,7 +58,7 @@ static NSMutableDictionary *forwardableSelectorsPerClass = nil;
 #define CLASS_HIERARCHY_MAX_DEPTH 100
 
         NSInteger  classHierarchyDepth = 0;
-        Class      targetClass         = self;
+        Class      targetClass         = NULL;
 
         for (classHierarchyDepth = 0, targetClass = self;
              classHierarchyDepth < CLASS_HIERARCHY_MAX_DEPTH && targetClass != nil;


### PR DESCRIPTION
Not a major issue by any definition of the word, but we're seeing static analysis issues come through in our build logs when including RxSwift as a subproject. 

I could use some guidance here on your project's style and approach: there are 11 additional static analysis warnings as follows:

```
RxSwift/RxCocoa/Common/_RXObjCRuntime.m:599:16: warning: Potential null dereference.  According to coding standards in 'Creating and Returning NSError Objects' the parameter may be null
        *error = [NSError errorWithDomain:RXObjCRuntimeErrorDomain
        ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I see that you've annotated the `NSError *__autoreleasing *__nonnull`, however if you [read Apple's blog post on nullability](https://developer.apple.com/swift/blog/?id=25), they specifically say:

> The particular type NSError ** is so often used to return errors via method parameters that it is always assumed to be a nullable pointer to a nullable NSError reference.

So these issues are only going to go away if the code is changed to treat them as nullable. I'm happy to make this change (something as simple as an early return, or a parameter assertion), but I wasn't sure which approach you'd prefer. 

It's also worth noting that [people have filed radars against this issue](http://www.openradar.me/21766176), however I'd like to see this resolved sooner rather than later.