### PR TITLE
Add countDownDuration for UIDatePicker

### DIFF
--- a/RxCocoa/iOS/UIDatePicker+Rx.swift
+++ b/RxCocoa/iOS/UIDatePicker+Rx.swift
@@ -18,7 +18,7 @@ extension Reactive where Base: UIDatePicker {
     public var date: ControlProperty<Date> {
         return value
     }
-    
+
     /// Reactive wrapper for `date` property.
     public var value: ControlProperty<Date> {
         return UIControl.rx.value(
@@ -30,7 +30,18 @@ extension Reactive where Base: UIDatePicker {
             }
         )
     }
-    
+
+    /// Reactive wrapper for `countDownDuration` property.
+    public var countDownDuration: ControlProperty<TimeInterval> {
+        return UIControl.rx.value(
+            self.base,
+            getter: { datePicker in
+                datePicker.countDownDuration
+            }, setter: { datePicker, value in
+                datePicker.countDownDuration = value
+            }
+        )
+    }
 }
 
 #endif


### PR DESCRIPTION
Hello. My first contribution here, I am just starting to play around with RxSwift. 

I noticed that the current `value` implementation does not make sense when UIDatePicker is in `.countDownTimer` mode. This PR adds another observable property that can be used for countDownDuration handling. I tested fork with my project and works fine.
