### PR TITLE
Add `Event.isCompleted`

### DIFF
--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -36,7 +36,7 @@ extension Event : CustomDebugStringConvertible {
 }
 
 extension Event {
-    /// Is `Completed` or `Error` event.
+    /// Is `completed` or `error` event.
     public var isStopEvent: Bool {
         switch self {
         case .next: return false
@@ -44,7 +44,7 @@ extension Event {
         }
     }
 
-    /// If `Next` event, returns element value.
+    /// If `next` event, returns element value.
     public var element: Element? {
         if case .next(let value) = self {
             return value
@@ -52,12 +52,20 @@ extension Event {
         return nil
     }
 
-    /// If `Error` event, returns error.
+    /// If `error` event, returns error.
     public var error: Swift.Error? {
         if case .error(let error) = self {
             return error
         }
         return nil
+    }
+
+    /// If `completed` event, returns true.
+    public var isCompleted: Bool {
+        if case .completed = self {
+            return true
+        }
+        return false
     }
 }
 


### PR DESCRIPTION
Currently `Event.isCompleted` is missing, and it will be useful especially when [`materialize()`](https://github.com/RxSwiftCommunity/RxSwiftExt/blob/2.1.0/Source/materialize.swift).