### PR TITLE
Update for Xcode 8 beta 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,6 @@ import PackageDescription
 #if os(OSX)
 let package = Package(
     name: "RxSwift",
-    exclude: [
-        "Sources/RxCocoa",
-        "Sources/RxTests",
-        "Sources/AllTests"
-    ],
     targets: [
         Target(
             name: "RxSwift"
@@ -32,14 +27,16 @@ let package = Package(
                 .Target(name: "RxTests")
             ]
         )
+    ],
+    exclude: [
+        "Sources/RxCocoa",
+        "Sources/RxTests",
+        "Sources/AllTests"
     ]
 )
 #elseif os(Linux)
 let package = Package(
     name: "RxSwift",
-    exclude: [
-        "Sources/RxCocoa",
-    ],
     targets: [
         Target(
             name: "RxSwift"
@@ -64,6 +61,9 @@ let package = Package(
                 .Target(name: "RxTests")
             ]
         )
+    ],
+    exclude: [
+        "Sources/RxCocoa",
     ]
 )
 #endif


### PR DESCRIPTION
Newer versions of Swift-3.0 require parameters to be passed in the same order as specified in the interface.  This pull request fixes Package.swift so the Swift package manager won't complain when instantiating Package()