### PR TITLE
Fix error with branch name for Carthage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ $ pod install
 Add this to `Cartfile`
 
 ```
-github "ReactiveX/RxSwift" "3.0.0-beta.1"
+github "ReactiveX/RxSwift" "master"
 ```
 
 ```


### PR DESCRIPTION
When the branch `"3.0.0-beta.1"` is specified in the `Cartfile` carthage launch the following error with `carthage update`:

    Failed to check out repository into /Users/UserName/Library/Caches/org.carthage.CarthageKit/dependencies/RxSwift: No object named "3.0.0-beta.1" exists

As no exist a branch with this name I suppose Carthage not find any in the repository. Specifying `"master"` as the branch RxSwift is downloaded correctly and fully compatible with Swift 3.0.