### PR TITLE
Update for Xcode 8 beta 2.

### DIFF
--- a/RxSwift/Platform/Platform.Darwin.swift
+++ b/RxSwift/Platform/Platform.Darwin.swift
@@ -23,7 +23,7 @@
 
     extension Thread {
         static func setThreadLocalStorageValue<T: AnyObject>(_ value: T?, forKey key: protocol<AnyObject, NSCopying>) {
-            let currentThread = Thread.current()
+            let currentThread = Thread.current
             let threadDictionary = currentThread.threadDictionary
 
             if let newValue = value {
@@ -35,7 +35,7 @@
 
         }
         static func getThreadLocalStorageValueForKey<T>(_ key: protocol<AnyObject, NSCopying>) -> T? {
-            let currentThread = Thread.current()
+            let currentThread = Thread.current
             let threadDictionary = currentThread.threadDictionary
             
             return threadDictionary[key] as? T

--- a/RxSwift/Schedulers/ConcurrentMainScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentMainScheduler.swift
@@ -46,7 +46,7 @@ public final class ConcurrentMainScheduler : SchedulerType {
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
     public func schedule<StateType>(_ state: StateType, action: (StateType) -> Disposable) -> Disposable {
-        if Thread.current().isMainThread {
+        if Thread.current.isMainThread {
             return action(state)
         }
 

--- a/RxSwift/Schedulers/MainScheduler.swift
+++ b/RxSwift/Schedulers/MainScheduler.swift
@@ -44,7 +44,7 @@ public final class MainScheduler : SerialDispatchQueueScheduler {
     In case this method is called on a background thread it will throw an exception.
     */
     public class func ensureExecutingOnScheduler(errorMessage: String? = nil) {
-        if !Thread.current().isMainThread {
+        if !Thread.current.isMainThread {
             rxFatalError(errorMessage ?? "Executing on backgound thread. Please use `MainScheduler.instance.schedule` to schedule work on main thread.")
         }
     }
@@ -52,7 +52,7 @@ public final class MainScheduler : SerialDispatchQueueScheduler {
     override func scheduleInternal<StateType>(_ state: StateType, action: (StateType) -> Disposable) -> Disposable {
         let currentNumberEnqueued = AtomicIncrement(&numberEnqueued)
 
-        if Thread.current().isMainThread && currentNumberEnqueued == 1 {
+        if Thread.current.isMainThread && currentNumberEnqueued == 1 {
             let disposable = action(state)
             _ = AtomicDecrement(&numberEnqueued)
             return disposable


### PR DESCRIPTION
`Thread.current` is a class property, not a method.