### PR TITLE
Use  `defer` instead of intermediate variable for increment/decrement a

### DIFF
--- a/RxSwift/Rx.swift
+++ b/RxSwift/Rx.swift
@@ -27,16 +27,14 @@ func incrementChecked(_ i: inout Int) throws -> Int {
     if i == Int.max {
         throw RxError.overflow
     }
-    let result = i
-    i += 1
-    return result
+    defer { i += 1 }
+    return i
 }
 
 func decrementChecked(_ i: inout Int) throws -> Int {
     if i == Int.min {
         throw RxError.overflow
     }
-    let result = i
-    i -= 1
-    return result
+    defer { i -= 1 }
+    return i
 }


### PR DESCRIPTION
I thought that using a `defer` here would make this code a little more concise.
The `defer` will be inlined anyway so I don't think there is any performance hit.

Hope it helps!

Thanks,

Nick 