### PR TITLE
Add `rx.` syntax on Types.

### DIFF
--- a/RxCocoa/Common/Reactive.swift
+++ b/RxCocoa/Common/Reactive.swift
@@ -43,10 +43,14 @@ public struct Reactive<Base> {
  */
 public protocol ReactiveCompatible {
     associatedtype CompatibleType
+    static var rx: Reactive<CompatibleType>.Type { get }
     var rx: Reactive<CompatibleType> { get }
 }
 
 public extension ReactiveCompatible {
+    public static var rx: Reactive<Self>.Type {
+        return Reactive<Self>.self
+    }
     public var rx: Reactive<Self> {
         return Reactive(self)
     }

--- a/RxCocoa/OSX/NSButton+Rx.swift
+++ b/RxCocoa/OSX/NSButton+Rx.swift
@@ -25,7 +25,7 @@ extension Reactive where Base: NSButton {
     Reactive wrapper for `state` property`.
     */
     public var state: ControlProperty<Int> {
-        return Reactive<NSButton>.value(
+        return NSButton.rx.value(
             base,
             getter: { control in
                 return control.state

--- a/RxCocoa/OSX/NSSlider+Rx.swift
+++ b/RxCocoa/OSX/NSSlider+Rx.swift
@@ -18,7 +18,7 @@ extension Reactive where Base: NSSlider {
     Reactive wrapper for `value` property.
     */
     public var value: ControlProperty<Double> {
-        return Reactive<NSControl>.value(
+        return NSControl.rx.value(
             base,
             getter: { control in
                 return control.doubleValue

--- a/RxCocoa/iOS/UIDatePicker+Rx.swift
+++ b/RxCocoa/iOS/UIDatePicker+Rx.swift
@@ -20,7 +20,7 @@ extension Reactive where Base: UIDatePicker {
     Reactive wrapper for `date` property.
     */
     public var date: ControlProperty<Date> {
-        return Reactive<UIControl>.value(
+        return UIControl.rx.value(
             self.base,
             getter: { datePicker in
                 datePicker.date

--- a/RxCocoa/iOS/UISegmentedControl+Rx.swift
+++ b/RxCocoa/iOS/UISegmentedControl+Rx.swift
@@ -20,7 +20,7 @@ extension Reactive where Base: UISegmentedControl {
     Reactive wrapper for `selectedSegmentIndex` property.
     */
     public var value: ControlProperty<Int> {
-        return Reactive<UIControl>.value(
+        return UIControl.rx.value(
             self.base,
             getter: { segmentedControl in
                 segmentedControl.selectedSegmentIndex

--- a/RxCocoa/iOS/UISlider+Rx.swift
+++ b/RxCocoa/iOS/UISlider+Rx.swift
@@ -20,7 +20,7 @@ extension Reactive where Base: UISlider {
     Reactive wrapper for `value` property.
     */
     public var value: ControlProperty<Float> {
-        return Reactive<UIControl>.value(
+        return UIControl.rx.value(
             self.base,
             getter: { slider in
                 slider.value

--- a/RxCocoa/iOS/UIStepper+Rx.swift
+++ b/RxCocoa/iOS/UIStepper+Rx.swift
@@ -20,7 +20,7 @@ extension Reactive where Base: UIStepper {
     Reactive wrapper for `value` property.
     */
     public var value: ControlProperty<Double> {
-        return Reactive<UIControl>.value(
+        return UIControl.rx.value(
             self.base,
             getter: { stepper in
                 stepper.value

--- a/RxCocoa/iOS/UISwitch+Rx.swift
+++ b/RxCocoa/iOS/UISwitch+Rx.swift
@@ -24,7 +24,7 @@ extension Reactive where Base: UISwitch {
      to UISwitch.⚠️**
     */
     public var value: ControlProperty<Bool> {
-        return Reactive<UIControl>.value(
+        return UIControl.rx.value(
             self.base,
             getter: { uiSwitch in
                 uiSwitch.isOn

--- a/RxCocoa/iOS/UITextField+Rx.swift
+++ b/RxCocoa/iOS/UITextField+Rx.swift
@@ -20,7 +20,7 @@ extension Reactive where Base: UITextField {
     Reactive wrapper for `text` property.
     */
     public var text: ControlProperty<String> {
-        return Reactive<UIControl>.value(
+        return UIControl.rx.value(
             base,
             getter: { textField in
                 textField.text ?? ""

--- a/RxExample/RxExample/Examples/ImagePicker/ImagePickerController.swift
+++ b/RxExample/RxExample/Examples/ImagePicker/ImagePickerController.swift
@@ -28,7 +28,7 @@ class ImagePickerController: ViewController {
 
         cameraButton.rx.tap
             .flatMapLatest { [weak self] _ in
-                return Reactive<UIImagePickerController>.createWithParent(self) { picker in
+                return UIImagePickerController.rx.createWithParent(self) { picker in
                     picker.sourceType = .camera
                     picker.allowsEditing = false
                 }
@@ -43,7 +43,7 @@ class ImagePickerController: ViewController {
 
         galleryButton.rx.tap
             .flatMapLatest { [weak self] _ in
-                return Reactive<UIImagePickerController>.createWithParent(self) { picker in
+                return UIImagePickerController.rx.createWithParent(self) { picker in
                     picker.sourceType = .photoLibrary
                     picker.allowsEditing = false
                 }
@@ -60,7 +60,7 @@ class ImagePickerController: ViewController {
 
         cropButton.rx.tap
             .flatMapLatest { [weak self] _ in
-                return Reactive<UIImagePickerController>.createWithParent(self) { picker in
+                return UIImagePickerController.rx.createWithParent(self) { picker in
                     picker.sourceType = .photoLibrary
                     picker.allowsEditing = true
                 }


### PR DESCRIPTION
Following #832, this pull request adds `rx.` dot syntax to types through static var.
Thus instead of `Reactive<UIControl>.value(...)` one can write `UIControl.rx.value(...)`.