### PR TITLE
Enable `asCompletable` on any `ObservableType`

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1208,6 +1208,7 @@
 		CDDEF16B1D4FB40000CA8546 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
 		CDDEF16C1D4FB40000CA8546 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
 		CDDEF16D1D4FB40000CA8546 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
+		CE3C5B161E8401DA000B7D78 /* AsCompletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3C5B151E8401DA000B7D78 /* AsCompletable.swift */; };
 		D203C4F31BB9C4CA00D02D00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F11B8A752B00B02D69 /* RxCollectionViewReactiveArrayDataSource.swift */; };
 		D203C4F41BB9C52400D02D00 /* RxTableViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F21B8A752B00B02D69 /* RxTableViewReactiveArrayDataSource.swift */; };
 		D203C4F51BB9C52900D02D00 /* ItemEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F41B8A752B00B02D69 /* ItemEvents.swift */; };
@@ -2015,6 +2016,7 @@
 		CB883B491BE369AA000AC2EE /* AddRef.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddRef.swift; sourceTree = "<group>"; };
 		CBEE771E1BD649A000AD584C /* ToArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ToArray.swift; sourceTree = "<group>"; };
 		CDDEF1691D4FB40000CA8546 /* Disposables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Disposables.swift; sourceTree = "<group>"; };
+		CE3C5B151E8401DA000B7D78 /* AsCompletable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsCompletable.swift; sourceTree = "<group>"; };
 		D2138C751BB9BE9800339B5C /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2245A1A1BD5657300E7146F /* WithLatestFrom.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WithLatestFrom.swift; sourceTree = "<group>"; };
 		D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipWhile.swift; sourceTree = "<group>"; };
@@ -2343,6 +2345,7 @@
 				252FC1DE1E0DC64C00D28877 /* SwitchIfEmpty.swift */,
 				C89814811E75B77B0035949C /* AsMaybe.swift */,
 				C89814861E75BE590035949C /* AsSingle.swift */,
+				CE3C5B151E8401DA000B7D78 /* AsCompletable.swift */,
 			);
 			path = Implementations;
 			sourceTree = "<group>";
@@ -4715,6 +4718,7 @@
 				C84CC5581BDCF51200E06A64 /* SynchronizedSubscribeType.swift in Sources */,
 				C8093D311B8A72BE0088E94D /* Reduce.swift in Sources */,
 				C8640A031BA5B12A00D3C4E8 /* Repeat.swift in Sources */,
+				CE3C5B161E8401DA000B7D78 /* AsCompletable.swift in Sources */,
 				C8093CF31B8A72BE0088E94D /* Errors.swift in Sources */,
 				C86B0A561D735CCC005D8A16 /* Delay.swift in Sources */,
 				C8093D131B8A72BE0088E94D /* Debug.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1209,6 +1209,9 @@
 		CDDEF16C1D4FB40000CA8546 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
 		CDDEF16D1D4FB40000CA8546 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
 		CE3C5B161E8401DA000B7D78 /* AsCompletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3C5B151E8401DA000B7D78 /* AsCompletable.swift */; };
+		CEE964D01E85885C006CE10F /* AsCompletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3C5B151E8401DA000B7D78 /* AsCompletable.swift */; };
+		CEE964D11E85885D006CE10F /* AsCompletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3C5B151E8401DA000B7D78 /* AsCompletable.swift */; };
+		CEE964D31E858860006CE10F /* AsCompletable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3C5B151E8401DA000B7D78 /* AsCompletable.swift */; };
 		D203C4F31BB9C4CA00D02D00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F11B8A752B00B02D69 /* RxCollectionViewReactiveArrayDataSource.swift */; };
 		D203C4F41BB9C52400D02D00 /* RxTableViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F21B8A752B00B02D69 /* RxTableViewReactiveArrayDataSource.swift */; };
 		D203C4F51BB9C52900D02D00 /* ItemEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F41B8A752B00B02D69 /* ItemEvents.swift */; };
@@ -4476,6 +4479,7 @@
 				C8093D441B8A72BE0088E94D /* Take.swift in Sources */,
 				C84CC5591BDCF51200E06A64 /* SynchronizedSubscribeType.swift in Sources */,
 				C8093D321B8A72BE0088E94D /* Reduce.swift in Sources */,
+				CEE964D01E85885C006CE10F /* AsCompletable.swift in Sources */,
 				C8640A041BA5B12A00D3C4E8 /* Repeat.swift in Sources */,
 				C8093CF41B8A72BE0088E94D /* Errors.swift in Sources */,
 				C86B0A571D735CCC005D8A16 /* Delay.swift in Sources */,
