### PR TITLE
Add UIButton’s reactive wrapper for `setAttributedTitle(_:controlStat…

### DIFF
--- a/RxCocoa/iOS/UIButton+Rx.swift
+++ b/RxCocoa/iOS/UIButton+Rx.swift
@@ -59,3 +59,22 @@ extension Reactive where Base: UIButton {
     
 }
 #endif
+
+#if os(iOS) || os(tvOS)
+    
+#if !RX_NO_MODULE
+    import RxSwift
+#endif
+    import UIKit
+    
+    extension Reactive where Base: UIButton {
+        
+        /// Reactive wrapper for `setAttributedTitle(_:controlState:)`
+        public func attributedTitle(for controlState: UIControlState = []) -> UIBindingObserver<Base, NSAttributedString?> {
+            return UIBindingObserver<Base, NSAttributedString?>(UIElement: self.base) { (button, attributedTitle) -> () in
+                button.setAttributedTitle(attributedTitle, for: controlState)
+            }
+        }
+        
+    }
+#endif

--- a/Tests/RxCocoaTests/UIButton+RxTests.swift
+++ b/Tests/RxCocoaTests/UIButton+RxTests.swift
@@ -39,6 +39,30 @@ extension UIButtonTests {
         _ = Observable.just("normal").subscribe(button.rx.title())
         XCTAssertTrue(button.title(for: []) == "normal")
     }
+    
+    func testAttributedTitleNormal() {
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        
+        XCTAssertFalse(button.attributedTitle(for: []) == NSAttributedString(string: "normal"))
+        _ = Observable.just(NSAttributedString(string: "normal")).subscribe(button.rx.attributedTitle(for: []))
+        XCTAssertTrue(button.attributedTitle(for: []) == NSAttributedString(string: "normal"))
+    }
+    
+    func testAttributedTitleSelected() {
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        
+        XCTAssertFalse(button.attributedTitle(for: .selected) == NSAttributedString(string: "normal"))
+        _ = Observable.just(NSAttributedString(string: "normal")).subscribe(button.rx.attributedTitle(for: .selected))
+        XCTAssertTrue(button.attributedTitle(for: .selected) == NSAttributedString(string: "normal"))
+    }
+    
+    func testAttributedTitleDefault() {
+        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        
+        XCTAssertFalse(button.attributedTitle(for: []) == NSAttributedString(string: "normal"))
+        _ = Observable.just(NSAttributedString(string: "normal")).subscribe(button.rx.attributedTitle())
+        XCTAssertTrue(button.attributedTitle(for: []) == NSAttributedString(string: "normal"))
+    }
 }
 
 #if os(iOS)


### PR DESCRIPTION
…e:)`

I Added bindable `setAttributedTitle(_:controlState:)` property to UIButton.
And, I've also included a test.

```
Obserbavle.just(NSAttributedString(string: ""))
    .bindTo(UIButton().rx.attributedTitle(for: .default))
    .addDisposableTo(disposeBag)
```