### PR TITLE
Fix documentation of UnitTests

### DIFF
--- a/Documentation/UnitTests.md
+++ b/Documentation/UnitTests.md
@@ -35,7 +35,7 @@ func testMap_Range() {
         // * Run the simulation and record all events
         //   using observer referenced by `res`.
         // * Subscribe at virtual time 200
-        // * Dispose subscription at virtual time 1000
+        // * Dispose subscription at virtual time 300
         let res = scheduler.start { xs.map { $0 * 2 } }
 
         let correctMessages = [


### PR DESCRIPTION
In the UnitTests documentation, the virtual time disposing subscription is 300 because the code below is written.

```
let correctSubscriptions = [
    Subscription(200, 300)
]
```

This correction has no effect to the production, so master branch is base.