### PR TITLE
[RxExamples] Cleanup/fixes in WikipediaImageSearch

### DIFF
--- a/RxExample/RxExample/Examples/WikipediaImageSearch/ViewModels/SearchResultViewModel.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/ViewModels/SearchResultViewModel.swift
@@ -45,10 +45,10 @@ class SearchResultViewModel {
             .startWith(loadingValue)
             .map { URLs in
                 if let URLs = URLs {
-                    return "\(searchResult.title) (\(URLs.count)) pictures)"
+                    return "\(searchResult.title) (\(URLs.count) pictures)"
                 }
                 else {
-                    return "\(searchResult.title) loading ..."
+                    return "\(searchResult.title) (loading…)"
                 }
             }
             .retryOnBecomesReachable("⚠️ Service offline ⚠️", reachabilityService: $.reachabilityService)
@@ -65,5 +65,6 @@ class SearchResultViewModel {
                     return []
                 }
             }
+            .shareReplayLatestWhileConnected()
     }
 }

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaPage.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaPage.swift
@@ -15,11 +15,6 @@ struct WikipediaPage {
     let title: String
     let text: String
     
-    init(title: String, text: String) {
-        self.title = title
-        self.text = text
-    }
-    
     // tedious parsing part
     static func parseJSON(_ json: NSDictionary) throws -> WikipediaPage {
         guard

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaSearchResult.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaSearchResult.swift
@@ -16,28 +16,20 @@ struct WikipediaSearchResult: CustomDebugStringConvertible {
     let description: String
     let URL: Foundation.URL
 
-    init(title: String, description: String, URL: Foundation.URL) {
-        self.title = title
-        self.description = description
-        self.URL = URL
-    }
-
     // tedious parsing part
     static func parseJSON(_ json: [AnyObject]) throws -> [WikipediaSearchResult] {
-        let rootArrayTyped = json.map { $0 as? [AnyObject] }
-            .filter { $0 != nil }
-            .map { $0! }
-
-        if rootArrayTyped.count != 3 {
+        let rootArrayTyped: [[AnyObject]] = json.flatMap { $0 as? [AnyObject] }
+        
+        guard rootArrayTyped.count == 3 else {
             throw WikipediaParseError
         }
-
-        let titleAndDescription = Array(zip(rootArrayTyped[0], rootArrayTyped[1]))
-        let titleDescriptionAndUrl: [((AnyObject, AnyObject), AnyObject)] = Array(zip(titleAndDescription, rootArrayTyped[2]))
         
-        let searchResults: [WikipediaSearchResult] = try titleDescriptionAndUrl.map ( { result -> WikipediaSearchResult in
-            let (first, url) = result
-            let (title, description) = first
+        let (titles, descriptions, urls) = (rootArrayTyped[0], rootArrayTyped[1], rootArrayTyped[2])
+
+        let titleDescriptionAndUrl: [((AnyObject, AnyObject), AnyObject)] = Array(zip(zip(titles, descriptions), urls))
+        
+        return try titleDescriptionAndUrl.map { result -> WikipediaSearchResult in
+            let ((title, description), url) = result
 
             guard let titleString = title as? String,
                   let descriptionString = description as? String,
@@ -47,9 +39,7 @@ struct WikipediaSearchResult: CustomDebugStringConvertible {
             }
 
             return WikipediaSearchResult(title: titleString, description: descriptionString, URL: URL)
-        })
-
-        return searchResults
+        }
     }
 }
 


### PR DESCRIPTION
Fixed two subtle mistakes in the wikipedia image search example:

- article urls weren't shared, so the article was fetched and parsed twice (for the title and for image urls field)
- typo in the title

plus I tweaked Swift code here and there to be cleaner.