### PR TITLE
Extend the UIScrollView reactive wrappers: `scrollViewDidEndScrollingAnimation(_:)`

### DIFF
--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -84,6 +84,12 @@ extension Reactive where Base: UIScrollView {
         let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidScrollToTop(_:))).map { _ in }
         return ControlEvent(events: source)
     }
+    
+    /// Reactive wrapper for delegate method `scrollViewDidEndScrollingAnimation`
+    public var didEndScrollingAnimation: ControlEvent<Void> {
+        let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidEndScrollingAnimation(_:))).map { _ in }
+        return ControlEvent(events: source)
+    }
 
     /// Installs delegate as forwarding delegate on `delegate`.
     /// Delegate won't be retained.

--- a/Tests/RxCocoaTests/UIScrollView+RxTests.swift
+++ b/Tests/RxCocoaTests/UIScrollView+RxTests.swift
@@ -172,13 +172,16 @@ extension UIScrollViewTests {
     }
 
     func testDidEndScrollingAnimation() {
-        // direct call `scrollViewDidEndScrollingAnimation`
+        var completed = false
+
         autoreleasepool {
             let scrollView = UIScrollView()
             var didEndScrollingAnimation = false
             
-            let subscription = scrollView.rx.didEndScrollingAnimation.subscribe(onNext: {
+            _ = scrollView.rx.didEndScrollingAnimation.subscribe(onNext: {
                 didEndScrollingAnimation = true
+            }, onCompleted: {
+                completed = true
             })
             
             XCTAssertFalse(didEndScrollingAnimation)
@@ -186,36 +189,9 @@ extension UIScrollViewTests {
             scrollView.delegate!.scrollViewDidEndScrollingAnimation!(scrollView)
             
             XCTAssertTrue(didEndScrollingAnimation)
-            subscription.dispose()
         }
         
-        // change contentOffset with animation
-        autoreleasepool {
-            let scrollView = UIScrollView(frame: CGRect(origin: .zero, size: CGSize(width: 10.0, height: 10.0)))
-            var didEndScrollingAnimation = false
-            
-            let subscription = scrollView.rx.didEndScrollingAnimation.subscribe(onNext: {
-                didEndScrollingAnimation = true
-            })
-            
-            XCTAssertFalse(didEndScrollingAnimation)
-            
-            scrollView.contentSize = CGSize(width: 10.0, height: 40.0)
-
-            // without animation
-            scrollView.setContentOffset(CGPoint(x: 0.0, y: 10.0), animated: false)
-            XCTAssertFalse(didEndScrollingAnimation)
-
-            // with animation but same position
-            scrollView.setContentOffset(CGPoint(x: 0.0, y: 10.0), animated: true)
-            XCTAssertFalse(didEndScrollingAnimation)
-            
-            // with animation
-            scrollView.setContentOffset(CGPoint(x: 0.0, y: 20.0), animated: true)
-            
-            XCTAssertTrue(didEndScrollingAnimation)
-            subscription.dispose()
-        }
+        XCTAssertTrue(completed)
     }
 }
 

--- a/Tests/RxCocoaTests/UIScrollView+RxTests.swift
+++ b/Tests/RxCocoaTests/UIScrollView+RxTests.swift
@@ -170,6 +170,53 @@ extension UIScrollViewTests {
         XCTAssertTrue(didScrollToTop)
         subscription.dispose()
     }
+
+    func testDidEndScrollingAnimation() {
+        // direct call `scrollViewDidEndScrollingAnimation`
+        autoreleasepool {
+            let scrollView = UIScrollView()
+            var didEndScrollingAnimation = false
+            
+            let subscription = scrollView.rx.didEndScrollingAnimation.subscribe(onNext: {
+                didEndScrollingAnimation = true
+            })
+            
+            XCTAssertFalse(didEndScrollingAnimation)
+            
+            scrollView.delegate!.scrollViewDidEndScrollingAnimation!(scrollView)
+            
+            XCTAssertTrue(didEndScrollingAnimation)
+            subscription.dispose()
+        }
+        
+        // change contentOffset with animation
+        autoreleasepool {
+            let scrollView = UIScrollView(frame: CGRect(origin: .zero, size: CGSize(width: 10.0, height: 10.0)))
+            var didEndScrollingAnimation = false
+            
+            let subscription = scrollView.rx.didEndScrollingAnimation.subscribe(onNext: {
+                didEndScrollingAnimation = true
+            })
+            
+            XCTAssertFalse(didEndScrollingAnimation)
+            
+            scrollView.contentSize = CGSize(width: 10.0, height: 40.0)
+
+            // without animation
+            scrollView.setContentOffset(CGPoint(x: 0.0, y: 10.0), animated: false)
+            XCTAssertFalse(didEndScrollingAnimation)
+
+            // with animation but same position
+            scrollView.setContentOffset(CGPoint(x: 0.0, y: 10.0), animated: true)
+            XCTAssertFalse(didEndScrollingAnimation)
+            
+            // with animation
+            scrollView.setContentOffset(CGPoint(x: 0.0, y: 20.0), animated: true)
+            
+            XCTAssertTrue(didEndScrollingAnimation)
+            subscription.dispose()
+        }
+    }
 }
 
 @objc class MockScrollViewDelegate


### PR DESCRIPTION
It extends the current implementation of the UIScrollView reactive wrapper adding the support for the delegate methods `scrollViewDidEndScrollingAnimation(_:)`

Related : #1030