### PR TITLE
Add Optional<Equatable> .distinctUntilChanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## Master
 
+* Adds a `.distinctUntilChanged()` operator for `Observable`s & `SharedSequence`s of `Element`s that are `Optional`s where the `Wrapped` type conforms to `Equatable`
+
 ## [3.0.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.0.0) (Xcode 8 / Swift 3.0 compatible)
 
 * Prefixes boolean properties with `is` and makes `String?` properties consistent.

--- a/RxCocoa/CocoaUnits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/CocoaUnits/SharedSequence/SharedSequence+Operators.swift
@@ -142,6 +142,20 @@ extension SharedSequenceConvertibleType {
 }
 
 // MARK: distinctUntilChanged
+extension SharedSequence where Element: AnyOptional, Element.T: Equatable {
+    
+    /**
+    Returns an observable sequence that contains only distinct contiguous elements according to equality operator.
+    
+    - returns: An observable sequence only containing the distinct contiguous elements, based on equality operator, from the source sequence.
+    */
+    func distinctUntilChanged() -> SharedSequence<SharingStrategy, Element> {
+        return self.distinctUntilChanged { (lhs, rhs) -> Bool in
+            return lhs.asOptional == rhs.asOptional
+        }
+    }
+}
+
 extension SharedSequenceConvertibleType where E: Equatable {
     
     /**

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -22,13 +22,17 @@ extension Optional: AnyOptional {
 // MARK: distinct until changed
 
 extension ObservableType where Element: AnyOptional, Element.T: Equatable {
+    
+    /**
+    Returns an observable sequence that contains only distinct contiguous elements according to equality operator.
+
+    - seealso: [distinct operator on reactivex.io](http://reactivex.io/documentation/operators/distinct.html)
+    
+    - returns: An observable sequence only containing the distinct contiguous elements, based on equality operator, from the source sequence.
+    */
     public func distinctUntilChanged() -> Observable<Element> {
         return self.distinctUntilChanged { (lhs, rhs) -> Bool in
-            switch (lhs.asOptional, rhs.asOptional) {
-            case (.some(let l), .some(let r)):      return l == r
-            case (.none, .none):                    return true
-            case (.some, .none), (.none, .some):    return false
-            }
+            return lhs.asOptional == rhs.asOptional
         }
     }
 }

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -21,7 +21,7 @@ extension Optional: AnyOptional {
 
 // MARK: distinct until changed
 
-extension ObservableType where Element: AnyOptional, Element.T: Equatable {
+extension ObservableType where E: AnyOptional, E.T: Equatable {
     
     /**
     Returns an observable sequence that contains only distinct contiguous elements according to equality operator.
@@ -30,7 +30,7 @@ extension ObservableType where Element: AnyOptional, Element.T: Equatable {
     
     - returns: An observable sequence only containing the distinct contiguous elements, based on equality operator, from the source sequence.
     */
-    public func distinctUntilChanged() -> Observable<Element> {
+    public func distinctUntilChanged() -> Observable<E> {
         return self.distinctUntilChanged { (lhs, rhs) -> Bool in
             return lhs.asOptional == rhs.asOptional
         }

--- a/RxSwift/Observables/Observable+Single.swift
+++ b/RxSwift/Observables/Observable+Single.swift
@@ -8,7 +8,30 @@
 
 import Foundation
 
+/// Type erased OptionalType
+public protocol AnyOptional {
+    associatedtype T
+    var asOptional: T? { get }
+}
+extension Optional: AnyOptional {
+    public var asOptional: Wrapped? {
+        return self
+    }   
+}
+
 // MARK: distinct until changed
+
+extension ObservableType where Element: AnyOptional, Element.T: Equatable {
+    public func distinctUntilChanged() -> Observable<Element> {
+        return self.distinctUntilChanged { (lhs, rhs) -> Bool in
+            switch (lhs.asOptional, rhs.asOptional) {
+            case (.some(let l), .some(let r)):      return l == r
+            case (.none, .none):                    return true
+            case (.some, .none), (.none, .some):    return false
+            }
+        }
+    }
+}
 
 extension ObservableType where E: Equatable {
     


### PR DESCRIPTION
This is implemented for other collections like Array and Dictionary, so I thought it would be intuitive to include for Observables.
I was quite confused when I couldn't write just `.distinctUntilChanged()` for one of my `Observable<Type?>`s, and instead had to fill it out with this `switch`

Not sure about the type erased `AnyOptional` protocol I defined, and where it should be.
