### PR TITLE
Support array parameter for the startWith method.

### DIFF
--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -168,6 +168,20 @@ extension ObservableType {
         -> Observable<E> {
         return StartWith(source: self.asObservable(), elements: elements)
     }
+    
+    /**
+    Prepends a sequence of values to an observable sequence.
+
+    - seealso: [startWith operator on reactivex.io](http://reactivex.io/documentation/operators/startwith.html)
+    
+    - parameter elements: Elements to prepend to the specified sequence.
+    - returns: The source sequence prepended with the specified values.
+    */
+    @warn_unused_result(message="http://git.io/rxs.uo")
+    public func startWith(elements: [E])
+        -> Observable<E> {
+        return StartWith(source: self.asObservable(), elements: elements)
+    }
 }
 
 // MARK: retry


### PR DESCRIPTION
There is a lack of the possibility to call `startWith` with an array because of the current swift compiler implementation (Swift 2.2).

There is no way to e.g. create this code because of this:
```swift
let resultSequence = Observable.deferred { [unowned self] in
    let yourInitialValue = self.someEvents // Here we have array of events that should be sent at first
    return originalSequence.startWith(yourInitialValue) // Here will be compilation error because array can't be passed to the variadic parameter
}
```

Theres is also related conversation to this topic https://github.com/ReactiveX/RxSwift/issues/852