### PR TITLE
[Swift 3.0] Fix ActivityToken dispose type.

### DIFF
--- a/RxExample/RxExample/Services/ActivityIndicator.swift
+++ b/RxExample/RxExample/Services/ActivityIndicator.swift
@@ -14,7 +14,7 @@ import RxCocoa
 
 private struct ActivityToken<E> : ObservableConvertibleType, Disposable {
     private let _source: Observable<E>
-    private let _dispose: AnonymousDisposable
+    private let _dispose: Cancelable
 
     init(source: Observable<E>, disposeAction: () -> ()) {
         _source = source


### PR DESCRIPTION
After upgrade to `Disposables.create(...)` syntax, `RxExample` projects didn't compile anymore because of a missing `AnonymousDisposable` to `Cancelable` type update.

This PR fix this.