### PR TITLE
Fix custom operator sample code

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -608,7 +608,7 @@ Lets see how an unoptimized map operator can be implemented.
 
 ```swift
 extension ObservableType {
-    func myMap<R>(transform: E -> R) -> Observable<R> {
+    func myMap<R>(transform: @escaping (E) -> R) -> Observable<R> {
         return Observable.create { observer in
             let subscription = self.subscribe { e in
                     switch e {


### PR DESCRIPTION
The sample code for a custom operator in the getting started docs won't compile in Swift 3 — it's missing a few parentheses and the `@escaping` attribute that are now required. This fixes that.