### PR TITLE
Add AnyVariable (get-only Variable)

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -168,6 +168,7 @@ custom_categories:
   - ScheduledItemType
 - name: RxSwift/Subjects
   children:
+  - AnyVariable
   - AsyncSubject
   - BehaviorSubject
   - PublishSubject

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -21,6 +21,13 @@
 		1AF67DA61CED430100C310FA /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
 		1AF67DA71CED430100C310FA /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
 		1AF67DA81CED430100C310FA /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
+		1FC9E3EA1E64EE92006B00D7 /* AnyVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC9E3E91E64EE92006B00D7 /* AnyVariable.swift */; };
+		1FC9E3EB1E64EF08006B00D7 /* AnyVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC9E3E91E64EE92006B00D7 /* AnyVariable.swift */; };
+		1FC9E3EC1E64EF09006B00D7 /* AnyVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC9E3E91E64EE92006B00D7 /* AnyVariable.swift */; };
+		1FC9E3ED1E64EF09006B00D7 /* AnyVariable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC9E3E91E64EE92006B00D7 /* AnyVariable.swift */; };
+		1FC9E3EF1E64EF57006B00D7 /* AnyVariableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC9E3EE1E64EF57006B00D7 /* AnyVariableTest.swift */; };
+		1FC9E3F01E64EF57006B00D7 /* AnyVariableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC9E3EE1E64EF57006B00D7 /* AnyVariableTest.swift */; };
+		1FC9E3F11E64EF57006B00D7 /* AnyVariableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FC9E3EE1E64EF57006B00D7 /* AnyVariableTest.swift */; };
 		252FC1CF1E0D250500D28877 /* DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FC1CE1E0D250500D28877 /* DefaultIfEmpty.swift */; };
 		252FC1D01E0D250500D28877 /* DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FC1CE1E0D250500D28877 /* DefaultIfEmpty.swift */; };
 		252FC1D11E0D250500D28877 /* DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 252FC1CE1E0D250500D28877 /* DefaultIfEmpty.swift */; };
@@ -1540,6 +1547,8 @@
 		0BA9496B1E224B9C0036DD06 /* AsyncSubjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncSubjectTests.swift; sourceTree = "<group>"; };
 		1AF67DA11CED420A00C310FA /* PublishSubjectTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublishSubjectTest.swift; sourceTree = "<group>"; };
 		1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplaySubjectTest.swift; sourceTree = "<group>"; };
+		1FC9E3E91E64EE92006B00D7 /* AnyVariable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyVariable.swift; sourceTree = "<group>"; };
+		1FC9E3EE1E64EF57006B00D7 /* AnyVariableTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyVariableTest.swift; sourceTree = "<group>"; };
 		252FC1CE1E0D250500D28877 /* DefaultIfEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultIfEmpty.swift; sourceTree = "<group>"; };
 		252FC1DE1E0DC64C00D28877 /* SwitchIfEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchIfEmpty.swift; sourceTree = "<group>"; };
 		271A97401CFC996B00D64125 /* UIViewController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
@@ -2326,6 +2335,7 @@
 				C8093CC01B8A72BE0088E94D /* ReplaySubject.swift */,
 				C8093CC11B8A72BE0088E94D /* SubjectType.swift */,
 				C8093CC21B8A72BE0088E94D /* Variable.swift */,
+				1FC9E3E91E64EE92006B00D7 /* AnyVariable.swift */,
 			);
 			path = Subjects;
 			sourceTree = "<group>";
@@ -2518,6 +2528,7 @@
 				1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */,
 				C835091A1C38706D0027C24C /* SubjectConcurrencyTest.swift */,
 				C835091B1C38706D0027C24C /* VariableTest.swift */,
+				1FC9E3EE1E64EF57006B00D7 /* AnyVariableTest.swift */,
 				C835091C1C38706D0027C24C /* VirtualSchedulerTest.swift */,
 				C86B1E211D42BF5200130546 /* SchedulerTests.swift */,
 				C822BAC51DB4048F00F98810 /* Event+Test.swift */,
@@ -3990,6 +4001,7 @@
 				C835092D1C38706E0027C24C /* Control+RxTests.swift in Sources */,
 				C83509601C38706E0027C24C /* Observable+TimeTest.swift in Sources */,
 				C834F6C21DB394E100C29244 /* Observable+BlockingTest.swift in Sources */,
+				1FC9E3EF1E64EF57006B00D7 /* AnyVariableTest.swift in Sources */,
 				C8BAA78D1E34F8D400EEC727 /* RecursiveLockTest.swift in Sources */,
 				C835093F1C38706E0027C24C /* ElementIndexPair.swift in Sources */,
 				C83509381C38706E0027C24C /* NSObject+RxTests.swift in Sources */,
