### PR TITLE
Fix installation link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ KVO observing, async operations and streams are all unified under [abstraction o
 
 ###### ... install
 
-* Integrate RxSwift/RxCocoa with my app. [Installation Guide](Documentation/Installation.md)
+* Integrate RxSwift/RxCocoa with my app. [Installation Guide](#installation)
 
 ###### ... hack around
 


### PR DESCRIPTION
The link for installation is dead. Using installation anchor point on README instead.