### PR TITLE
Remove typealias Parent line in Filter.swift

### DIFF
--- a/RxSwift/Observables/Implementations/Filter.swift
+++ b/RxSwift/Observables/Implementations/Filter.swift
@@ -12,8 +12,6 @@ class FilterSink<O : ObserverType>: Sink<O>, ObserverType {
     typealias Predicate = (Element) throws -> Bool
     typealias Element = O.E
     
-    typealias Parent = Filter<Element>
-    
     private let _predicate: Predicate
     
     init(predicate: Predicate, observer: O) {


### PR DESCRIPTION
When I studying RxSwift internal sources, I found that unused code line. So, remove the code and request Pull-Request. 😄 