@@ -4140,6 +4152,7 @@
 				C86B1E231D42BF5200130546 /* SchedulerTests.swift in Sources */,
 				C860EC961C42E26100A664B3 /* SectionedViewDataSourceMock.swift in Sources */,
 				C8350A0F1C3875630027C24C /* Observable+MultipleTest+Zip.swift in Sources */,
+				1FC9E3F01E64EF57006B00D7 /* AnyVariableTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4168,6 +4181,7 @@
 				C8BAA78F1E34F8D400EEC727 /* RecursiveLockTest.swift in Sources */,
 				C8350A0B1C38755E0027C24C /* Observable+ConcurrencyTest.swift in Sources */,
 				C822BAD01DB424EC00F98810 /* Reactive+Tests.swift in Sources */,
+				1FC9E3F11E64EF57006B00D7 /* AnyVariableTest.swift in Sources */,
 				C83509E21C3875580027C24C /* BackgroundThreadPrimitiveHotObservable.swift in Sources */,
 				C8350A0E1C3875630027C24C /* Observable+MultipleTest+Zip.swift in Sources */,
 				C83509CF1C3875260027C24C /* NSView+RxTests.swift in Sources */,
@@ -4326,6 +4340,7 @@
 				C8093DA61B8A72BE0088E94D /* SubjectType.swift in Sources */,
 				C8093D5C1B8A72BE0088E94D /* Observable+Debug.swift in Sources */,
 				C8093D581B8A72BE0088E94D /* Observable+Concurrency.swift in Sources */,
+				1FC9E3EB1E64EF08006B00D7 /* AnyVariable.swift in Sources */,
 				C8093D6C1B8A72BE0088E94D /* AnonymousObserver.swift in Sources */,
 				C8093DA21B8A72BE0088E94D /* PublishSubject.swift in Sources */,
 				C83D73C91C1DBAEE003DC470 /* ScheduledItemType.swift in Sources */,
@@ -4563,6 +4578,7 @@
 				C8093D5B1B8A72BE0088E94D /* Observable+Debug.swift in Sources */,
 				C8093D571B8A72BE0088E94D /* Observable+Concurrency.swift in Sources */,
 				C8093D6B1B8A72BE0088E94D /* AnonymousObserver.swift in Sources */,
+				1FC9E3EA1E64EE92006B00D7 /* AnyVariable.swift in Sources */,
 				C8093DA11B8A72BE0088E94D /* PublishSubject.swift in Sources */,
 				C83D73C81C1DBAEE003DC470 /* ScheduledItemType.swift in Sources */,
 				C8093D231B8A72BE0088E94D /* Merge.swift in Sources */,
@@ -4728,6 +4744,7 @@
 				C8F0BFBE1BBBFB8B001B112F /* SubjectType.swift in Sources */,
 				C8F0BFBF1BBBFB8B001B112F /* Observable+Debug.swift in Sources */,
 				C8F0BFC01BBBFB8B001B112F /* Observable+Concurrency.swift in Sources */,
+				1FC9E3ED1E64EF09006B00D7 /* AnyVariable.swift in Sources */,
 				C8F0BFC11BBBFB8B001B112F /* AnonymousObserver.swift in Sources */,
 				C8F0BFC21BBBFB8B001B112F /* PublishSubject.swift in Sources */,
 				C83D73CB1C1DBAEE003DC470 /* ScheduledItemType.swift in Sources */,
@@ -5078,6 +5095,7 @@
 				D2EBEB081BB9B6C1003A27DC /* DelaySubscription.swift in Sources */,
 				D2EBEADE1BB9B697003A27DC /* Disposable.swift in Sources */,
 				D2EBEB2F1BB9B6CA003A27DC /* Observable+Debug.swift in Sources */,
+				1FC9E3EC1E64EF09006B00D7 /* AnyVariable.swift in Sources */,
 				D2EBEAE61BB9B697003A27DC /* ObserverType.swift in Sources */,
 				C83D73CA1C1DBAEE003DC470 /* ScheduledItemType.swift in Sources */,
 				D2EBEB011BB9B6BA003A27DC /* CombineLatest.swift in Sources */,

--- a/RxSwift/Subjects/AnyVariable.swift
+++ b/RxSwift/Subjects/AnyVariable.swift
@@ -1,0 +1,42 @@
+//
+//  AnyVariable.swift
+//  RxSwift
+//
+//  Created by Yasuhiro Inami on 2/28/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+/// A get-only `Variable`.
+public final class AnyVariable<Element>: ObservableConvertibleType {
+
+    public typealias E = Element
+
+    let _variable: Variable<E>
+
+    /// Gets current value of variable.
+    public var value: E {
+        get {
+            return _variable.value
+        }
+    }
+
+    /// Initializes variable with initial value.
+    ///
+    /// - parameter value: Initial variable value.
+    public init(_ value: E) {
+        _variable = Variable(value)
+    }
+
+    /// Initializes variable with `Variable`.
+    ///
+    /// - parameter value: Initial `Variable`.
+    public init(_ variable: Variable<E>) {
+        _variable = variable
+    }
+
+    /// - returns: Canonical interface for push style sequence
+    public func asObservable() -> Observable<E> {
+        return _variable.asObservable()
+    }
+
+}

