### PR TITLE
Fix NSTextInputClient conformance issues with NSTextField

### DIFF
--- a/RxCocoa/Common/TextInput.swift
+++ b/RxCocoa/Common/TextInput.swift
@@ -53,7 +53,7 @@ import Foundation
     import Cocoa
 
     /// Represents text input with reactive extensions.
-    public struct TextInput<Base: NSTextInput> {
+    public struct TextInput<Base: NSTextInputClient> {
         /// Base text input to extend.
         public let base: Base
 
@@ -70,15 +70,11 @@ import Foundation
         }
     }
 
-    extension Reactive where Base: NSTextField {
+    extension Reactive where Base: NSTextField, Base: NSTextInputClient {
         /// Reactive text input.
-        public var textInput: TextInput<NSTextField> {
+        public var textInput: TextInput<Base> {
             return TextInput(base: base, text: self.text)
         }
-    }
-
-    extension NSTextField : NSTextInput {
-        
     }
 
 #endif

--- a/RxCocoa/Runtime/_RXObjCRuntime.m
+++ b/RxCocoa/Runtime/_RXObjCRuntime.m
@@ -295,7 +295,7 @@ replacementImplementationGenerator:(IMP (^)(IMP originalImplementation))replacem
  that every action is properly locked.
  */
 IMP __nullable RX_ensure_observing(id __nonnull target, SEL __nonnull selector, NSError ** __nonnull error) {
-    __block IMP __nonnull targetImplementation = nil;
+    __block IMP __nonnull targetImplementation;
     // Target is the second object that needs to be synchronized to TRY to make sure other swizzling framework
     // won't do something in parallel.
     // Even though this is too fine grained locking and more coarse grained locks should exist, this is just in case


### PR DESCRIPTION
This PR fixes a potential crasher on macOS by addressing 2 issues:

1. The `NSTextInput` protocol was deprecated in OS X 10.6 (Snow Leopard) - we should be using `NSTextInputClient` now.
2. Not all `NSTextField`s conform to `NSTextInputClient` (as you see when putting the non-deprecated API into the empty extension here). I've just constrained the extension on `Reactive` to only work with `NSTextField` instances that conform to `NSTextInputClient`.