### PR TITLE
Publicize SharedSequence arity static functions

### DIFF
--- a/RxCocoa/CocoaUnits/SharedSequence/SharedSequence+Operators+arity.tt
+++ b/RxCocoa/CocoaUnits/SharedSequence/SharedSequence+Operators+arity.tt
@@ -15,7 +15,7 @@ import RxSwift
 
 // <%= i %>
 
-extension SharedSequence {
+public extension SharedSequence {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -34,7 +34,7 @@ extension SharedSequence {
     }
 }
 
-extension SharedSequence {
+public extension SharedSequence {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences produces an element.
 


### PR DESCRIPTION
I can't find these functions outside of the RxCocoa target 😮

That seems like a problem