### PR TITLE
Variable should implement ObservableConvertibleType

### DIFF
--- a/RxSwift/Subjects/Variable.swift
+++ b/RxSwift/Subjects/Variable.swift
@@ -10,7 +10,7 @@
 ///
 /// Unlike `BehaviorSubject` it can't terminate with error, and when variable is deallocated
 /// it will complete it's observable sequence (`asObservable`).
-public final class Variable<Element> {
+public final class Variable<Element> : ObservableConvertibleType {
 
     public typealias E = Element
     


### PR DESCRIPTION
Variable should implement ObservableConvertibleType, even if it no longer implements ObservableType.  It already has the asObservable() function anyway.  It would make it compatible with code expecting ObservableConvertibleType, without having to call asObservable() everywhere.

I am developing a new framework that relies as much as possible on ObservableConvertibleType to make the API cleaner and more concise to use.  To my understanding, asObservable() is just a workaround because of the limitations of Swift dealing with protocols and generics, no?

Also, I don't understand why all operators (filter, map...) are not defined as extensions of ObservableConvertibleType (instead of ObservableType), in order to make them usable with as many classes as possible. I am still new with Swift and RxSwift (even though I have worked with ReactiveX for many years in different languages, like Rx for C#, RxJava, RxJS and UniRx for Unity) so I guess there might be legitimate motivations for this approach, though I would appreciate understanding them.

Thank you for this great library and all the efforts you put in it! :)