### PR TITLE
Refactor duplicates of generic parameters from Sink implementation.

### DIFF
--- a/RxSwift/Observables/Implementations/Amb.swift
+++ b/RxSwift/Observables/Implementations/Amb.swift
@@ -14,10 +14,10 @@ enum AmbState {
     case right
 }
 
-class AmbObserver<ElementType, O: ObserverType> : ObserverType where O.E == ElementType {
-    typealias Element = ElementType
-    typealias Parent = AmbSink<ElementType, O>
-    typealias This = AmbObserver<ElementType, O>
+class AmbObserver<O: ObserverType> : ObserverType {
+    typealias Element = O.E
+    typealias Parent = AmbSink<O>
+    typealias This = AmbObserver<O>
     typealias Sink = (This, Event<Element>) -> Void
     
     fileprivate let _parent: Parent
@@ -48,9 +48,10 @@ class AmbObserver<ElementType, O: ObserverType> : ObserverType where O.E == Elem
     }
 }
 
-class AmbSink<ElementType, O: ObserverType> : Sink<O> where O.E == ElementType {
+class AmbSink<O: ObserverType> : Sink<O> {
+    typealias ElementType = O.E
     typealias Parent = Amb<ElementType>
-    typealias AmbObserverType = AmbObserver<ElementType, O>
+    typealias AmbObserverType = AmbObserver<O>
 
     private let _parent: Parent
     

--- a/RxSwift/Observables/Implementations/CombineLatest+Collection.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest+Collection.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 
-class CombineLatestCollectionTypeSink<C: Collection, R, O: ObserverType>
-    : Sink<O> where C.Iterator.Element : ObservableConvertibleType, O.E == R {
+class CombineLatestCollectionTypeSink<C: Collection, O: ObserverType>
+    : Sink<O> where C.Iterator.Element : ObservableConvertibleType {
+    typealias R = O.E
     typealias Parent = CombineLatestCollectionType<C, R>
     typealias SourceElement = C.Iterator.Element.E
     

--- a/RxSwift/Observables/Implementations/Delay.swift
+++ b/RxSwift/Observables/Implementations/Delay.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-class DelaySink<ElementType, O: ObserverType>
+class DelaySink<O: ObserverType>
     : Sink<O>
-    , ObserverType where O.E == ElementType {
+    , ObserverType {
     typealias E = O.E
     typealias Source = Observable<E>
     typealias DisposeKey = Bag<Disposable>.KeyType

--- a/RxSwift/Observables/Implementations/DelaySubscription.swift
+++ b/RxSwift/Observables/Implementations/DelaySubscription.swift
@@ -8,11 +8,10 @@
 
 import Foundation
 
-class DelaySubscriptionSink<ElementType, O: ObserverType>
-    : Sink<O>
-    , ObserverType where O.E == ElementType {
-    typealias Parent = DelaySubscription<ElementType>
+class DelaySubscriptionSink<O: ObserverType>
+    : Sink<O>, ObserverType {
     typealias E = O.E
+    typealias Parent = DelaySubscription<E>
     
     private let _parent: Parent
     

--- a/RxSwift/Observables/Implementations/ElementAt.swift
+++ b/RxSwift/Observables/Implementations/ElementAt.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 
-class ElementAtSink<SourceType, O: ObserverType> : Sink<O>, ObserverType where O.E == SourceType {
+class ElementAtSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias SourceType = O.E
     typealias Parent = ElementAt<SourceType>
     
     let _parent: Parent

--- a/RxSwift/Observables/Implementations/Sample.swift
+++ b/RxSwift/Observables/Implementations/Sample.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-class SamplerSink<O: ObserverType, ElementType, SampleType>
+class SamplerSink<O: ObserverType, SampleType>
     : ObserverType
     , LockOwnerType
-    , SynchronizedOnType where O.E == ElementType {
+    , SynchronizedOnType {
     typealias E = SampleType
     
     typealias Parent = SampleSequenceSink<O, SampleType>

--- a/RxSwift/Observables/Implementations/Scan.swift
+++ b/RxSwift/Observables/Implementations/Scan.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-class ScanSink<ElementType, Accumulate, O: ObserverType> : Sink<O>, ObserverType where O.E == Accumulate {
+class ScanSink<ElementType, O: ObserverType> : Sink<O>, ObserverType {
+    typealias Accumulate = O.E
     typealias Parent = Scan<ElementType, Accumulate>
     typealias E = ElementType
     

--- a/RxSwift/Observables/Implementations/SingleAsync.swift
+++ b/RxSwift/Observables/Implementations/SingleAsync.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-class SingleAsyncSink<ElementType, O: ObserverType> : Sink<O>, ObserverType where O.E == ElementType {
+class SingleAsyncSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias ElementType = O.E
     typealias Parent = SingleAsync<ElementType>
     typealias E = ElementType
     

--- a/RxSwift/Observables/Implementations/Skip.swift
+++ b/RxSwift/Observables/Implementations/Skip.swift
@@ -10,9 +10,9 @@ import Foundation
 
 // count version
 
-class SkipCountSink<ElementType, O: ObserverType> : Sink<O>, ObserverType where O.E == ElementType {
-    typealias Parent = SkipCount<ElementType>
-    typealias Element = ElementType
+class SkipCountSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias Element = O.E
+    typealias Parent = SkipCount<Element>
     
     let parent: Parent
     

--- a/RxSwift/Observables/Implementations/SkipUntil.swift
+++ b/RxSwift/Observables/Implementations/SkipUntil.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-class SkipUntilSinkOther<ElementType, Other, O: ObserverType>
+class SkipUntilSinkOther<Other, O: ObserverType>
     : ObserverType
     , LockOwnerType
-    , SynchronizedOnType where O.E == ElementType {
-    typealias Parent = SkipUntilSink<ElementType, Other, O>
+    , SynchronizedOnType {
+    typealias Parent = SkipUntilSink<Other, O>
     typealias E = Other
     
     fileprivate let _parent: Parent
@@ -56,12 +56,12 @@ class SkipUntilSinkOther<ElementType, Other, O: ObserverType>
 }
 
 
-class SkipUntilSink<ElementType, Other, O: ObserverType>
+class SkipUntilSink<Other, O: ObserverType>
     : Sink<O>
     , ObserverType
     , LockOwnerType
-    , SynchronizedOnType where O.E == ElementType {
-    typealias E = ElementType
+    , SynchronizedOnType {
+    typealias E = O.E
     typealias Parent = SkipUntil<E, Other>
     
     let _lock = NSRecursiveLock()

--- a/RxSwift/Observables/Implementations/SkipWhile.swift
+++ b/RxSwift/Observables/Implementations/SkipWhile.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-class SkipWhileSink<ElementType, O: ObserverType> : Sink<O>, ObserverType where O.E == ElementType {
+class SkipWhileSink<O: ObserverType> : Sink<O>, ObserverType {
 
-    typealias Parent = SkipWhile<ElementType>
-    typealias Element = ElementType
+    typealias Element = O.E
+    typealias Parent = SkipWhile<Element>
 
     fileprivate let _parent: Parent
     fileprivate var _running = false
@@ -42,10 +42,10 @@ class SkipWhileSink<ElementType, O: ObserverType> : Sink<O>, ObserverType where 
     }
 }
 
-class SkipWhileSinkWithIndex<ElementType, O: ObserverType> : Sink<O>, ObserverType where O.E == ElementType {
+class SkipWhileSinkWithIndex<O: ObserverType> : Sink<O>, ObserverType {
 
-    typealias Parent = SkipWhile<ElementType>
-    typealias Element = ElementType
+    typealias Element = O.E
+    typealias Parent = SkipWhile<Element>
 
     fileprivate let _parent: Parent
     fileprivate var _index = 0

--- a/RxSwift/Observables/Implementations/Take.swift
+++ b/RxSwift/Observables/Implementations/Take.swift
@@ -10,9 +10,9 @@ import Foundation
 
 // count version
 
-class TakeCountSink<ElementType, O: ObserverType> : Sink<O>, ObserverType where O.E == ElementType {
-    typealias Parent = TakeCount<ElementType>
-    typealias E = ElementType
+class TakeCountSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias E = O.E
+    typealias Parent = TakeCount<E>
     
     private let _parent: Parent
     

--- a/RxSwift/Observables/Implementations/TakeLast.swift
+++ b/RxSwift/Observables/Implementations/TakeLast.swift
@@ -9,17 +9,17 @@
 import Foundation
 
 
-class TakeLastSink<ElementType, O: ObserverType> : Sink<O>, ObserverType where O.E == ElementType {
-    typealias Parent = TakeLast<ElementType>
-    typealias E = ElementType
+class TakeLastSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias E = O.E
+    typealias Parent = TakeLast<E>
     
     private let _parent: Parent
     
-    private var _elements: Queue<ElementType>
+    private var _elements: Queue<E>
     
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
-        _elements = Queue<ElementType>(capacity: parent._count + 1)
+        _elements = Queue<E>(capacity: parent._count + 1)
         super.init(observer: observer, cancel: cancel)
     }
     

--- a/RxSwift/Observables/Implementations/TakeUntil.swift
+++ b/RxSwift/Observables/Implementations/TakeUntil.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-class TakeUntilSinkOther<ElementType, Other, O: ObserverType>
+class TakeUntilSinkOther<Other, O: ObserverType>
     : ObserverType
     , LockOwnerType
-    , SynchronizedOnType where O.E == ElementType {
-    typealias Parent = TakeUntilSink<ElementType, Other, O>
+    , SynchronizedOnType {
+    typealias Parent = TakeUntilSink<Other, O>
     typealias E = Other
     
     fileprivate let _parent: Parent
@@ -55,12 +55,12 @@ class TakeUntilSinkOther<ElementType, Other, O: ObserverType>
 #endif
 }
 
-class TakeUntilSink<ElementType, Other, O: ObserverType>
+class TakeUntilSink<Other, O: ObserverType>
     : Sink<O>
     , LockOwnerType
     , ObserverType
-    , SynchronizedOnType where O.E == ElementType {
-    typealias E = ElementType
+    , SynchronizedOnType {
+    typealias E = O.E
     typealias Parent = TakeUntil<E, Other>
     
     fileprivate let _parent: Parent

--- a/RxSwift/Observables/Implementations/TakeWhile.swift
+++ b/RxSwift/Observables/Implementations/TakeWhile.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-class TakeWhileSink<ElementType, O: ObserverType>
+class TakeWhileSink<O: ObserverType>
     : Sink<O>
-    , ObserverType where O.E == ElementType {
-    typealias Parent = TakeWhile<ElementType>
-    typealias Element = ElementType
+    , ObserverType {
+    typealias Element = O.E
+    typealias Parent = TakeWhile<Element>
 
     fileprivate let _parent: Parent
 
@@ -52,11 +52,11 @@ class TakeWhileSink<ElementType, O: ObserverType>
     
 }
 
-class TakeWhileSinkWithIndex<ElementType, O: ObserverType>
+class TakeWhileSinkWithIndex<O: ObserverType>
     : Sink<O>
-    , ObserverType where O.E == ElementType {
-    typealias Parent = TakeWhile<ElementType>
-    typealias Element = ElementType
+    , ObserverType {
+    typealias Element = O.E
+    typealias Parent = TakeWhile<Element>
     
     fileprivate let _parent: Parent
     

--- a/RxSwift/Observables/Implementations/Timeout.swift
+++ b/RxSwift/Observables/Implementations/Timeout.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-class TimeoutSink<ElementType, O: ObserverType>: Sink<O>, LockOwnerType, ObserverType where O.E == ElementType {
-    typealias E = ElementType
+class TimeoutSink<O: ObserverType>: Sink<O>, LockOwnerType, ObserverType {
+    typealias E = O.E
     typealias Parent = Timeout<E>
     
     private let _parent: Parent

--- a/RxSwift/Observables/Implementations/Using.swift
+++ b/RxSwift/Observables/Implementations/Using.swift
@@ -8,10 +8,9 @@
 
 import Foundation
 
-class UsingSink<SourceType, ResourceType: Disposable, O: ObserverType> : Sink<O>, ObserverType where O.E == SourceType {
-
+class UsingSink<ResourceType: Disposable, O: ObserverType> : Sink<O>, ObserverType {
+    typealias SourceType = O.E
     typealias Parent = Using<SourceType, ResourceType>
-    typealias E = O.E
 
     private let _parent: Parent
     
@@ -40,7 +39,7 @@ class UsingSink<SourceType, ResourceType: Disposable, O: ObserverType> : Sink<O>
         }
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<SourceType>) {
         switch event {
         case let .next(value):
             forwardOn(.next(value))

--- a/RxSwift/Observables/Implementations/WithLatestFrom.swift
+++ b/RxSwift/Observables/Implementations/WithLatestFrom.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-class WithLatestFromSink<FirstType, SecondType, ResultType, O: ObserverType>
+class WithLatestFromSink<FirstType, SecondType, O: ObserverType>
     : Sink<O>
     , ObserverType
     , LockOwnerType
-    , SynchronizedOnType where O.E == ResultType {
-
+    , SynchronizedOnType {
+    typealias ResultType = O.E
     typealias Parent = WithLatestFrom<FirstType, SecondType, ResultType>
     typealias E = FirstType
     
@@ -64,12 +64,13 @@ class WithLatestFromSink<FirstType, SecondType, ResultType, O: ObserverType>
     }
 }
 
-class WithLatestFromSecond<FirstType, SecondType, ResultType, O: ObserverType>
+class WithLatestFromSecond<FirstType, SecondType, O: ObserverType>
     : ObserverType
     , LockOwnerType
-    , SynchronizedOnType where O.E == ResultType {
+    , SynchronizedOnType {
     
-    typealias Parent = WithLatestFromSink<FirstType, SecondType, ResultType, O>
+    typealias ResultType = O.E
+    typealias Parent = WithLatestFromSink<FirstType, SecondType, O>
     typealias E = SecondType
     
     private let _parent: Parent

--- a/RxSwift/Observables/Implementations/Zip+Collection.swift
+++ b/RxSwift/Observables/Implementations/Zip+Collection.swift
@@ -8,8 +8,9 @@
 
 import Foundation
 
-class ZipCollectionTypeSink<C: Collection, R, O: ObserverType>
-    : Sink<O> where C.Iterator.Element : ObservableConvertibleType, O.E == R {
+class ZipCollectionTypeSink<C: Collection, O: ObserverType>
+    : Sink<O> where C.Iterator.Element : ObservableConvertibleType {
+    typealias R = O.E
     typealias Parent = ZipCollectionType<C, R>
     typealias SourceElement = C.Iterator.Element.E
     


### PR DESCRIPTION
I found 2-way declaration of generic type in implementations of `Sink`.
Case-A is
```swift
class XXXSink<Element, O: ObserverType> : Sink<O>, 
  ObserverType 
  where O.E == Element {
```
This implementation was used in `amb`,  `delay`, `sample`, and etc.

Case-B is
```swift
class XXXSink<O: ObserverType> : Sink<O>, 
  ObserverType {
  typealias Element = O.E
```
This implementation was used in `distinctUntilChanged`, `do`, `filter`, and etc.

I'm not sure why there are 2-way declaration of Generics type, but I think Case-B is better than Case-A there reasons. 
1. The generic parameters of Case-A are duplicated.
2. The generic parameter of Case-B gets more simply, and be more easy to understand.

I refactored implementation of Case-A as Case-B, and checked that passing tests.