### PR TITLE
[RxExamples] Clean up the Calculator example

### DIFF
--- a/RxExample/RxExample/Examples/Calculator/CalculatorState.swift
+++ b/RxExample/RxExample/Examples/Calculator/CalculatorState.swift
@@ -61,20 +61,23 @@ extension CalculatorState {
             
             switch action {
             case .operation(let op):
+                let result: String
                 switch op {
                 case .addition:
-                    let result = "\(previous + current)"
-                    return CalculatorState(previousNumber: result, action: .operation(o), currentNumber: nil, inScreen: result, replace: true)
+                    result = "\(previous + current)"
+                    
                 case .subtraction:
-                    let result = "\(previous - current)"
-                    return CalculatorState(previousNumber: result, action: .operation(o), currentNumber: nil, inScreen: result, replace: true)
+                    result = "\(previous - current)"
+                    
                 case .multiplication:
-                    let result = "\(previous * current)"
-                    return CalculatorState(previousNumber: result, action: .operation(o), currentNumber: nil, inScreen: result, replace: true)
+                    result = "\(previous * current)"
+                    
                 case .division:
-                    let result = "\(previous / current)"
-                    return CalculatorState(previousNumber: result, action: .operation(o), currentNumber: nil, inScreen: result, replace: true)
+                    result = "\(previous / current)"
                 }
+                
+                return CalculatorState(previousNumber: result, action: .operation(o), currentNumber: nil, inScreen: result, replace: true)
+                
             default:
                 return CalculatorState(previousNumber: nil, action: .operation(o), currentNumber: currentNumber, inScreen: inScreen, replace: true)
             }
@@ -84,26 +87,28 @@ extension CalculatorState {
     }
     
     func performEqual() -> CalculatorState {
-        let previous = Double(previousNumber ?? "0")
+        let previous = Double(previousNumber ?? "0")!
         let current = Double(inScreen)!
         
         switch action {
         case .operation(let op):
+            let result: Double
             switch op {
             case .addition:
-                let result = "\(previous! + current)"
-                return CalculatorState(previousNumber: nil, action: .clear, currentNumber: result, inScreen: result, replace: true)
+                result = previous + current
+                
             case .subtraction:
-                let result = "\(previous! - current)"
-                return CalculatorState(previousNumber: nil, action: .clear, currentNumber: result, inScreen: result, replace: true)
+                result = previous - current
+                
             case .multiplication:
-                let result = "\(previous! * current)"
-                return CalculatorState(previousNumber: nil, action: .clear, currentNumber: result, inScreen: result, replace: true)
+                result = previous * current
+                
             case .division:
-                let result = previous! / current
-                let resultText = result == Double.infinity ? "0" : "\(result)"
-                return CalculatorState(previousNumber: nil, action: .clear, currentNumber: resultText, inScreen: resultText, replace: true)
+                result = previous / current
             }
+            let resultText = (result == Double.infinity) ? "0" : "\(result)"
+            return CalculatorState(previousNumber: nil, action: .clear, currentNumber: resultText, inScreen: resultText, replace: true)
+            
         default:
             return CalculatorState(previousNumber: nil, action: .clear, currentNumber: currentNumber, inScreen: inScreen, replace: true)
         }

--- a/RxExample/RxExample/Examples/Calculator/CalculatorState.swift
+++ b/RxExample/RxExample/Examples/Calculator/CalculatorState.swift
@@ -54,62 +54,28 @@ extension CalculatorState {
         
         if previousNumber == nil {
             return CalculatorState(previousNumber: currentNumber, action: .operation(o), currentNumber: nil, inScreen: currentNumber, replace: true)
-        }
-        else {
+        } else {
             let previous = Double(previousNumber)!
             let current = Double(inScreen)!
             
-            switch action {
-            case .operation(let op):
-                let result: String
-                switch op {
-                case .addition:
-                    result = "\(previous + current)"
-                    
-                case .subtraction:
-                    result = "\(previous - current)"
-                    
-                case .multiplication:
-                    result = "\(previous * current)"
-                    
-                case .division:
-                    result = "\(previous / current)"
-                }
-                
+            if case let .operation(op) = action {
+                let result = "\(op.perform(previous, current))"
                 return CalculatorState(previousNumber: result, action: .operation(o), currentNumber: nil, inScreen: result, replace: true)
-                
-            default:
+            } else {
                 return CalculatorState(previousNumber: nil, action: .operation(o), currentNumber: currentNumber, inScreen: inScreen, replace: true)
             }
-            
         }
-        
     }
     
     func performEqual() -> CalculatorState {
         let previous = Double(previousNumber ?? "0")!
         let current = Double(inScreen)!
         
-        switch action {
-        case .operation(let op):
-            let result: Double
-            switch op {
-            case .addition:
-                result = previous + current
-                
-            case .subtraction:
-                result = previous - current
-                
-            case .multiplication:
-                result = previous * current
-                
-            case .division:
-                result = previous / current
-            }
+        if case let .operation(op) = action {
+            let result = op.perform(previous, current)
             let resultText = (result == Double.infinity) ? "0" : "\(result)"
             return CalculatorState(previousNumber: nil, action: .clear, currentNumber: resultText, inScreen: resultText, replace: true)
-            
-        default:
+        } else {
             return CalculatorState(previousNumber: nil, action: .clear, currentNumber: currentNumber, inScreen: inScreen, replace: true)
         }
     }

--- a/RxExample/RxExample/Examples/Calculator/CalculatorViewController.swift
+++ b/RxExample/RxExample/Examples/Calculator/CalculatorViewController.swift
@@ -75,7 +75,7 @@ class CalculatorViewController: ViewController {
             }
             .debug("calculator state")
             .subscribe(onNext: { [weak self] calState in
-                self?.resultLabel.text = calState.inScreen
+                self?.resultLabel.text = self?.formatResult(calState.inScreen)
                 
                 if case let .operation(operation) = calState.action {
                     self?.lastSignLabel.text = operation.sign
@@ -85,13 +85,12 @@ class CalculatorViewController: ViewController {
             })
             .addDisposableTo(disposeBag)
     }
-    
-//swifts string api sucks
 
-    func prettyFormat(str: String) -> String {
-        if str.hasSuffix(".0") {
-//            return str[str.startIndex..<str.endIndex.pre]
+    func formatResult(_ result: String) -> String {
+        if result.hasSuffix(".0") {
+            return result.substring(to: result.index(result.endIndex, offsetBy: -2))
+        } else {
+            return result
         }
-        return str
     }
 }

--- a/RxExample/RxExample/Examples/Calculator/CalculatorViewController.swift
+++ b/RxExample/RxExample/Examples/Calculator/CalculatorViewController.swift
@@ -12,7 +12,6 @@ import RxSwift
 import RxCocoa
 #endif
 
-
 class CalculatorViewController: ViewController {
 
     @IBOutlet weak var lastSignLabel: UILabel!
@@ -71,25 +70,16 @@ class CalculatorViewController: ViewController {
         
         Observable.from(commands)
             .merge()
-            .scan(CalculatorState.CLEAR_STATE) { a, x in
-                return a.tranformState(x)
+            .scan(CalculatorState.CLEAR_STATE) { previous, action in
+                previous.tranformState(action)
             }
-            .debug("debugging")
+            .debug("calculator state")
             .subscribe(onNext: { [weak self] calState in
                 self?.resultLabel.text = calState.inScreen
-                switch calState.action {
-                case .operation(let operation):
-                    switch operation {
-                    case .addition:
-                        self?.lastSignLabel.text = "+"
-                    case .subtraction:
-                        self?.lastSignLabel.text = "-"
-                    case .multiplication:
-                        self?.lastSignLabel.text = "x"
-                    case .division:
-                        self?.lastSignLabel.text = "/"
-                    }
-                default:
+                
+                if case let .operation(operation) = calState.action {
+                    self?.lastSignLabel.text = operation.sign
+                } else {
                     self?.lastSignLabel.text = ""
                 }
             })
@@ -105,8 +95,3 @@ class CalculatorViewController: ViewController {
         return str
     }
 }
-
-
-
-
-

--- a/RxExample/RxExample/Examples/Calculator/Operation.swift
+++ b/RxExample/RxExample/Examples/Calculator/Operation.swift
@@ -14,3 +14,14 @@ enum Operator {
     case multiplication
     case division
 }
+
+extension Operator {
+    var sign: String {
+        switch self {
+        case .addition:         return "+"
+        case .subtraction:      return "-"
+        case .multiplication:   return "×"
+        case .division:         return "/"
+        }
+    }
+}

--- a/RxExample/RxExample/Examples/Calculator/Operation.swift
+++ b/RxExample/RxExample/Examples/Calculator/Operation.swift
@@ -24,4 +24,13 @@ extension Operator {
         case .division:         return "/"
         }
     }
+    
+    var perform: (Double, Double) -> Double {
+        switch self {
+        case .addition:         return (+)
+        case .subtraction:      return (-)
+        case .multiplication:   return (*)
+        case .division:         return (/)
+        }
+    }
 }


### PR DESCRIPTION
I refactored the Calculator example to be a bit cleaner:

- removed repetitive code
- abstracted away unnecessary switches
- cleaned up Swift syntax

Hopefully I helps future generations a bit ;)