### PR TITLE
[RxCocoa] Remove unnecessary variable assignment in response(request:) method in URLSession+Rx.swift

### DIFF
--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -158,9 +158,7 @@ extension Reactive where Base: URLSession {
                 observer.on(.completed)
             }
 
-
-            let t = task
-            t.resume()
+            task.resume()
 
             return Disposables.create(with: task.cancel)
         }


### PR DESCRIPTION
Hi RxSwift team!

It seems that `let t = task` variable assignment in `response(request:)` method in URLSession+Rx.swift is unnecessary, so I removed the line to make it clearer. I checked [the PR that added it][1], and I think it should be no problem to remove it. Please let me know if I am missing something with this variable assignment. I ran `./scripts/all-tests.sh` locally and it passed.

Can I please ask you to review this PR? Thank you!

[1]: https://github.com/ReactiveX/RxSwift/pull/66
