### PR TITLE
Improves auto implementing observing mechanism for `DelegateProxy`. #1081 #1087

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 
 * Adds `AsyncSubject` implementation
 
+## Anomalies
+* #1081, #1087 - Improves DelegateProxy `responds(to:)` selector logic to only respond to used selectors.
+
 ## [3.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.2.0) (Xcode 8 / Swift 3.0 compatible)
 
 * Adds `groupBy` operator

--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -15,16 +15,16 @@
     #endif
 #endif
 
-var delegateAssociatedTag: UInt8 = 0
-var dataSourceAssociatedTag: UInt8 = 0
+var delegateAssociatedTag: UnsafeRawPointer = UnsafeRawPointer(UnsafeMutablePointer<UInt8>.allocate(capacity: 1))
+var dataSourceAssociatedTag: UnsafeRawPointer = UnsafeRawPointer(UnsafeMutablePointer<UInt8>.allocate(capacity: 1))
 
 /// Base class for `DelegateProxyType` protocol.
 ///
 /// This implementation is not thread safe and can be used only from one thread (Main thread).
 open class DelegateProxy : _RXDelegateProxy {
 
-    private var sentMessageForSelector = [Selector: PublishSubject<[Any]>]()
-    private var methodInvokedForSelector = [Selector: PublishSubject<[Any]>]()
+    private var sentMessageForSelector = [Selector: MessageDispatcher]()
+    private var methodInvokedForSelector = [Selector: MessageDispatcher]()
 
     /// Parent object associated with delegate proxy.
     weak private(set) var parentObject: AnyObject?
@@ -85,17 +85,18 @@ open class DelegateProxy : _RXDelegateProxy {
     - returns: Observable sequence of arguments passed to `selector` method.
     */
     open func sentMessage(_ selector: Selector) -> Observable<[Any]> {
+        MainScheduler.ensureExecutingOnScheduler()
         checkSelectorIsObservable(selector)
 
         let subject = sentMessageForSelector[selector]
         
         if let subject = subject {
-            return subject
+            return subject.asObservable()
         }
         else {
-            let subject = PublishSubject<[Any]>()
+            let subject = MessageDispatcher(delegateProxy: self)
             sentMessageForSelector[selector] = subject
-            return subject
+            return subject.asObservable()
         }
     }
 
@@ -142,17 +143,18 @@ open class DelegateProxy : _RXDelegateProxy {
     - returns: Observable sequence of arguments passed to `selector` method.
      */
     open func methodInvoked(_ selector: Selector) -> Observable<[Any]> {
+        MainScheduler.ensureExecutingOnScheduler()
         checkSelectorIsObservable(selector)
 
         let subject = methodInvokedForSelector[selector]
 
         if let subject = subject {
-            return subject
+            return subject.asObservable()
         }
         else {
-            let subject = PublishSubject<[Any]>()
+            let subject = MessageDispatcher(delegateProxy: self)
             methodInvokedForSelector[selector] = subject
-            return subject
+            return subject.asObservable()
         }
     }
 
@@ -161,15 +163,10 @@ open class DelegateProxy : _RXDelegateProxy {
 
         if hasWiredImplementation(for: selector) {
             print("Delegate proxy is already implementing `\(selector)`, a more performant way of registering might exist.")
+            return
         }
 
-        // It's important to see if super class reponds to selector and not self,
-        // because super class (_RxDelegateProxy) returns all methods delegate proxy
-        // can respond to.
-        // Because of https://github.com/ReactiveX/RxSwift/issues/907 , and possibly
-        // some other reasons, subclasses could overrride `responds(to:)`, but it shouldn't matter
-        // for this case.
-        if !super.responds(to: selector) {
+        guard (self.forwardToDelegate()?.responds(to: selector) ?? false) || voidDelegateMethodsContain(selector) else {
             rxFatalError("This class doesn't respond to selector \(selector)")
         }
     }
@@ -188,7 +185,7 @@ open class DelegateProxy : _RXDelegateProxy {
     ///
     /// - returns: Associated object tag.
     open class func delegateAssociatedObjectTag() -> UnsafeRawPointer {
-        return _pointer(&delegateAssociatedTag)
+        return delegateAssociatedTag
     }
     
     /// Initializes new instance of delegate proxy.
@@ -223,7 +220,11 @@ open class DelegateProxy : _RXDelegateProxy {
     /// - parameter forwardToDelegate: Reference of delegate that receives all messages through `self`.
     /// - parameter retainDelegate: Should `self` retain `forwardToDelegate`.
     open func setForwardToDelegate(_ delegate: AnyObject?, retainDelegate: Bool) {
+        #if DEBUG // 4.0 all configurations
+            MainScheduler.ensureExecutingOnScheduler()
+        #endif
         self._setForward(toDelegate: delegate, retainDelegate: retainDelegate)
+        self.reset()
     }
    
     /// Returns reference of normal delegate that receives all forwarded messages
@@ -233,7 +234,36 @@ open class DelegateProxy : _RXDelegateProxy {
     open func forwardToDelegate() -> AnyObject? {
         return self._forwardToDelegate
     }
+
+    private func hasObservers(selector: Selector) -> Bool {
+        return (sentMessageForSelector[selector]?.hasObservers ?? false)
+            || (methodInvokedForSelector[selector]?.hasObservers ?? false)
+    }
     
+    override open func responds(to aSelector: Selector!) -> Bool {
+        return super.responds(to: aSelector)
+            || (self._forwardToDelegate?.responds(to: aSelector) ?? false)
+            || (self.voidDelegateMethodsContain(aSelector) && self.hasObservers(selector: aSelector))
+    }
+
+    internal func reset() {
+        guard let delegateProxySelf = self as? DelegateProxyType else {
+            rxFatalErrorInDebug("\(self) doesn't implement delegate proxy type.")
+            return
+        }
+        
+        guard let parentObject = self.parentObject else { return }
+
+        let selfType = type(of: delegateProxySelf)
+
+        let maybeCurrentDelegate = selfType.currentDelegateFor(parentObject)
+
+        if maybeCurrentDelegate === self {
+            selfType.setCurrentDelegate(nil, toObject: parentObject)
+            selfType.setCurrentDelegate(self, toObject: parentObject)
+        }
+    }
+
     deinit {
         for v in sentMessageForSelector.values {
             v.on(.completed)
@@ -245,13 +275,37 @@ open class DelegateProxy : _RXDelegateProxy {
         _ = Resources.decrementTotal()
 #endif
     }
-
-    // MARK: Pointer
-
-    final class func _pointer(_ p: UnsafeRawPointer) -> UnsafeRawPointer {
-        return p
-    }
 }
 
-#endif
+fileprivate let mainScheduler = MainScheduler()
 
+fileprivate final class MessageDispatcher {
+    private let dispatcher: PublishSubject<[Any]>
+    private let result: Observable<[Any]>
+
+    init(delegateProxy _delegateProxy: DelegateProxy) {
+        weak var weakDelegateProxy = _delegateProxy
+
+        let dispatcher = PublishSubject<[Any]>()
+        self.dispatcher = dispatcher
+
+        self.result = dispatcher
+            .do(onSubscribed: { weakDelegateProxy?.reset() }, onDispose: { weakDelegateProxy?.reset() })
+            .share()
+            .subscribeOn(mainScheduler)
+    }
+
+    var on: (Event<[Any]>) -> () {
+        return self.dispatcher.on
+    }
+
+    var hasObservers: Bool {
+        return self.dispatcher.hasObservers
+    }
+
+    func asObservable() -> Observable<[Any]> {
+        return self.result
+    }
+}
+    
+#endif

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -176,7 +176,7 @@ extension DelegateProxyType {
             assert(Self.currentDelegateFor(object) === proxy)
             assert(proxy.forwardToDelegate() === currentDelegate)
         }
-        
+
         return proxy
     }
 
@@ -199,13 +199,6 @@ extension DelegateProxyType {
             "Hint: Maybe delegate was already set in xib or storyboard and now it's being overwritten in code.\n")
 
         proxy.setForwardToDelegate(forwardDelegate, retainDelegate: retainDelegate)
-        
-        // refresh properties after delegate is set
-        // some views like UITableView cache `respondsToSelector`
-        Self.setCurrentDelegate(nil, toObject: object)
-        Self.setCurrentDelegate(proxy, toObject: object)
-        
-        assert(proxy.forwardToDelegate() === forwardDelegate, "Setting of delegate failed:\ncurrent:\n\(String(describing: proxy.forwardToDelegate()))\nexpected:\n\(forwardDelegate)")
         
         return Disposables.create {
             MainScheduler.ensureExecutingOnScheduler()

--- a/RxCocoa/Runtime/_RXDelegateProxy.m
+++ b/RxCocoa/Runtime/_RXDelegateProxy.m
@@ -18,11 +18,11 @@
 
 @end
 
-static NSMutableDictionary *forwardableSelectorsPerClass = nil;
+static NSMutableDictionary *voidSelectorsPerClass = nil;
 
 @implementation _RXDelegateProxy
 
-+(NSSet*)collectSelectorsForProtocol:(Protocol *)protocol {
++(NSSet*)collectVoidSelectorsForProtocol:(Protocol *)protocol {
     NSMutableSet *selectors = [NSMutableSet set];
 
     unsigned int protocolMethodCount = 0;
@@ -41,7 +41,7 @@ static NSMutableDictionary *forwardableSelectorsPerClass = nil;
     Protocol * __unsafe_unretained * pSubprotocols = protocol_copyProtocolList(protocol, &numberOfBaseProtocols);
 
     for (unsigned int i = 0; i < numberOfBaseProtocols; ++i) {
-        [selectors unionSet:[self collectSelectorsForProtocol:pSubprotocols[i]]];
+        [selectors unionSet:[self collectVoidSelectorsForProtocol:pSubprotocols[i]]];
     }
     
     free(pSubprotocols);
@@ -51,11 +51,11 @@ static NSMutableDictionary *forwardableSelectorsPerClass = nil;
 
 +(void)initialize {
     @synchronized (_RXDelegateProxy.class) {
-        if (forwardableSelectorsPerClass == nil) {
-            forwardableSelectorsPerClass = [[NSMutableDictionary alloc] init];
+        if (voidSelectorsPerClass == nil) {
+            voidSelectorsPerClass = [[NSMutableDictionary alloc] init];
         }
 
-        NSMutableSet *allowedSelectors = [NSMutableSet set];
+        NSMutableSet *voidSelectors = [NSMutableSet set];
 
 #define CLASS_HIERARCHY_MAX_DEPTH 100
 
@@ -70,8 +70,8 @@ static NSMutableDictionary *forwardableSelectorsPerClass = nil;
             Protocol *__unsafe_unretained *pProtocols = class_copyProtocolList(targetClass, &count);
             
             for (unsigned int i = 0; i < count; i++) {
-                NSSet *selectorsForProtocol = [self collectSelectorsForProtocol:pProtocols[i]];
-                [allowedSelectors unionSet:selectorsForProtocol];
+                NSSet *selectorsForProtocol = [self collectVoidSelectorsForProtocol:pProtocols[i]];
+                [voidSelectors unionSet:selectorsForProtocol];
             }
             
             free(pProtocols);
@@ -84,7 +84,7 @@ static NSMutableDictionary *forwardableSelectorsPerClass = nil;
 #endif
         }
         
-        forwardableSelectorsPerClass[CLASS_VALUE(self)] = allowedSelectors;
+        voidSelectorsPerClass[CLASS_VALUE(self)] = voidSelectors;
     }
 }
 
@@ -106,18 +106,12 @@ static NSMutableDictionary *forwardableSelectorsPerClass = nil;
     return [super respondsToSelector:selector];
 }
 
--(BOOL)canRespondToSelector:(SEL)selector {
+-(BOOL)voidDelegateMethodsContain:(SEL)selector {
     @synchronized(_RXDelegateProxy.class) {
-        NSSet *allowedMethods = forwardableSelectorsPerClass[CLASS_VALUE(self.class)];
-        NSAssert(allowedMethods != nil, @"Set of allowed methods not initialized");
-        return [allowedMethods containsObject:SEL_VALUE(selector)];
+        NSSet *voidSelectors = voidSelectorsPerClass[CLASS_VALUE(self.class)];
+        NSAssert(voidSelectors != nil, @"Set of allowed methods not initialized");
+        return [voidSelectors containsObject:SEL_VALUE(selector)];
     }
-}
-
--(BOOL)respondsToSelector:(SEL)aSelector {
-    return [super respondsToSelector:aSelector]
-    || [self._forwardToDelegate respondsToSelector:aSelector]
-    || [self canRespondToSelector:aSelector];
 }
 
 -(void)forwardInvocation:(NSInvocation *)anInvocation {

--- a/RxCocoa/Runtime/include/_RXDelegateProxy.h
+++ b/RxCocoa/Runtime/include/_RXDelegateProxy.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void)_setForwardToDelegate:(id __nullable)forwardToDelegate retainDelegate:(BOOL)retainDelegate;
 
 -(BOOL)hasWiredImplementationForSelector:(SEL)selector;
+-(BOOL)voidDelegateMethodsContain:(SEL)selector;
 
 -(void)_sentMessage:(SEL)selector withArguments:(NSArray*)arguments;
 -(void)_methodInvoked:(SEL)selector withArguments:(NSArray*)arguments;

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
@@ -72,7 +72,7 @@ public class RxCollectionViewDataSourceProxy
 
     /// For more information take a look at `DelegateProxyType`.
     public override class func delegateAssociatedObjectTag() -> UnsafeRawPointer {
-        return _pointer(&dataSourceAssociatedTag)
+        return dataSourceAssociatedTag
     }
 
     /// For more information take a look at `DelegateProxyType`.
@@ -97,9 +97,11 @@ public class RxCollectionViewDataSourceProxy
 
     private func refreshCollectionViewDataSource() {
         if self.collectionView?.dataSource === self {
-            self.collectionView?.dataSource = nil
             if _requiredMethodsDataSource != nil && _requiredMethodsDataSource !== collectionViewDataSourceNotSet {
                 self.collectionView?.dataSource = self
+            }
+            else {
+                self.collectionView?.dataSource = nil
             }
         }
     }

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
@@ -37,45 +37,6 @@ public class RxTableViewDataSourceProxy
     /// Typed parent object.
     public weak fileprivate(set) var tableView: UITableView?
 
-    // issue https://github.com/ReactiveX/RxSwift/issues/907
-    private var _numberOfObservers = 0
-    private var _commitForRowAtSequenceSentMessage: CachedCommitForRowAt? = nil
-    private var _commitForRowAtSequenceMethodInvoked: CachedCommitForRowAt? = nil
-
-    fileprivate final class Counter {
-        var hasObservers: Bool = false
-    }
-    
-    fileprivate final class CachedCommitForRowAt {
-        let sequence: Observable<[Any]>
-        let counter: Counter
-
-        var hasObservers: Bool {
-            return counter.hasObservers
-        }
-
-        init(sequence: Observable<[Any]>, counter: Counter) {
-            self.sequence = sequence
-            self.counter = counter
-        }
-        
-        static func createFor(commitForRowAt: Observable<[Any]>, proxy: RxTableViewDataSourceProxy) -> CachedCommitForRowAt {
-            let counter = Counter()
-
-            let commitForRowAtSequence = commitForRowAt.do(onSubscribe: { [weak proxy] in
-                        counter.hasObservers = true
-                        proxy?.refreshTableViewDataSource()
-                    }, onDispose: { [weak proxy] in
-                        counter.hasObservers = false
-                        proxy?.refreshTableViewDataSource()
-                    })
-                .subscribeOn(MainScheduler())
-                .share()
-
-            return CachedCommitForRowAt(sequence: commitForRowAtSequence, counter: counter)
-        }
-    }
-
     fileprivate weak var _requiredMethodsDataSource: UITableViewDataSource? = tableViewDataSourceNotSet
 
     /// Initializes `RxTableViewDataSourceProxy`
@@ -108,7 +69,7 @@ public class RxTableViewDataSourceProxy
 
     /// For more information take a look at `DelegateProxyType`.
     public override class func delegateAssociatedObjectTag() -> UnsafeRawPointer {
-        return _pointer(&dataSourceAssociatedTag)
+        return dataSourceAssociatedTag
     }
 
     /// For more information take a look at `DelegateProxyType`.
@@ -131,68 +92,16 @@ public class RxTableViewDataSourceProxy
         refreshTableViewDataSource()
     }
 
-    override open func methodInvoked(_ selector: Selector) -> Observable<[Any]> {
-        MainScheduler.ensureExecutingOnScheduler()
-
-        // This is special behavior for commit:forRowAt:
-        // If proxy data source responds to this selector then table view will show
-        // swipe to delete option even when nobody is observing.
-        // https://github.com/ReactiveX/RxSwift/issues/907
-        if selector == #selector(UITableViewDataSource.tableView(_:commit:forRowAt:)) {
-            guard let commitForRowAtSequenceMethodInvoked = _commitForRowAtSequenceMethodInvoked else {
-                let commitForRowAtSequenceMethodInvoked = CachedCommitForRowAt.createFor(commitForRowAt: super.methodInvoked(selector), proxy: self)
-                _commitForRowAtSequenceMethodInvoked = commitForRowAtSequenceMethodInvoked
-                return commitForRowAtSequenceMethodInvoked.sequence
-            }
-
-            return commitForRowAtSequenceMethodInvoked.sequence
-        }
-
-        return super.methodInvoked(selector)
-    }
-
-    override open func sentMessage(_ selector: Selector) -> Observable<[Any]> {
-        MainScheduler.ensureExecutingOnScheduler()
-
-        // This is special behavior for commit:forRowAt:
-        // If proxy data source responds to this selector then table view will show
-        // swipe to delete option even when nobody is observing.
-        // https://github.com/ReactiveX/RxSwift/issues/907
-        if selector == #selector(UITableViewDataSource.tableView(_:commit:forRowAt:)) {
-            guard let commitForRowAtSequenceSentMessage = _commitForRowAtSequenceSentMessage else {
-                let commitForRowAtSequenceSentMessage = CachedCommitForRowAt.createFor(commitForRowAt: super.sentMessage(selector), proxy: self)
-                _commitForRowAtSequenceSentMessage = commitForRowAtSequenceSentMessage
-                return commitForRowAtSequenceSentMessage.sequence
-            }
-
-            return commitForRowAtSequenceSentMessage.sequence
-        }
-
-        return super.sentMessage(selector)
-    }
-
     // https://github.com/ReactiveX/RxSwift/issues/907
     private func refreshTableViewDataSource() {
         if self.tableView?.dataSource === self {
-            self.tableView?.dataSource = nil
             if _requiredMethodsDataSource != nil && _requiredMethodsDataSource !== tableViewDataSourceNotSet {
                 self.tableView?.dataSource = self
             }
+            else {
+                self.tableView?.dataSource = nil
+            }
         }
-    }
-
-    override open func responds(to aSelector: Selector!) -> Bool {
-        // https://github.com/ReactiveX/RxSwift/issues/907
-        let commitForRowAtSelector = #selector(UITableViewDataSource.tableView(_:commit:forRowAt:))
-        if aSelector == commitForRowAtSelector {
-            // without `as? UITableViewDataSource` `responds(to:)` fails, 🍻 compiler team
-            let forwardDelegateResponds = (self.forwardToDelegate() as? UITableViewDataSource)?.responds(to: commitForRowAtSelector)
-            return (_commitForRowAtSequenceSentMessage?.hasObservers ?? false)
-                || (_commitForRowAtSequenceMethodInvoked?.hasObservers ?? false)
-                || (forwardDelegateResponds ?? false)
-        }
-
-        return super.responds(to: aSelector)
     }
 }
 

--- a/Sources/RxCocoaRuntime/include/_RXDelegateProxy.h
+++ b/Sources/RxCocoaRuntime/include/_RXDelegateProxy.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void)_setForwardToDelegate:(id __nullable)forwardToDelegate retainDelegate:(BOOL)retainDelegate;
 
 -(BOOL)hasWiredImplementationForSelector:(SEL)selector;
+-(BOOL)voidDelegateMethodsContain:(SEL)selector;
 
 -(void)_sentMessage:(SEL)selector withArguments:(NSArray*)arguments;
 -(void)_methodInvoked:(SEL)selector withArguments:(NSArray*)arguments;

--- a/Tests/RxCocoaTests/DelegateProxyTest+Cocoa.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+Cocoa.swift
@@ -40,16 +40,8 @@ final class NSTextFieldSubclass
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {

--- a/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
@@ -140,18 +140,10 @@ final class UITableViewSubclass1
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
+    
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
         return RxScrollViewDelegateProxy.installForwardDelegate(testDelegate, retainDelegate: false, onProxyForObject: self)
     }
@@ -181,16 +173,8 @@ final class UITableViewSubclass2
         }
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.dataSource
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.dataSource
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.dataSource
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -220,16 +204,8 @@ final class UICollectionViewSubclass1
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -261,16 +237,8 @@ final class UICollectionViewSubclass2
         }
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.dataSource
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.dataSource
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.dataSource
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -300,16 +268,8 @@ final class UIScrollViewSubclass
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -341,16 +301,8 @@ final class UISearchBarSubclass
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
     
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -381,16 +333,8 @@ final class UITextViewSubclass
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -418,18 +362,9 @@ final class UISearchControllerSubclass
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
     
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
         return RxSearchControllerDelegateProxy.installForwardDelegate(testDelegate, retainDelegate: false, onProxyForObject: self)
@@ -457,18 +392,10 @@ final class UIPickerViewSubclass
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
     
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
 
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-    
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
         return RxPickerViewDelegateProxy.installForwardDelegate(testDelegate,
                                                                 retainDelegate: false,
@@ -494,15 +421,8 @@ final class UIWebViewSubclass: UIWebView, TestDelegateControl {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -538,16 +458,8 @@ final class NSTextStorageSubclass
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
 
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
 
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -590,16 +502,8 @@ final class UITabBarControllerSubclass
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
     
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
     
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
@@ -616,16 +520,8 @@ final class UITabBarSubclass: UITabBar, TestDelegateControl {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
     
-    var testSentMessage: Observable<Int> {
-        return rx.delegate
-            .sentMessage(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
-    }
-
-    var testMethodInvoked: Observable<Int> {
-        return rx.delegate
-            .methodInvoked(#selector(TestDelegateProtocol.testEventHappened(_:)))
-            .map { a in (a[0] as! NSNumber).intValue }
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
     }
     
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {


### PR DESCRIPTION
Hi @ishkawa, @djmadcat.

I've modified delegate proxy to make it more generic and only respond to those selectors that are being currently observed.

This feature is at the expense of more frequent delegate setting. I've also removed ugly specific hack for table view data source in favor of this PR.

It would be great if you could run this and see if it works for you. Give it a little smoke test.

I would like to release this potentially in a patch release so **I would appreciate if anyone who is relying on UI{Table,Collection}View extensions could also smoke test in their app and see does it cause any issues for them**.