### PR TITLE
WIP. Update for Xcode 8 beta 4.

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -79,7 +79,7 @@ Sequences in Rx are described by a push interface (aka callback).
 ```swift
 enum Event<Element>  {
     case Next(Element)      // next element of a sequence
-    case Error(ErrorProtocol)   // sequence failed with error
+    case Error(Swift.Error)   // sequence failed with error
     case Completed          // sequence terminated successfully
 }
 
@@ -102,7 +102,7 @@ If a sequence does not terminate in some way, resources will be allocated perman
 
 **Using dispose bags or `takeUntil` operator is a robust way of making sure resources are cleaned up. We recommend using them in production even if the sequences will terminate in finite time.**
 
-In case you are curious why `ErrorProtocol` isn't generic, you can find explanation [here](DesignRationale.md#why-error-type-isnt-generic).
+In case you are curious why `Swift.Error` isn't generic, you can find explanation [here](DesignRationale.md#why-error-type-isnt-generic).
 
 ## Disposing
 

--- a/Documentation/Linux.md
+++ b/Documentation/Linux.md
@@ -28,4 +28,4 @@ What works:
 What doesn't work:
 * Schedulers - because they are dependent on https://github.com/apple/swift-corelibs-libdispatch and it still hasn't been released
 * Multithreading - still no access to c11 locks
-* For some reason it looks like Swift compiler generates wrong code when using `ErrorProtocol` on `Linux`, so don't use errors, otherwise you can get weird crashes.
+* For some reason it looks like Swift compiler generates wrong code when using `Swift.Error` on `Linux`, so don't use errors, otherwise you can get weird crashes.

--- a/Rx.playground/Sources/SupportCode.swift
+++ b/Rx.playground/Sources/SupportCode.swift
@@ -14,7 +14,7 @@ public func printExampleHeader(description: String) {
     print("\n--- \(description) example ---")
 }
 
-public enum Error: ErrorProtocol {
+public enum Error: Swift.Error {
     case test
 }
 
@@ -27,7 +27,7 @@ public enum Error: ErrorProtocol {
 public func delay(delay: Double, closure: (Void) -> Void) {
 
     let delayTime = DispatchTime.now() + DispatchTimeInterval.seconds(Int(delay))
-    DispatchQueue.main.after(when: delayTime) {
+    DispatchQueue.main.asyncAfter(deadline: delayTime) {
         closure()
     }
 }

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -22,7 +22,7 @@ extension BlockingObservable {
     public func toArray() throws -> [E] {
         var elements: [E] = Array<E>()
 
-        var error: ErrorProtocol?
+        var error: Swift.Error?
 
         let lock = RunLoopLock()
 
@@ -70,7 +70,7 @@ extension BlockingObservable {
     public func first() throws -> E? {
         var element: E?
 
-        var error: ErrorProtocol?
+        var error: Swift.Error?
 
         let d = SingleAssignmentDisposable()
 
@@ -122,7 +122,7 @@ extension BlockingObservable {
     public func last() throws -> E? {
         var element: E?
 
-        var error: ErrorProtocol?
+        var error: Swift.Error?
 
         let d = SingleAssignmentDisposable()
 
@@ -183,7 +183,7 @@ extension BlockingObservable {
     public func single(_ predicate: (E) throws -> Bool) throws -> E? {
         var element: E?
         
-        var error: ErrorProtocol?
+        var error: Swift.Error?
         
         let d = SingleAssignmentDisposable()
         

--- a/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
+++ b/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift
@@ -137,7 +137,7 @@ extension DriverConvertibleType {
     - returns: The source sequence with the side-effecting behavior applied.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOn(onNext: ((E) -> Void)? = nil, onError: ((ErrorProtocol) -> Void)? = nil, onCompleted: (() -> Void)? = nil)
+    public func doOn(onNext: ((E) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil, onCompleted: (() -> Void)? = nil)
         -> Driver<E> {
         let source = self.asObservable()
             .doOn(onNext: onNext, onError: onError, onCompleted: onCompleted)

--- a/RxCocoa/Common/CocoaUnits/Driver/ObservableConvertibleType+Driver.swift
+++ b/RxCocoa/Common/CocoaUnits/Driver/ObservableConvertibleType+Driver.swift
@@ -51,7 +51,7 @@ extension ObservableConvertibleType {
     - returns: Driving observable sequence.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func asDriver(onErrorRecover: (error: ErrorProtocol) -> Driver<E>) -> Driver<E> {
+    public func asDriver(onErrorRecover: (error: Swift.Error) -> Driver<E>) -> Driver<E> {
         let source = self
             .asObservable()
             .observeOn(driverObserveOnScheduler)

--- a/RxCocoa/Common/Observables/NSObject+Rx.swift
+++ b/RxCocoa/Common/Observables/NSObject+Rx.swift
@@ -126,10 +126,6 @@ extension NSObject {
      - returns: Observable sequence of object deallocating events.
      */
     public func rx_sentMessage(_ selector: Selector) -> Observable<[AnyObject]> {
-        return Observable.create { _ in
-            return AnonymousDisposable {}
-        }
-        /*
         return rx_synchronized {
             // in case of dealloc selector replay subject behavior needs to be used
             if selector == deallocSelector {
@@ -164,7 +160,7 @@ extension NSObject {
 
             subject.targetImplementation = targetImplementation
             return subject.asObservable()
-        }*/
+        }
     }
 
     /**
@@ -178,10 +174,6 @@ extension NSObject {
     - returns: Observable sequence of object deallocating events.
     */
     public var rx_deallocating: Observable<()> {
-        return Observable.create { _ in
-            return AnonymousDisposable {}
-        }
-        /*
         return rx_synchronized {
 
             let subject: DeallocatingObservable
@@ -210,7 +202,7 @@ extension NSObject {
 
             subject.targetImplementation = targetImplementation!
             return subject.asObservable()
-        }*/
+        }
     }
 #endif
 }

--- a/RxCocoa/Common/Observables/NSObject+Rx.swift
+++ b/RxCocoa/Common/Observables/NSObject+Rx.swift
@@ -126,6 +126,10 @@ extension NSObject {
      - returns: Observable sequence of object deallocating events.
      */
     public func rx_sentMessage(_ selector: Selector) -> Observable<[AnyObject]> {
+        return Observable.create { _ in
+            return AnonymousDisposable {}
+        }
+        /*
         return rx_synchronized {
             // in case of dealloc selector replay subject behavior needs to be used
             if selector == deallocSelector {
@@ -160,7 +164,7 @@ extension NSObject {
 
             subject.targetImplementation = targetImplementation
             return subject.asObservable()
-        }
+        }*/
     }
 
     /**
@@ -174,6 +178,10 @@ extension NSObject {
     - returns: Observable sequence of object deallocating events.
     */
     public var rx_deallocating: Observable<()> {
+        return Observable.create { _ in
+            return AnonymousDisposable {}
+        }
+        /*
         return rx_synchronized {
 
             let subject: DeallocatingObservable
@@ -202,7 +210,7 @@ extension NSObject {
 
             subject.targetImplementation = targetImplementation!
             return subject.asObservable()
-        }
+        }*/
     }
 #endif
 }

--- a/RxCocoa/Common/Observables/NSURLSession+Rx.swift
+++ b/RxCocoa/Common/Observables/NSURLSession+Rx.swift
@@ -15,7 +15,7 @@ import RxSwift
 RxCocoa URL errors.
 */
 public enum RxCocoaURLError
-    : ErrorProtocol
+    : Swift.Error
     , CustomDebugStringConvertible {
     /**
     Unknown error occurred.
@@ -32,7 +32,7 @@ public enum RxCocoaURLError
     /**
     Deserialization error.
     */
-    case deserializationError(error: ErrorProtocol)
+    case deserializationError(error: Swift.Error)
 }
 
 public extension RxCocoaURLError {

--- a/RxCocoa/Common/RxCocoa.swift
+++ b/RxCocoa/Common/RxCocoa.swift
@@ -296,16 +296,18 @@ let delegateNotSet = "Delegate not set"
 
 // MARK: Conversions `NSError` > `RxCocoaObjCRuntimeError`
 
-extension NSError {
+extension Error {
     func rxCocoaErrorForTarget(_ target: AnyObject) -> RxCocoaObjCRuntimeError {
-        if domain == RXObjCRuntimeErrorDomain {
-            let errorCode = RXObjCRuntimeError(rawValue: self.code) ?? .unknown
-
+        let error = self as NSError
+        
+        if error.domain == RXObjCRuntimeErrorDomain {
+            let errorCode = RXObjCRuntimeError(rawValue: error.code) ?? .unknown
+            
             switch errorCode {
             case .unknown:
                 return .unknown(target: target)
             case .objectMessagesAlreadyBeingIntercepted:
-                let isKVO = (self.userInfo[RXObjCRuntimeErrorIsKVOKey] as? NSNumber)?.boolValue ?? false
+                let isKVO = (error.userInfo[RXObjCRuntimeErrorIsKVOKey] as? NSNumber)?.boolValue ?? false
                 return .objectMessagesAlreadyBeingIntercepted(target: target, interceptionMechanism: isKVO ? .kvo : .unknown)
             case .selectorNotImplemented:
                 return .selectorNotImplemented(target: target)
@@ -323,7 +325,7 @@ extension NSError {
                 return .observingMessagesWithUnsupportedReturnType(target: target)
             }
         }
-
+        
         return RxCocoaObjCRuntimeError.unknown(target: target)
     }
 }

--- a/RxCocoa/Common/RxCocoa.swift
+++ b/RxCocoa/Common/RxCocoa.swift
@@ -18,7 +18,7 @@ import RxSwift
 RxCocoa errors.
 */
 public enum RxCocoaError
-    : ErrorProtocol
+    : Swift.Error
     , CustomDebugStringConvertible {
     /**
     Unknown error has occurred.
@@ -69,7 +69,7 @@ public enum RxCocoaInterceptionMechanism {
 RxCocoa ObjC runtime modification errors.
  */
 public enum RxCocoaObjCRuntimeError
-    : ErrorProtocol
+    : Swift.Error
     , CustomDebugStringConvertible {
     /**
     Unknown error has occurred.
@@ -193,23 +193,23 @@ public extension RxCocoaObjCRuntimeError {
         switch self {
         case let .unknown(target):
             return "Unknown error occurred.\nTarget: `\(target)`"
-        case let objectMessagesAlreadyBeingIntercepted(target, interceptionMechanism):
+        case let .objectMessagesAlreadyBeingIntercepted(target, interceptionMechanism):
             let interceptionMechanismDescription = interceptionMechanism == .kvo ? "KVO" : "other interception mechanism"
             return "Collision between RxCocoa interception mechanism and \(interceptionMechanismDescription)."
             + " To resolve this conflict please use this interception mechanism first.\nTarget: \(target)"
-        case let selectorNotImplemented(target):
+        case let .selectorNotImplemented(target):
             return "Trying to observe messages for selector that isn't implemented.\nTarget: \(target)"
-        case let cantInterceptCoreFoundationTollFreeBridgedObjects(target):
+        case let .cantInterceptCoreFoundationTollFreeBridgedObjects(target):
             return "Interception of messages sent to Core Foundation isn't supported.\nTarget: \(target)"
-        case let threadingCollisionWithOtherInterceptionMechanism(target):
+        case let .threadingCollisionWithOtherInterceptionMechanism(target):
             return "Detected a conflict while modifying ObjC runtime.\nTarget: \(target)"
-        case let savingOriginalForwardingMethodFailed(target):
+        case let .savingOriginalForwardingMethodFailed(target):
             return "Saving original method implementation failed.\nTarget: \(target)"
-        case let replacingMethodWithForwardingImplementation(target):
+        case let .replacingMethodWithForwardingImplementation(target):
             return "Intercepting a sent message by replacing a method implementation with `_objc_msgForward` failed for some reason.\nTarget: \(target)"
-        case let observingPerformanceSensitiveMessages(target):
+        case let .observingPerformanceSensitiveMessages(target):
             return "Attempt to intercept one of the performance sensitive methods. \nTarget: \(target)"
-        case let observingMessagesWithUnsupportedReturnType(target):
+        case let .observingMessagesWithUnsupportedReturnType(target):
             return "Attempt to intercept a method with unsupported return type. \nTarget: \(target)"
         }
     }
@@ -219,7 +219,7 @@ public extension RxCocoaObjCRuntimeError {
 
 // MARK: Error binding policies
 
-func bindingErrorToInterface(_ error: ErrorProtocol) {
+func bindingErrorToInterface(_ error: Swift.Error) {
     let error = "Binding error to UI: \(error)"
 #if DEBUG
     rxFatalError(error)

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -135,7 +135,7 @@ extension UICollectionView {
             .addDisposableTo(disposeBag)
     */
     public func rx_itemsWithDataSource<
-            DataSource: protocol<RxCollectionViewDataSourceType, UICollectionViewDataSource>,
+            DataSource: RxCollectionViewDataSourceType & UICollectionViewDataSource,
             O: ObservableType where DataSource.Element == O.E
         >
         (_ dataSource: DataSource)

--- a/RxCocoa/iOS/UILabel+Rx.swift
+++ b/RxCocoa/iOS/UILabel+Rx.swift
@@ -28,7 +28,7 @@ extension UILabel {
     /**
     Bindable sink for `attributedText` property.
     */
-    public var rx_attributedText: AnyObserver<AttributedString?> {
+    public var rx_attributedText: AnyObserver<NSAttributedString?> {
         return UIBindingObserver(UIElement: self) { label, text in
             label.attributedText = text
         }.asObserver()

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -138,7 +138,7 @@ extension UITableView {
             .addDisposableTo(disposeBag)
     */
     public func rx_itemsWithDataSource<
-            DataSource: protocol<RxTableViewDataSourceType, UITableViewDataSource>,
+            DataSource: RxTableViewDataSourceType & UITableViewDataSource,
             O: ObservableType where DataSource.Element == O.E
         >
         (_ dataSource: DataSource)

--- a/RxExample/RxDataSources/DataSources/DataSources.swift
+++ b/RxExample/RxDataSources/DataSources/DataSources.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum RxDataSourceError : ErrorProtocol {
+enum RxDataSourceError : Swift.Error {
     case unwrappingOptional
     case preconditionFailed(message: String)
 }
@@ -22,7 +22,7 @@ func rxPrecondition(_ condition: Bool, _ message: @autoclosure() -> String) thro
     throw RxDataSourceError.preconditionFailed(message: message())
 }
 
-func rxDebugFatalError(_ error: ErrorProtocol) {
+func rxDebugFatalError(_ error: Swift.Error) {
     rxDebugFatalError("\(error)")
 }
 

--- a/RxExample/RxDataSources/DataSources/Differentiator.swift
+++ b/RxExample/RxDataSources/DataSources/Differentiator.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum DifferentiatorError
-    : ErrorProtocol
+    : Swift.Error
     , CustomDebugStringConvertible {
     case duplicateItem(item: Any)
     case duplicateSection(section: Any)

--- a/RxExample/RxExample-iOSTests/TestScheduler+MarbleTests.swift
+++ b/RxExample/RxExample-iOSTests/TestScheduler+MarbleTests.swift
@@ -41,7 +41,7 @@ extension TestScheduler {
     - `|` marks sequence completed
 
     */
-    func parseEventsAndTimes<T>(timeline: String, values: [String: T], errors: [String: ErrorProtocol] = [:]) -> [[Recorded<Event<T>>]] {
+    func parseEventsAndTimes<T>(timeline: String, values: [String: T], errors: [String: Swift.Error] = [:]) -> [[Recorded<Event<T>>]] {
         //print("parsing: \(timeline)")
         typealias RecordedEvent = Recorded<Event<T>>
         
@@ -112,7 +112,7 @@ extension TestScheduler {
 
      - returns: Observable sequence specified by timeline and values.
     */
-    func createObservable<T>(timeline: String, values: [String: T], errors: [String: ErrorProtocol] = [:]) -> Observable<T> {
+    func createObservable<T>(timeline: String, values: [String: T], errors: [String: Swift.Error] = [:]) -> Observable<T> {
         let events = self.parseEventsAndTimes(timeline: timeline, values: values, errors: errors)
         return createObservable(events)
     }
@@ -174,7 +174,7 @@ extension TestScheduler {
      - returns: Implementation of method that accepts arguments with parameter `Arg` and returns observable sequence
         with parameter `Ret`.
      */
-    func mock<Arg, Ret>(values: [String: Ret], errors: [String: ErrorProtocol] = [:], timelineSelector: (Arg) -> String) -> (Arg) -> Observable<Ret> {
+    func mock<Arg, Ret>(values: [String: Ret], errors: [String: Swift.Error] = [:], timelineSelector: (Arg) -> String) -> (Arg) -> Observable<Ret> {
         return { (parameters: Arg) -> Observable<Ret> in
             let timeline = timelineSelector(parameters)
 

--- a/RxExample/RxExample/Services/ActivityIndicator.swift
+++ b/RxExample/RxExample/Services/ActivityIndicator.swift
@@ -39,7 +39,7 @@ When all activities complete `false` will be sent.
 public class ActivityIndicator : DriverConvertibleType {
     public typealias E = Bool
 
-    private let _lock = RecursiveLock()
+    private let _lock = NSRecursiveLock()
     private let _variable = Variable(0)
     private let _loading: Driver<Bool>
 

--- a/RxExample/RxExample/Services/Reachability.swift
+++ b/RxExample/RxExample/Services/Reachability.swift
@@ -28,7 +28,7 @@ POSSIBILITY OF SUCH DAMAGE.
 import SystemConfiguration
 import Foundation
 
-enum ReachabilityError: ErrorProtocol {
+enum ReachabilityError: Swift.Error {
     case failedToCreateWithAddress(sockaddr_in)
     case failedToCreateWithHostname(String)
     case unableToSetCallback

--- a/RxSwift/Concurrency/Lock.swift
+++ b/RxSwift/Concurrency/Lock.swift
@@ -59,10 +59,10 @@ protocol Lock {
 #else
 
     // https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151214/000321.html
-    typealias SpinLock = RecursiveLock
+    typealias SpinLock = NSRecursiveLock
 #endif
 
-extension RecursiveLock : Lock {
+extension NSRecursiveLock : Lock {
     func performLocked( _ action: @noescape() -> Void) {
         lock(); defer { unlock() }
         action()

--- a/RxSwift/Concurrency/LockOwnerType.swift
+++ b/RxSwift/Concurrency/LockOwnerType.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol LockOwnerType : class, Lock {
-    var _lock: RecursiveLock { get }
+    var _lock: NSRecursiveLock { get }
 }
 
 extension LockOwnerType {

--- a/RxSwift/Errors.swift
+++ b/RxSwift/Errors.swift
@@ -15,7 +15,7 @@ let RxCompositeFailures = "RxCompositeFailures"
 Generic Rx error codes.
 */
 public enum RxError
-    : ErrorProtocol
+    : Swift.Error
     , CustomDebugStringConvertible {
     /**
     Unknown error occured.

--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -19,7 +19,7 @@ public enum Event<Element> {
     case next(Element)
 
     /// Sequence terminated with an error.
-    case error(ErrorProtocol)
+    case error(Swift.Error)
 
     /// Sequence completed successfully.
     case completed
@@ -57,7 +57,7 @@ extension Event {
     }
 
     /// - returns: If `Error` event, returns error.
-    public var error: ErrorProtocol? {
+    public var error: Swift.Error? {
         if case .error(let error) = self {
             return error
         }

--- a/RxSwift/Observable+Extensions.swift
+++ b/RxSwift/Observable+Extensions.swift
@@ -35,7 +35,7 @@ extension ObservableType {
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
     // @warn_unused_result(message: "http://git.io/rxs.ud")
-    public func subscribe(onNext: ((E) -> Void)? = nil, onError: ((ErrorProtocol) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
+    public func subscribe(onNext: ((E) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
         -> Disposable {
 
         let disposable: Disposable
@@ -89,7 +89,7 @@ extension ObservableType {
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
     // @warn_unused_result(message: "http://git.io/rxs.ud")
-    public func subscribeError(_ onError: (ErrorProtocol) -> Void)
+    public func subscribeError(_ onError: (Swift.Error) -> Void)
         -> Disposable {
         let observer = AnonymousObserver<E> { e in
             if case .error(let error) = e {

--- a/RxSwift/Observables/Implementations/Amb.swift
+++ b/RxSwift/Observables/Implementations/Amb.swift
@@ -54,7 +54,7 @@ class AmbSink<ElementType, O: ObserverType where O.E == ElementType> : Sink<O> {
 
     private let _parent: Parent
     
-    private let _lock = RecursiveLock()
+    private let _lock = NSRecursiveLock()
     // state
     private var _choice = AmbState.neither
     

--- a/RxSwift/Observables/Implementations/Buffer.swift
+++ b/RxSwift/Observables/Implementations/Buffer.swift
@@ -39,7 +39,7 @@ class BufferTimeCountSink<Element, O: ObserverType where O.E == [Element]>
     
     private let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     // state
     private let _timerD = SerialDisposable()

--- a/RxSwift/Observables/Implementations/Catch.swift
+++ b/RxSwift/Observables/Implementations/Catch.swift
@@ -76,7 +76,7 @@ class CatchSink<O: ObserverType> : Sink<O>, ObserverType {
 }
 
 class Catch<Element> : Producer<Element> {
-    typealias Handler = (ErrorProtocol) throws -> Observable<Element>
+    typealias Handler = (Swift.Error) throws -> Observable<Element>
     
     private let _source: Observable<Element>
     private let _handler: Handler
@@ -101,7 +101,7 @@ class CatchSequenceSink<S: Sequence, O: ObserverType where S.Iterator.Element : 
     typealias Element = O.E
     typealias Parent = CatchSequence<S>
     
-    private var _lastError: ErrorProtocol?
+    private var _lastError: Swift.Error?
     
     override init(observer: O) {
         super.init(observer: observer)

--- a/RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest+CollectionType.swift
@@ -15,7 +15,7 @@ class CombineLatestCollectionTypeSink<C: Collection, R, O: ObserverType where C.
     
     let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
 
     // state
     var _numberOfValues = 0

--- a/RxSwift/Observables/Implementations/CombineLatest.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest.swift
@@ -10,7 +10,7 @@ import Foundation
 
 protocol CombineLatestProtocol : class {
     func next(_ index: Int)
-    func fail(_ error: ErrorProtocol)
+    func fail(_ error: Swift.Error)
     func done(_ index: Int)
 }
 
@@ -19,7 +19,7 @@ class CombineLatestSink<O: ObserverType>
     , CombineLatestProtocol {
     typealias Element = O.E
    
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
 
     private let _arity: Int
     private var _numberOfValues = 0
@@ -72,7 +72,7 @@ class CombineLatestSink<O: ObserverType>
         }
     }
     
-    func fail(_ error: ErrorProtocol) {
+    func fail(_ error: Swift.Error) {
         forwardOn(.error(error))
         dispose()
     }
@@ -101,12 +101,12 @@ class CombineLatestObserver<ElementType>
     
     private let _parent: CombineLatestProtocol
     
-    let _lock: RecursiveLock
+    let _lock: NSRecursiveLock
     private let _index: Int
     private let _this: Disposable
     private let _setLatestValue: ValueSetter
     
-    init(lock: RecursiveLock, parent: CombineLatestProtocol, index: Int, setLatestValue: ValueSetter, this: Disposable) {
+    init(lock: NSRecursiveLock, parent: CombineLatestProtocol, index: Int, setLatestValue: ValueSetter, this: Disposable) {
         _lock = lock
         _parent = parent
         _index = index

--- a/RxSwift/Observables/Implementations/ConnectableObservable.swift
+++ b/RxSwift/Observables/Implementations/ConnectableObservable.swift
@@ -27,12 +27,12 @@ public class ConnectableObservable<Element>
 
 class Connection<S: SubjectType> : Disposable {
 
-    private var _lock: RecursiveLock
+    private var _lock: NSRecursiveLock
     // state
     private var _parent: ConnectableObservableAdapter<S>?
     private var _subscription : Disposable?
 
-    init(parent: ConnectableObservableAdapter<S>, lock: RecursiveLock, subscription: Disposable) {
+    init(parent: ConnectableObservableAdapter<S>, lock: NSRecursiveLock, subscription: Disposable) {
         _parent = parent
         _subscription = subscription
         _lock = lock
@@ -66,7 +66,7 @@ class ConnectableObservableAdapter<S: SubjectType>
     private let _subject: S
     private let _source: Observable<S.SubjectObserverType.E>
     
-    private let _lock = RecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
     private var _connection: ConnectionType?

--- a/RxSwift/Observables/Implementations/Error.swift
+++ b/RxSwift/Observables/Implementations/Error.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 class Error<Element> : Producer<Element> {
-    private let _error: ErrorProtocol
+    private let _error: Swift.Error
     
-    init(error: ErrorProtocol) {
+    init(error: Swift.Error) {
         _error = error
     }
     

--- a/RxSwift/Observables/Implementations/Merge.swift
+++ b/RxSwift/Observables/Implementations/Merge.swift
@@ -21,7 +21,7 @@ class MergeLimitedSinkIter<S: ObservableConvertibleType, O: ObserverType where S
     private let _parent: Parent
     private let _disposeKey: DisposeKey
 
-    var _lock: RecursiveLock {
+    var _lock: NSRecursiveLock {
         return _parent._lock
     }
     
@@ -68,7 +68,7 @@ class MergeLimitedSink<S: ObservableConvertibleType, O: ObserverType where S.E =
 
     private let _maxConcurrent: Int
 
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
 
     // state
     private var _stopped = false
@@ -276,7 +276,7 @@ class MergeSink<SourceType, S: ObservableConvertibleType, O: ObserverType where 
     typealias ResultType = O.E
     typealias Element = SourceType
 
-    private let _lock = RecursiveLock()
+    private let _lock = NSRecursiveLock()
 
     private var subscribeNext: Bool {
         return true

--- a/RxSwift/Observables/Implementations/RefCount.swift
+++ b/RxSwift/Observables/Implementations/RefCount.swift
@@ -64,7 +64,7 @@ class RefCountSink<CO: ConnectableObservableType, O: ObserverType where CO.E == 
 }
 
 class RefCount<CO: ConnectableObservableType>: Producer<CO.E> {
-    private let _lock = RecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
     private var _count = 0

--- a/RxSwift/Observables/Implementations/RetryWhen.swift
+++ b/RxSwift/Observables/Implementations/RetryWhen.swift
@@ -84,11 +84,11 @@ class RetryWhenSequenceSink<S: Sequence, O: ObserverType, TriggerObservable: Obs
     typealias Element = O.E
     typealias Parent = RetryWhenSequence<S, TriggerObservable, Error>
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     private let _parent: Parent
     
-    private var _lastError: ErrorProtocol?
+    private var _lastError: Swift.Error?
     private let _errorSubject = PublishSubject<Error>()
     private let _handler: Observable<TriggerObservable.E>
     private let _notifier = PublishSubject<TriggerObservable.E>()

--- a/RxSwift/Observables/Implementations/Sample.swift
+++ b/RxSwift/Observables/Implementations/Sample.swift
@@ -18,7 +18,7 @@ class SamplerSink<O: ObserverType, ElementType, SampleType where O.E == ElementT
     
     private let _parent: Parent
 
-    var _lock: RecursiveLock {
+    var _lock: NSRecursiveLock {
         return _parent._lock
     }
     
@@ -71,7 +71,7 @@ class SampleSequenceSink<O: ObserverType, SampleType>
     
     private let _parent: Parent
 
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     // state
     private var _element = nil as Element?

--- a/RxSwift/Observables/Implementations/ShareReplay1.swift
+++ b/RxSwift/Observables/Implementations/ShareReplay1.swift
@@ -18,7 +18,7 @@ final class ShareReplay1<Element>
 
     private let _source: Observable<Element>
 
-    private var _lock = RecursiveLock()
+    private var _lock = NSRecursiveLock()
 
     private var _connection: SingleAssignmentDisposable?
     private var _element: Element?

--- a/RxSwift/Observables/Implementations/ShareReplay1WhileConnected.swift
+++ b/RxSwift/Observables/Implementations/ShareReplay1WhileConnected.swift
@@ -18,7 +18,7 @@ final class ShareReplay1WhileConnected<Element>
 
     private let _source: Observable<Element>
 
-    private var _lock = RecursiveLock()
+    private var _lock = NSRecursiveLock()
 
     private var _connection: SingleAssignmentDisposable?
     private var _element: Element?

--- a/RxSwift/Observables/Implementations/SingleAsync.swift
+++ b/RxSwift/Observables/Implementations/SingleAsync.swift
@@ -30,7 +30,7 @@ class SingleAsyncSink<ElementType, O: ObserverType where O.E == ElementType> : S
                 }
             }
             catch let error {
-                forwardOn(.error(error as ErrorProtocol))
+                forwardOn(.error(error as Swift.Error))
                 dispose()
                 return
             }

--- a/RxSwift/Observables/Implementations/SkipUntil.swift
+++ b/RxSwift/Observables/Implementations/SkipUntil.swift
@@ -17,7 +17,7 @@ class SkipUntilSinkOther<ElementType, Other, O: ObserverType where O.E == Elemen
     
     private let _parent: Parent
 
-    var _lock: RecursiveLock {
+    var _lock: NSRecursiveLock {
         return _parent._lock
     }
     
@@ -64,7 +64,7 @@ class SkipUntilSink<ElementType, Other, O: ObserverType where O.E == ElementType
     typealias E = ElementType
     typealias Parent = SkipUntil<E, Other>
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     private let _parent: Parent
     private var _forwardElements = false
     

--- a/RxSwift/Observables/Implementations/Switch.swift
+++ b/RxSwift/Observables/Implementations/Switch.swift
@@ -18,7 +18,7 @@ class SwitchSink<SourceType, S: ObservableConvertibleType, O: ObserverType where
     private let _subscriptions: SingleAssignmentDisposable = SingleAssignmentDisposable()
     private let _innerSubscription: SerialDisposable = SerialDisposable()
 
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     // state
     private var _stopped = false
@@ -90,7 +90,7 @@ class SwitchSinkIter<SourceType, S: ObservableConvertibleType, O: ObserverType w
     private let _id: Int
     private let _self: Disposable
 
-    var _lock: RecursiveLock {
+    var _lock: NSRecursiveLock {
         return _parent._lock
     }
 

--- a/RxSwift/Observables/Implementations/Take.swift
+++ b/RxSwift/Observables/Implementations/Take.swift
@@ -80,7 +80,7 @@ class TakeTimeSink<ElementType, O: ObserverType where O.E == ElementType>
 
     private let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     init(parent: Parent, observer: O) {
         _parent = parent

--- a/RxSwift/Observables/Implementations/TakeUntil.swift
+++ b/RxSwift/Observables/Implementations/TakeUntil.swift
@@ -17,7 +17,7 @@ class TakeUntilSinkOther<ElementType, Other, O: ObserverType where O.E == Elemen
     
     private let _parent: Parent
 
-    var _lock: RecursiveLock {
+    var _lock: NSRecursiveLock {
         return _parent._lock
     }
     
@@ -65,7 +65,7 @@ class TakeUntilSink<ElementType, Other, O: ObserverType where O.E == ElementType
     
     private let _parent: Parent
  
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     // state
     private var _open = false

--- a/RxSwift/Observables/Implementations/Throttle.swift
+++ b/RxSwift/Observables/Implementations/Throttle.swift
@@ -18,7 +18,7 @@ class ThrottleSink<O: ObserverType>
     
     private let _parent: ParentType
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     // state
     private var _id = 0 as UInt64

--- a/RxSwift/Observables/Implementations/Timeout.swift
+++ b/RxSwift/Observables/Implementations/Timeout.swift
@@ -14,7 +14,7 @@ class TimeoutSink<ElementType, O: ObserverType where O.E == ElementType>: Sink<O
     
     private let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
 
     private let _timerD = SerialDisposable()
     private let _subscription = SerialDisposable()

--- a/RxSwift/Observables/Implementations/Window.swift
+++ b/RxSwift/Observables/Implementations/Window.swift
@@ -18,7 +18,7 @@ class WindowTimeCountSink<Element, O: ObserverType where O.E == Observable<Eleme
     
     private let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     private var _subject = PublishSubject<Element>()
     private var _count = 0
@@ -68,7 +68,7 @@ class WindowTimeCountSink<Element, O: ObserverType where O.E == Observable<Eleme
             do {
                 let _ = try incrementChecked(&_count)
             } catch (let e) {
-                _subject.on(.error(e as ErrorProtocol))
+                _subject.on(.error(e as Swift.Error))
                 dispose()
             }
             

--- a/RxSwift/Observables/Implementations/WithLatestFrom.swift
+++ b/RxSwift/Observables/Implementations/WithLatestFrom.swift
@@ -19,7 +19,7 @@ class WithLatestFromSink<FirstType, SecondType, ResultType, O: ObserverType wher
     
     private let _parent: Parent
     
-    var _lock = RecursiveLock()
+    var _lock = NSRecursiveLock()
     private var _latest: SecondType?
 
     init(parent: Parent, observer: O) {
@@ -75,7 +75,7 @@ class WithLatestFromSecond<FirstType, SecondType, ResultType, O: ObserverType wh
     private let _parent: Parent
     private let _disposable: Disposable
 
-    var _lock: RecursiveLock {
+    var _lock: NSRecursiveLock {
         return _parent._lock
     }
 

--- a/RxSwift/Observables/Implementations/Zip+CollectionType.swift
+++ b/RxSwift/Observables/Implementations/Zip+CollectionType.swift
@@ -15,7 +15,7 @@ class ZipCollectionTypeSink<C: Collection, R, O: ObserverType where C.Iterator.E
     
     private let _parent: Parent
     
-    private let _lock = RecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
     private var _numberOfValues = 0

--- a/RxSwift/Observables/Implementations/Zip.swift
+++ b/RxSwift/Observables/Implementations/Zip.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol ZipSinkProtocol : class
 {
     func next(_ index: Int)
-    func fail(_ error: ErrorProtocol)
+    func fail(_ error: Swift.Error)
     func done(_ index: Int)
 }
 
@@ -20,7 +20,7 @@ class ZipSink<O: ObserverType> : Sink<O>, ZipSinkProtocol {
     
     let _arity: Int
 
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
 
     // state
     private var _isDone: [Bool]
@@ -78,7 +78,7 @@ class ZipSink<O: ObserverType> : Sink<O>, ZipSinkProtocol {
         }
     }
     
-    func fail(_ error: ErrorProtocol) {
+    func fail(_ error: Swift.Error) {
         forwardOn(.error(error))
         dispose()
     }
@@ -111,14 +111,14 @@ class ZipObserver<ElementType>
 
     private var _parent: ZipSinkProtocol?
     
-    let _lock: RecursiveLock
+    let _lock: NSRecursiveLock
     
     // state
     private let _index: Int
     private let _this: Disposable
     private let _setNextValue: ValueSetter
     
-    init(lock: RecursiveLock, parent: ZipSinkProtocol, index: Int, setNextValue: ValueSetter, this: Disposable) {
+    init(lock: NSRecursiveLock, parent: ZipSinkProtocol, index: Int, setNextValue: ValueSetter, this: Disposable) {
         _lock = lock
         _parent = parent
         _index = index

--- a/RxSwift/Observables/Observable+Creation.swift
+++ b/RxSwift/Observables/Observable+Creation.swift
@@ -83,7 +83,7 @@ extension Observable {
     - returns: The observable sequence that terminates with specified error.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public static func error(_ error: ErrorProtocol) -> Observable<E> {
+    public static func error(_ error: Swift.Error) -> Observable<E> {
         return Error(error: error)
     }
 

--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -187,7 +187,7 @@ extension ObservableType {
     - returns: An observable sequence containing the source sequence's elements, followed by the elements produced by the handler's resulting observable sequence in case an error occurred.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func catchError(_ handler: (ErrorProtocol) throws -> Observable<E>)
+    public func catchError(_ handler: (Swift.Error) throws -> Observable<E>)
         -> Observable<E> {
         return Catch(source: asObservable(), handler: handler)
     }

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -100,7 +100,7 @@ extension ObservableType {
     - returns: The source sequence with the side-effecting behavior applied.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func doOn(onNext: ((E) throws -> Void)? = nil, onError: ((ErrorProtocol) throws -> Void)? = nil, onCompleted: (() throws -> Void)? = nil)
+    public func doOn(onNext: ((E) throws -> Void)? = nil, onError: ((Swift.Error) throws -> Void)? = nil, onCompleted: (() throws -> Void)? = nil)
         -> Observable<E> {
         return Do(source: self.asObservable()) { e in
             switch e {
@@ -133,7 +133,7 @@ extension ObservableType {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func `do`(onError: ((ErrorProtocol) throws -> Void))
+    public func `do`(onError: ((Swift.Error) throws -> Void))
         -> Observable<E> {
         return self.doOn(onError: onError)
     }
@@ -214,7 +214,7 @@ extension ObservableType {
     - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func retryWhen<TriggerObservable: ObservableType, Error: ErrorProtocol>(_ notificationHandler: (Observable<Error>) -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType, Error: Swift.Error>(_ notificationHandler: (Observable<Error>) -> TriggerObservable)
         -> Observable<E> {
             return RetryWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
     }
@@ -229,7 +229,7 @@ extension ObservableType {
     - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
     */
     // @warn_unused_result(message:"http://git.io/rxs.uo")
-    public func retryWhen<TriggerObservable: ObservableType>(_ notificationHandler: (Observable<ErrorProtocol>) -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType>(_ notificationHandler: (Observable<Swift.Error>) -> TriggerObservable)
         -> Observable<E> {
             return RetryWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
     }

--- a/RxSwift/ObserverType.swift
+++ b/RxSwift/ObserverType.swift
@@ -47,10 +47,10 @@ public extension ObserverType {
     }
     
     /**
-    Convenience method equivalent to `on(.Error(error: ErrorProtocol))`
-    - parameter error: ErrorProtocol to send to observer(s)
+    Convenience method equivalent to `on(.Error(error: Swift.Error))`
+    - parameter error: Swift.Error to send to observer(s)
     */
-    final func onError(_ error: ErrorProtocol) {
+    final func onError(_ error: Swift.Error) {
         on(.error(error))
     }
 }

--- a/RxSwift/Platform/Platform.Darwin.swift
+++ b/RxSwift/Platform/Platform.Darwin.swift
@@ -22,7 +22,8 @@
     let AtomicDecrement = OSAtomicDecrement32
 
     extension Thread {
-        static func setThreadLocalStorageValue<T: AnyObject>(_ value: T?, forKey key: protocol<AnyObject, NSCopying>) {
+        static func setThreadLocalStorageValue<T: AnyObject>(_ value: T?, forKey key: AnyObject & NSCopying
+            ) {
             let currentThread = Thread.current
             let threadDictionary = currentThread.threadDictionary
 
@@ -34,7 +35,7 @@
             }
 
         }
-        static func getThreadLocalStorageValueForKey<T>(_ key: protocol<AnyObject, NSCopying>) -> T? {
+        static func getThreadLocalStorageValueForKey<T>(_ key: AnyObject & NSCopying) -> T? {
             let currentThread = Thread.current
             let threadDictionary = currentThread.threadDictionary
             

--- a/RxSwift/Platform/Platform.Linux.swift
+++ b/RxSwift/Platform/Platform.Linux.swift
@@ -215,7 +215,7 @@
             return Expectation()
         }
 
-        public func waitForExpectationsWithTimeout(time: NSTimeInterval, action: ErrorProtocol? -> Void) {
+        public func waitForExpectationsWithTimeout(time: NSTimeInterval, action: Swift.Error? -> Void) {
         }
     }
 

--- a/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
@@ -39,10 +39,11 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
      */
     @available(iOS 8, OSX 10.10, *)
     public convenience init(globalConcurrentQueueQOS: DispatchQueueSchedulerQOS, leeway: DispatchTimeInterval = DispatchTimeInterval.nanoseconds(0)) {
-        let priority = globalConcurrentQueueQOS.QOSClass
+        let priority = globalConcurrentQueueQOS.qos
         self.init(queue: DispatchQueue(
             label: "rxswift.queue.\(globalConcurrentQueueQOS)",
-            attributes: [priority, DispatchQueueAttributes.concurrent],
+            qos: priority,
+            attributes: [DispatchQueue.Attributes.concurrent],
             target: nil),
             leeway: leeway
         )

--- a/RxSwift/Schedulers/DispatchQueueSchedulerQOS.swift
+++ b/RxSwift/Schedulers/DispatchQueueSchedulerQOS.swift
@@ -42,13 +42,13 @@ public enum DispatchQueueSchedulerQOS {
 
 @available(iOS 8, OSX 10.10, *)
 extension DispatchQueueSchedulerQOS {
-    var QOSClass: DispatchQueueAttributes {
+    var qos: DispatchQoS {
         switch self {
-        case .userInteractive: return .qosUserInteractive
-        case .userInitiated:   return .qosUserInitiated
-        case .default:         return .qosDefault
-        case .utility:         return .qosUtility
-        case .background:      return .qosBackground
+        case .userInteractive: return .userInteractive
+        case .userInitiated:   return .userInitiated
+        case .default:         return .default
+        case .utility:         return .utility
+        case .background:      return .background
         }
     }
 }

--- a/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
+++ b/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
@@ -41,7 +41,7 @@ extension DispatchQueueConfiguration {
 
         let compositeDisposable = CompositeDisposable()
 
-        let timer = DispatchSource.timer(queue: queue)
+        let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.scheduleOneshot(deadline: deadline)
 
         // TODO:
@@ -75,7 +75,7 @@ extension DispatchQueueConfiguration {
 
         var timerState = state
 
-        let timer = DispatchSource.timer(queue: queue)
+        let timer = DispatchSource.makeTimerSource(queue: queue)
         timer.scheduleRepeating(deadline: initial, interval: dispatchInterval(period), leeway: leeway)
 
         // TODO:

--- a/RxSwift/Schedulers/RecursiveScheduler.swift
+++ b/RxSwift/Schedulers/RecursiveScheduler.swift
@@ -14,7 +14,7 @@ Type erased recursive scheduler.
 class AnyRecursiveScheduler<State> {
     typealias Action =  (state: State, scheduler: AnyRecursiveScheduler<State>) -> Void
 
-    private let _lock = RecursiveLock()
+    private let _lock = NSRecursiveLock()
     
     // state
     private let _group = CompositeDisposable()

--- a/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
@@ -51,7 +51,7 @@ public class SerialDispatchQueueScheduler : SchedulerType {
     - parameter serialQueueConfiguration: Additional configuration of internal serial dispatch queue.
     */
     public convenience init(internalSerialQueueName: String, serialQueueConfiguration: ((DispatchQueue) -> Void)? = nil, leeway: DispatchTimeInterval = DispatchTimeInterval.nanoseconds(0)) {
-        let queue = DispatchQueue(label: internalSerialQueueName, attributes: DispatchQueueAttributes.serial)
+        let queue = DispatchQueue(label: internalSerialQueueName, attributes: [])
         serialQueueConfiguration?(queue)
         self.init(serialQueue: queue, leeway: leeway)
     }
@@ -65,7 +65,7 @@ public class SerialDispatchQueueScheduler : SchedulerType {
     public convenience init(queue: DispatchQueue, internalSerialQueueName: String, leeway: DispatchTimeInterval = DispatchTimeInterval.nanoseconds(0)) {
         // Swift 3.0 IUO
         let serialQueue = DispatchQueue(label: internalSerialQueueName,
-                                        attributes: DispatchQueueAttributes.serial,
+                                        attributes: [],
                                         target: queue)
         self.init(serialQueue: serialQueue, leeway: leeway)
     }
@@ -78,8 +78,8 @@ public class SerialDispatchQueueScheduler : SchedulerType {
      */
     @available(iOS 8, OSX 10.10, *)
     public convenience init(globalConcurrentQueueQOS: DispatchQueueSchedulerQOS, internalSerialQueueName: String = "rx.global_dispatch_queue.serial", leeway: DispatchTimeInterval = DispatchTimeInterval.nanoseconds(0)) {
-        let priority = globalConcurrentQueueQOS.QOSClass
-        self.init(queue: DispatchQueue.global(attributes: DispatchQueue.GlobalAttributes(rawValue: UInt64(priority.rawValue))), internalSerialQueueName: internalSerialQueueName, leeway: leeway)
+        let priority = globalConcurrentQueueQOS.qos
+        self.init(queue: DispatchQueue.global(qos: priority.qosClass), internalSerialQueueName: internalSerialQueueName, leeway: leeway)
     }
     
     /**

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -30,7 +30,7 @@ public final class BehaviorSubject<Element>
         return _observers.count > 0
     }
     
-    let _lock = RecursiveLock()
+    let _lock = NSRecursiveLock()
     
     // state
     private var _disposed = false

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -31,7 +31,7 @@ final public class PublishSubject<Element>
         return _observers.count > 0
     }
     
-    private var _lock = RecursiveLock()
+    private var _lock = NSRecursiveLock()
     
     // state
     private var _disposed = false

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -28,7 +28,7 @@ public class ReplaySubject<Element>
         return _observers.count > 0
     }
     
-    private var _lock = RecursiveLock()
+    private var _lock = NSRecursiveLock()
     
     // state
     private var _disposed = false

--- a/RxTests/XCTest+Rx.swift
+++ b/RxTests/XCTest+Rx.swift
@@ -41,7 +41,7 @@ require specifying `self.*`, they are made global.
 
      - parameter time: Recorded virtual time the `.Completed` event occurs.
     */
-    public func error<T>(_ time: TestTime, _ error: ErrorProtocol, _ type: T.Type = T.self) -> Recorded<Event<T>> {
+    public func error<T>(_ time: TestTime, _ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> {
         return Recorded(time: time, event: .error(error))
     }
 //}

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -991,7 +991,7 @@ extension KVOObservableTests {
     func testObserveWeak_PropertyDoesntExist() {
         var root: HasStrongProperty! = HasStrongProperty()
         
-        var lastError: ErrorProtocol? = nil
+        var lastError: Swift.Error? = nil
         
         _ = root.rx_observeWeakly(NSNumber.self, "notExist")
             .subscribeError { error in
@@ -1017,7 +1017,7 @@ extension KVOObservableTests {
     func testObserveWeak_HierarchyPropertyDoesntExist() {
         var root: HasStrongProperty! = HasStrongProperty()
         
-        var lastError: ErrorProtocol? = nil
+        var lastError: Swift.Error? = nil
         
         _ = root.rx_observeWeakly(NSNumber.self, "property.notExist")
             .subscribeError { error in

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
@@ -22,7 +22,7 @@ class PrimitiveHotObservable<ElementType> : ObservableType {
     var subscriptions: [Subscription]
     var observers: Bag<AnyObserver<E>>
 
-    let lock = RecursiveLock()
+    let lock = NSRecursiveLock()
     
     init() {
         self.subscriptions = []

--- a/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+SingleTest.swift
@@ -644,7 +644,7 @@ extension ObservableSingleTest {
             error(250, testError)
             ])
 
-        var recordedError: ErrorProtocol!
+        var recordedError: Swift.Error!
         var numberOfTimesInvoked = 0
 
         let res = scheduler.start { xs.do(onError: { error in
@@ -995,7 +995,7 @@ extension ObservableSingleTest {
     }
 }
 
-struct CustomErrorType : ErrorProtocol {
+struct CustomErrorType : Swift.Error {
 
 }
 
@@ -1305,7 +1305,7 @@ extension ObservableSingleTest {
         let maxAttempts = 4
 
         let res = scheduler.start(800) {
-            xs.retryWhen { (errors: Observable<ErrorProtocol>) in
+            xs.retryWhen { (errors: Observable<Swift.Error>) in
                 return errors.flatMapWithIndex { (e, a) -> Observable<Int64> in
                     if a >= maxAttempts - 1 {
                         return Observable.error(e)

--- a/Tests/RxSwiftTests/Tests/Observable+SubscriptionTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+SubscriptionTest.swift
@@ -20,7 +20,7 @@ class ObservableSubscriptionTests : RxTest {
         var onDisposedCalled = 0
 
         var lastElement: Int? = nil
-        var lastError: ErrorProtocol? = nil
+        var lastError: Swift.Error? = nil
 
         let subscription = publishSubject.subscribe(onNext: { n in
                 lastElement = n
@@ -70,7 +70,7 @@ class ObservableSubscriptionTests : RxTest {
         var onDisposedCalled = 0
 
         var lastElement: Int? = nil
-        var lastError: ErrorProtocol? = nil
+        var lastError: Swift.Error? = nil
 
         let subscription = publishSubject.subscribe(onNext: { n in
                 lastElement = n
@@ -121,7 +121,7 @@ class ObservableSubscriptionTests : RxTest {
         var onDisposedCalled = 0
 
         var lastElement: Int? = nil
-        var lastError: ErrorProtocol? = nil
+        var lastError: Swift.Error? = nil
 
         let subscription = publishSubject.subscribe(onNext: { n in
             lastElement = n
@@ -172,7 +172,7 @@ class ObservableSubscriptionTests : RxTest {
         var onDisposedCalled = 0
 
         var lastElement: Int? = nil
-        var lastError: ErrorProtocol? = nil
+        var lastError: Swift.Error? = nil
 
         let subscription = publishSubject.subscribe(onNext: { n in
             lastElement = n

--- a/Tests/RxSwiftTests/Tests/ObserverTests.swift
+++ b/Tests/RxSwiftTests/Tests/ObserverTests.swift
@@ -42,7 +42,7 @@ extension ObserverTests {
         }
 
         var elements = [Int]()
-        var errorNotification: ErrorProtocol!
+        var errorNotification: Swift.Error!
 
         _ = a.subscribe(
             onNext: { n in elements.append(n) },

--- a/Tests/Tests/Recorded+Timeless.swift
+++ b/Tests/Tests/Recorded+Timeless.swift
@@ -18,6 +18,6 @@ func completed<T>() -> Recorded<Event<T>> {
     return Recorded(time: 0, event: .completed)
 }
 
-func error<T>(_ error: ErrorProtocol) -> Recorded<Event<T>> {
+func error<T>(_ error: Swift.Error) -> Recorded<Event<T>> {
     return Recorded(time: 0, event: .error(error))
 }

--- a/Tests/Tests/XCTest+AllTests.swift
+++ b/Tests/Tests/XCTest+AllTests.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxTests
 import XCTest
 
-func XCTAssertErrorEqual(_ lhs: ErrorProtocol, _ rhs: ErrorProtocol) {
+func XCTAssertErrorEqual(_ lhs: Swift.Error, _ rhs: Swift.Error) {
     let event1: Event<Int> = .error(lhs)
     let event2: Event<Int> = .error(rhs)
     


### PR DESCRIPTION
I am updating for Xcode 8 beta 4.
However, I have no idea how to solve the below error:

```
$ xcodebuild -workspace Rx.xcworkspace -scheme RxCocoa-iOS clean build

