### PR TITLE
Fix file reference for multiple groups

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -2359,11 +2359,6 @@
 				C8F27DB11CE6711600D5FB4F /* UITextView+RxTests.swift */,
 				C83508F11C38706D0027C24C /* UIView+RxTests.swift */,
 				271A97421CFC99FE00D64125 /* UIViewControler+RxTests.swift */,
-				844BC8B71CE5023200F5C7CB /* UIPickerView+RxTests.swift */,
-				914FCD661CCDB82E0058B304 /* UIPageControl+RxTest.swift */,
-				033C2EF41D081B2A0050C015 /* UIScrollView+RxTests.swift */,
-				C8379EF31D1DD326003EF8FC /* UIButton+RxTests.swift */,
-				C8A9B6F31DAD752200C9B027 /* Observable+BindTests.swift */,
 				4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */,
 			);
 			path = RxCocoaTests;


### PR DESCRIPTION
I got the following error in master branch. Looks like the file references was added unexpectedly in this PR, so I just deleted them.
https://github.com/ReactiveX/RxSwift/commit/3bb067dbbc695bd428c671b63a785abfac8d0738#diff-c90a2dc060001fb39284f2394e511d20R2362

```
2016-12-08 11:19:39.357 xcodebuild[8288:17762595] warning:  The file reference for "UIPickerView+RxTests.swift" is a member of multiple groups ("RxCocoaTests" and "RxCocoaTests"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
2016-12-08 11:19:39.357 xcodebuild[8288:17762595] warning:  The file reference for "UIPageControl+RxTest.swift" is a member of multiple groups ("RxCocoaTests" and "RxCocoaTests"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
2016-12-08 11:19:39.357 xcodebuild[8288:17762595] warning:  The file reference for "UIScrollView+RxTests.swift" is a member of multiple groups ("RxCocoaTests" and "RxCocoaTests"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
2016-12-08 11:19:39.357 xcodebuild[8288:17762595] warning:  The file reference for "UIButton+RxTests.swift" is a member of multiple groups ("RxCocoaTests" and "RxCocoaTests"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
2016-12-08 11:19:39.357 xcodebuild[8288:17762595] warning:  The file reference for "Observable+BindTests.swift" is a member of multiple groups ("RxCocoaTests" and "RxCocoaTests"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
```