@@ -4889,6 +4893,7 @@
 				C8F0BFE41BBBFB8B001B112F /* Take.swift in Sources */,
 				C84CC55B1BDCF51200E06A64 /* SynchronizedSubscribeType.swift in Sources */,
 				C8F0BFE51BBBFB8B001B112F /* Reduce.swift in Sources */,
+				CEE964D31E858860006CE10F /* AsCompletable.swift in Sources */,
 				C8F0BFE71BBBFB8B001B112F /* Repeat.swift in Sources */,
 				C8F0BFE81BBBFB8B001B112F /* Errors.swift in Sources */,
 				C86B0A591D735CCC005D8A16 /* Delay.swift in Sources */,
@@ -5246,6 +5251,7 @@
 				D2EBEB3B1BB9B6D8003A27DC /* OperationQueueScheduler.swift in Sources */,
 				D2EBEAE51BB9B697003A27DC /* AnyObserver.swift in Sources */,
 				D2EBEB3D1BB9B6D8003A27DC /* SchedulerServices+Emulation.swift in Sources */,
+				CEE964D11E85885D006CE10F /* AsCompletable.swift in Sources */,
 				D2EBEB1C1BB9B6C1003A27DC /* Sample.swift in Sources */,
 				D2EBEAFD1BB9B6BA003A27DC /* AnonymousObservable.swift in Sources */,
 				C86B0A581D735CCC005D8A16 /* Delay.swift in Sources */,

--- a/RxSwift/Errors.swift
+++ b/RxSwift/Errors.swift
@@ -25,6 +25,8 @@ public enum RxError
     case noElements
     /// Sequence contains more than one element.
     case moreThanOneElement
+    /// Sequence contains some elements
+    case someElements
     /// Timeout error.
     case timeout
 }
@@ -43,6 +45,8 @@ extension RxError {
             return "Argument out of range."
         case .noElements:
             return "Sequence doesn't contain any elements."
+        case .someElements:
+            return "Sequence contains some elements."
         case .moreThanOneElement:
             return "Sequence contains more than one element."
         case .timeout:

--- a/RxSwift/Observables/Implementations/AsCompletable.swift
+++ b/RxSwift/Observables/Implementations/AsCompletable.swift
@@ -1,0 +1,41 @@
+//
+//  AsCompletable.swift
+//  RxSwift
+//
+//  Created by Mostafa Amer on 23/03/2017.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+fileprivate final class AsCompletableSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias ElementType = O.E
+    typealias E = ElementType
+    
+    private var _element: Event<E>? = nil
+    
+    func on(_ event: Event<E>) {
+        switch event {
+        case .next:
+            forwardOn(.error(RxError.someElements))
+        case .error:
+            forwardOn(event)
+        case .completed:
+            forwardOn(.completed)
+        }
+        dispose()
+    }
+}
+
+final class AsCompletable<Element>: Producer<Swift.Never> {
+    fileprivate let _source: Observable<Element>
+    
+    init(source: Observable<Element>) {
+        _source = source
+    }
+    
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+        let sink = AsCompletableSink(observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+    
+}

--- a/RxSwift/Units/PrimitiveSequence.swift
+++ b/RxSwift/Units/PrimitiveSequence.swift
@@ -593,12 +593,11 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Never {
+extension ObservableType {
     /**
     - returns: An observable sequence that completes.
      */
-    public func asCompletable()
-        -> Completable {
-        return PrimitiveSequence(raw: self.asObservable())
+    public func asCompletable() -> Completable {
+        return PrimitiveSequence(raw: AsCompletable(source: self.asObservable()))
     }
 }

--- a/Tests/RxSwiftTests/PrimitiveSequenceTest.swift
+++ b/Tests/RxSwiftTests/PrimitiveSequenceTest.swift
@@ -968,6 +968,29 @@ extension PrimitiveSequenceTest {
             ])
     }
 
+    func testAsCompletable_One() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(220, 1),
+            completed(250),
+            error(260, testError)
+            ])
+        
+        let res = scheduler.start { () -> Observable<Never> in
+            let completable: Completable = xs.asCompletable()
+            return completable.asObservable()
+        }
+        
+        XCTAssertEqual(res.events, [
+            error(220, RxError.someElements)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 220)
+            ])
+    }
+    
     func testAsCompletable_Error() {
         let scheduler = TestScheduler(initialClock: 0)
 


### PR DESCRIPTION
This PR drops generic constraint on `ObservableType` extension containing `asCompletable() -> Completable`

It will allow `asCompletable()` to behave similar to `asSingle()` and `asMaybe()` by:
- Removing generic constraint of `ObservableType` extension limited usage for only `Swift.Never`.
- Error if received any next events
