### PR TITLE
Rename data structures 

### DIFF
--- a/Platform/DataStructures/PriorityQueue.swift
+++ b/Platform/DataStructures/PriorityQueue.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-struct PriorityQueue<Element> {
+struct RxPriorityQueue<Element> {
     private let _hasHigherPriority: (Element, Element) -> Bool
     private let _isEqual: (Element, Element) -> Bool
 
@@ -105,7 +105,7 @@ struct PriorityQueue<Element> {
     }
 }
 
-extension PriorityQueue : CustomDebugStringConvertible {
+extension RxPriorityQueue : CustomDebugStringConvertible {
     var debugDescription: String {
         return _elements.debugDescription
     }

--- a/Platform/DataStructures/Queue.swift
+++ b/Platform/DataStructures/Queue.swift
@@ -14,7 +14,7 @@ averaged over N operations.
 
 Complexity of `peek` is O(1).
 */
-struct Queue<T>: Sequence {
+struct RxQueue<T>: Sequence {
     /// Type of generator.
     typealias Generator = AnyIterator<T>
 

--- a/Platform/Platform.Linux.swift
+++ b/Platform/Platform.Linux.swift
@@ -16,7 +16,7 @@
     final class AtomicInt {
         typealias IntegerLiteralType = Int
         fileprivate var value: Int32 = 0
-        fileprivate var _lock = RecursiveLock()
+        fileprivate var _lock = RxRecursiveLock()
 
         func lock() {
           _lock.lock()

--- a/Platform/RecursiveLock.swift
+++ b/Platform/RecursiveLock.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 #if TRACE_RESOURCES
-    class RecursiveLock: NSRecursiveLock {
+    class RxRecursiveLock: NSRecursiveLock {
         override init() {
             _ = Resources.incrementTotal()
             super.init()
@@ -30,5 +30,5 @@ import Foundation
         }
     }
 #else
-    typealias RecursiveLock = NSRecursiveLock
+    typealias RxRecursiveLock = NSRecursiveLock
 #endif

--- a/RxSwift/Concurrency/AsyncLock.swift
+++ b/RxSwift/Concurrency/AsyncLock.swift
@@ -18,13 +18,13 @@ That means that enqueued work could possibly be executed later on a different th
 */
 final class AsyncLock<I: InvocableType>
     : Disposable
-    , Lock
+    , RxLock
     , SynchronizedDisposeType {
     typealias Action = () -> Void
     
-    var _lock = SpinLock()
+    var _lock = RxSpinLock()
     
-    private var _queue: Queue<I> = Queue(capacity: 0)
+    private var _queue: RxQueue<I> = RxQueue(capacity: 0)
 
     private var _isExecuting: Bool = false
     private var _hasFaulted: Bool = false
@@ -96,7 +96,7 @@ final class AsyncLock<I: InvocableType>
     }
 
     func _synchronized_dispose() {
-        _queue = Queue(capacity: 0)
+        _queue = RxQueue(capacity: 0)
         _hasFaulted = true
     }
 }

--- a/RxSwift/Concurrency/Lock.swift
+++ b/RxSwift/Concurrency/Lock.swift
@@ -6,15 +6,15 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-protocol Lock {
+protocol RxLock {
     func lock()
     func unlock()
 }
 
 // https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151214/000321.html
-typealias SpinLock = RecursiveLock
+typealias RxSpinLock = RxRecursiveLock
 
-extension RecursiveLock : Lock {
+extension RxRecursiveLock : RxLock {
     @inline(__always)
     final func performLocked(_ action: () -> Void) {
         lock(); defer { unlock() }

--- a/RxSwift/Concurrency/LockOwnerType.swift
+++ b/RxSwift/Concurrency/LockOwnerType.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-protocol LockOwnerType : class, Lock {
-    var _lock: RecursiveLock { get }
+protocol LockOwnerType : class, RxLock {
+    var _lock: RxRecursiveLock { get }
 }
 
 extension LockOwnerType {

--- a/RxSwift/Concurrency/SynchronizedDisposeType.swift
+++ b/RxSwift/Concurrency/SynchronizedDisposeType.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-protocol SynchronizedDisposeType : class, Disposable, Lock {
+protocol SynchronizedDisposeType : class, Disposable, RxLock {
     func _synchronized_dispose()
 }
 

--- a/RxSwift/Concurrency/SynchronizedOnType.swift
+++ b/RxSwift/Concurrency/SynchronizedOnType.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-protocol SynchronizedOnType : class, ObserverType, Lock {
+protocol SynchronizedOnType : class, ObserverType, RxLock {
     func _synchronized_on(_ event: Event<E>)
 }
 

--- a/RxSwift/Concurrency/SynchronizedSubscribeType.swift
+++ b/RxSwift/Concurrency/SynchronizedSubscribeType.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-protocol SynchronizedSubscribeType : class, ObservableType, Lock {
+protocol SynchronizedSubscribeType : class, ObservableType, RxLock {
     func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E
 }
 

--- a/RxSwift/Disposables/CompositeDisposable.swift
+++ b/RxSwift/Disposables/CompositeDisposable.swift
@@ -16,7 +16,7 @@ public final class CompositeDisposable : DisposeBase, Disposable, Cancelable {
         }
     }
 
-    private var _lock = SpinLock()
+    private var _lock = RxSpinLock()
     
     // state
     private var _disposables: Bag<Disposable>? = Bag()

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -29,7 +29,7 @@ In case explicit disposal is necessary, there is also `CompositeDisposable`.
 */
 public final class DisposeBag: DisposeBase {
     
-    private var _lock = SpinLock()
+    private var _lock = RxSpinLock()
     
     // state
     private var _disposables = [Disposable]()

--- a/RxSwift/Disposables/RefCountDisposable.swift
+++ b/RxSwift/Disposables/RefCountDisposable.swift
@@ -8,7 +8,7 @@
 
 /// Represents a disposable resource that only disposes its underlying disposable resource when all dependent disposable objects have been disposed.
 public final class RefCountDisposable : DisposeBase, Cancelable {
-    private var _lock = SpinLock()
+    private var _lock = RxSpinLock()
     private var _disposable = nil as Disposable?
     private var _primaryDisposed = false
     private var _count = 0

--- a/RxSwift/Disposables/SerialDisposable.swift
+++ b/RxSwift/Disposables/SerialDisposable.swift
@@ -8,7 +8,7 @@
 
 /// Represents a disposable resource whose underlying disposable resource can be replaced by another disposable resource, causing automatic disposal of the previous underlying disposable resource.
 public final class SerialDisposable : DisposeBase, Cancelable {
-    private var _lock = SpinLock()
+    private var _lock = RxSpinLock()
     
     // state
     private var _current = nil as Disposable?

--- a/RxSwift/Observables/Implementations/Amb.swift
+++ b/RxSwift/Observables/Implementations/Amb.swift
@@ -53,7 +53,7 @@ final class AmbSink<O: ObserverType> : Sink<O> {
 
     private let _parent: Parent
     
-    private let _lock = RecursiveLock()
+    private let _lock = RxRecursiveLock()
     // state
     private var _choice = AmbState.neither
     

--- a/RxSwift/Observables/Implementations/Buffer.swift
+++ b/RxSwift/Observables/Implementations/Buffer.swift
@@ -37,7 +37,7 @@ final class BufferTimeCountSink<Element, O: ObserverType>
     
     private let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     // state
     private let _timerD = SerialDisposable()

--- a/RxSwift/Observables/Implementations/CombineLatest+Collection.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest+Collection.swift
@@ -14,7 +14,7 @@ final class CombineLatestCollectionTypeSink<C: Collection, O: ObserverType>
     
     let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
 
     // state
     var _numberOfValues = 0

--- a/RxSwift/Observables/Implementations/CombineLatest.swift
+++ b/RxSwift/Observables/Implementations/CombineLatest.swift
@@ -17,7 +17,7 @@ class CombineLatestSink<O: ObserverType>
     , CombineLatestProtocol {
     typealias Element = O.E
    
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
 
     private let _arity: Int
     private var _numberOfValues = 0
@@ -99,12 +99,12 @@ final class CombineLatestObserver<ElementType>
     
     private let _parent: CombineLatestProtocol
     
-    let _lock: RecursiveLock
+    let _lock: RxRecursiveLock
     private let _index: Int
     private let _this: Disposable
     private let _setLatestValue: ValueSetter
     
-    init(lock: RecursiveLock, parent: CombineLatestProtocol, index: Int, setLatestValue: @escaping ValueSetter, this: Disposable) {
+    init(lock: RxRecursiveLock, parent: CombineLatestProtocol, index: Int, setLatestValue: @escaping ValueSetter, this: Disposable) {
         _lock = lock
         _parent = parent
         _index = index

--- a/RxSwift/Observables/Implementations/ConnectableObservable.swift
+++ b/RxSwift/Observables/Implementations/ConnectableObservable.swift
@@ -26,7 +26,7 @@ public class ConnectableObservable<Element>
 final class Connection<S: SubjectType> : ObserverType, Disposable {
     typealias E = S.SubjectObserverType.E
 
-    private var _lock: RecursiveLock
+    private var _lock: RxRecursiveLock
     // state
     private var _parent: ConnectableObservableAdapter<S>?
     private var _subscription : Disposable?
@@ -34,7 +34,7 @@ final class Connection<S: SubjectType> : ObserverType, Disposable {
 
     private var _disposed: Bool = false
 
-    init(parent: ConnectableObservableAdapter<S>, subjectObserver: S.SubjectObserverType, lock: RecursiveLock, subscription: Disposable) {
+    init(parent: ConnectableObservableAdapter<S>, subjectObserver: S.SubjectObserverType, lock: RxRecursiveLock, subscription: Disposable) {
         _parent = parent
         _subscription = subscription
         _lock = lock
@@ -76,7 +76,7 @@ final class ConnectableObservableAdapter<S: SubjectType>
     fileprivate let _subject: S
     fileprivate let _source: Observable<S.SubjectObserverType.E>
     
-    fileprivate let _lock = RecursiveLock()
+    fileprivate let _lock = RxRecursiveLock()
     
     // state
     fileprivate var _connection: ConnectionType?

--- a/RxSwift/Observables/Implementations/Debounce.swift
+++ b/RxSwift/Observables/Implementations/Debounce.swift
@@ -16,7 +16,7 @@ final class DebounceSink<O: ObserverType>
 
     private let _parent: ParentType
 
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
 
     // state
     private var _id = 0 as UInt64

--- a/RxSwift/Observables/Implementations/Delay.swift
+++ b/RxSwift/Observables/Implementations/Delay.swift
@@ -15,7 +15,7 @@ final class DelaySink<O: ObserverType>
     typealias Source = Observable<E>
     typealias DisposeKey = Bag<Disposable>.KeyType
     
-    private let _lock = RecursiveLock()
+    private let _lock = RxRecursiveLock()
 
     private let _dueTime: RxTimeInterval
     private let _scheduler: SchedulerType
@@ -30,7 +30,7 @@ final class DelaySink<O: ObserverType>
     private var _errorEvent: Event<E>? = nil
 
     // state
-    private var _queue = Queue<(eventTime: RxTime, event: Event<E>)>(capacity: 0)
+    private var _queue = RxQueue<(eventTime: RxTime, event: Event<E>)>(capacity: 0)
     private var _disposed = false
     
     init(observer: O, dueTime: RxTimeInterval, scheduler: SchedulerType, cancel: Cancelable) {
@@ -118,7 +118,7 @@ final class DelaySink<O: ObserverType>
         case .error(_):
             _lock.lock()    // {
                 let shouldSendImmediatelly = !_running
-                _queue = Queue(capacity: 0)
+                _queue = RxQueue(capacity: 0)
                 _errorEvent = event
             _lock.unlock()  // }
 

--- a/RxSwift/Observables/Implementations/Merge.swift
+++ b/RxSwift/Observables/Implementations/Merge.swift
@@ -19,7 +19,7 @@ fileprivate final class MergeLimitedSinkIter<S: ObservableConvertibleType, O: Ob
     private let _parent: Parent
     private let _disposeKey: DisposeKey
 
-    var _lock: RecursiveLock {
+    var _lock: RxRecursiveLock {
         return _parent._lock
     }
     
@@ -62,11 +62,11 @@ fileprivate final class MergeLimitedSink<S: ObservableConvertibleType, O: Observ
     , LockOwnerType
     , SynchronizedOnType where S.E == O.E {
     typealias E = S
-    typealias QueueType = Queue<S>
+    typealias QueueType = RxQueue<S>
 
     let _maxConcurrent: Int
 
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
 
     // state
     var _stopped = false
@@ -260,7 +260,7 @@ fileprivate class MergeSink<SourceType, S: ObservableConvertibleType, O: Observe
     typealias ResultType = O.E
     typealias Element = SourceType
 
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
 
     var subscribeNext: Bool {
         return true

--- a/RxSwift/Observables/Implementations/ObserveOn.swift
+++ b/RxSwift/Observables/Implementations/ObserveOn.swift
@@ -44,12 +44,12 @@ final class ObserveOnSink<O: ObserverType> : ObserverBase<O.E> {
     
     let _scheduler: ImmediateSchedulerType
 
-    var _lock = SpinLock()
+    var _lock = RxSpinLock()
     let _observer: O
 
     // state
     var _state = ObserveOnState.stopped
-    var _queue = Queue<Event<E>>(capacity: 10)
+    var _queue = RxQueue<Event<E>>(capacity: 10)
 
     let _scheduleDisposable = SerialDisposable()
     let _cancel: Cancelable

--- a/RxSwift/Observables/Implementations/RefCount.swift
+++ b/RxSwift/Observables/Implementations/RefCount.swift
@@ -66,7 +66,7 @@ final class RefCountSink<CO: ConnectableObservableType, O: ObserverType>
 }
 
 final class RefCount<CO: ConnectableObservableType>: Producer<CO.E> {
-    fileprivate let _lock = RecursiveLock()
+    fileprivate let _lock = RxRecursiveLock()
     
     // state
     fileprivate var _count = 0

--- a/RxSwift/Observables/Implementations/RetryWhen.swift
+++ b/RxSwift/Observables/Implementations/RetryWhen.swift
@@ -84,7 +84,7 @@ final class RetryWhenSequenceSink<S: Sequence, O: ObserverType, TriggerObservabl
     typealias Element = O.E
     typealias Parent = RetryWhenSequence<S, TriggerObservable, Error>
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     fileprivate let _parent: Parent
     

--- a/RxSwift/Observables/Implementations/Sample.swift
+++ b/RxSwift/Observables/Implementations/Sample.swift
@@ -16,7 +16,7 @@ final class SamplerSink<O: ObserverType, SampleType>
     
     fileprivate let _parent: Parent
 
-    var _lock: RecursiveLock {
+    var _lock: RxRecursiveLock {
         return _parent._lock
     }
     
@@ -66,7 +66,7 @@ final class SampleSequenceSink<O: ObserverType, SampleType>
     
     fileprivate let _parent: Parent
 
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     // state
     fileprivate var _element = nil as Element?

--- a/RxSwift/Observables/Implementations/ShareReplay1.swift
+++ b/RxSwift/Observables/Implementations/ShareReplay1.swift
@@ -17,7 +17,7 @@ final class ShareReplay1<Element>
 
     private let _source: Observable<Element>
 
-    private let _lock = RecursiveLock()
+    private let _lock = RxRecursiveLock()
 
     private var _connection: SingleAssignmentDisposable?
     private var _element: Element?

--- a/RxSwift/Observables/Implementations/ShareReplay1WhileConnected.swift
+++ b/RxSwift/Observables/Implementations/ShareReplay1WhileConnected.swift
@@ -17,12 +17,12 @@ fileprivate final class ShareReplay1WhileConnectedConnection<Element>
     private let _parent: Parent
     private let _subscription = SingleAssignmentDisposable()
 
-    private let _lock: RecursiveLock
+    private let _lock: RxRecursiveLock
     private var _disposed: Bool = false
     fileprivate var _observers = Observers()
     fileprivate var _element: Element?
 
-    init(parent: Parent, lock: RecursiveLock) {
+    init(parent: Parent, lock: RxRecursiveLock) {
         _parent = parent
         _lock = lock
 
@@ -111,7 +111,7 @@ final class ShareReplay1WhileConnected<Element>
 
     fileprivate let _source: Observable<Element>
 
-    fileprivate let _lock = RecursiveLock()
+    fileprivate let _lock = RxRecursiveLock()
 
     fileprivate var _connection: Connection?
 

--- a/RxSwift/Observables/Implementations/SkipUntil.swift
+++ b/RxSwift/Observables/Implementations/SkipUntil.swift
@@ -15,7 +15,7 @@ final class SkipUntilSinkOther<Other, O: ObserverType>
     
     fileprivate let _parent: Parent
 
-    var _lock: RecursiveLock {
+    var _lock: RxRecursiveLock {
         return _parent._lock
     }
     
@@ -62,7 +62,7 @@ final class SkipUntilSink<Other, O: ObserverType>
     typealias E = O.E
     typealias Parent = SkipUntil<E, Other>
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     fileprivate let _parent: Parent
     fileprivate var _forwardElements = false
     

--- a/RxSwift/Observables/Implementations/Switch.swift
+++ b/RxSwift/Observables/Implementations/Switch.swift
@@ -16,7 +16,7 @@ class SwitchSink<SourceType, S: ObservableConvertibleType, O: ObserverType>
     fileprivate let _subscriptions: SingleAssignmentDisposable = SingleAssignmentDisposable()
     fileprivate let _innerSubscription: SerialDisposable = SerialDisposable()
 
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     // state
     fileprivate var _stopped = false
@@ -88,7 +88,7 @@ final class SwitchSinkIter<SourceType, S: ObservableConvertibleType, O: Observer
     fileprivate let _id: Int
     fileprivate let _self: Disposable
 
-    var _lock: RecursiveLock {
+    var _lock: RxRecursiveLock {
         return _parent._lock
     }
 

--- a/RxSwift/Observables/Implementations/Take.swift
+++ b/RxSwift/Observables/Implementations/Take.swift
@@ -78,7 +78,7 @@ final class TakeTimeSink<ElementType, O: ObserverType>
 
     fileprivate let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent

--- a/RxSwift/Observables/Implementations/TakeLast.swift
+++ b/RxSwift/Observables/Implementations/TakeLast.swift
@@ -12,11 +12,11 @@ final class TakeLastSink<O: ObserverType> : Sink<O>, ObserverType {
     
     private let _parent: Parent
     
-    private var _elements: Queue<E>
+    private var _elements: RxQueue<E>
     
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
-        _elements = Queue<E>(capacity: parent._count + 1)
+        _elements = RxQueue<E>(capacity: parent._count + 1)
         super.init(observer: observer, cancel: cancel)
     }
     

--- a/RxSwift/Observables/Implementations/TakeUntil.swift
+++ b/RxSwift/Observables/Implementations/TakeUntil.swift
@@ -15,7 +15,7 @@ final fileprivate class TakeUntilSinkOther<Other, O: ObserverType>
     
     fileprivate let _parent: Parent
 
-    var _lock: RecursiveLock {
+    var _lock: RxRecursiveLock {
         return _parent._lock
     }
     
@@ -62,7 +62,7 @@ final class TakeUntilSink<Other, O: ObserverType>
     
     fileprivate let _parent: Parent
  
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     
     init(parent: Parent, observer: O, cancel: Cancelable) {

--- a/RxSwift/Observables/Implementations/Throttle.swift
+++ b/RxSwift/Observables/Implementations/Throttle.swift
@@ -18,7 +18,7 @@ final class ThrottleSink<O: ObserverType>
     
     private let _parent: ParentType
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     // state
     private var _lastUnsentElement: Element? = nil

--- a/RxSwift/Observables/Implementations/Timeout.swift
+++ b/RxSwift/Observables/Implementations/Timeout.swift
@@ -12,7 +12,7 @@ final class TimeoutSink<O: ObserverType>: Sink<O>, LockOwnerType, ObserverType {
     
     private let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
 
     private let _timerD = SerialDisposable()
     private let _subscription = SerialDisposable()

--- a/RxSwift/Observables/Implementations/Window.swift
+++ b/RxSwift/Observables/Implementations/Window.swift
@@ -16,7 +16,7 @@ final class WindowTimeCountSink<Element, O: ObserverType>
     
     private let _parent: Parent
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     private var _subject = PublishSubject<Element>()
     private var _count = 0

--- a/RxSwift/Observables/Implementations/WithLatestFrom.swift
+++ b/RxSwift/Observables/Implementations/WithLatestFrom.swift
@@ -17,7 +17,7 @@ final class WithLatestFromSink<FirstType, SecondType, O: ObserverType>
     
     fileprivate let _parent: Parent
     
-    var _lock = RecursiveLock()
+    var _lock = RxRecursiveLock()
     fileprivate var _latest: SecondType?
 
     init(parent: Parent, observer: O, cancel: Cancelable) {
@@ -74,7 +74,7 @@ final class WithLatestFromSecond<FirstType, SecondType, O: ObserverType>
     private let _parent: Parent
     private let _disposable: Disposable
 
-    var _lock: RecursiveLock {
+    var _lock: RxRecursiveLock {
         return _parent._lock
     }
 

--- a/RxSwift/Observables/Implementations/Zip+Collection.swift
+++ b/RxSwift/Observables/Implementations/Zip+Collection.swift
@@ -14,18 +14,18 @@ final fileprivate class ZipCollectionTypeSink<C: Collection, O: ObserverType>
     
     private let _parent: Parent
     
-    private let _lock = RecursiveLock()
+    private let _lock = RxRecursiveLock()
     
     // state
     private var _numberOfValues = 0
-    private var _values: [Queue<SourceElement>]
+    private var _values: [RxQueue<SourceElement>]
     private var _isDone: [Bool]
     private var _numberOfDone = 0
     private var _subscriptions: [SingleAssignmentDisposable]
     
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
-        _values = [Queue<SourceElement>](repeating: Queue(capacity: 4), count: parent.count)
+        _values = [RxQueue<SourceElement>](repeating: RxQueue(capacity: 4), count: parent.count)
         _isDone = [Bool](repeating: false, count: parent.count)
         _subscriptions = Array<SingleAssignmentDisposable>()
         _subscriptions.reserveCapacity(parent.count)

--- a/RxSwift/Observables/Implementations/Zip+arity.swift
+++ b/RxSwift/Observables/Implementations/Zip+arity.swift
@@ -54,8 +54,8 @@ final class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
 
     let _parent: Parent
 
-    var _values1: Queue<E1> = Queue(capacity: 2)
-    var _values2: Queue<E2> = Queue(capacity: 2)
+    var _values1: RxQueue<E1> = RxQueue(capacity: 2)
+    var _values2: RxQueue<E2> = RxQueue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
@@ -164,9 +164,9 @@ final class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
 
     let _parent: Parent
 
-    var _values1: Queue<E1> = Queue(capacity: 2)
-    var _values2: Queue<E2> = Queue(capacity: 2)
-    var _values3: Queue<E3> = Queue(capacity: 2)
+    var _values1: RxQueue<E1> = RxQueue(capacity: 2)
+    var _values2: RxQueue<E2> = RxQueue(capacity: 2)
+    var _values3: RxQueue<E3> = RxQueue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
@@ -282,10 +282,10 @@ final class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
 
     let _parent: Parent
 
-    var _values1: Queue<E1> = Queue(capacity: 2)
-    var _values2: Queue<E2> = Queue(capacity: 2)
-    var _values3: Queue<E3> = Queue(capacity: 2)
-    var _values4: Queue<E4> = Queue(capacity: 2)
+    var _values1: RxQueue<E1> = RxQueue(capacity: 2)
+    var _values2: RxQueue<E2> = RxQueue(capacity: 2)
+    var _values3: RxQueue<E3> = RxQueue(capacity: 2)
+    var _values4: RxQueue<E4> = RxQueue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
@@ -408,11 +408,11 @@ final class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
 
     let _parent: Parent
 
-    var _values1: Queue<E1> = Queue(capacity: 2)
-    var _values2: Queue<E2> = Queue(capacity: 2)
-    var _values3: Queue<E3> = Queue(capacity: 2)
-    var _values4: Queue<E4> = Queue(capacity: 2)
-    var _values5: Queue<E5> = Queue(capacity: 2)
+    var _values1: RxQueue<E1> = RxQueue(capacity: 2)
+    var _values2: RxQueue<E2> = RxQueue(capacity: 2)
+    var _values3: RxQueue<E3> = RxQueue(capacity: 2)
+    var _values4: RxQueue<E4> = RxQueue(capacity: 2)
+    var _values5: RxQueue<E5> = RxQueue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
@@ -542,12 +542,12 @@ final class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
 
     let _parent: Parent
 
-    var _values1: Queue<E1> = Queue(capacity: 2)
-    var _values2: Queue<E2> = Queue(capacity: 2)
-    var _values3: Queue<E3> = Queue(capacity: 2)
-    var _values4: Queue<E4> = Queue(capacity: 2)
-    var _values5: Queue<E5> = Queue(capacity: 2)
-    var _values6: Queue<E6> = Queue(capacity: 2)
+    var _values1: RxQueue<E1> = RxQueue(capacity: 2)
+    var _values2: RxQueue<E2> = RxQueue(capacity: 2)
+    var _values3: RxQueue<E3> = RxQueue(capacity: 2)
+    var _values4: RxQueue<E4> = RxQueue(capacity: 2)
+    var _values5: RxQueue<E5> = RxQueue(capacity: 2)
+    var _values6: RxQueue<E6> = RxQueue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
@@ -684,13 +684,13 @@ final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> 
 
     let _parent: Parent
 
-    var _values1: Queue<E1> = Queue(capacity: 2)
-    var _values2: Queue<E2> = Queue(capacity: 2)
-    var _values3: Queue<E3> = Queue(capacity: 2)
-    var _values4: Queue<E4> = Queue(capacity: 2)
-    var _values5: Queue<E5> = Queue(capacity: 2)
-    var _values6: Queue<E6> = Queue(capacity: 2)
-    var _values7: Queue<E7> = Queue(capacity: 2)
+    var _values1: RxQueue<E1> = RxQueue(capacity: 2)
+    var _values2: RxQueue<E2> = RxQueue(capacity: 2)
+    var _values3: RxQueue<E3> = RxQueue(capacity: 2)
+    var _values4: RxQueue<E4> = RxQueue(capacity: 2)
+    var _values5: RxQueue<E5> = RxQueue(capacity: 2)
+    var _values6: RxQueue<E6> = RxQueue(capacity: 2)
+    var _values7: RxQueue<E7> = RxQueue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent
@@ -834,14 +834,14 @@ final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink
 
     let _parent: Parent
 
-    var _values1: Queue<E1> = Queue(capacity: 2)
-    var _values2: Queue<E2> = Queue(capacity: 2)
-    var _values3: Queue<E3> = Queue(capacity: 2)
-    var _values4: Queue<E4> = Queue(capacity: 2)
-    var _values5: Queue<E5> = Queue(capacity: 2)
-    var _values6: Queue<E6> = Queue(capacity: 2)
-    var _values7: Queue<E7> = Queue(capacity: 2)
-    var _values8: Queue<E8> = Queue(capacity: 2)
+    var _values1: RxQueue<E1> = RxQueue(capacity: 2)
+    var _values2: RxQueue<E2> = RxQueue(capacity: 2)
+    var _values3: RxQueue<E3> = RxQueue(capacity: 2)
+    var _values4: RxQueue<E4> = RxQueue(capacity: 2)
+    var _values5: RxQueue<E5> = RxQueue(capacity: 2)
+    var _values6: RxQueue<E6> = RxQueue(capacity: 2)
+    var _values7: RxQueue<E7> = RxQueue(capacity: 2)
+    var _values8: RxQueue<E8> = RxQueue(capacity: 2)
 
     init(parent: Parent, observer: O, cancel: Cancelable) {
         _parent = parent

--- a/RxSwift/Observables/Implementations/Zip+arity.tt
+++ b/RxSwift/Observables/Implementations/Zip+arity.tt
@@ -54,7 +54,7 @@ final class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separato
     let _parent: Parent
 
 <%= (Array(1...i).map {
-"    var _values\($0): Queue<E\($0)> = Queue(capacity: 2)"
+"    var _values\($0): RxQueue<E\($0)> = RxQueue(capacity: 2)"
 }).joined(separator: "\n") %>
 
     init(parent: Parent, observer: O, cancel: Cancelable) {

--- a/RxSwift/Observables/Implementations/Zip.swift
+++ b/RxSwift/Observables/Implementations/Zip.swift
@@ -18,7 +18,7 @@ class ZipSink<O: ObserverType> : Sink<O>, ZipSinkProtocol {
     
     let _arity: Int
 
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
 
     // state
     private var _isDone: [Bool]
@@ -109,14 +109,14 @@ final class ZipObserver<ElementType>
 
     private var _parent: ZipSinkProtocol?
     
-    let _lock: RecursiveLock
+    let _lock: RxRecursiveLock
     
     // state
     private let _index: Int
     private let _this: Disposable
     private let _setNextValue: ValueSetter
     
-    init(lock: RecursiveLock, parent: ZipSinkProtocol, index: Int, setNextValue: @escaping ValueSetter, this: Disposable) {
+    init(lock: RxRecursiveLock, parent: ZipSinkProtocol, index: Int, setNextValue: @escaping ValueSetter, this: Disposable) {
         _lock = lock
         _parent = parent
         _index = index

--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -43,7 +43,7 @@ import Dispatch
 ///
 /// This scheduler is also sometimes called `trampoline scheduler`.
 public class CurrentThreadScheduler : ImmediateSchedulerType {
-    typealias ScheduleQueue = RxMutableBox<Queue<ScheduledItemType>>
+    typealias ScheduleQueue = RxMutableBox<RxQueue<ScheduledItemType>>
 
     /// The singleton instance of the current thread scheduler.
     public static let instance = CurrentThreadScheduler()
@@ -119,12 +119,12 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
 
         let existingQueue = CurrentThreadScheduler.queue
 
-        let queue: RxMutableBox<Queue<ScheduledItemType>>
+        let queue: RxMutableBox<RxQueue<ScheduledItemType>>
         if let existingQueue = existingQueue {
             queue = existingQueue
         }
         else {
-            queue = RxMutableBox(Queue<ScheduledItemType>(capacity: 1))
+            queue = RxMutableBox(RxQueue<ScheduledItemType>(capacity: 1))
             CurrentThreadScheduler.queue = queue
         }
 

--- a/RxSwift/Schedulers/RecursiveScheduler.swift
+++ b/RxSwift/Schedulers/RecursiveScheduler.swift
@@ -17,7 +17,7 @@ final class AnyRecursiveScheduler<State> {
     
     typealias Action =  (State, AnyRecursiveScheduler<State>) -> Void
 
-    private let _lock = RecursiveLock()
+    private let _lock = RxRecursiveLock()
     
     // state
     private let _group = CompositeDisposable()
@@ -151,7 +151,7 @@ final class AnyRecursiveScheduler<State> {
 final class RecursiveImmediateScheduler<State> {
     typealias Action =  (_ state: State, _ recurse: (State) -> Void) -> Void
     
-    private var _lock = SpinLock()
+    private var _lock = RxSpinLock()
     private let _group = CompositeDisposable()
     
     private var _action: Action?

--- a/RxSwift/Schedulers/VirtualTimeScheduler.swift
+++ b/RxSwift/Schedulers/VirtualTimeScheduler.swift
@@ -17,7 +17,7 @@ open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
 
     private var _clock: VirtualTime
 
-    fileprivate var _schedulerQueue : PriorityQueue<VirtualSchedulerItem<VirtualTime>>
+    fileprivate var _schedulerQueue : RxPriorityQueue<VirtualSchedulerItem<VirtualTime>>
     private var _converter: Converter
 
     private var _nextId = 0
@@ -39,7 +39,7 @@ open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
         _clock = initialClock
         _running = false
         _converter = converter
-        _schedulerQueue = PriorityQueue(hasHigherPriority: {
+        _schedulerQueue = RxPriorityQueue(hasHigherPriority: {
             switch converter.compareVirtualTime($0.time, $1.time) {
             case .lessThan:
                 return true

--- a/RxSwift/Subjects/AsyncSubject.swift
+++ b/RxSwift/Subjects/AsyncSubject.swift
@@ -26,7 +26,7 @@ public final class AsyncSubject<Element>
         return _observers.count > 0
     }
 
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
 
     // state
     private var _observers = Observers()

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -28,7 +28,7 @@ public final class BehaviorSubject<Element>
         return value
     }
     
-    let _lock = RecursiveLock()
+    let _lock = RxRecursiveLock()
     
     // state
     private var _isDisposed = false

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -28,7 +28,7 @@ public final class PublishSubject<Element>
         return count
     }
     
-    private let _lock = RecursiveLock()
+    private let _lock = RxRecursiveLock()
     
     // state
     private var _isDisposed = false

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -27,7 +27,7 @@ public class ReplaySubject<Element>
         return value
     }
     
-    fileprivate let _lock = RecursiveLock()
+    fileprivate let _lock = RxRecursiveLock()
     
     // state
     fileprivate var _isDisposed = false
@@ -224,10 +224,10 @@ final class ReplayOne<Element> : ReplayBufferBase<Element> {
 }
 
 class ReplayManyBase<Element> : ReplayBufferBase<Element> {
-    fileprivate var _queue: Queue<Element>
+    fileprivate var _queue: RxQueue<Element>
     
     init(queueSize: Int) {
-        _queue = Queue(capacity: queueSize + 1)
+        _queue = RxQueue(capacity: queueSize + 1)
     }
     
     override func addValueToBuffer(_ value: Element) {
@@ -242,7 +242,7 @@ class ReplayManyBase<Element> : ReplayBufferBase<Element> {
 
     override func _synchronized_dispose() {
         super._synchronized_dispose()
-        _queue = Queue(capacity: 0)
+        _queue = RxQueue(capacity: 0)
     }
 }
 

--- a/RxSwift/Subjects/Variable.swift
+++ b/RxSwift/Subjects/Variable.swift
@@ -16,7 +16,7 @@ public final class Variable<Element> {
     
     private let _subject: BehaviorSubject<Element>
     
-    private var _lock = SpinLock()
+    private var _lock = RxSpinLock()
  
     // state
     private var _value: E

--- a/Tests/RxSwiftTests/QueueTests.swift
+++ b/Tests/RxSwiftTests/QueueTests.swift
@@ -22,7 +22,7 @@ class QueueTest : RxTest {
 
 extension QueueTest {
     func test() {
-        var queue: Queue<Int> = Queue(capacity: 2)
+        var queue: RxQueue<Int> = RxQueue(capacity: 2)
         
         XCTAssertEqual(queue.count, 0)
         
@@ -48,7 +48,7 @@ extension QueueTest {
     }
     
     func testComplexity() {
-        var queue: Queue<Int> = Queue(capacity: 2)
+        var queue: RxQueue<Int> = RxQueue(capacity: 2)
         
         XCTAssertEqual(queue.count, 0)
         

--- a/Tests/RxSwiftTests/RecursiveLockTest.swift
+++ b/Tests/RxSwiftTests/RecursiveLockTest.swift
@@ -69,7 +69,7 @@ fileprivate protocol Lock {
     func unlock()
 }
 
-extension RecursiveLock: Lock {
+extension RxRecursiveLock: Lock {
 
 }
 
@@ -114,12 +114,12 @@ extension RecursiveLockTests {
             XCTAssertEqual(values, expectedValues)
         }
 
-        performTestLock(lock: RecursiveLock(), expectedValues: [1, 2])
+        performTestLock(lock: RxRecursiveLock(), expectedValues: [1, 2])
         performTestLock(lock: NoLock(), expectedValues: [2, 1])
     }
 
     func testIsReentrant() {
-        let recursiveLock = RecursiveLock()
+        let recursiveLock = RxRecursiveLock()
 
         recursiveLock.lock()
         recursiveLock.lock()
@@ -129,7 +129,7 @@ extension RecursiveLockTests {
 
     #if TRACE_RESOURCES
         func testLockUnlockCountsResources() {
-            let lock = RecursiveLock()
+            let lock = RxRecursiveLock()
 
             let initial = Resources.total
 

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
@@ -22,7 +22,7 @@ class PrimitiveHotObservable<ElementType> : ObservableType {
     var subscriptions = [Subscription]()
     let observers = PublishSubject<ElementType>()
 
-    let lock = RecursiveLock()
+    let lock = RxRecursiveLock()
     
     init() {
     }


### PR DESCRIPTION
Currently a handful of primitives and data structures used by framework contains prefix Rx. Example: RxMutableBox.

Rename the rest to minimize a chance of name collisions.