### PR TITLE
Make Bool as KVORepresentable, to avoid ambiguty in observe()

### DIFF
--- a/RxCocoa/Common/KVORepresentable+Swift.swift
+++ b/RxCocoa/Common/KVORepresentable+Swift.swift
@@ -74,6 +74,17 @@ extension UInt64 : KVORepresentable {
     }
 }
 
+extension Bool : KVORepresentable {
+    public typealias KVOType = NSNumber
+
+    /**
+     Constructs `Self` using KVO value.
+    */
+    public init?(KVOValue: KVOType) {
+        self.init(KVOValue.boolValue)
+    }
+}
+
 
 extension RawRepresentable where RawValue: KVORepresentable {
     /**

--- a/RxCocoa/Common/TextInput.swift
+++ b/RxCocoa/Common/TextInput.swift
@@ -132,6 +132,7 @@ import Foundation
         var rx_text: ControlProperty<String> { get }
     }
 
+    @available(*, deprecated)
     extension NSTextField : RxTextInput {
         /**
          Reactive wrapper for `text` property.


### PR DESCRIPTION
Since updating to RxSwift v3 alpha and Xcode 8b6, I was getting a compile error when observing a Bool property with KVO.

Also marked an rx_text usage as deprecated, to avoid warning.