### PR TITLE
Even if Variable no longer implements ObservableType, it should still…

### DIFF
--- a/RxSwift/Subjects/Variable.swift
+++ b/RxSwift/Subjects/Variable.swift
@@ -10,7 +10,7 @@
 ///
 /// Unlike `BehaviorSubject` it can't terminate with error, and when variable is deallocated
 /// it will complete it's observable sequence (`asObservable`).
-public final class Variable<Element> {
+public final class Variable<Element> : ObservableConvertibleType {
 
     public typealias E = Element
     


### PR DESCRIPTION
… implement ObservableConvertibleType (and it already has the asObservable() function anyway) in order to make it  compatible with code expecting ObservableConvertibleType (without having to call asObservable() everywhere).

I am developing a new framework that relies as much as possible on ObservableConvertibleType to make the API cleaner and more concise to use.

Also, I don't understand why all operators are not defined as extensions of ObservableConvertibleType (instead of ObservableType), in order to make them usable with as many classes as possible.  I am still new with Swift and RxSwift (even though I have worked with ReactiveX for many years in different languages) so I guess there might be reasons for this approach, I would appreciate understanding them.

Thank you for this great library and all the efforts you put in it! :)