### PR TITLE
Fix "Datasource is not set" crash in UICollectionViewController when de-initialized

### DIFF
--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -253,8 +253,8 @@ extension DelegateProxyType {
                     
                 return Disposables.create { [weak object] in
                     subscription.dispose()
-                    unregisterDelegate.dispose()
                     object?.layoutIfNeeded()
+                    unregisterDelegate.dispose()
                 }
             }
         }


### PR DESCRIPTION
Fixed #1154 with @kzaher 's suggestion!