### PR TITLE
Add better API for Disposable when adding to DisposeBag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,13 +105,13 @@ let text: Observable<String> = Observable.just("")
 // Previously `map { $0 }` was needed because of mismatch betweeen sequence `String` type and `String?` type
 // on binding `rx.text` observer.
 text.bindTo(label.rx.text)  
-   .addDisposableTo(disposeBag)
+   .disposed(by: disposeBag)
 
 ...
 
 let text = Driver.just("")
 text.drive(label.rx.text)
-   .addDisposableTo(disposeBag)
+   .disposed(by: disposeBag)
 ```
 
 * Adds trim output parameter to `debug` operator. #930

--- a/Documentation/Examples.md
+++ b/Documentation/Examples.md
@@ -174,7 +174,7 @@ self.usernameOutlet.rx.text
 // pending async operations.
 // Instead of doing it manually, which is tedious,
 // let's dispose everything automagically upon view controller dealloc.
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 ```
 
 It doesn't get any simpler than that. There are [more examples](../RxExample) in the repository, so feel free to check them out.

--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -97,7 +97,7 @@ protocol ObserverType {
 
 **To cancel production of sequence elements and free resources immediately, call `dispose` on the returned subscription.**
 
-If a sequence terminates in finite time, not calling `dispose` or not using `addDisposableTo(disposeBag)` won't cause any permanent resource leaks. However, those resources will be used until the sequence completes, either by finishing production of elements or returning an error.
+If a sequence terminates in finite time, not calling `dispose` or not using `disposed(by: disposeBag)` won't cause any permanent resource leaks. However, those resources will be used until the sequence completes, either by finishing production of elements or returning an error.
 
 If a sequence does not terminate in some way, resources will be allocated permanently unless `dispose` is called manually, automatically inside of a `disposeBag`, `takeUntil` or in some other way.
 
@@ -670,7 +670,7 @@ This isn't something that should be practiced often, and is a bad code smell, bu
     .subscribe(onNext: { being in     // exit the Rx monad  
         self.doSomeStateMagic(being)
     })
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 
   //
   //  Mess
@@ -700,7 +700,7 @@ Every time you do this, somebody will probably write this code somewhere
     .subscribe(onNext: { kitten in
       // so something with kitten
     })
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 ```
 
 so please try not to do this.

--- a/Documentation/Migration.md
+++ b/Documentation/Migration.md
@@ -11,7 +11,7 @@ The migration should be pretty straightforward. Changes are mostly cosmetic, so 
 * Find replace all `empty` to `Observable.empty`
 * Since we've moved from `>-` to `.`, free functions are now methods, so use `.switchLatest()`, `.distinctUntilChanged()`, ... instead of `>- switchLatest`, `>- distinctUntilChanged`
 * We've moved from free functions to extensions so it's now `[a, b, c].concat()`, `.merge()`, ... instead of `concat([a, b, c])`, `merge(sequences)`
-* Similarly, it's now `subscribe { n in ... }.addDisposableTo(disposeBag)` instead of `>- disposeBag.addDisposable`
+* Similarly, it's now `subscribe { n in ... }.disposed(by: disposeBag)` instead of `>- disposeBag.addDisposable`
 * The method `next` on `Variable` is now `value` setter
 * If you want to use `UITableView` and/or  `UICollectionView`, this is the basic use case now:
 
@@ -20,7 +20,7 @@ viewModel.rows
     .bindTo(resultsTableView.rx_itemsWithCellIdentifier("WikipediaSearchCell", cellType: WikipediaSearchCell.self)) { (_, viewModel, cell) in
         cell.viewModel = viewModel
     }
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 ```
 
 If you have any doubts about how some concept in RxSwift 2.0 works, check out the [Example app](../RxExample) or playgrounds.

--- a/Documentation/Units.md
+++ b/Documentation/Units.md
@@ -173,13 +173,13 @@ let results = query.rx.text
 results
     .map { "\($0.count)" }
     .bindTo(resultCount.rx.text)
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 
 results
     .bindTo(resultsTableView.rx.items(cellIdentifier: "Cell")) { (_, result, cell) in
         cell.textLabel?.text = "\(result)"
     }
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 ```
 
 The intended behavior of this code was to:
@@ -208,13 +208,13 @@ let results = query.rx.text
 results
     .map { "\($0.count)" }
     .bindTo(resultCount.rx.text)
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 
 results
     .bindTo(resultsTableView.rx.items(cellIdentifier: "Cell")) { (_, result, cell) in
         cell.textLabel?.text = "\(result)"
     }
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 ```
 
 Making sure all of these requirements are properly handled in large systems can be challenging, but there is a simpler way of using the compiler and units to prove these requirements are met.
@@ -232,13 +232,13 @@ let results = query.rx.text.asDriver()        // This converts a normal sequence
 results
     .map { "\($0.count)" }
     .drive(resultCount.rx.text)               // If there is a `drive` method available instead of `bindTo`,
-    .addDisposableTo(disposeBag)              // that means that the compiler has proven that all properties
+    .disposed(by: disposeBag)              // that means that the compiler has proven that all properties
                                               // are satisfied.
 results
     .drive(resultsTableView.rx.items(cellIdentifier: "Cell")) { (_, result, cell) in
         cell.textLabel?.text = "\(result)"
     }
-    .addDisposableTo(disposeBag)
+    .disposed(by: disposeBag)
 ```
 
 So what is happening here?

--- a/Documentation/Warnings.md
+++ b/Documentation/Warnings.md
@@ -23,7 +23,7 @@ xs
 
 The `subscribe` function returns a subscription `Disposable` that can be used to cancel computation and free resources.  However, not using it (and thus not disposing it) will result in an error.
 
-The preferred way of terminating these fluent calls is by using a `DisposeBag`, either through chaining a call to `.addDisposableTo(disposeBag)` or by adding the disposable directly to the bag.
+The preferred way of terminating these fluent calls is by using a `DisposeBag`, either through chaining a call to `.disposed(by: disposeBag)` or by adding the disposable directly to the bag.
 
 ```Swift
 let xs: Observable<E> ....
@@ -38,7 +38,7 @@ xs
   }, onError: {
     ...
   })
