### PR TITLE
[Swift 3.0] Remove first parameter names for Observables.

### DIFF
--- a/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
+++ b/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
@@ -123,7 +123,7 @@ extension DriverConvertibleType {
     public func doOn(_ eventHandler: (Event<E>) -> Void)
         -> Driver<E> {
         let source = self.asObservable()
-            .doOn(eventHandler: eventHandler)
+            .doOn(eventHandler)
         
         return Driver(source)
     }
@@ -137,7 +137,7 @@ extension DriverConvertibleType {
     - returns: The source sequence with the side-effecting behavior applied.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOn(_ onNext: ((E) -> Void)? = nil, onError: ((ErrorProtocol) -> Void)? = nil, onCompleted: (() -> Void)? = nil)
+    public func doOn(onNext: ((E) -> Void)? = nil, onError: ((ErrorProtocol) -> Void)? = nil, onCompleted: (() -> Void)? = nil)
         -> Driver<E> {
         let source = self.asObservable()
             .doOn(onNext: onNext, onError: onError, onCompleted: onCompleted)
@@ -152,9 +152,9 @@ extension DriverConvertibleType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOnNext(_ onNext: ((E) -> Void))
+    public func `do`(onNext: ((E) -> Void))
         -> Driver<E> {
-        return self.doOn(onNext)
+        return self.doOn(onNext: onNext)
     }
 
     /**
@@ -164,7 +164,7 @@ extension DriverConvertibleType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOnCompleted(_ onCompleted: (() -> Void))
+    public func `do`(onCompleted: (() -> Void))
         -> Driver<E> {
         return self.doOn(onCompleted: onCompleted)
     }
@@ -399,7 +399,7 @@ extension Collection where Iterator.Element : DriverConvertibleType {
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
     public func zip<R>(_ resultSelector: ([Generator.Element.E]) throws -> R) -> Driver<R> {
-        let source = self.map { $0.asDriver().asObservable() }.zip(resultSelector: resultSelector)
+        let source = self.map { $0.asDriver().asObservable() }.zip(resultSelector)
         return Driver<R>(source)
     }
 }
@@ -415,7 +415,7 @@ extension Collection where Iterator.Element : DriverConvertibleType {
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
     public func combineLatest<R>(_ resultSelector: ([Generator.Element.E]) throws -> R) -> Driver<R> {
-        let source = self.map { $0.asDriver().asObservable() }.combineLatest(resultSelector: resultSelector)
+        let source = self.map { $0.asDriver().asObservable() }.combineLatest(resultSelector)
         return Driver<R>(source)
     }
 }

--- a/RxExample/RxExample/Services/ImageService.swift
+++ b/RxExample/RxExample/Services/ImageService.swift
@@ -75,17 +75,17 @@ class DefaultImageService: ImageService {
                     else {
                         // fetch from network
                         decodedImage = self.$.URLSession.rx_data(URLRequest(url: url))
-                            .doOnNext { data in
+                            .do(onNext: { data in
                                 self._imageDataCache.setObject(data, forKey: url)
-                            }
+                            })
                             .flatMap(self.decodeImage)
                             .trackActivity(self.loadingImage)
                     }
                 }
                 
-                return decodedImage.doOnNext { image in
+                return decodedImage.do(onNext: { image in
                     self._imageCache.setObject(image, forKey: url)
-                }
+                })
             }
     }
 

--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -21,7 +21,7 @@ extension Collection where Iterator.Element : ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func combineLatest<R>(resultSelector: ([Generator.Element.E]) throws -> R) -> Observable<R> {
+    public func combineLatest<R>(_ resultSelector: ([Generator.Element.E]) throws -> R) -> Observable<R> {
         return CombineLatestCollectionType(sources: self, resultSelector: resultSelector)
     }
 }
@@ -39,7 +39,7 @@ extension Collection where Iterator.Element : ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func zip<R>(resultSelector: ([Generator.Element.E]) throws -> R) -> Observable<R> {
+    public func zip<R>(_ resultSelector: ([Generator.Element.E]) throws -> R) -> Observable<R> {
         return ZipCollectionType(sources: self, resultSelector: resultSelector)
     }
 }

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -84,7 +84,7 @@ extension ObservableType {
     - returns: The source sequence with the side-effecting behavior applied.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOn(eventHandler: (Event<E>) throws -> Void)
+    public func doOn(_ eventHandler: (Event<E>) throws -> Void)
         -> Observable<E> {
         return Do(source: self.asObservable(), eventHandler: eventHandler)
     }
@@ -121,7 +121,7 @@ extension ObservableType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOnNext(onNext: ((E) throws -> Void))
+    public func `do`(onNext: ((E) throws -> Void))
         -> Observable<E> {
         return self.doOn(onNext: onNext)
     }
@@ -133,7 +133,7 @@ extension ObservableType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOnError(onError: ((ErrorProtocol) throws -> Void))
+    public func `do`(onError: ((ErrorProtocol) throws -> Void))
         -> Observable<E> {
         return self.doOn(onError: onError)
     }
@@ -145,7 +145,7 @@ extension ObservableType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOnCompleted(onCompleted: (() throws -> Void))
+    public func `do`(onCompleted: (() throws -> Void))
         -> Observable<E> {
         return self.doOn(onCompleted: onCompleted)
     }
@@ -229,7 +229,7 @@ extension ObservableType {
     - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func retryWhen<TriggerObservable: ObservableType>(notificationHandler: (Observable<ErrorProtocol>) -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType>(_ notificationHandler: (Observable<ErrorProtocol>) -> TriggerObservable)
         -> Observable<E> {
             return RetryWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
     }

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -548,10 +548,10 @@ extension DriverTest {
 
         var events = [Int]()
 
-        let driver = hotObservable.asDriver(onErrorJustReturn: -1).doOnNext { e in
+        let driver = hotObservable.asDriver(onErrorJustReturn: -1).do(onNext: { e in
             XCTAssertTrue(isMainThread())
             events.append(e)
-        }
+        })
 
         let results = subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription(driver) {
             XCTAssertTrue(hotObservable.subscriptions == [SubscribedToHotObservable])
@@ -572,10 +572,10 @@ extension DriverTest {
         let hotObservable = BackgroundThreadPrimitiveHotObservable<Int>()
 
         var completed = false
-        let driver = hotObservable.asDriver(onErrorJustReturn: -1).doOnCompleted { e in
+        let driver = hotObservable.asDriver(onErrorJustReturn: -1).do(onCompleted: { e in
             XCTAssertTrue(isMainThread())
             completed = true
-        }
+        })
 
         let results = subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription(driver) {
             XCTAssertTrue(hotObservable.subscriptions == [SubscribedToHotObservable])

--- a/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
@@ -573,9 +573,9 @@ extension ObservableSingleTest {
 
         var numberOfTimesInvoked = 0
 
-        let res = scheduler.start { xs.doOnNext { error in
+        let res = scheduler.start { xs.do(onNext: { error in
                 numberOfTimesInvoked = numberOfTimesInvoked + 1
-            }
+            })
         }
 
         let correctMessages = [
@@ -610,12 +610,12 @@ extension ObservableSingleTest {
 
         var numberOfTimesInvoked = 0
 
-        let res = scheduler.start { xs.doOnNext { error in
+        let res = scheduler.start { xs.do(onNext: { error in
                 if numberOfTimesInvoked > 2 {
                     throw testError
                 }
                 numberOfTimesInvoked = numberOfTimesInvoked + 1
-            }
+            })
         }
 
         let correctMessages = [
@@ -647,10 +647,10 @@ extension ObservableSingleTest {
         var recordedError: ErrorProtocol!
         var numberOfTimesInvoked = 0
 
-        let res = scheduler.start { xs.doOnError { error in
+        let res = scheduler.start { xs.do(onError: { error in
                 recordedError = error
                 numberOfTimesInvoked = numberOfTimesInvoked + 1
-            }
+            })
         }
 
         let correctMessages = [
@@ -678,9 +678,9 @@ extension ObservableSingleTest {
             error(250, testError)
             ])
 
-        let res = scheduler.start { xs.doOnError { _ in
+        let res = scheduler.start { xs.do(onError: { _ in
                 throw testError1
-            }
+            })
         }
 
         let correctMessages = [
@@ -710,9 +710,9 @@ extension ObservableSingleTest {
 
         var didComplete = false
 
-        let res = scheduler.start { xs.doOnCompleted { error in
+        let res = scheduler.start { xs.do(onCompleted: { error in
                 didComplete = true
-            }
+            })
         }
 
         let correctMessages = [
@@ -745,9 +745,9 @@ extension ObservableSingleTest {
             completed(250)
             ])
 
-        let res = scheduler.start { xs.doOnCompleted { error in
+        let res = scheduler.start { xs.do(onCompleted: { error in
                 throw testError
-            }
+            })
         }
 
         let correctMessages = [


### PR DESCRIPTION
I've noticed that few first parameter names were now mandatory in comparison to RxSwift for Swift 2.2. I went through all observables and I've tried to find which one were mandatory in version for Swift 3.0 and wasn't for Swift 2.2. If this is desired behavior then I'm sorry 🙊