### PR TITLE
fix example code

### DIFF
--- a/Documentation/Units.md
+++ b/Documentation/Units.md
@@ -176,7 +176,7 @@ results
     .addDisposableTo(disposeBag)
 
 results
-    .bindTo(resultsTableView.rx.itemsWithCellIdentifier("Cell")) { (_, result, cell) in
+    .bindTo(resultsTableView.rx.items(cellIdentifier: "Cell")) { (_, result, cell) in
         cell.textLabel?.text = "\(result)"
     }
     .addDisposableTo(disposeBag)
@@ -211,7 +211,7 @@ results
     .addDisposableTo(disposeBag)
 
 results
-    .bindTo(resultTableView.rx.itemsWithCellIdentifier("Cell")) { (_, result, cell) in
+    .bindTo(resultTableView.rx.items(cellIdentifier: "Cell")) { (_, result, cell) in
         cell.textLabel?.text = "\(result)"
     }
     .addDisposableTo(disposeBag)
@@ -235,7 +235,7 @@ results
     .addDisposableTo(disposeBag)              // that means that the compiler has proven that all properties
                                               // are satisfied.
 results
-    .drive(resultTableView.rx.itemsWithCellIdentifier("Cell")) { (_, result, cell) in
+    .drive(resultTableView.rx.items(cellIdentifier: "Cell")) { (_, result, cell) in
         cell.textLabel?.text = "\(result)"
     }
     .addDisposableTo(disposeBag)


### PR DESCRIPTION
This PR fixes example code for RxSwift 3.0 version.

replace `itemsWithCellIdentifier(_)` with `items(cellIdentifier: _)`