### PR TITLE
[Swift 3.0] Renames `disposed` to `isDisposed`

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -387,7 +387,7 @@ func myInterval(interval: NSTimeInterval) -> Observable<Int> {
             dispatch_source_cancel(timer)
         }
         dispatch_source_set_event_handler(timer, {
-            if cancel.disposed {
+            if cancel.isDisposed {
                 return
             }
             observer.on(.Next(next))

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -30,7 +30,7 @@ extension BlockingObservable {
 
         lock.dispatch {
             d.disposable = self.source.subscribe { e in
-                if d.disposed {
+                if d.isDisposed {
                     return
                 }
                 switch e {
@@ -78,7 +78,7 @@ extension BlockingObservable {
 
         lock.dispatch {
             d.disposable = self.source.subscribe { e in
-                if d.disposed {
+                if d.isDisposed {
                     return
                 }
 
@@ -130,7 +130,7 @@ extension BlockingObservable {
 
         lock.dispatch {
             d.disposable = self.source.subscribe { e in
-                if d.disposed {
+                if d.isDisposed {
                     return
                 }
                 switch e {
@@ -191,7 +191,7 @@ extension BlockingObservable {
         
         lock.dispatch {
             d.disposable = self.source.subscribe { e in
-                if d.disposed {
+                if d.isDisposed {
                     return
                 }
                 switch e {

--- a/RxSwift/Cancelable.swift
+++ b/RxSwift/Cancelable.swift
@@ -15,5 +15,5 @@ public protocol Cancelable : Disposable {
     /**
     - returns: Was resource disposed.
     */
-    var disposed: Bool { get }
+    var isDisposed: Bool { get }
 }

--- a/RxSwift/Cancelable.swift
+++ b/RxSwift/Cancelable.swift
@@ -17,3 +17,12 @@ public protocol Cancelable : Disposable {
     */
     var isDisposed: Bool { get }
 }
+
+public extension Cancelable {
+    
+    @available(*, deprecated, renamed: "isDisposed")
+    var disposed: Bool {
+        return isDisposed
+    }
+    
+}

--- a/RxSwift/Disposables/AnonymousDisposable.swift
+++ b/RxSwift/Disposables/AnonymousDisposable.swift
@@ -16,14 +16,14 @@ When dispose method is called, disposal action will be dereferenced.
 public final class AnonymousDisposable : DisposeBase, Cancelable {
     public typealias DisposeAction = () -> Void
 
-    private var _disposed: AtomicInt = 0
+    private var _isDisposed: AtomicInt = 0
     private var _disposeAction: DisposeAction?
 
     /**
     - returns: Was resource disposed.
     */
-    public var disposed: Bool {
-        return _disposed == 1
+    public var isDisposed: Bool {
+        return _isDisposed == 1
     }
 
     /**
@@ -42,8 +42,8 @@ public final class AnonymousDisposable : DisposeBase, Cancelable {
     After invoking disposal action, disposal action will be dereferenced.
     */
     public func dispose() {
-        if AtomicCompareAndSwap(0, 1, &_disposed) {
-            assert(_disposed == 1)
+        if AtomicCompareAndSwap(0, 1, &_isDisposed) {
+            assert(_isDisposed == 1)
 
             if let action = _disposeAction {
                 _disposeAction = nil

--- a/RxSwift/Disposables/BinaryDisposable.swift
+++ b/RxSwift/Disposables/BinaryDisposable.swift
@@ -13,7 +13,7 @@ Represents two disposable resources that are disposed together.
 */
 public final class BinaryDisposable : DisposeBase, Cancelable {
 
-    private var _disposed: AtomicInt = 0
+    private var _isDisposed: AtomicInt = 0
 
     // state
     private var _disposable1: Disposable?
@@ -22,8 +22,8 @@ public final class BinaryDisposable : DisposeBase, Cancelable {
     /**
     - returns: Was resource disposed.
     */
-    public var disposed: Bool {
-        return _disposed > 0
+    public var isDisposed: Bool {
+        return _isDisposed > 0
     }
 
     /**
@@ -44,7 +44,7 @@ public final class BinaryDisposable : DisposeBase, Cancelable {
     After invoking disposal action, disposal action will be dereferenced.
     */
     public func dispose() {
-        if AtomicCompareAndSwap(0, 1, &_disposed) {
+        if AtomicCompareAndSwap(0, 1, &_isDisposed) {
             _disposable1?.dispose()
             _disposable2?.dispose()
             _disposable1 = nil

--- a/RxSwift/Disposables/BinaryDisposable.swift
+++ b/RxSwift/Disposables/BinaryDisposable.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
 Represents two disposable resources that are disposed together.
 */
-public final class BinaryDisposable : DisposeBase, Cancelable {
+final class BinaryDisposable : DisposeBase, Cancelable {
 
     private var _isDisposed: AtomicInt = 0
 
@@ -22,7 +22,7 @@ public final class BinaryDisposable : DisposeBase, Cancelable {
     /**
     - returns: Was resource disposed.
     */
-    public var isDisposed: Bool {
+    var isDisposed: Bool {
         return _isDisposed > 0
     }
 
@@ -43,7 +43,7 @@ public final class BinaryDisposable : DisposeBase, Cancelable {
 
     After invoking disposal action, disposal action will be dereferenced.
     */
-    public func dispose() {
+    func dispose() {
         if AtomicCompareAndSwap(0, 1, &_isDisposed) {
             _disposable1?.dispose()
             _disposable2?.dispose()

--- a/RxSwift/Disposables/BooleanDisposable.swift
+++ b/RxSwift/Disposables/BooleanDisposable.swift
@@ -13,8 +13,8 @@ Represents a disposable resource that can be checked for disposal status.
 */
 public class BooleanDisposable : Disposable, Cancelable {
  
-    internal static let BooleanDisposableTrue = BooleanDisposable(disposed: true)
-    private var _disposed = false
+    internal static let BooleanDisposableTrue = BooleanDisposable(isDisposed: true)
+    private var _isDisposed = false
     
     /**
         Initializes a new instance of the `BooleanDisposable` class
@@ -25,21 +25,21 @@ public class BooleanDisposable : Disposable, Cancelable {
     /**
         Initializes a new instance of the `BooleanDisposable` class with given value
      */
-    public init(disposed: Bool) {
-        self._disposed = disposed
+    public init(isDisposed: Bool) {
+        self._isDisposed = isDisposed
     }
     
     /**
         - returns: Was resource disposed.
      */
-    public var disposed: Bool {
-        return _disposed
+    public var isDisposed: Bool {
+        return _isDisposed
     }
     
     /**
-        Sets the status to disposed, which can be observer through the `disposed` property.
+        Sets the status to disposed, which can be observer through the `isDisposed` property.
      */
     public func dispose() {
-        _disposed = true
+        _isDisposed = true
     }
 }

--- a/RxSwift/Disposables/CompositeDisposable.swift
+++ b/RxSwift/Disposables/CompositeDisposable.swift
@@ -19,7 +19,7 @@ public class CompositeDisposable : DisposeBase, Disposable, Cancelable {
     // state
     private var _disposables: Bag<Disposable>? = Bag()
 
-    public var disposed: Bool {
+    public var isDisposed: Bool {
         _lock.lock(); defer { _lock.unlock() }
         return _disposables == nil
     }

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -37,7 +37,7 @@ public class DisposeBag: DisposeBase {
     
     // state
     private var _disposables = [Disposable]()
-    private var _disposed = false
+    private var _isDisposed = false
     
     /**
     Constructs new empty dispose bag.
@@ -67,7 +67,7 @@ public class DisposeBag: DisposeBase {
     
     private func _insert(_ disposable: Disposable) -> Disposable? {
         _lock.lock(); defer { _lock.unlock() }
-        if _disposed {
+        if _isDisposed {
             return disposable
         }
 
@@ -93,7 +93,7 @@ public class DisposeBag: DisposeBase {
         let disposables = _disposables
         
         _disposables.removeAll(keepingCapacity: false)
-        _disposed = true
+        _isDisposed = true
         
         return disposables
     }

--- a/RxSwift/Disposables/RefCountDisposable.swift
+++ b/RxSwift/Disposables/RefCountDisposable.swift
@@ -20,7 +20,7 @@ public class RefCountDisposable : DisposeBase, Cancelable {
     /**
      - returns: Was resource disposed.
      */
-    public var disposed: Bool {
+    public var isDisposed: Bool {
         _lock.lock(); defer { _lock.unlock() }
         return _disposable == nil
     }
@@ -110,7 +110,7 @@ public class RefCountDisposable : DisposeBase, Cancelable {
 internal final class RefCountInnerDisposable: DisposeBase, Disposable
 {
     private let _parent: RefCountDisposable
-    private var _disposed: AtomicInt = 0
+    private var _isDisposed: AtomicInt = 0
 
     init(_ parent: RefCountDisposable)
     {
@@ -120,7 +120,7 @@ internal final class RefCountInnerDisposable: DisposeBase, Disposable
 
     internal func dispose()
     {
-        if AtomicCompareAndSwap(0, 1, &_disposed) {
+        if AtomicCompareAndSwap(0, 1, &_isDisposed) {
             _parent.release()
         }
     }

--- a/RxSwift/Disposables/ScheduledDisposable.swift
+++ b/RxSwift/Disposables/ScheduledDisposable.swift
@@ -19,7 +19,7 @@ Represents a disposable resource whose disposal invocation will be scheduled on 
 public class ScheduledDisposable : Cancelable {
     public let scheduler: ImmediateSchedulerType
 
-    private var _disposed: AtomicInt = 0
+    private var _isDisposed: AtomicInt = 0
 
     // state
     private var _disposable: Disposable?
@@ -27,8 +27,8 @@ public class ScheduledDisposable : Cancelable {
     /**
     - returns: Was resource disposed.
     */
-    public var disposed: Bool {
-        return _disposed == 1
+    public var isDisposed: Bool {
+        return _isDisposed == 1
     }
 
     /**
@@ -50,7 +50,7 @@ public class ScheduledDisposable : Cancelable {
     }
 
     func disposeInner() {
-        if AtomicCompareAndSwap(0, 1, &_disposed) {
+        if AtomicCompareAndSwap(0, 1, &_isDisposed) {
             _disposable!.dispose()
             _disposable = nil
         }

--- a/RxSwift/Disposables/SerialDisposable.swift
+++ b/RxSwift/Disposables/SerialDisposable.swift
@@ -16,13 +16,13 @@ public class SerialDisposable : DisposeBase, Cancelable {
     
     // state
     private var _current = nil as Disposable?
-    private var _disposed = false
+    private var _isDisposed = false
     
     /**
     - returns: Was resource disposed.
     */
-    public var disposed: Bool {
-        return _disposed
+    public var isDisposed: Bool {
+        return _isDisposed
     }
     
     /**
@@ -47,7 +47,7 @@ public class SerialDisposable : DisposeBase, Cancelable {
         }
         set (newDisposable) {
             let disposable: Disposable? = _lock.calculateLocked {
-                if _disposed {
+                if _isDisposed {
                     return newDisposable
                 }
                 else {
@@ -72,11 +72,11 @@ public class SerialDisposable : DisposeBase, Cancelable {
 
     private func _dispose() -> Disposable? {
         _lock.lock(); defer { _lock.unlock() }
-        if _disposed {
+        if _isDisposed {
             return nil
         }
         else {
-            _disposed = true
+            _isDisposed = true
             let current = _current
             _current = nil
             return current

--- a/RxSwift/Disposables/SingleAssignmentDisposable.swift
+++ b/RxSwift/Disposables/SingleAssignmentDisposable.swift
@@ -17,15 +17,15 @@ public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
     private var _lock = SpinLock()
     
     // state
-    private var _disposed = false
+    private var _isDisposed = false
     private var _disposableSet = false
     private var _disposable = nil as Disposable?
 
     /**
     - returns: A value that indicates whether the object is disposed.
     */
-    public var disposed: Bool {
-        return _disposed
+    public var isDisposed: Bool {
+        return _isDisposed
     }
 
     /**
@@ -58,7 +58,7 @@ public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
 
         _disposableSet = true
 
-        if _disposed {
+        if _isDisposed {
             return newValue
         }
 
@@ -71,7 +71,7 @@ public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
     Disposes the underlying disposable.
     */
     public func dispose() {
-        if _disposed {
+        if _isDisposed {
             return
         }
         _dispose()?.dispose()
@@ -80,7 +80,7 @@ public class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
     private func _dispose() -> Disposable? {
         _lock.lock(); defer { _lock.unlock() }
 
-        _disposed = true
+        _isDisposed = true
         let disposable = _disposable
         _disposable = nil
 

--- a/RxSwift/Observables/Implementations/Buffer.swift
+++ b/RxSwift/Observables/Implementations/Buffer.swift
@@ -92,7 +92,7 @@ class BufferTimeCountSink<Element, O: ObserverType where O.E == [Element]>
     }
     
     func createTimer(_ windowID: Int) {
-        if _timerD.disposed {
+        if _timerD.isDisposed {
             return
         }
         

--- a/RxSwift/Observables/Implementations/Debug.swift
+++ b/RxSwift/Observables/Implementations/Debug.swift
@@ -46,7 +46,7 @@ class DebugSink<Source: ObservableType, O: ObserverType where O.E == Source.E> :
     }
     
     override func dispose() {
-        logEvent(_parent._identifier, dateFormat: _timestampFormatter, content: "disposed")
+        logEvent(_parent._identifier, dateFormat: _timestampFormatter, content: "isDisposed")
         super.dispose()
     }
 }

--- a/RxSwift/Observables/Implementations/Sink.swift
+++ b/RxSwift/Observables/Implementations/Sink.swift
@@ -19,7 +19,7 @@ class Sink<O : ObserverType> : SingleAssignmentDisposable {
     }
     
     final func forwardOn(_ event: Event<O.E>) {
-        if disposed {
+        if isDisposed {
             return
         }
         _observer.on(event)

--- a/RxSwift/Observables/Implementations/Timeout.swift
+++ b/RxSwift/Observables/Implementations/Timeout.swift
@@ -72,7 +72,7 @@ class TimeoutSink<ElementType, O: ObserverType where O.E == ElementType>: Sink<O
     }
     
     private func _createTimeoutTimer() {
-        if _timerD.disposed {
+        if _timerD.isDisposed {
             return
         }
         

--- a/RxSwift/Observables/Implementations/Window.swift
+++ b/RxSwift/Observables/Implementations/Window.swift
@@ -96,7 +96,7 @@ class WindowTimeCountSink<Element, O: ObserverType where O.E == Observable<Eleme
     }
     
     func createTimer(_ windowId: Int) {
-        if _timerD.disposed {
+        if _timerD.isDisposed {
             return
         }
         

--- a/RxSwift/Observers/TailRecursiveSink.swift
+++ b/RxSwift/Observers/TailRecursiveSink.swift
@@ -26,7 +26,7 @@ class TailRecursiveSink<S: Sequence, O: ObserverType where S.Iterator.Element: O
     typealias SequenceGenerator = (generator: S.Iterator, remaining: IntMax?)
 
     var _generators: [SequenceGenerator] = []
-    var _disposed = false
+    var _isDisposed = false
     var _subscription = SerialDisposable()
 
     // this is thread safe object
@@ -77,7 +77,7 @@ class TailRecursiveSink<S: Sequence, O: ObserverType where S.Iterator.Element: O
                 break
             }
             
-            if _disposed {
+            if _isDisposed {
                 return
             }
 
@@ -137,7 +137,7 @@ class TailRecursiveSink<S: Sequence, O: ObserverType where S.Iterator.Element: O
     }
 
     func disposeCommand() {
-        _disposed = true
+        _isDisposed = true
         _generators.removeAll(keepingCapacity: false)
     }
 

--- a/RxSwift/Schedulers/ConcurrentMainScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentMainScheduler.swift
@@ -53,7 +53,7 @@ public final class ConcurrentMainScheduler : SchedulerType {
         let cancel = SingleAssignmentDisposable()
 
         _mainQueue.async {
-            if cancel.disposed {
+            if cancel.isDisposed {
                 return
             }
 

--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -120,7 +120,7 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
             }
 
             while let latest = queue.value.dequeue() {
-                if latest.disposed {
+                if latest.isDisposed {
                     continue
                 }
                 latest.invoke()

--- a/RxSwift/Schedulers/ImmediateScheduler.swift
+++ b/RxSwift/Schedulers/ImmediateScheduler.swift
@@ -28,7 +28,7 @@ private class ImmediateScheduler : ImmediateSchedulerType {
     func schedule<StateType>(_ state: StateType, action: (StateType) -> Disposable) -> Disposable {
         let disposable = SingleAssignmentDisposable()
         _asyncLock.invoke(AnonymousInvocable {
-            if disposable.disposed {
+            if disposable.isDisposed {
                 return
             }
             disposable.disposable = action(state)

--- a/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
+++ b/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
@@ -25,7 +25,7 @@ extension DispatchQueueConfiguration {
         let cancel = SingleAssignmentDisposable()
 
         queue.async {
-            if cancel.disposed {
+            if cancel.isDisposed {
                 return
             }
 
@@ -57,7 +57,7 @@ extension DispatchQueueConfiguration {
         }
 
         timer.setEventHandler(handler: {
-            if compositeDisposable.disposed {
+            if compositeDisposable.isDisposed {
                 return
             }
             _ = compositeDisposable.insert(action(state))
@@ -91,7 +91,7 @@ extension DispatchQueueConfiguration {
         }
 
         timer.setEventHandler(handler: {
-            if cancelTimer.disposed {
+            if cancelTimer.isDisposed {
                 return
             }
             timerState = action(timerState)

--- a/RxSwift/Schedulers/Internal/ScheduledItem.swift
+++ b/RxSwift/Schedulers/Internal/ScheduledItem.swift
@@ -18,8 +18,8 @@ struct ScheduledItem<T>
 
     private let _disposable = SingleAssignmentDisposable()
 
-    var disposed: Bool {
-        return _disposable.disposed
+    var isDisposed: Bool {
+        return _disposable.isDisposed
     }
     
     init(action: Action, state: T) {

--- a/RxSwift/Schedulers/MainScheduler.swift
+++ b/RxSwift/Schedulers/MainScheduler.swift
@@ -61,7 +61,7 @@ public final class MainScheduler : SerialDispatchQueueScheduler {
         let cancel = SingleAssignmentDisposable()
 
         _mainQueue.async {
-            if !cancel.disposed {
+            if !cancel.isDisposed {
                 _ = action(state)
             }
 

--- a/RxSwift/Schedulers/OperationQueueScheduler.swift
+++ b/RxSwift/Schedulers/OperationQueueScheduler.swift
@@ -39,7 +39,7 @@ public class OperationQueueScheduler: ImmediateSchedulerType {
         weak var compositeDisposableWeak = compositeDisposable
         
         let operation = BlockOperation {
-            if compositeDisposableWeak?.disposed ?? false {
+            if compositeDisposableWeak?.isDisposed ?? false {
                 return
             }
             

--- a/RxSwift/Schedulers/RecursiveScheduler.swift
+++ b/RxSwift/Schedulers/RecursiveScheduler.swift
@@ -41,7 +41,7 @@ class AnyRecursiveScheduler<State> {
         var removeKey: CompositeDisposable.DisposeKey? = nil
         let d = _scheduler.scheduleRelative(state, dueTime: dueTime) { (state) -> Disposable in
             // best effort
-            if self._group.disposed {
+            if self._group.isDisposed {
                 return NopDisposable.instance
             }
             
@@ -84,7 +84,7 @@ class AnyRecursiveScheduler<State> {
         var removeKey: CompositeDisposable.DisposeKey? = nil
         let d = _scheduler.schedule(state) { (state) -> Disposable in
             // best effort
-            if self._group.disposed {
+            if self._group.isDisposed {
                 return NopDisposable.instance
             }
             
@@ -154,7 +154,7 @@ class RecursiveImmediateScheduler<State> {
         var removeKey: CompositeDisposable.DisposeKey? = nil
         let d = _scheduler.schedule(state) { (state) -> Disposable in
             // best effort
-            if self._group.disposed {
+            if self._group.isDisposed {
                 return NopDisposable.instance
             }
             

--- a/RxSwift/Schedulers/VirtualTimeScheduler.swift
+++ b/RxSwift/Schedulers/VirtualTimeScheduler.swift
@@ -169,7 +169,7 @@ public class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
 
     func findNext() -> VirtualSchedulerItem<VirtualTime>? {
         while let front = _schedulerQueue.peek() {
-            if front.disposed {
+            if front.isDisposed {
                 _schedulerQueue.remove(front)
                 continue
             }
@@ -263,8 +263,8 @@ class VirtualSchedulerItem<Time>
     let time: Time
     let id: Int
 
-    var disposed: Bool {
-        return disposable.disposed
+    var isDisposed: Bool {
+        return disposable.isDisposed
     }
     
     var disposable = SingleAssignmentDisposable()

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -33,7 +33,7 @@ public final class BehaviorSubject<Element>
     let _lock = NSRecursiveLock()
     
     // state
-    private var _disposed = false
+    private var _isDisposed = false
     private var _value: Element
     private var _observers = Bag<AnyObserver<Element>>()
     private var _stoppedEvent: Event<Element>?
@@ -41,8 +41,8 @@ public final class BehaviorSubject<Element>
     /**
     Indicates whether the subject has been disposed.
     */
-    public var disposed: Bool {
-        return _disposed
+    public var isDisposed: Bool {
+        return _isDisposed
     }
  
     /**
@@ -61,7 +61,7 @@ public final class BehaviorSubject<Element>
     */
     public func value() throws -> Element {
         _lock.lock(); defer { _lock.unlock() } // {
-            if _disposed {
+            if _isDisposed {
                 throw RxError.disposed(object: self)
             }
             
@@ -86,7 +86,7 @@ public final class BehaviorSubject<Element>
     }
 
     func _synchronized_on(_ event: Event<E>) {
-        if _stoppedEvent != nil || _disposed {
+        if _stoppedEvent != nil || _isDisposed {
             return
         }
         
@@ -112,7 +112,7 @@ public final class BehaviorSubject<Element>
     }
 
     func _synchronized_subscribe<O : ObserverType where O.E == E>(_ observer: O) -> Disposable {
-        if _disposed {
+        if _isDisposed {
             observer.on(.error(RxError.disposed(object: self)))
             return NopDisposable.instance
         }
@@ -134,7 +134,7 @@ public final class BehaviorSubject<Element>
     }
 
     func _synchronized_unsubscribe(_ disposeKey: DisposeKey) {
-        if _disposed {
+        if _isDisposed {
             return
         }
 
@@ -153,7 +153,7 @@ public final class BehaviorSubject<Element>
     */
     public func dispose() {
         _lock.performLocked {
-            _disposed = true
+            _isDisposed = true
             _observers.removeAll()
             _stoppedEvent = nil
         }

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -34,16 +34,16 @@ final public class PublishSubject<Element>
     private var _lock = NSRecursiveLock()
     
     // state
-    private var _disposed = false
+    private var _isDisposed = false
     private var _observers = Bag<AnyObserver<Element>>()
     private var _stopped = false
     private var _stoppedEvent = nil as Event<Element>?
     
     /**
-    Indicates whether the subject has been disposed.
+    Indicates whether the subject has been isDisposed.
     */
-    public var disposed: Bool {
-        return _disposed
+    public var isDisposed: Bool {
+        return _isDisposed
     }
     
     /**
@@ -66,7 +66,7 @@ final public class PublishSubject<Element>
     func _synchronized_on(_ event: Event<E>) {
         switch event {
         case .next(_):
-            if _disposed || _stopped {
+            if _isDisposed || _stopped {
                 return
             }
             
@@ -98,7 +98,7 @@ final public class PublishSubject<Element>
             return NopDisposable.instance
         }
         
-        if _disposed {
+        if _isDisposed {
             observer.on(.error(RxError.disposed(object: self)))
             return NopDisposable.instance
         }
@@ -132,7 +132,7 @@ final public class PublishSubject<Element>
     }
 
     final func _synchronized_dispose() {
-        _disposed = true
+        _isDisposed = true
         _observers.removeAll()
         _stoppedEvent = nil
     }

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -31,7 +31,7 @@ public class ReplaySubject<Element>
     private var _lock = NSRecursiveLock()
     
     // state
-    private var _disposed = false
+    private var _isDisposed = false
     private var _stoppedEvent = nil as Event<Element>?
     private var _observers = Bag<AnyObserver<Element>>()
     
@@ -110,7 +110,7 @@ class ReplayBufferBase<Element>
     }
 
     func _synchronized_on(_ event: Event<E>) {
-        if _disposed {
+        if _isDisposed {
             return
         }
         
@@ -137,7 +137,7 @@ class ReplayBufferBase<Element>
     }
 
     func _synchronized_subscribe<O : ObserverType where O.E == E>(_ observer: O) -> Disposable {
-        if _disposed {
+        if _isDisposed {
             observer.on(.error(RxError.disposed(object: self)))
             return NopDisposable.instance
         }
@@ -161,7 +161,7 @@ class ReplayBufferBase<Element>
     }
 
     func _synchronized_unsubscribe(_ disposeKey: DisposeKey) {
-        if _disposed {
+        if _isDisposed {
             return
         }
         
@@ -180,7 +180,7 @@ class ReplayBufferBase<Element>
     }
 
     func _synchronized_dispose() {
-        _disposed = true
+        _isDisposed = true
         _stoppedEvent = nil
         _observers.removeAll()
     }

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -241,7 +241,7 @@ extension KVOObservableTests {
     
     func test_ObserveAndDontRetainWorks() {
         var latest: String?
-        var disposed = false
+        var isDisposed = false
         
         var parent: Parent! = Parent { n in
             latest = n
@@ -249,26 +249,26 @@ extension KVOObservableTests {
         
         _ = parent.rx_deallocated
             .subscribe(onCompleted: {
-                disposed = true
+                isDisposed = true
             })
         
         XCTAssertTrue(latest == "")
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         parent.val = "1"
         
         XCTAssertTrue(latest == "1")
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         parent = nil
         
         XCTAssertTrue(latest == "1")
-        XCTAssertTrue(disposed == true)
+        XCTAssertTrue(isDisposed == true)
     }
     
     func test_ObserveAndDontRetainWorks2() {
         var latest: String?
-        var disposed = false
+        var isDisposed = false
         
         var parent: ParentWithChild! = ParentWithChild { n in
             latest = n
@@ -276,21 +276,21 @@ extension KVOObservableTests {
         
         _ = parent.rx_deallocated
             .subscribe(onCompleted: {
-                disposed = true
+                isDisposed = true
             })
         
         XCTAssertTrue(latest == "")
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         parent.val = "1"
         
         XCTAssertTrue(latest == "1")
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         parent = nil
         
         XCTAssertTrue(latest == "1")
-        XCTAssertTrue(disposed == true)
+        XCTAssertTrue(isDisposed == true)
     }
 }
 
@@ -301,7 +301,7 @@ extension KVOObservableTests {
     
     func testObserveWeak_SimpleStrongProperty() {
         var latest: String?
-        var disposed = false
+        var isDisposed = false
         
         var root: HasStrongProperty! = HasStrongProperty()
         
@@ -312,26 +312,26 @@ extension KVOObservableTests {
         
         _ = root.rx_deallocated
             .subscribe(onCompleted: {
-                disposed = true
+                isDisposed = true
             })
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(!disposed)
+        XCTAssertTrue(!isDisposed)
         
         root.property = "a"
 
         XCTAssertTrue(latest == "a")
-        XCTAssertTrue(!disposed)
+        XCTAssertTrue(!isDisposed)
         
         root = nil
 
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed)
+        XCTAssertTrue(isDisposed)
     }
     
     func testObserveWeak_SimpleWeakProperty() {
         var latest: String?
-        var disposed = false
+        var isDisposed = false
         
         var root: HasWeakProperty! = HasWeakProperty()
         
@@ -342,28 +342,28 @@ extension KVOObservableTests {
         
         _ = root.rx_deallocated
             .subscribe(onCompleted: {
-                disposed = true
+                isDisposed = true
         })
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(!disposed)
+        XCTAssertTrue(!isDisposed)
     
         let a: NSString! = "a"
         
         root.property = a
         
         XCTAssertTrue(latest == "a")
-        XCTAssertTrue(!disposed)
+        XCTAssertTrue(!isDisposed)
         
         root = nil
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed)
+        XCTAssertTrue(isDisposed)
     }
 
     func testObserveWeak_ObserveFirst_Weak_Strong_Basic() {
         var latest: String?
-        var disposed = false
+        var isDisposed = false
         
         var child: HasStrongProperty! = HasStrongProperty()
         
@@ -376,34 +376,34 @@ extension KVOObservableTests {
         
         _ = root.rx_deallocated
             .subscribe(onCompleted: {
-                disposed = true
+                isDisposed = true
             })
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         root.property = child
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         let one: NSString! = "1"
         
         child.property = one
         
         XCTAssertTrue(latest == "1")
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         root = nil
         child = nil
      
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == true)
+        XCTAssertTrue(isDisposed == true)
     }
     
     func testObserveWeak_Weak_Strong_Observe_Basic() {
         var latest: String?
-        var disposed = false
+        var isDisposed = false
         
         var child: HasStrongProperty! = HasStrongProperty()
         
@@ -416,7 +416,7 @@ extension KVOObservableTests {
         child.property = one
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         _ = root.rx_observeWeakly(String.self, "property.property")
             .subscribe(onNext: { n in
@@ -425,22 +425,22 @@ extension KVOObservableTests {
         
         _ = root.rx_deallocated
             .subscribe(onCompleted: {
-                disposed = true
+                isDisposed = true
         })
         
         XCTAssertTrue(latest == "1")
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         root = nil
         child = nil
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == true)
+        XCTAssertTrue(isDisposed == true)
     }
     
     func testObserveWeak_ObserveFirst_Strong_Weak_Basic() {
         var latest: String?
-        var disposed = false
+        var isDisposed = false
         
         var child: HasWeakProperty! = HasWeakProperty()
         
@@ -453,34 +453,34 @@ extension KVOObservableTests {
         
         _ = root.rx_deallocated
             .subscribe(onCompleted: {
-                disposed = true
+                isDisposed = true
         })
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         root.property = child
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         let one: NSString! = "1"
         
         child.property = one
         
         XCTAssertTrue(latest == "1")
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         root = nil
         child = nil
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == true)
+        XCTAssertTrue(isDisposed == true)
     }
     
     func testObserveWeak_Strong_Weak_Observe_Basic() {
         var latest: String?
-        var disposed = false
+        var isDisposed = false
         
         var child: HasWeakProperty! = HasWeakProperty()
         
@@ -493,7 +493,7 @@ extension KVOObservableTests {
         child.property = one
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         _ = root.rx_observeWeakly(String.self, "property.property")
             .subscribe(onNext: { n in
@@ -502,17 +502,17 @@ extension KVOObservableTests {
         
         _ = root.rx_deallocated
             .subscribe(onCompleted: {
-                disposed = true
+                isDisposed = true
         })
         
         XCTAssertTrue(latest == "1")
-        XCTAssertTrue(disposed == false)
+        XCTAssertTrue(isDisposed == false)
         
         root = nil
         child = nil
         
         XCTAssertTrue(latest == nil)
-        XCTAssertTrue(disposed == true)
+        XCTAssertTrue(isDisposed == true)
     }
     
     // compiler won't release weak references otherwise :(

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
@@ -22,7 +22,7 @@ class MySubject<Element where Element : Hashable> : SubjectType, ObserverType {
         return _subscribeCount
     }
     
-    var diposed: Bool {
+    var isDisposed: Bool {
         return _isDisposed
     }
     

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
@@ -16,14 +16,14 @@ class MySubject<Element where Element : Hashable> : SubjectType, ObserverType {
     var _disposeOn: [Element : Disposable] = [:]
     var _observer: AnyObserver<Element>! = nil
     var _subscribeCount: Int = 0
-    var _disposed: Bool = false
+    var _isDisposed: Bool = false
     
     var subscribeCount: Int {
         return _subscribeCount
     }
     
     var diposed: Bool {
-        return _disposed
+        return _isDisposed
     }
     
     func disposeOn(_ value: Element, disposable: Disposable) {
@@ -47,7 +47,7 @@ class MySubject<Element where Element : Hashable> : SubjectType, ObserverType {
         
         return AnonymousDisposable {
             self._observer = AnyObserver { _ -> Void in () }
-            self._disposed = true
+            self._isDisposed = true
         }
     }
 

--- a/Tests/RxSwiftTests/Tests/DisposableTest.swift
+++ b/Tests/RxSwiftTests/Tests/DisposableTest.swift
@@ -158,21 +158,21 @@ class DisposableTest : RxTest {
         let d = BooleanDisposable()
         let r = RefCountDisposable(disposable: d)
         
-        XCTAssertEqual(r.disposed, false)
+        XCTAssertEqual(r.isDisposed, false)
         
         let d1 = r.retain()
         let d2 = r.retain()
         
-        XCTAssertEqual(d.disposed, false)
+        XCTAssertEqual(d.isDisposed, false)
         
         d1.dispose()
-        XCTAssertEqual(d.disposed, false)
+        XCTAssertEqual(d.isDisposed, false)
         
         d2.dispose()
-        XCTAssertEqual(d.disposed, false)
+        XCTAssertEqual(d.isDisposed, false)
         
         r.dispose()
-        XCTAssertEqual(d.disposed, true)
+        XCTAssertEqual(d.isDisposed, true)
         
         let d3 = r.retain()
         d3.dispose()
@@ -182,21 +182,21 @@ class DisposableTest : RxTest {
         let d = BooleanDisposable()
         let r = RefCountDisposable(disposable: d)
         
-        XCTAssertEqual(r.disposed, false)
+        XCTAssertEqual(r.isDisposed, false)
         
         let d1 = r.retain()
         let d2 = r.retain()
         
-        XCTAssertEqual(d.disposed, false)
+        XCTAssertEqual(d.isDisposed, false)
         
         d1.dispose()
-        XCTAssertEqual(d.disposed, false)
+        XCTAssertEqual(d.isDisposed, false)
         
         r.dispose()
-        XCTAssertEqual(d.disposed, false)
+        XCTAssertEqual(d.isDisposed, false)
         
         d2.dispose()
-        XCTAssertEqual(d.disposed, true)
+        XCTAssertEqual(d.isDisposed, true)
         
     }
 }

--- a/Tests/RxSwiftTests/Tests/Observable+BindingTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+BindingTest.swift
@@ -293,7 +293,7 @@ extension ObservableBindingTest {
             completed(250)
         ])
         
-        XCTAssertTrue(subject.diposed)
+        XCTAssertTrue(subject.isDisposed)
     }
     
     func testRefCount_NotConnected() {

--- a/Tests/RxSwiftTests/Tests/Observable+MultipleTest.swift
+++ b/Tests/RxSwiftTests/Tests/Observable+MultipleTest.swift
@@ -4251,7 +4251,7 @@ extension ObservableMultipleTest {
     func testSkipUntil_HasCompletedCausesDisposal() {
         let scheduler = TestScheduler(initialClock: 0)
         
-        var disposed = false
+        var isDisposed = false
         
         let l = scheduler.createHotObservable([
             next(150, 1),
@@ -4264,7 +4264,7 @@ extension ObservableMultipleTest {
         
         let r: Observable<Int> = Observable.create { o in
             return AnonymousDisposable {
-                disposed = true
+                isDisposed = true
             }
         }
         
@@ -4275,7 +4275,7 @@ extension ObservableMultipleTest {
         XCTAssertEqual(res.events, [
         ])
         
-        XCTAssert(disposed, "disposed")
+        XCTAssert(isDisposed, "isDisposed")
     }
 }
 


### PR DESCRIPTION
Note that this is a breaking change as it changes the `Cancelable` protocol requirements. But I don’t expect this to be too disruptive as there’s no breaking at the call site (only a deprecation) and relatively speaking there shouldn’t be too many new _conformances_ to `Cancelable` externally.