### PR TITLE
Simplify logic for `case .error, .completed`

### DIFF
--- a/RxSwift/Observers/ObserverBase.swift
+++ b/RxSwift/Observers/ObserverBase.swift
@@ -18,12 +18,9 @@ class ObserverBase<ElementType> : Disposable, ObserverType {
                 onCore(event)
             }
         case .error, .completed:
-
-            if !AtomicCompareAndSwap(0, 1, &_isStopped) {
-                return
+            if AtomicCompareAndSwap(0, 1, &_isStopped) {
+                onCore(event)
             }
-
-            onCore(event)
         }
     }
 


### PR DESCRIPTION
I thought that instead of returning on `!AtomicCompareAndSwap(0, 1, &_isStopped)`
it would read easier to just switch the logic of the if statement and call `onCore(event)` 
in the body if the condition passes.