### PR TITLE
Add the UITextField reactive wrappers: UITextField Delegate

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -285,6 +285,7 @@ custom_categories:
   - RxTabBarDelegateProxy
   - RxTableViewDataSourceProxy
   - RxTableViewDelegateProxy
+  - RxTextFieldDelegateProxy
   - RxTextStorageDelegateProxy
   - RxTextViewDelegateProxy
   - RxWebViewDelegateProxy

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -41,6 +41,9 @@
 		54D2138E1CE0824E0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
 		54D213921CE08D0C0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
 		54D213931CE08DDB0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
+		603ABADA1E87C5D9004F98DF /* RxTextFieldDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604759691E852EDD0029D878 /* RxTextFieldDelegateProxy.swift */; };
+		603ABADB1E87C5DA004F98DF /* RxTextFieldDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604759691E852EDD0029D878 /* RxTextFieldDelegateProxy.swift */; };
+		603ABADC1E87C5DA004F98DF /* RxTextFieldDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604759691E852EDD0029D878 /* RxTextFieldDelegateProxy.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEBE1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
@@ -1593,6 +1596,7 @@
 		46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Rx.swift"; sourceTree = "<group>"; };
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
+		604759691E852EDD0029D878 /* RxTextFieldDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTextFieldDelegateProxy.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -2810,6 +2814,7 @@
 				88D98F2D1CE7549A00D50457 /* RxTabBarDelegateProxy.swift */,
 				C88254001B8A752B00B02D69 /* RxTableViewDataSourceProxy.swift */,
 				C88254011B8A752B00B02D69 /* RxTableViewDelegateProxy.swift */,
+				604759691E852EDD0029D878 /* RxTextFieldDelegateProxy.swift */,
 				C88254021B8A752B00B02D69 /* RxTextViewDelegateProxy.swift */,
 				84C225A21C33F00B008724EC /* RxTextStorageDelegateProxy.swift */,
 				846436E11C9AF64C0035B40D /* RxSearchControllerDelegateProxy.swift */,
@@ -3898,6 +3903,7 @@
 				C8093EE11B8A732E0088E94D /* DelegateProxy.swift in Sources */,
 				C89AB2501DAAC3A60065FBE6 /* _RXObjCRuntime.m in Sources */,
 				C89AB21E1DAAC3350065FBE6 /* NSObject+Rx.swift in Sources */,
+				603ABADA1E87C5D9004F98DF /* RxTextFieldDelegateProxy.swift in Sources */,
 				88718CFE1CE5D80000D88D60 /* UITabBar+Rx.swift in Sources */,
 				88D98F2E1CE7549A00D50457 /* RxTabBarDelegateProxy.swift in Sources */,
 				C88254331B8A752B00B02D69 /* UISwitch+Rx.swift in Sources */,
@@ -4971,6 +4977,7 @@
 				844BC8AE1CE4FA6600F5C7CB /* RxPickerViewDelegateProxy.swift in Sources */,
 				C8BCD3F71C14B6D1005F1280 /* NSLayoutConstraint+Rx.swift in Sources */,
 				C89AB1C91DAAC3350065FBE6 /* ControlEvent.swift in Sources */,
+				603ABADC1E87C5DA004F98DF /* RxTextFieldDelegateProxy.swift in Sources */,
 				C89AB1E91DAAC3350065FBE6 /* ObservableConvertibleType+SharedSequence.swift in Sources */,
 				C8F0C0301BBBFBB9001B112F /* UIGestureRecognizer+Rx.swift in Sources */,
 				C89AB2091DAAC3350065FBE6 /* KVORepresentable+Swift.swift in Sources */,
@@ -5049,6 +5056,7 @@
 				C8D132461C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */,
 				D203C4F31BB9C4CA00D02D00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */,
 				D203C50B1BB9C53E00D02D00 /* UIScrollView+Rx.swift in Sources */,
