### PR TITLE
Fix playground page ordering

### DIFF
--- a/Rx.playground/Pages/Connectable_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Connectable_Operators.xcplaygroundpage/Contents.swift
@@ -11,7 +11,7 @@ import RxSwift
 
 playgroundShouldContinueIndefinitely()
 /*:
-## Connectable Operators
+# Connectable Operators
  Connectable `Observable` sequences resembles ordinary `Observable` sequences, except that they not begin emitting elements when subscribed to, but instead, only when their `connect()` method is called. In this way, you can wait for all intended subscribers to subscribe to a connectable `Observable` sequence before it begins emitting elements.
  > Within each example on this page is a commented-out method. Uncomment that method to run the example, and then comment it out again to stop running the example.
  #

--- a/Rx.playground/contents.xcplayground
+++ b/Rx.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='osx' display-mode='raw' last-migration='0800'>
+<playground version='6.0' target-platform='osx' display-mode='rendered'>
     <pages>
         <page name='Table_of_Contents'/>
         <page name='Introduction'/>

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -1896,6 +1896,7 @@
 				C82E1DBA1DC69E8D004A6413 /* Release-Tests */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		C83366D81AD0293800C668A7 /* Build configuration list for PBXProject "RxExample" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
Fixed ordering of playground pages so that clicking Next / Previous goes to correct page, per table of contents.
Fixed formatting of a page header.