### PR TITLE
Playground: fix wording

### DIFF
--- a/Rx.playground/Pages/Combining_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Combining_Operators.xcplaygroundpage/Contents.swift
@@ -110,7 +110,7 @@ example("combineLatest") {
     
     stringSubject.onNext("🆎")
 }
-//: There is also a `combineLatest` extension on `Array`:
+//: There is also a variant of `combineLatest` that takes an `Array` (or any other collection of `Observable` sequences):
 example("Array.combineLatest") {
     let disposeBag = DisposeBag()
     
@@ -125,7 +125,7 @@ example("Array.combineLatest") {
         .addDisposableTo(disposeBag)
 }
 /*:
- > The `combineLatest` extension on `Array` requires that all source `Observable` sequences are of the same type.
+ > Because the `combineLatest` variant that takes a collection passes an array of values to the selector function, it requires that all source `Observable` sequences are of the same type.
  ----
  ## `switchLatest`
  Transforms the elements emitted by an `Observable` sequence into `Observable` sequences, and emits elements from the most recent inner `Observable` sequence. [More info](http://reactivex.io/documentation/operators/switch.html)

--- a/Rx.playground/Pages/Creating_and_Subscribing_to_Observables.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Creating_and_Subscribing_to_Observables.xcplaygroundpage/Contents.swift
@@ -80,7 +80,7 @@ example("of") {
 ```
  ----
  ## from
- Creates an `Observable` sequence from a `SequenceType`, such as an `Array`, `Dictionary`, or `Set`.
+ Creates an `Observable` sequence from a `Sequence`, such as an `Array`, `Dictionary`, or `Set`.
  */
 example("from") {
     let disposeBag = DisposeBag()

--- a/Rx.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Introduction.xcplaygroundpage/Contents.swift
@@ -25,10 +25,10 @@ All of these various systems makes our code needlessly complex. Wouldn't it be b
  
  **Every `Observable` instance is just a sequence.**
  
- The key advantage for an `Observable` sequence vs. Swift's `SequenceType` is that it can also receive elements asynchronously. _This is the essence of RxSwift._ Everything else expands upon this concept.
+ The key advantage for an `Observable` sequence vs. Swift's `Sequence` is that it can also receive elements asynchronously. _This is the essence of RxSwift._ Everything else expands upon this concept.
 
- * An `Observable` (`ObservableType`) is equivalent to a `SequenceType`.
- * The `ObservableType.subscribe(_:)` method is equivalent to `SequenceType.generate()`.
+ * An `Observable` (`ObservableType`) is equivalent to a `Sequence`.
+ * The `ObservableType.subscribe(_:)` method is equivalent to `Sequence.makeIterator()`.
  * `ObservableType.subscribe(_:)` takes an observer (`ObserverType`) parameter, which will be subscribed to automatically receive sequence events and elements emitted by the `Observable`, instead of manually calling `next()` on the returned generator.
  */
 /*:


### PR DESCRIPTION
I noticed some inaccuracies in the example playground:

* Some terms from Swift 2 hadn't been updated to Swift 3 (`SequenceType`, `generate()`).
* The section on `combineLatest` spoke of a "`combineLatest` extension on `Array`", which confused me because it isn't actually an extension on `Array`; it works on arrays (and other collections).