+				603ABADB1E87C5DA004F98DF /* RxTextFieldDelegateProxy.swift in Sources */,
 				C89AB1E81DAAC3350065FBE6 /* ObservableConvertibleType+SharedSequence.swift in Sources */,
 				C89AB1A81DAAC25A0065FBE6 /* RxCocoaObjCRuntimeError+Extensions.swift in Sources */,
 				D203C50C1BB9C53E00D02D00 /* UISearchBar+Rx.swift in Sources */,

--- a/RxCocoa/iOS/Proxies/RxTextFieldDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextFieldDelegateProxy.swift
@@ -1,0 +1,104 @@
+//
+//  RxTextFieldDelegateProxy.swift
+//  RxCocoa
+//
+//  Created by Takeshi Ihara on 24/3/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+#if !RX_NO_MODULE
+import RxSwift
+#endif
+import UIKit
+
+/// For more information take a look at `DelegateProxyType`.
+public class RxTextFieldDelegateProxy
+    : DelegateProxy
+    , UITextFieldDelegate
+    , DelegateProxyType {
+
+    fileprivate var _shouldClearPublishSubject: PublishSubject<()>?
+    fileprivate var _shouldReturnPublishSubject: PublishSubject<()>?
+
+    /// Typed parent object.
+    public weak fileprivate(set) var textField: UITextField?
+
+    /// Optimized version used for observing content offset changes.
+    internal var shouldClearPublishSubject: PublishSubject<()> {
+        if let subject = _shouldClearPublishSubject {
+            return subject
+        }
+
+        let subject = PublishSubject<()>()
+        _shouldClearPublishSubject = subject
+
+        return subject
+    }
+
+    /// Optimized version used for observing content offset changes.
+    internal var shouldReturnPublishSubject: PublishSubject<()> {
+        if let subject = _shouldReturnPublishSubject {
+            return subject
+        }
+
+        let subject = PublishSubject<()>()
+        _shouldReturnPublishSubject = subject
+
+        return subject
+    }
+
+    /// Initializes `RxTextFieldViewDelegateProxy`
+    ///
+    /// - parameter parentObject: Parent object for delegate proxy.
+    public required init(parentObject: AnyObject) {
+        self.textField = castOrFatalError(parentObject)
+        super.init(parentObject: parentObject)
+    }
+
+    // MARK: delegate methods
+
+    /// For more information take a look at `DelegateProxyType`.
+    public func textFieldShouldClear(_ textField: UITextField) -> Bool {
+        _shouldClearPublishSubject?.onNext()
+        return self._forwardToDelegate?.textFieldShouldClear?(textField) ?? true
+    }
+
+    /// For more information take a look at `DelegateProxyType`.
+    public func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        _shouldReturnPublishSubject?.onNext()
+        return self._forwardToDelegate?.textFieldShouldReturn?(textField) ?? true
+    }
+
+    // MARK: delegate proxy
+
+    /// For more information take a look at `DelegateProxyType`.
+    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
+        let textField: UITextField = castOrFatalError(object)
+        return textField.createRxDelegateProxy()
+    }
+
+    /// For more information take a look at `DelegateProxyType`.
+    public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {
+        let textField: UITextField = castOrFatalError(object)
+        textField.delegate = castOptionalOrFatalError(delegate)
+    }
+
+    /// For more information take a look at `DelegateProxyType`.
+    public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
+        let textField: UITextField = castOrFatalError(object)
+        return textField.delegate
+    }
+
+    deinit {
+        if let subject = _shouldClearPublishSubject {
+            subject.on(.completed)
+        }
+        if let subject = _shouldReturnPublishSubject {
+            subject.on(.completed)
+        }
+    }
+}
+
+#endif

--- a/RxCocoa/iOS/UITextField+Rx.swift
+++ b/RxCocoa/iOS/UITextField+Rx.swift
@@ -13,7 +13,26 @@ import RxSwift
 #endif
 import UIKit
 