CompileSwift normal arm64 /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/RxCocoa.swift
    cd /Users/XXXXX/Workspace/RxSwift
    /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift -frontend -c /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UISlider+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIScrollView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIPickerView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/DelegateProxyType.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/RxTarget.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxImagePickerDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UITextView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/DataSources/RxTableViewReactiveArrayDataSource.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/Driver/ControlProperty+Driver.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/Driver/ControlEvent+Driver.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift -primary-file /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/RxCocoa.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIRefreshControl+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIStepper+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIImageView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/ControlEvent.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIControl+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/NSObject+Rx+RawRepresentable.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/KVORepresentable.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/SectionedViewDataSourceType.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/Driver/Variable+Driver.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UISearchController+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UITableView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/DataSources/RxCollectionViewReactiveArrayDataSource.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/Implementations/KVOObserver.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIAlertAction+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/RxTextInput.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UILabel+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UINavigationItem+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIPageControl+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/Driver/ObservableConvertibleType+Driver.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UITabBarItem+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIApplication+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/Driver/Driver+Subscription.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/Implementations/DeallocObservable.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observable+Bind.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UISegmentedControl+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/Implementations/KVOObservable.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Reactive.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIProgressView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIViewController+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/KVORepresentable+Swift.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/Driver/Driver+Operators+arity.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIButton+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CLLocationManager+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/Driver/Driver.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/NSObject+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIActivityIndicatorView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/NSTextStorage+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIBarButtonItem+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/Implementations/MessageSentObserver.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/ControlProperty.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIDatePicker+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/NSLayoutConstraint+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIGestureRecognizer+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/DelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UITabBar+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Proxies/RxCLLocationManagerDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UISwitch+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UIImagePickerController+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/NSObject+Rx+KVORepresentable.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Logging.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UICollectionView+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Protocols/RxCollectionViewDataSourceType.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/NSNotificationCenter+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UITextField+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/NSURLSession+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/Observables/Implementations/ControlTarget.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/UISearchBar+Rx.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Events/ItemEvents.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/KVORepresentable+CoreGraphics.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/Common/CocoaUnits/UIBindingObserver.swift /Users/XXXXX/Workspace/RxSwift/RxCocoa/iOS/Protocols/RxTableViewDataSourceType.swift -target arm64-apple-ios8.0 -Xllvm -aarch64-use-tbi -enable-objc-interop -sdk /Applications/Xcode-beta.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk -I /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Products/Debug-iphoneos -F /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Products/Debug-iphoneos -application-extension -enable-testing -g -import-underlying-module -module-cache-path /Users/XXXXX/Library/Developer/Xcode/DerivedData/ModuleCache -D TRACE_RESOURCES -D DEBUG -serialize-debugging-options -Xcc -I/Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/RxCocoa-generated-files.hmap -Xcc -I/Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/RxCocoa-own-target-headers.hmap -Xcc -I/Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/RxCocoa-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/RxCocoa-project-headers.hmap -Xcc -I/Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Products/Debug-iphoneos/include -Xcc -I/Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/DerivedSources/arm64 -Xcc -I/Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/DerivedSources -Xcc -DDEBUG=1 -Xcc -DTRACE_RESOURCES=1 -Xcc -ivfsoverlay -Xcc /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/unextended-module-overlay.yaml -Xcc -working-directory/Users/XXXXX/Workspace/RxSwift -emit-module-doc-path /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/Objects-normal/arm64/RxCocoa~partial.swiftdoc -Onone -module-name RxCocoa -emit-module-path /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/Objects-normal/arm64/RxCocoa~partial.swiftmodule -serialize-diagnostics-path /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/Objects-normal/arm64/RxCocoa.dia -emit-dependencies-path /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/Objects-normal/arm64/RxCocoa.d -emit-reference-dependencies-path /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/Objects-normal/arm64/RxCocoa.swiftdeps -o /Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/Objects-normal/arm64/RxCocoa.o -embed-bitcode-marker
