### PR TITLE
Added missing orEmpty in an example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ KVO observing, async operations and streams are all unified under [abstraction o
   </tr>
   <tr>
     <td><div class="highlight highlight-source-swift"><pre>
-let searchResults = searchBar.rx.text
+let searchResults = searchBar.rx.text.orEmpty
     .throttle(0.3, scheduler: MainScheduler.instance)
     .distinctUntilChanged()
     .flatMapLatest { query -> Observable<[Repository]> in


### PR DESCRIPTION
I realized when I was reading the RxExample project that `orEmpty` is missing from the sample code in README.  Since the string should not be optional in this case I added 'orEmpty' to it!