### PR TITLE
Add code to reproduce output shown in GettingStarted documentation

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -112,6 +112,7 @@ There is one additional way an observed sequence can terminate. When we are done
 Here is an example with the `interval` operator.
 
 ```swift
+let scheduler = SerialDispatchQueueScheduler(qos: .default)
 let subscription = Observable<Int>.interval(0.3, scheduler: scheduler)
     .subscribe { event in
         print(event)
@@ -120,7 +121,6 @@ let subscription = Observable<Int>.interval(0.3, scheduler: scheduler)
 Thread.sleep(forTimeInterval: 2.0)
 
 subscription.dispose()
-
 ```
 
 This will print:


### PR DESCRIPTION
I added a scheduler that will actually produce the output shown in the documentation when the code sample is run on the main thread. The interval observable needs to run on a separate thread from the code that is being made to sleep so that the events can get sent. This may be helpful to those trying out the code samples.