### PR TITLE
Add `var changed: Observable<E>` to `Variable`

### DIFF
--- a/RxSwift/Subjects/Variable.swift
+++ b/RxSwift/Subjects/Variable.swift
@@ -60,10 +60,17 @@ public final class Variable<Element> {
         _value = value
         _subject = BehaviorSubject(value: value)
     }
-    
+
+    /// Observable that synchronously sends current element and then changed elements.
+    ///
     /// - returns: Canonical interface for push style sequence
     public func asObservable() -> Observable<E> {
         return _subject
+    }
+
+    /// Observable that only sends changed elements, ignoring current element.
+    public var changed: Observable<E> {
+        return asObservable().skip(1)
     }
 
     deinit {


### PR DESCRIPTION
There are often cases when one wants to **ignore `Variable`'s current value and only observe changed values**.
Though using `variable.asObservable().skip(1).subscribe(...)` is an easy solution, it is not as declarative as `variable.changed.subscribe(...)` (people often ask "why skip(1)?"), so I think adding `var changed: Observable<E>` to `Variable` helps code readability.

The basic idea is almost same as `ControlProperty.changed`.