### PR TITLE
[RxTests] Make equatable operator for Recorded public.

### DIFF
--- a/RxTests/Recorded.swift
+++ b/RxTests/Recorded.swift
@@ -41,10 +41,10 @@ extension Recorded {
     }
 }
 
-func == <T: Equatable>(lhs: Recorded<T>, rhs: Recorded<T>) -> Bool {
+public func == <T: Equatable>(lhs: Recorded<T>, rhs: Recorded<T>) -> Bool {
     return lhs.time == rhs.time && lhs.value == rhs.value
 }
 
-func == <T: Equatable>(lhs: Recorded<Event<T>>, rhs: Recorded<Event<T>>) -> Bool {
+public func == <T: Equatable>(lhs: Recorded<Event<T>>, rhs: Recorded<Event<T>>) -> Bool {
     return lhs.time == rhs.time && lhs.value == rhs.value
 }


### PR DESCRIPTION
To make our life easier using **Nimble** instead of `XCTest`. While using Nimble I had to explicitly add `==` parameter for `Recorded` while comparing.