Invalid bitcast
  %.asUnsubstituted = bitcast i64 %8 to %swift.error*, !dbg !758
LLVM ERROR: Broken function found, compilation aborted!
2016-08-02 15:48:28.305 xcodebuild[4647:1097007]  DVTAssertions: Warning in /Library/Caches/com.apple.xbs/Sources/IDEFrameworks/IDEFrameworks-11222.4/IDEFoundation/Playgrounds/IDEPlaygroundAuxiliarySourceCompilerOperation.m:383
Details:  Unable to read diagnostics from file "/Users/XXXXX/Library/Developer/Xcode/DerivedData/Rx-cjudovxsdfkcnyctzmjtirtbpnbd/Build/Intermediates/Rx.build/Debug-iphoneos/RxCocoa-iOS.build/Objects-normal/arm64/RxCocoa.dia" (Invalid File): Invalid diagnostics signature
Function: void XCGenerateDiagnosticsFromFile(NSString *__strong, NSString *__strong, NSDictionary *__strong, NSDictionary *__strong, IDEActivityLogSectionRecorder *__strong, BOOL (^__strong)(IDEActivityLogMessage *__strong))
Thread:   <NSThread: 0x7f81ce6d48e0>{number = 20, name = (null)}
Please file a bug at http://bugreport.apple.com with this warning message and any useful information you can provide.

Command /Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc failed with exit code 1
```