### PR TITLE
Fix RxExample: driver creation needs to be inside driveOnScheduler

### DIFF
--- a/RxExample/RxExample-iOSTests/RxExample_iOSTests.swift
+++ b/RxExample/RxExample-iOSTests/RxExample_iOSTests.swift
@@ -141,6 +141,7 @@ class RxExample_iOSTests
         This method enables using mock schedulers for while testing drivers.
         */
         driveOnScheduler(scheduler) {
+            
             let viewModel = GithubSignupViewModel2(
                 input: (
                     username: scheduler.createHotObservable(usernameEvents).asDriver(onErrorJustReturn: ""),
@@ -154,9 +155,7 @@ class RxExample_iOSTests
                     wireframe: wireframe
                 )
             )
-          
-          
-          
+                              
             // run experiment
             let recordedSignupEnabled = scheduler.record(source: viewModel.signupEnabled)
             let recordedValidatedUsername = scheduler.record(source: viewModel.validatedUsername)

--- a/RxExample/RxExample-iOSTests/RxExample_iOSTests.swift
+++ b/RxExample/RxExample-iOSTests/RxExample_iOSTests.swift
@@ -155,7 +155,7 @@ class RxExample_iOSTests
                     wireframe: wireframe
                 )
             )
-                              
+            
             // run experiment
             let recordedSignupEnabled = scheduler.record(source: viewModel.signupEnabled)
             let recordedValidatedUsername = scheduler.record(source: viewModel.validatedUsername)

--- a/RxExample/RxExample-iOSTests/RxExample_iOSTests.swift
+++ b/RxExample/RxExample-iOSTests/RxExample_iOSTests.swift
@@ -133,20 +133,6 @@ class RxExample_iOSTests
         let wireframe = MockWireframe()
         let validationService = GitHubDefaultValidationService(API: mockAPI)
 
-        let viewModel = GithubSignupViewModel2(
-            input: (
-                username: scheduler.createHotObservable(usernameEvents).asDriver(onErrorJustReturn: ""),
-                password: scheduler.createHotObservable(passwordEvents).asDriver(onErrorJustReturn: ""),
-                repeatedPassword: scheduler.createHotObservable(repeatedPasswordEvents).asDriver(onErrorJustReturn: ""),
-                loginTaps: scheduler.createHotObservable(loginTapEvents).asDriver(onErrorJustReturn: ())
-            ),
-            dependency: (
-                API: mockAPI,
-                validationService: validationService,
-                wireframe: wireframe
-            )
-        )
-
         /**
         This is important because driver will try to ensure that elements are being pumped on main scheduler,
         and that sometimes means that it will get queued using `dispatch_async` to main dispatch queue and
@@ -155,6 +141,22 @@ class RxExample_iOSTests
         This method enables using mock schedulers for while testing drivers.
         */
         driveOnScheduler(scheduler) {
+            let viewModel = GithubSignupViewModel2(
+                input: (
+                    username: scheduler.createHotObservable(usernameEvents).asDriver(onErrorJustReturn: ""),
+                    password: scheduler.createHotObservable(passwordEvents).asDriver(onErrorJustReturn: ""),
+                    repeatedPassword: scheduler.createHotObservable(repeatedPasswordEvents).asDriver(onErrorJustReturn: ""),
+                    loginTaps: scheduler.createHotObservable(loginTapEvents).asDriver(onErrorJustReturn: ())
+                ),
+                dependency: (
+                    API: mockAPI,
+                    validationService: validationService,
+                    wireframe: wireframe
+                )
+            )
+          
+          
+          
             // run experiment
             let recordedSignupEnabled = scheduler.record(source: viewModel.signupEnabled)
             let recordedValidatedUsername = scheduler.record(source: viewModel.validatedUsername)

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -390,7 +390,7 @@
 		C8477FEC1D29DE8C0074454A /* RxTableViewSectionedAnimatedDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTableViewSectionedAnimatedDataSource.swift; sourceTree = "<group>"; };
 		C8477FED1D29DE8C0074454A /* RxTableViewSectionedReloadDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTableViewSectionedReloadDataSource.swift; sourceTree = "<group>"; };
 		C849EF611C3190360048AC4A /* RxExample-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "RxExample-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C849EF631C3190360048AC4A /* RxExample_iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxExample_iOSTests.swift; sourceTree = "<group>"; };
+		C849EF631C3190360048AC4A /* RxExample_iOSTests.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = RxExample_iOSTests.swift; sourceTree = "<group>"; tabWidth = 4; };
 		C849EF651C3190360048AC4A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C849EF7E1C3193B10048AC4A /* GitHubSignupViewController1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSignupViewController1.swift; sourceTree = "<group>"; };
 		C849EF7F1C3193B10048AC4A /* GithubSignupViewModel1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubSignupViewModel1.swift; sourceTree = "<group>"; };


### PR DESCRIPTION
Driver creation needs to be inside driveOnScheduler(scheduler).

The following test will fail:

scheduler.createDriver can be replaced by `scheduler.parseEventsAndTimes()`, followed by a `scheduler.createHotObservable().asDriver()` giving the same result

```
import XCTest 
import RxSwift
import RxTest
import RxCocoa 

class DriverMergeTests: XCTestCase {

  let voidValues: [String: Void] = ["v": ()]
  let resultValues = ["1": 1, "2": 2, "3": 3]

  struct MockViewModel {
    let result: Driver<Int>

    init(a: Driver<Void>, b: Driver<Void>, c: Driver<Void>) {
      result = Driver.of(a.map { 1 }, b.map { 2 }, c.map { 3 }).merge()
    }
  }

  func testMockViewModel() {


    let scheduler = TestScheduler(initialClock: 0, resolution: resolution, simulateProcessingDelay: false)

  let expectedResult = scheduler.parseEventsAndTimes(timeline: "--1--2--3-----", values: resultValues).first!

    let aDriver = scheduler.createDriver(timeline: "--v-----------", values: voidValues)
    let bDriver = scheduler.createDriver(timeline: "-----v--------", values: voidValues)
    let cDriver = scheduler.createDriver(timeline: "--------v-----", values: voidValues)


    let viewModel = MockViewModel(a: aDriver, b: bDriver, c: cDriver)

    driveOnScheduler(scheduler) {

      let recordedResults = scheduler.record(source: viewModel.result)

      scheduler.start()

      XCTAssertEqual(recordedResults.events, expectedResult)
      // XCTAssertEqual failed: ("[]") is not equal to ("[next(1) @ 2, next(2) @ 5, next(3) @ 8]")
    }

  }

}
```

moving the driver creation into the `driveOnSchedeler(scheduler)` to the following code fixes this issue 

```
driveOnScheduler(scheduler) {

    let aDriver = scheduler.createDriver(timeline: "--v-----------", values: voidValues)
    let bDriver = scheduler.createDriver(timeline: "-----v--------", values: voidValues)
    let cDriver = scheduler.createDriver(timeline: "--------v-----", values: voidValues)

    let viewModel = MockViewModel(a: aDriver, b: bDriver, c: cDriver)

    let recordedResults = scheduler.record(source: viewModel.result)

    scheduler.start()

     XCTAssertEqual(recordedResults.events, expectedResult)     
}
```
