### PR TITLE
Fixed wrong missing CHANGELOG detection in Dangerfile

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -10,7 +10,7 @@ declared_trivial = pr_title.include? "#trivial"
 warn("PR is classed as Work in Progress") if pr_title.include? "[WIP]"
 
 # Warn no CHANGELOG
-warn("No CHANGELOG changes made") if lines_of_code > 50 && !modified_files.include?("CHANGELOG.yml") && !declared_trivial
+warn("No CHANGELOG changes made") if lines_of_code > 50 && !modified_files.include?("CHANGELOG.md") && !declared_trivial
 
 # Warn pod spec changes
 warn("RxCocoa.podspec changed") if modified_files.include?("RxCocoa.podspec")


### PR DESCRIPTION
Just noticed every PR I push is marked as missing a CHANGELOG entry. Seems the Dangerfile is looking for a YAML changelog instead of a Markdown one. 