### PR TITLE
Fixes retain cycle in GitHubSearchRepositoriesViewController

### DIFF
--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
@@ -42,10 +42,10 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
         }
 
 
+        let tableView: UITableView = self.tableView
         let loadNextPageTrigger = self.tableView.rx.contentOffset
-            .flatMap { [weak self] _ -> Observable<Void> in
-                guard let `self` = self else { return Observable.empty() }
-                return self.tableView.isNearBottomEdge(edgeOffset: 20.0)
+            .flatMap { _ in
+                return tableView.isNearBottomEdge(edgeOffset: 20.0)
                     ? Observable.just(())
                     : Observable.empty()
             }
@@ -79,12 +79,11 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
             })
             .disposed(by: disposeBag)
 
-        // dismiss keyboard on scroll
+        let searchBar: UISearchBar = self.searchBar
         tableView.rx.contentOffset
-            .subscribe { [weak self] _ in
-                guard let `self` = self else { return }
-                if self.searchBar.isFirstResponder {
-                    _ = self.searchBar.resignFirstResponder()
+            .subscribe { _ in
+                if searchBar.isFirstResponder {
+                    _ = searchBar.resignFirstResponder()
                 }
             }
             .disposed(by: disposeBag)

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
@@ -43,8 +43,9 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
 
 
         let loadNextPageTrigger = self.tableView.rx.contentOffset
-            .flatMap { _ in
-                self.tableView.isNearBottomEdge(edgeOffset: 20.0)
+            .flatMap { [weak self] _ -> Observable<Void> in
+                guard let `self` = self else { return Observable.empty() }
+                return self.tableView.isNearBottomEdge(edgeOffset: 20.0)
                     ? Observable.just(())
                     : Observable.empty()
             }
@@ -80,7 +81,8 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
 
         // dismiss keyboard on scroll
         tableView.rx.contentOffset
-            .subscribe { _ in
+            .subscribe { [weak self] _ in
+                guard let `self` = self else { return }
                 if self.searchBar.isFirstResponder {
                     _ = self.searchBar.resignFirstResponder()
                 }


### PR DESCRIPTION
I've found the retain cycle issue inside `GitHubSearchRepositoriesViewController.swift`.
The fix is pretty simple, I've just added missing `[weak self]` in 2 places inside the viewController

- [x] `./scripts/all-tests.sh` passes 👌

### Before:
<img width="1023" alt="zrzut ekranu 2017-02-13 07 16 23" src="https://cloud.githubusercontent.com/assets/3684577/22873640/a129a77e-f1c1-11e6-82ae-a29e957a188c.png">

### After:
<img width="1027" alt="zrzut ekranu 2017-02-13 07 51 00" src="https://cloud.githubusercontent.com/assets/3684577/22873645/a88a09aa-f1c1-11e6-9bc8-ecf3aa3f0e08.png">
