### PR TITLE
Fix RxBlocking in Swift 3

### DIFF
--- a/RxBlocking/RunLoopLock.swift
+++ b/RxBlocking/RunLoopLock.swift
@@ -39,7 +39,6 @@ class RunLoopLock {
     }
 
     func dispatch(_ action: () -> ()) {
-        
         CFRunLoopPerformBlock(currentRunLoop, CFRunLoopMode.defaultMode.rawValue) {
             if CurrentThreadScheduler.isScheduleRequired {
                 _ = CurrentThreadScheduler.instance.schedule(()) { _ in

--- a/RxBlocking/RunLoopLock.swift
+++ b/RxBlocking/RunLoopLock.swift
@@ -39,7 +39,8 @@ class RunLoopLock {
     }
 
     func dispatch(_ action: () -> ()) {
-        CFRunLoopPerformBlock(currentRunLoop, CFRunLoopMode.defaultMode as! CFTypeRef) {
+        
+        CFRunLoopPerformBlock(currentRunLoop, CFRunLoopMode.defaultMode.rawValue) {
             if CurrentThreadScheduler.isScheduleRequired {
                 _ = CurrentThreadScheduler.instance.schedule(()) { _ in
                     action()
@@ -57,7 +58,7 @@ class RunLoopLock {
         if AtomicIncrement(&calledStop) != 1 {
             return
         }
-        CFRunLoopPerformBlock(currentRunLoop, CFRunLoopMode.defaultMode as! CFTypeRef) {
+        CFRunLoopPerformBlock(currentRunLoop, CFRunLoopMode.defaultMode.rawValue) {
             CFRunLoopStop(self.currentRunLoop)
         }
         CFRunLoopWakeUp(currentRunLoop)

--- a/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
@@ -125,14 +125,14 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
         
     
         let initial = MainScheduler.convertTimeIntervalToDispatchTime(startAfter)
-        let dispatchInterval = MainScheduler.convertTimeIntervalToDispatchInterval(period)
         
         var timerState = state
         
-        let validDispatchInterval = dispatchInterval < 0 ? 0 : dispatchInterval
+        let validDispatchInterval = period < 0.0 ? 0.0 : period
         
-        let timer = DispatchSource.timer(flags: DispatchSource.TimerFlags(rawValue: UInt(0)), queue: _queue)    
-        timer.scheduleRepeating(deadline: initial, interval: DispatchTimeInterval.seconds(Int(validDispatchInterval)), leeway: DispatchTimeInterval.microseconds(0))
+        let timer = DispatchSource.timer(flags: [], queue: _queue)
+        timer.scheduleRepeating(deadline: initial, interval: validDispatchInterval, leeway: DispatchTimeInterval.microseconds(0))
+        
         let cancel = AnonymousDisposable {
             timer.cancel()
         }


### PR DESCRIPTION
Remove force cast in favor of rawValue to fix crash at runtime