### PR TITLE
Feature/zip with

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ Carthage/Build
 
 .build/
 Packages/
+
+# AppCode
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 * Adds `AsyncSubject` implementation
+* Adds `zip(with:)` operator
 
 ## Anomalies
 * #1081, #1087 - Improves DelegateProxy `responds(to:)` selector logic to only respond to used selectors.

--- a/RxSwift/Observables/Observable+Multiple.swift
+++ b/RxSwift/Observables/Observable+Multiple.swift
@@ -40,6 +40,21 @@ extension Observable {
     }
 }
 
+extension ObservableType {
+
+    /**
+     Zips `self` with the second observable sequence into one observable sequence by using the selector function whenever all of the observable sequences have produced an element.
+
+     - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
+     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+     */
+    public func zip<O2: ObservableConvertibleType, ResultType>(with second: O2, resultSelector: @escaping (E, O2.E) throws -> ResultType) -> Observable<ResultType> {
+        return Observable.zip(asObservable(), second.asObservable(), resultSelector: resultSelector)
+    }
+}
+
 // MARK: switch
 
 extension ObservableType where E : ObservableConvertibleType {

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -858,6 +858,8 @@ final class ObservableMultipleTest_ : ObservableMultipleTest, RxTestCase {
     ("testZip_RightCompletesFirst", ObservableMultipleTest.testZip_RightCompletesFirst),
     ("testZip_LeftTriggersSelectorError", ObservableMultipleTest.testZip_LeftTriggersSelectorError),
     ("testZip_RightTriggersSelectorError", ObservableMultipleTest.testZip_RightTriggersSelectorError),
+    ("testZipWith_SourcesNotEmpty_ZipCompletes", ObservableMultipleTest.testZipWith_SourcesNotEmpty_ZipCompletes),
+    ("testZipWith_SourceEmpty_ZipCompletesEmpty", ObservableMultipleTest.testZipWith_SourceEmpty_ZipCompletesEmpty),
     ("testCatch_ErrorSpecific_Caught", ObservableMultipleTest.testCatch_ErrorSpecific_Caught),
     ("testCatch_HandlerThrows", ObservableMultipleTest.testCatch_HandlerThrows),
     ("testCatchSequenceOf_IEofIO", ObservableMultipleTest.testCatchSequenceOf_IEofIO),

--- a/Tests/RxSwiftTests/Observable+MultipleTest.swift
+++ b/Tests/RxSwiftTests/Observable+MultipleTest.swift
@@ -650,6 +650,44 @@ extension ObservableMultipleTest {
     #endif
 }
 
+// MARK: zipWith
+struct Pair<F: Equatable, S: Equatable> {
+    let first: F
+    let second: S
+}
+extension Pair: Equatable {}
+func ==<F, S>(lhs: Pair<F, S>, rhs: Pair<F, S>) -> Bool {
+    return lhs.first == rhs.first && lhs.second == rhs.second
+}
+
+extension ObservableMultipleTest {
+    func testZipWith_SourcesNotEmpty_ZipCompletes () {
+        let scheduler = TestScheduler(initialClock: 0)
+        let source1 = Observable.just(1)
+        let source2 = Observable.just(2)
+
+        let res = scheduler.start {
+            source1.zip(with: source2) { Pair(first: $0, second: $1) }
+        }
+
+        let expected = [next(200, Pair(first: 1, second: 2)), completed(200)]
+        XCTAssertEqual(res.events, expected)
+    }
+
+    func testZipWith_SourceEmpty_ZipCompletesEmpty () {
+        let scheduler = TestScheduler(initialClock: 0)
+        let source1 = Observable.just(1)
+        let source2 = Observable<Int>.empty()
+
+        let res = scheduler.start {
+            source1.zip(with: source2) { Pair(first: $0, second: $1) }
+        }
+
+        let expected: [Recorded<Event<Pair<Int, Int>>>] = [completed(200)]
+        XCTAssertEqual(res.events, expected)
+    }
+}
+
 // MARK: switchIfEmpty
 extension ObservableMultipleTest {
     func testSwitchIfEmpty_SourceNotEmpty_SwitchCompletes() {


### PR DESCRIPTION
This PR adds a convenience operator to `ObservableType`.`zip(with:)` that zips two observable sequences into one sequence on the same Rx Monad.