### PR TITLE
Update SupportCode of Rx.playground

### DIFF
--- a/Rx.playground/Sources/SupportCode.swift
+++ b/Rx.playground/Sources/SupportCode.swift
@@ -26,8 +26,7 @@ public enum TestError: Swift.Error {
  */
 public func delay(_ delay: Double, closure: @escaping (Void) -> Void) {
 
-    let delayTime = DispatchTime.now() + DispatchTimeInterval.seconds(Int(delay))
-    DispatchQueue.main.asyncAfter(deadline: delayTime) {
+    DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
         closure()
     }
 }


### PR DESCRIPTION
Just remove smoe redundant code of `DispatchTimeInterval`.

With the overloading of `+` operator,

```
public func +(time: DispatchTime, seconds: Double) -> DispatchTime
```

we can combine our `DispatchTime` more gracefully.