-  .addDisposableTo(disposeBag) // <--- note `addDisposableTo`
+  .disposed(by: disposeBag) // <--- note `addDisposableTo`
 ```
 
 When `disposeBag` gets deallocated, the disposables contained within it will be automatically disposed as well.
@@ -118,5 +118,5 @@ xs
     // use the element
     print(nextElement)
   })
-  .addDisposableTo(disposeBag)
+  .disposed(by: disposeBag)
 ```

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ searchResults
         cell.textLabel?.text = repository.name
         cell.detailTextLabel?.text = repository.url
     }
-    .addDisposableTo(disposeBag)</pre></div></td>
+    .disposed(by: disposeBag)</pre></div></td>
   </tr>
 </table>
 

--- a/Rx.playground/Pages/Combining_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Combining_Operators.xcplaygroundpage/Contents.swift
@@ -23,7 +23,7 @@ example("startWith") {
         .startWith("2️⃣")
         .startWith("3️⃣", "🅰️", "🅱️")
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  > As this example demonstrates, `startWith` can be chained on a last-in-first-out basis, i.e., each successive `startWith`'s elements will be prepended before the prior `startWith`'s elements.
@@ -41,7 +41,7 @@ example("merge") {
     Observable.of(subject1, subject2)
         .merge()
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     subject1.onNext("🅰️")
     
@@ -71,7 +71,7 @@ example("zip") {
         "\(stringElement) \(intElement)"
         }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     stringSubject.onNext("🅰️")
     stringSubject.onNext("🅱️")
@@ -99,7 +99,7 @@ example("combineLatest") {
             "\(stringElement) \(intElement)"
         }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     stringSubject.onNext("🅰️")
     
@@ -122,7 +122,7 @@ example("Array.combineLatest") {
             "\($0[0]) \($0[1]) \($0[2])"
         }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  > Because the `combineLatest` variant that takes a collection passes an array of values to the selector function, it requires that all source `Observable` sequences are of the same type.
@@ -142,7 +142,7 @@ example("switchLatest") {
     variable.asObservable()
         .switchLatest()
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     subject1.onNext("🏈")
     subject1.onNext("🏀")

--- a/Rx.playground/Pages/Creating_and_Subscribing_to_Observables.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Creating_and_Subscribing_to_Observables.xcplaygroundpage/Contents.swift
@@ -23,7 +23,7 @@ example("never") {
             print("This will never be printed")
     }
     
-    neverSequenceSubscription.addDisposableTo(disposeBag)
+    neverSequenceSubscription.disposed(by: disposeBag)
 }
 /*:
  ----
@@ -37,7 +37,7 @@ example("empty") {
         .subscribe { event in
             print(event)
         }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  > This example also introduces chaining together creating and subscribing to an `Observable` sequence.
@@ -52,7 +52,7 @@ example("just") {
         .subscribe { event in
             print(event)
         }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -66,7 +66,7 @@ example("of") {
         .subscribe(onNext: { element in
             print(element)
         })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  > This example also introduces using the `subscribe(onNext:)` convenience method. Unlike `subscribe(_:)`, which subscribes an _event_ handler for all event types (Next, Error, and Completed), `subscribe(onNext:)` subscribes an _element_ handler that will ignore Error and Completed events and only produce Next event elements. There are also `subscribe(onError:)` and `subscribe(onCompleted:)` convenience methods, should you only want to subscribe to those event types. And there is a `subscribe(onNext:onError:onCompleted:onDisposed:)` method, which allows you to react to one or more event types and when the subscription is terminated for any reason, or disposed, in a single call:
@@ -87,7 +87,7 @@ example("from") {
     
     Observable.from(["🐶", "🐱", "🐭", "🐹"])
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  > This example also demonstrates using the default argument name `$0` instead of explicitly naming the argument.
@@ -108,7 +108,7 @@ example("create") {
         
     myJust("🔴")
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -120,7 +120,7 @@ example("range") {
     
     Observable.range(start: 1, count: 10)
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -133,7 +133,7 @@ example("repeatElement") {
     Observable.repeatElement("🔴")
         .take(3)
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  > This example also introduces using the `take` operator to return a specified number of elements from the start of a sequence.
@@ -150,7 +150,7 @@ example("generate") {
             iterate: { $0 + 1 }
         )
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -176,11 +176,11 @@ example("deferred") {
     
     deferredSequence
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     deferredSequence
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -192,7 +192,7 @@ example("error") {
         
     Observable<Int>.error(TestError.test)
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -205,7 +205,7 @@ example("doOn") {
     Observable.of("🍎", "🍐", "🍊", "🍋")
         .do(onNext: { print("Intercepted:", $0) }, onError: { print("Intercepted error:", $0) }, onCompleted: { print("Completed")  })
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 //: > There are also `doOnNext(_:)`, `doOnError(_:)`, and `doOnCompleted(_:)` convenience methods to intercept those specific events, and `doOn(onNext:onError:onCompleted:)` to intercept one or more events in a single call.
 

--- a/Rx.playground/Pages/Debugging_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Debugging_Operators.xcplaygroundpage/Contents.swift
@@ -41,7 +41,7 @@ example("debug") {
         .retry(3)
         .debug()
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----

--- a/Rx.playground/Pages/Error_Handling_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Error_Handling_Operators.xcplaygroundpage/Contents.swift
@@ -23,7 +23,7 @@ example("catchErrorJustReturn") {
     sequenceThatFails
         .catchErrorJustReturn("😊")
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     sequenceThatFails.onNext("😬")
     sequenceThatFails.onNext("😨")
@@ -49,7 +49,7 @@ example("catchError") {
             return recoverySequence
         }
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     sequenceThatFails.onNext("😬")
     sequenceThatFails.onNext("😨")
@@ -91,7 +91,7 @@ example("retry") {
     sequenceThatErrors
         .retry()
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -125,7 +125,7 @@ example("retry maxAttemptCount") {
     sequenceThatErrors
         .retry(3)
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 
 //: [Next](@next) - [Table of Contents](Table_of_Contents)

--- a/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage/Contents.swift
@@ -26,7 +26,7 @@ example("filter") {
             $0 == "🐱"
         }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -40,7 +40,7 @@ example("distinctUntilChanged") {
     Observable.of("🐱", "🐷", "🐱", "🐱", "🐱", "🐵", "🐱")
         .distinctUntilChanged()
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -54,7 +54,7 @@ example("elementAt") {
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
         .elementAt(3)
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -67,7 +67,7 @@ example("single") {
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
         .single()
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 
 example("single with conditions") {
@@ -76,17 +76,17 @@ example("single with conditions") {
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
         .single { $0 == "🐸" }
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     Observable.of("🐱", "🐰", "🐶", "🐱", "🐰", "🐶")
         .single { $0 == "🐰" }
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
         .single { $0 == "🔵" }
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -100,7 +100,7 @@ example("take") {
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
         .take(3)
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -114,7 +114,7 @@ example("takeLast") {
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
         .takeLast(3)
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -128,7 +128,7 @@ example("takeWhile") {
     Observable.of(1, 2, 3, 4, 5, 6)
         .takeWhile { $0 < 4 }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -145,7 +145,7 @@ example("takeUntil") {
     sourceSequence
         .takeUntil(referenceSequence)
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     sourceSequence.onNext("🐱")
     sourceSequence.onNext("🐰")
@@ -169,7 +169,7 @@ example("skip") {
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
         .skip(2)
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -183,7 +183,7 @@ example("skipWhile") {
     Observable.of(1, 2, 3, 4, 5, 6)
         .skipWhile { $0 < 4 }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -198,7 +198,7 @@ example("skipWhileWithIndex") {
             index < 3
         }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -215,7 +215,7 @@ example("skipUntil") {
     sourceSequence
         .skipUntil(referenceSequence)
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     sourceSequence.onNext("🐱")
     sourceSequence.onNext("🐰")

--- a/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
@@ -21,7 +21,7 @@ example("toArray") {
     Observable.range(start: 1, count: 10)
         .toArray()
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -35,7 +35,7 @@ example("reduce") {
     Observable.of(10, 100, 1000)
         .reduce(1, accumulator: +)
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -54,7 +54,7 @@ example("concat") {
     variable.asObservable()
         .concat()
         .subscribe { print($0) }
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     subject1.onNext("🍐")
     subject1.onNext("🍊")

--- a/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift
@@ -20,7 +20,7 @@ example("map") {
     Observable.of(1, 2, 3)
         .map { $0 * $0 }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 /*:
  ----
@@ -43,7 +43,7 @@ example("flatMap and flatMapLatest") {
     player.asObservable()
         .flatMap { $0.score.asObservable() } // Change flatMap to flatMapLatest and observe change in printed output
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
     
     👦🏻.score.value = 85
     
@@ -72,7 +72,7 @@ example("scan") {
             aggregateValue + newValue
         }
         .subscribe(onNext: { print($0) })
-        .addDisposableTo(disposeBag)
+        .disposed(by: disposeBag)
 }
 
 //: [Next](@next) - [Table of Contents](Table_of_Contents)

--- a/Rx.playground/Pages/Working_with_Subjects.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Working_with_Subjects.xcplaygroundpage/Contents.swift
@@ -38,11 +38,11 @@ example("PublishSubject") {
     let disposeBag = DisposeBag()
     let subject = PublishSubject<String>()
     
-    subject.addObserver("1").addDisposableTo(disposeBag)
+    subject.addObserver("1").disposed(by: disposeBag)
     subject.onNext("🐶")
     subject.onNext("🐱")
     
-    subject.addObserver("2").addDisposableTo(disposeBag)
+    subject.addObserver("2").disposed(by: disposeBag)
     subject.onNext("🅰️")
     subject.onNext("🅱️")
 }
@@ -57,11 +57,11 @@ example("ReplaySubject") {
     let disposeBag = DisposeBag()
     let subject = ReplaySubject<String>.create(bufferSize: 1)
     
-    subject.addObserver("1").addDisposableTo(disposeBag)
+    subject.addObserver("1").disposed(by: disposeBag)
     subject.onNext("🐶")
     subject.onNext("🐱")
     
-    subject.addObserver("2").addDisposableTo(disposeBag)
+    subject.addObserver("2").disposed(by: disposeBag)
     subject.onNext("🅰️")
     subject.onNext("🅱️")
 }
@@ -75,15 +75,15 @@ example("BehaviorSubject") {
     let disposeBag = DisposeBag()
     let subject = BehaviorSubject(value: "🔴")
     
-    subject.addObserver("1").addDisposableTo(disposeBag)
+    subject.addObserver("1").disposed(by: disposeBag)
     subject.onNext("🐶")
     subject.onNext("🐱")
     
-    subject.addObserver("2").addDisposableTo(disposeBag)
+    subject.addObserver("2").disposed(by: disposeBag)
     subject.onNext("🅰️")
     subject.onNext("🅱️")
     
-    subject.addObserver("3").addDisposableTo(disposeBag)
+    subject.addObserver("3").disposed(by: disposeBag)
     subject.onNext("🍐")
     subject.onNext("🍊")
 }
@@ -97,11 +97,11 @@ example("Variable") {
     let disposeBag = DisposeBag()
     let variable = Variable("🔴")
     
-    variable.asObservable().addObserver("1").addDisposableTo(disposeBag)
+    variable.asObservable().addObserver("1").disposed(by: disposeBag)
     variable.value = "🐶"
     variable.value = "🐱"
     
-    variable.asObservable().addObserver("2").addDisposableTo(disposeBag)
+    variable.asObservable().addObserver("2").disposed(by: disposeBag)
     variable.value = "🅰️"
     variable.value = "🅱️"
 }

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -40,7 +40,7 @@ extension Reactive where Base: UICollectionView {
              cell.value?.text = "\(element) @ \(row)"
              return cell
          }
-         .addDisposableTo(disposeBag)
+         .disposed(by: disposeBag)
     */
     public func items<S: Sequence, O: ObservableType>
         (_ source: O)
@@ -74,7 +74,7 @@ extension Reactive where Base: UICollectionView {
              .bindTo(collectionView.rx.items(cellIdentifier: "Cell", cellType: NumberCell.self)) { (row, element, cell) in
                 cell.value?.text = "\(element) @ \(row)"
              }
-             .addDisposableTo(disposeBag)
+             .disposed(by: disposeBag)
     */
     public func items<S: Sequence, Cell: UICollectionViewCell, O : ObservableType>
         (cellIdentifier: String, cellType: Cell.Type = Cell.self)
@@ -133,7 +133,7 @@ extension Reactive where Base: UICollectionView {
 
          items
             .bindTo(collectionView.rx.items(dataSource: dataSource))
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     */
     public func items<
             DataSource: RxCollectionViewDataSourceType & UICollectionViewDataSource,

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -39,7 +39,7 @@ extension Reactive where Base: UITableView {
              cell.textLabel?.text = "\(element) @ row \(row)"
              return cell
          }
-         .addDisposableTo(disposeBag)
+         .disposed(by: disposeBag)
 
      */
     public func items<S: Sequence, O: ObservableType>
@@ -74,7 +74,7 @@ extension Reactive where Base: UITableView {
              .bindTo(tableView.rx.items(cellIdentifier: "Cell", cellType: UITableViewCell.self)) { (row, element, cell) in
                 cell.textLabel?.text = "\(element) @ row \(row)"
              }
-             .addDisposableTo(disposeBag)
+             .disposed(by: disposeBag)
     */
     public func items<S: Sequence, Cell: UITableViewCell, O : ObservableType>
         (cellIdentifier: String, cellType: Cell.Type = Cell.self)
@@ -137,7 +137,7 @@ extension Reactive where Base: UITableView {
 
         items
             .bindTo(tableView.rx.items(dataSource: dataSource))
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     */
     public func items<
             DataSource: RxTableViewDataSourceType & UITableViewDataSource,

--- a/RxExample/RxDataSources/DataSources+Rx/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/RxExample/RxDataSources/DataSources+Rx/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -46,7 +46,7 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
             .subscribe(onNext: { [weak self] event in
                 self?.collectionView(event.0, throttledObservedEvent: event.1)
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     /**

--- a/RxExample/RxExample/Examples/APIWrappers/APIWrappersViewController.swift
+++ b/RxExample/RxExample/Examples/APIWrappers/APIWrappersViewController.swift
@@ -66,7 +66,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UIBarButtonItem Tapped")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // MARK: UISegmentedControl
 
@@ -78,7 +78,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UISegmentedControl value \(x)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
 
         // MARK: UISwitch
@@ -91,13 +91,13 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UISwitch value \(x)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // MARK: UIActivityIndicatorView
 
         switcher.rx.value
             .bindTo(activityIndicator.rx.isAnimating)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // MARK: UIButton
 
@@ -105,7 +105,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UIButton Tapped")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
 
         // MARK: UISlider
@@ -118,7 +118,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UISlider value \(x)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
 
         // MARK: UIDatePicker
@@ -132,7 +132,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UIDatePicker date \(x)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
 
         // MARK: UITextField
@@ -145,7 +145,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UITextField text \(x)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
 
         // MARK: UIGestureRecognizer
@@ -154,7 +154,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UIGestureRecognizer event \(x.state)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
 
         // MARK: UITextView
@@ -167,7 +167,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { [weak self] x in
                 self?.debug("UITextView text \(x)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // MARK: CLLocationManager
 
@@ -179,7 +179,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { x in
                 print("rx.didUpdateLocations \(x)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         _ = manager.rx.didFailWithError
             .subscribe(onNext: { x in
@@ -190,7 +190,7 @@ class APIWrappersViewController: ViewController {
             .subscribe(onNext: { status in
                 print("Authorization status \(status)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         manager.startUpdatingLocation()
 

--- a/RxExample/RxExample/Examples/Calculator/CalculatorViewController.swift
+++ b/RxExample/RxExample/Examples/Calculator/CalculatorViewController.swift
@@ -83,7 +83,7 @@ class CalculatorViewController: ViewController {
                     self?.lastSignLabel.text = ""
                 }
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     func formatResult(_ result: String) -> String {

--- a/RxExample/RxExample/Examples/GeolocationExample/GeolocationViewController.swift
+++ b/RxExample/RxExample/Examples/GeolocationExample/GeolocationViewController.swift
@@ -37,23 +37,23 @@ class GeolocationViewController: ViewController {
         
         geolocationService.authorized
             .drive(noGeolocationView.rx.isHidden)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         geolocationService.location
             .drive(label.rx.coordinates)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         button.rx.tap
             .bindNext { [weak self] in
                 self?.openAppPreferences()
             }
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         button2.rx.tap
             .bindNext { [weak self] in
                 self?.openAppPreferences()
             }
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
     
     private func openAppPreferences() {

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
@@ -64,19 +64,19 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
         searchResult
             .map { $0.serviceState }
             .drive(navigationController!.rx.serviceState)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         searchResult
             .map { [SectionModel(model: "Repositories", items: $0.repositories)] }
             .drive(tableView.rx.items(dataSource: dataSource))
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         searchResult
             .filter { $0.limitExceeded }
             .drive(onNext: { n in
                 showAlert("Exceeded limit of 10 non authenticated requests per minute for GitHub API. Please wait a minute. :(\nhttps://developer.github.com/v3/#rate-limiting") 
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // dismiss keyboard on scroll
         tableView.rx.contentOffset
@@ -85,17 +85,17 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
                     _ = self.searchBar.resignFirstResponder()
                 }
             }
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // so normal delegate customization can also be used
         tableView.rx.setDelegate(self)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // activity indicator in status bar
         // {
         GitHubSearchRepositoriesAPI.sharedAPI.activityIndicator
             .drive(UIApplication.shared.rx.isNetworkActivityIndicatorVisible)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         // }
     }
 

--- a/RxExample/RxExample/Examples/GitHubSignup/UsingDriver/GitHubSignupViewController2.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/UsingDriver/GitHubSignupViewController2.swift
@@ -49,29 +49,29 @@ class GitHubSignupViewController2 : ViewController {
                 self?.signupOutlet.isEnabled = valid
                 self?.signupOutlet.alpha = valid ? 1.0 : 0.5
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.validatedUsername
             .drive(usernameValidationOutlet.rx.validationResult)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.validatedPassword
             .drive(passwordValidationOutlet.rx.validationResult)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.validatedPasswordRepeated
             .drive(repeatedPasswordValidationOutlet.rx.validationResult)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.signingIn
             .drive(signingUpOulet.rx.isAnimating)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.signedIn
             .drive(onNext: { signedIn in
                 print("User signed in \(signedIn)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         //}
 
         let tapBackground = UITapGestureRecognizer()
@@ -79,7 +79,7 @@ class GitHubSignupViewController2 : ViewController {
             .subscribe(onNext: { [weak self] _ in
                 self?.view.endEditing(true)
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         view.addGestureRecognizer(tapBackground)
     }
    

--- a/RxExample/RxExample/Examples/GitHubSignup/UsingVanillaObservables/GitHubSignupViewController1.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/UsingVanillaObservables/GitHubSignupViewController1.swift
@@ -49,29 +49,29 @@ class GitHubSignupViewController1 : ViewController {
                 self?.signupOutlet.isEnabled = valid
                 self?.signupOutlet.alpha = valid ? 1.0 : 0.5
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.validatedUsername
             .bindTo(usernameValidationOutlet.rx.validationResult)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.validatedPassword
             .bindTo(passwordValidationOutlet.rx.validationResult)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.validatedPasswordRepeated
             .bindTo(repeatedPasswordValidationOutlet.rx.validationResult)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.signingIn
             .bindTo(signingUpOulet.rx.isAnimating)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         viewModel.signedIn
             .subscribe(onNext: { signedIn in
                 print("User signed in \(signedIn)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         //}
 
         let tapBackground = UITapGestureRecognizer()
@@ -79,7 +79,7 @@ class GitHubSignupViewController1 : ViewController {
             .subscribe(onNext: { [weak self] _ in
                 self?.view.endEditing(true)
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         view.addGestureRecognizer(tapBackground)
     }
    

--- a/RxExample/RxExample/Examples/ImagePicker/ImagePickerController.swift
+++ b/RxExample/RxExample/Examples/ImagePicker/ImagePickerController.swift
@@ -39,7 +39,7 @@ class ImagePickerController: ViewController {
                 return info[UIImagePickerControllerOriginalImage] as? UIImage
             }
             .bindTo(imageView.rx.image)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         galleryButton.rx.tap
             .flatMapLatest { [weak self] _ in
@@ -56,7 +56,7 @@ class ImagePickerController: ViewController {
                 return info[UIImagePickerControllerOriginalImage] as? UIImage
             }
             .bindTo(imageView.rx.image)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         cropButton.rx.tap
             .flatMapLatest { [weak self] _ in
@@ -71,7 +71,7 @@ class ImagePickerController: ViewController {
                 return info[UIImagePickerControllerEditedImage] as? UIImage
             }
             .bindTo(imageView.rx.image)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
     
 }

--- a/RxExample/RxExample/Examples/Numbers/NumbersViewController.swift
+++ b/RxExample/RxExample/Examples/Numbers/NumbersViewController.swift
@@ -28,6 +28,6 @@ class NumbersViewController: ViewController {
             }
             .map { $0.description }
             .bindTo(result.rx.text)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 }

--- a/RxExample/RxExample/Examples/SimpleTableViewExample/SimpleTableViewExampleViewController.swift
+++ b/RxExample/RxExample/Examples/SimpleTableViewExample/SimpleTableViewExampleViewController.swift
@@ -27,7 +27,7 @@ class SimpleTableViewExampleViewController : ViewController, UITableViewDelegate
             .bindTo(tableView.rx.items(cellIdentifier: "Cell", cellType: UITableViewCell.self)) { (row, element, cell) in
                 cell.textLabel?.text = "\(element) @ row \(row)"
             }
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
 
         tableView.rx
@@ -35,14 +35,14 @@ class SimpleTableViewExampleViewController : ViewController, UITableViewDelegate
             .subscribe(onNext:  { value in
                 DefaultWireframe.presentAlert("Tapped `\(value)`")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         tableView.rx
             .itemAccessoryButtonTapped
             .subscribe(onNext: { indexPath in
                 DefaultWireframe.presentAlert("Tapped Detail @ \(indexPath.section),\(indexPath.row)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
     }
 

--- a/RxExample/RxExample/Examples/SimpleTableViewExampleSectioned/SimpleTableViewExampleSectionedViewController.swift
+++ b/RxExample/RxExample/Examples/SimpleTableViewExampleSectioned/SimpleTableViewExampleSectionedViewController.swift
@@ -51,7 +51,7 @@ class SimpleTableViewExampleSectionedViewController
 
         items
             .bindTo(tableView.rx.items(dataSource: dataSource))
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         tableView.rx
             .itemSelected
@@ -61,11 +61,11 @@ class SimpleTableViewExampleSectionedViewController
             .subscribe(onNext: { indexPath, model in
                 DefaultWireframe.presentAlert("Tapped `\(model)` @ \(indexPath)")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         tableView.rx
             .setDelegate(self)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/RxExample/RxExample/Examples/SimpleValidation/SimpleValidationViewController.swift
+++ b/RxExample/RxExample/Examples/SimpleValidation/SimpleValidationViewController.swift
@@ -45,23 +45,23 @@ class SimpleValidationViewController : ViewController {
 
         usernameValid
             .bindTo(passwordOutlet.rx.isEnabled)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         usernameValid
             .bindTo(usernameValidOutlet.rx.isHidden)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         passwordValid
             .bindTo(passwordValidOutlet.rx.isHidden)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         everythingValid
             .bindTo(doSomethingOutlet.rx.isEnabled)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         doSomethingOutlet.rx.tap
             .subscribe(onNext: { [weak self] in self?.showAlert() })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     func showAlert() {

--- a/RxExample/RxExample/Examples/TableViewPartialUpdates/PartialUpdatesViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewPartialUpdates/PartialUpdatesViewController.swift
@@ -88,11 +88,11 @@ class PartialUpdatesViewController : ViewController {
 
         self.sections.asObservable()
             .bindTo(partialUpdatesTableViewOutlet.rx.items(dataSource: tvAnimatedDataSource))
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         self.sections.asObservable()
             .bindTo(reloadTableViewOutlet.rx.items(dataSource: reloadDataSource))
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // Collection view logic works, but when clicking fast because of internal bugs
         // collection view will sometimes get confused. I know what you are thinking,
@@ -112,13 +112,13 @@ class PartialUpdatesViewController : ViewController {
 
             updates
                 .bindTo(partialUpdatesCollectionViewOutlet.rx.itemsWithDataSource(cvAnimatedDataSource))
-                .addDisposableTo(disposeBag)
+                .disposed(by: disposeBag)
         #else
             let cvReloadDataSource = RxCollectionViewSectionedReloadDataSource<NumberSection>()
             skinCollectionViewDataSource(cvReloadDataSource)
             self.sections.asObservable()
                 .bindTo(partialUpdatesCollectionViewOutlet.rx.items(dataSource: cvReloadDataSource))
-                .addDisposableTo(disposeBag)
+                .disposed(by: disposeBag)
         #endif
 
         // touches
@@ -127,14 +127,14 @@ class PartialUpdatesViewController : ViewController {
             .subscribe(onNext: { [weak self] i in
                 print("Let me guess, it's .... It's \(self?.generator.sections[i.section].items[i.item]), isn't it? Yeah, I've got it.")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         Observable.of(partialUpdatesTableViewOutlet.rx.itemSelected, reloadTableViewOutlet.rx.itemSelected)
             .merge()
             .subscribe(onNext: { [weak self] i in
                 print("I have a feeling it's .... \(self?.generator.sections[i.section].items[i.item])?")
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     func skinTableViewDataSource(_ dataSource: TableViewSectionedDataSource<NumberSection>) {

--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/DetailViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/DetailViewController.swift
@@ -34,7 +34,7 @@ class DetailViewController: ViewController {
             }
             .observeOn($.mainScheduler)
             .subscribe(imageView.rx.image)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         label.text = user.firstName + " " + user.lastName
     }

--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/TableViewWithEditingCommandsViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/TableViewWithEditingCommandsViewController.swift
@@ -103,7 +103,7 @@ class TableViewWithEditingCommandsViewController: ViewController, UITableViewDel
                 ]
             }
             .bindTo(tableView.rx.items(dataSource: dataSource))
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         tableView.rx.itemSelected
             .withLatestFrom(viewModel) { i, viewModel in
@@ -113,12 +113,12 @@ class TableViewWithEditingCommandsViewController: ViewController, UITableViewDel
             .subscribe(onNext: { [weak self] user in
                 self?.showDetailsForUser(user)
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         // customization using delegate
         // RxTableViewDelegateBridge will forward correct messages
         tableView.rx.setDelegate(self)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     override func setEditing(_ editing: Bool, animated: Bool) {

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/CollectionViewImageCell.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/CollectionViewImageCell.swift
@@ -25,7 +25,7 @@ public class CollectionViewImageCell: UICollectionViewCell {
             self.downloadableImage?
                 .asDriver(onErrorJustReturn: DownloadableImage.offlinePlaceholder)
                 .drive(imageOutlet.rx.downloadableImageAnimated(kCATransitionFade))
-                .addDisposableTo(disposeBag)
+                .disposed(by: disposeBag)
 
             self.disposeBag = disposeBag
         }

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchCell.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchCell.swift
@@ -40,7 +40,7 @@ public class WikipediaSearchCell: UITableViewCell {
             viewModel.title
                 .map(Optional.init)
                 .drive(self.titleOutlet.rx.text)
-                .addDisposableTo(disposeBag)
+                .disposed(by: disposeBag)
 
             self.URLOutlet.text = viewModel.searchResult.URL.absoluteString
 
@@ -53,7 +53,7 @@ public class WikipediaSearchCell: UITableViewCell {
                         cell.installHackBecauseOfAutomationLeaksOnIOS10(firstViewThatDoesntLeak: self!.superview!.superview!)
                     #endif
                 }
-                .addDisposableTo(disposeBag)
+                .disposed(by: disposeBag)
 
             self.disposeBag = disposeBag
 
@@ -102,7 +102,7 @@ fileprivate extension ReusableView {
                 firstViewThatDoesntLeak.rx.deallocated.subscribe(onNext: { [weak self] _ in
                         self?.prepareForReuse()
                     })
-                    .addDisposableTo(self.disposeBag!)
+                    .disposed(by: self.disposeBag!)
             }
         }
     }

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
@@ -62,12 +62,12 @@ class WikipediaSearchViewController: ViewController {
             .drive(resultsTableView.rx.items(cellIdentifier: "WikipediaSearchCell", cellType: WikipediaSearchCell.self)) { (_, viewModel, cell) in
                 cell.viewModel = viewModel
             }
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         results
             .map { $0.count != 0 }
             .drive(self.emptyView.rx.isHidden)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     func configureKeyboardDismissesOnScroll() {
@@ -80,7 +80,7 @@ class WikipediaSearchViewController: ViewController {
                     _ = searchBar?.resignFirstResponder()
                 }
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     func configureNavigateOnRowClick() {
@@ -91,7 +91,7 @@ class WikipediaSearchViewController: ViewController {
             .drive(onNext: { searchResult in
                 wireframe.open(url:searchResult.searchResult.URL)
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 
     func configureActivityIndicatorsShow() {
@@ -101,6 +101,6 @@ class WikipediaSearchViewController: ViewController {
         ) { $0 || $1 }
             .distinctUntilChanged()
             .drive(UIApplication.shared.rx.isNetworkActivityIndicatorVisible)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 }

--- a/RxExample/RxExample/Examples/macOS simple example/IntroductionExampleViewController.swift
+++ b/RxExample/RxExample/Examples/macOS simple example/IntroductionExampleViewController.swift
@@ -41,7 +41,7 @@ class IntroductionExampleViewController : ViewController {
                 return "\(a + b)"
             }
             .bindTo(c.rx.text)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         // Also, tell it out loud
         let speech = NSSpeechSynthesizer()
@@ -62,14 +62,14 @@ class IntroductionExampleViewController : ViewController {
                 
                 speech.startSpeaking(result)
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         
         slider.rx.value
             .subscribe(onNext: { value in
                 self.sliderValue.stringValue = "\(Int(value))"
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         sliderValue.rx.text.orEmpty
             .subscribe(onNext: { value in
@@ -77,13 +77,13 @@ class IntroductionExampleViewController : ViewController {
                 self.slider.doubleValue = doubleValue
                 self.sliderValue.stringValue = "\(Int(doubleValue))"
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
         
         disposeButton.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 print("Unbind everything")
                 self?.disposeBag = DisposeBag()
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
 }

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -13,6 +13,7 @@ extension Disposable {
     ///
     /// - parameter bag: `DisposeBag` to add `self` to.
     /// Deprecated in favor of `disposed(by:)`
+    // @available(*, deprecated, message="use disposed(by:) instead")
     public func addDisposableTo(_ bag: DisposeBag) {
         disposed(by: bag)
     }

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -12,6 +12,7 @@ extension Disposable {
     /// Adds `self` to `bag`.
     ///
     /// - parameter bag: `DisposeBag` to add `self` to.
+    /// Deprecated in favor of `disposed(by:)`
     public func addDisposableTo(_ bag: DisposeBag) {
         disposed(by: bag)
     }

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -20,7 +20,7 @@ extension Disposable {
     ///
     /// - parameter bag: `DisposeBag` to add `self` to.
     public func disposed(by bag: DisposeBag) {
-        addDisposableTo(bag)
+        bag.insert(self)
     }
 }
 

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -13,7 +13,7 @@ extension Disposable {
     ///
     /// - parameter bag: `DisposeBag` to add `self` to.
     public func addDisposableTo(_ bag: DisposeBag) {
-        bag.insert(self)
+        disposed(by: bag)
     }
     
     /// Adds `self` to `bag`

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -15,6 +15,13 @@ extension Disposable {
     public func addDisposableTo(_ bag: DisposeBag) {
         bag.insert(self)
     }
+    
+    /// Adds `self` to `bag`
+    ///
+    /// - parameter bag: `DisposeBag` to add `self` to.
+    public func disposed(by bag: DisposeBag) {
+        addDisposableTo(bag)
+    }
 }
 
 /**

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -34,7 +34,7 @@ final class Parent : NSObject {
         
         self.rx.observe(String.self, "val", options: [.initial, .new], retainSelf: false)
             .subscribe(onNext: callback)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
     
     deinit {
@@ -49,7 +49,7 @@ final class Child : NSObject {
         super.init()
         parent.rx.observe(String.self, "val", options: [.initial, .new], retainSelf: false)
             .subscribe(onNext: callback)
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
     }
     
     deinit {

--- a/Tests/RxCocoaTests/RxTest+Controls.swift
+++ b/Tests/RxCocoaTests/RxTest+Controls.swift
@@ -104,7 +104,7 @@ extension RxTest {
             let propertyObserver = observerSelector(control)
             let observable = observableSelector()
 
-            observable.bindTo(propertyObserver).addDisposableTo(disposeBag)
+            observable.bindTo(propertyObserver).disposed(by: disposeBag)
 
             _ = (control as NSObject).rx.deallocated.subscribe(onNext: { _ in
                 deallocated = true

--- a/Tests/RxCocoaTests/SentMessageTest.swift
+++ b/Tests/RxCocoaTests/SentMessageTest.swift
@@ -652,7 +652,7 @@ extension SentMessageTest {
         target.rx.observe(NSArray.self, "messages")
             .subscribe(onNext: { _ in
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         do {
             _ = try target.rx.sentMessage(#selector(SentMessageTestBase_shared.justCalledBool(toSay:)))
@@ -679,7 +679,7 @@ extension SentMessageTest {
         target.rx.observe(NSArray.self, "messages")
             .subscribe(onNext: { _ in
             })
-            .addDisposableTo(disposeBag)
+            .disposed(by: disposeBag)
 
         do {
             _ = try target.rx.methodInvoked(#selector(SentMessageTestBase_shared.justCalledBool(toSay:)))
@@ -886,7 +886,7 @@ extension SentMessageTest {
                 stages.append(.sentMessage)
                 }, onCompleted: {
                     completed = true
-            }).addDisposableTo(disposeBag)
+            }).disposed(by: disposeBag)
 
             target.justCalledBool(toSay: true)
         }
@@ -920,7 +920,7 @@ extension SentMessageTest {
                 stages.append(.methodInvoked)
                 }, onCompleted: {
                     completed = true
-            }).addDisposableTo(disposeBag)
+            }).disposed(by: disposeBag)
 
             target.justCalledBool(toSay: true)
         }


### PR DESCRIPTION
## Added
I brought up in the Slack channel that the original Disposable API `.addDisposableTo(_ bag: DisposeBag)` felt out of line with the newly minted Swift API guidelines.

Because an `Observable` returns a `Disposable` after using the `subscribe` API, it makes no sense to treat the `Disposable` API like it's an `Observable`.

After some discussion in the channel, the group generally favored `disposed(by bag: DisposeBag)` to _eventually_ replace `addDisposableTo`, which is why we've created it as an extension for the time being. People will be able to slowly transition from the old API to the new without being under duress.

The new APIs implementation is merely a wrapper around the old. I wrote it this way because I felt keeping one implementation of it would be beneficial, at least until the old one gets deprecated (if it ever will).

### Old API
`.addToDisposeBag(disposeBag)`

### New APU
`.disposed(by: disposeBag)`