### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,10 @@ KVO observing, async operations and streams are all unified under [abstraction o
   </tr>
   <tr>
     <td><div class="highlight highlight-source-swift"><pre>
-let searchResults = searchBar.rx.text
+let searchResults = searchBar.rx.text.orEmpty
     .throttle(0.3, scheduler: MainScheduler.instance)
     .distinctUntilChanged()
     .flatMapLatest { query -> Observable<[Repository]> in
-        if query.isEmpty {
-            return .just([])
-        }
-
         return searchGitHub(query)
             .catchErrorJustReturn([])
     }


### PR DESCRIPTION
The example advertised in the Usage section of the README is not working with latest versions of RxSwift.

After the transition from `rx_text` to `rx.text`, the result given is an `String?` instead of `String` preventing the use of  `distinctUntilChanged()` without any comparer parameter. Using the `orEmpty` fix the issue.

Simply adding `orEmpty` isn't enough as the following lines generates a compilation issue:
```
if query.isEmpty {
    return .just([])
}
```

Since I don't know how to fix this issue and since it doesn't bring much value to the example, I removed it.