+extension UITextField {
+
+    /// Factory method that enables subclasses to implement their own `delegate`.
+    ///
+    /// - returns: Instance of delegate proxy that wraps `delegate`.
+    public func createRxDelegateProxy() -> RxTextFieldDelegateProxy {
+        return RxTextFieldDelegateProxy(parentObject: self)
+    }
+
+}
+
 extension Reactive where Base: UITextField {
+
+    /// Reactive wrapper for `delegate`.
+    ///
+    /// For more information take a look at `DelegateProxyType` protocol documentation.
+    public var delegate: DelegateProxy {
+        return RxTextFieldDelegateProxy.proxyForObject(base)
+    }
+
     /// Reactive wrapper for `text` property.
     public var text: ControlProperty<String?> {
         return value
@@ -35,7 +54,30 @@ extension Reactive where Base: UITextField {
             }
         )
     }
-    
+
+    /// Reactive wrapper for delegate method `textFieldShouldClear`
+    public var shouldClear: ControlEvent<Void> {
+        let source = RxTextFieldDelegateProxy.proxyForObject(base).shouldClearPublishSubject.map { _ in return }
+        return ControlEvent(events: source)
+    }
+
+    /// Reactive wrapper for delegate method `textFieldShouldReturn`
+    public var shouldReturn: ControlEvent<Void> {
+        let source = RxTextFieldDelegateProxy.proxyForObject(base).shouldReturnPublishSubject.map { _ in return }
+        return ControlEvent(events: source)
+    }
+
+    /// Installs delegate as forwarding delegate on `delegate`.
+    /// Delegate won't be retained.
+    ///
+    /// It enables using normal delegate mechanism with reactive delegate mechanism.
+    ///
+    /// - parameter delegate: Delegate object.
+    /// - returns: Disposable object that can be used to unbind the delegate.
+    public func setDelegate(_ delegate: UITextFieldDelegate)
+        -> Disposable {
+            return RxTextFieldDelegateProxy.installForwardDelegate(delegate, retainDelegate: false, onProxyForObject: self.base)
+    }
 }
 
 #endif

--- a/Tests/RxCocoaTests/UITextField+RxTests.swift
+++ b/Tests/RxCocoaTests/UITextField+RxTests.swift
@@ -30,6 +30,52 @@ final class UITextFieldTests : RxTest {
         textField.rx.text.on(.next("Text2"))
         XCTAssertTrue(textField.set)
     }
+
+    func testTextFieldShouldClear() {
+        var completed = false
+
+        autoreleasepool {
+            let textField = UITextField()
+            var shouldClear = false
+
+            _ = textField.rx.shouldClear.subscribe(onNext: {
+                shouldClear = true
+            }, onCompleted: {
+                completed = true
+            })
+
+            XCTAssertFalse(shouldClear)
+
+            _ = textField.delegate!.textFieldShouldClear!(textField)
+
+            XCTAssertTrue(shouldClear)
+        }
+        
+        XCTAssertTrue(completed)
+    }
+
+    func testTextFieldShouldReturn() {
+        var completed = false
+
+        autoreleasepool {
+            let textField = UITextField()
+            var shouldReturn = false
+
+            _ = textField.rx.shouldReturn.subscribe(onNext: {
+                shouldReturn = true
+            }, onCompleted: {
+                completed = true
+            })
+
+            XCTAssertFalse(shouldReturn)
+
+            _ = textField.delegate!.textFieldShouldReturn!(textField)
+
+            XCTAssertTrue(shouldReturn)
+        }
+        
+        XCTAssertTrue(completed)
+    }
 }
 
 final class UITextFieldSubclass : UITextField {


### PR DESCRIPTION
It extends the current implementation of the UITextField reactive wrapper adding the support for the delegate methods.

- `textFieldDidBeginEditing(_:)`
- `textFieldDidEndEditing(_:)`
- `textFieldShouldClear(_:)`
- `textFieldShouldReturn(_:)`