--- a/RxSwift/Subjects/Variable.swift
+++ b/RxSwift/Subjects/Variable.swift
@@ -10,7 +10,7 @@
 ///
 /// Unlike `BehaviorSubject` it can't terminate with error, and when variable is deallocated
 /// it will complete it's observable sequence (`asObservable`).
-public final class Variable<Element> {
+public final class Variable<Element>: ObservableConvertibleType {
 
     public typealias E = Element
     

--- a/Sources/AllTestz/AnyVariableTest.swift
+++ b/Sources/AllTestz/AnyVariableTest.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/AnyVariableTest.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -988,6 +988,20 @@ final class ObservableMultipleTest_ : ObservableMultipleTest, RxTestCase {
     ] }
 }
 
+final class AnyVariableTest_ : AnyVariableTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (AnyVariableTest_) -> () -> ())] { return [
+    ("testAnyVariable_initialValues", AnyVariableTest.testAnyVariable_initialValues),
+    ("testAnyVariable_sendsCompletedOnDealloc", AnyVariableTest.testAnyVariable_sendsCompletedOnDealloc),
+    ("testAnyVariable_READMEExample", AnyVariableTest.testAnyVariable_READMEExample),
+    ] }
+}
+
 final class ObservableCreationTests_ : ObservableCreationTests, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1213,6 +1227,7 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(QueueTest_.allTests),
         testCase(ConcurrentDispatchQueueSchedulerTests_.allTests),
         testCase(ObservableMultipleTest_.allTests),
+        testCase(AnyVariableTest_.allTests),
         testCase(ObservableCreationTests_.allTests),
         testCase(BehaviorSubjectTest_.allTests),
         testCase(ObservableDebugTest_.allTests),

--- a/Sources/RxSwift/AnyVariable.swift
+++ b/Sources/RxSwift/AnyVariable.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Subjects/AnyVariable.swift

--- a/Tests/RxSwiftTests/AnyVariableTest.swift
+++ b/Tests/RxSwiftTests/AnyVariableTest.swift
@@ -1,0 +1,83 @@
+//
+//  AnyVariableTest.swift
+//  Tests
+//
+//  Created by Yasuhiro Inami on 2/28/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+
+class AnyVariableTest : RxTest {
+    func testAnyVariable_initialValues() {
+        let a = AnyVariable(1)
+        let b = AnyVariable(2)
+
+        let c = Observable.combineLatest(a.asObservable(), b.asObservable(), resultSelector: +)
+
+        var latestValue: Int?
+
+        _ = c.subscribe(onNext: { next in
+            latestValue = next
+        })
+
+        XCTAssertEqual(latestValue!, 3)
+    }
+
+    func testAnyVariable_sendsCompletedOnDealloc() {
+        var a = AnyVariable(1)
+
+        var latest = 0
+        var completed = false
+        _ = a.asObservable().subscribe(onNext: { n in
+            latest = n
+        }, onCompleted: {
+            completed = true
+        })
+
+        XCTAssertEqual(latest, 1)
+        XCTAssertFalse(completed)
+
+        a = AnyVariable(2)
+
+        XCTAssertEqual(latest, 1)
+        XCTAssertTrue(completed)
+    }
+
+    func testAnyVariable_READMEExample() {
+
+        // Two simple Rx variables
+        // Every variable is actually a sequence future values in disguise.
+        let a /*: Observable<Int>*/ = AnyVariable(1)
+        let b /*: Observable<Int>*/ = AnyVariable(2)
+
+        // Computed third variable (or sequence)
+        let c /*: Observable<Int>*/ = Observable.combineLatest(a.asObservable(), b.asObservable()) { $0 + $1 }
+
+        // Reading elements from c.
+        // This is just a demo example.
+        // Sequence elements are usually never enumerated like this.
+        // Sequences are usually combined using map/filter/combineLatest ...
+        //
+        // This will immediatelly print:
+        //      Next value of c = 3
+        // because variables have initial values (starting element)
+        var latestValueOfC : Int? = nil
+        // let _ = doesn't retain.
+        let d/*: Disposable*/  = c
+            .subscribe(onNext: { c in
+                //print("Next value of c = \(c)")
+                latestValueOfC = c
+            })
+
+        defer {
+            d.dispose()
+        }
+
+        XCTAssertEqual(latestValueOfC!, 3)
+
+    }
+
+}
+


### PR DESCRIPTION
This PR adds `AnyVariable` as a get-only `Variable`, which is highly useful when encapsulating `Variable` inside some view model, disallowing its binding from outside.

This type is almost the same as ReactiveSwift's [Property](https://github.com/ReactiveCocoa/ReactiveSwift/blob/1.0.1/Sources/Property.swift).