### PR TITLE
Extend the UIScrollView reactive wrappers

### DIFF
--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -57,6 +57,12 @@ extension Reactive where Base: UIScrollView {
         let source = RxScrollViewDelegateProxy.proxyForObject(base).contentOffsetPublishSubject
         return ControlEvent(events: source)
     }
+	
+	/// Reactive wrapper for delegate method `scrollViewDidEndDecelerating`
+	public var didEndDecelerating: ControlEvent<Void> {
+		let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidEndDecelerating(_:))).map { _ in }
+		return ControlEvent(events: source)
+	}
 
     /// Reactive wrapper for delegate method `scrollViewDidZoom`
     public var didZoom: ControlEvent<Void> {

--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -63,6 +63,15 @@ extension Reactive where Base: UIScrollView {
 		let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidEndDecelerating(_:))).map { _ in }
 		return ControlEvent(events: source)
 	}
+	
+	/// Reactive wrapper for delegate method `scrollViewDidEndDragging(_:willDecelerate:)`
+	public var didEndDragging: ControlEvent<Bool> {
+		let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidEndDragging(_:willDecelerate:))).map { value -> Bool in
+			let willDecelerate = value[1] as! Bool
+			return willDecelerate
+		}
+		return ControlEvent(events: source)
+	}
 
     /// Reactive wrapper for delegate method `scrollViewDidZoom`
     public var didZoom: ControlEvent<Void> {

--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -67,8 +67,7 @@ extension Reactive where Base: UIScrollView {
 	/// Reactive wrapper for delegate method `scrollViewDidEndDragging(_:willDecelerate:)`
 	public var didEndDragging: ControlEvent<Bool> {
 		let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidEndDragging(_:willDecelerate:))).map { value -> Bool in
-			let willDecelerate = value[1] as! Bool
-			return willDecelerate
+			return try castOrThrow(Bool.self, value[1])
 		}
 		return ControlEvent(events: source)
 	}

--- a/Tests/RxCocoaTests/UIScrollView+RxTests.swift
+++ b/Tests/RxCocoaTests/UIScrollView+RxTests.swift
@@ -62,6 +62,31 @@ extension UIScrollViewTests {
 
         XCTAssertTrue(completed)
     }
+	
+	
+	func testScrollViewDidEndDecelerating() {
+		var completed = false
+		
+		autoreleasepool {
+			let scrollView = UIScrollView()
+			var didEndDecelerating = false
+			
+			_ = scrollView.rx.didEndDecelerating.subscribe(onNext: {
+				didEndDecelerating = true
+			}, onCompleted: {
+				completed = true
+			})
+			
+			XCTAssertFalse(didEndDecelerating)
+			
+			scrollView.delegate!.scrollViewDidEndDecelerating!(scrollView)
+			
+			XCTAssertTrue(didEndDecelerating)
+		}
+		
+		XCTAssertTrue(completed)
+	}
+
 
     func testScrollViewContentOffset() {
         var completed = false


### PR DESCRIPTION
It extends the current implementation of the UIScrollView reactive wrapper adding the support for the delegate methods `scrollViewDidEndDecelerating(_:)` and `scrollViewDidEndDragging(_:willDecelerate:)`.