### PR TITLE
Update to latest Danger gem to fix Github Markdown issues

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,33 +1,31 @@
 # Warn about develop branch
-current_branch = env.request_source.pr_json["base"]["ref"]
-warn("Please target PRs to `develop` branch") if current_branch != "develop" && current_branch != "swift-3.0"
+warn("Please target PRs to `develop` branch") if github.branch_for_base != "develop" && github.branch_for_base != "swift-3.0"
 
 # Sometimes it's a README fix, or something like that - which isn't relevant for
 # including in a project's CHANGELOG for example
-declared_trivial = pr_title.include? "#trivial"
+declared_trivial = github.pr_title.include? "#trivial"
 
 # Make it more obvious that a PR is a work in progress and shouldn't be merged yet
-warn("PR is classed as Work in Progress") if pr_title.include? "[WIP]"
+warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
 
 # Warn no CHANGELOG
-warn("No CHANGELOG changes made") if lines_of_code > 50 && !modified_files.include?("CHANGELOG.yml") && !declared_trivial
+warn("No CHANGELOG changes made") if git.lines_of_code > 50 && !git.modified_files.include?("CHANGELOG.yml") && !declared_trivial
 
 # Warn pod spec changes
-warn("RxCocoa.podspec changed") if modified_files.include?("RxCocoa.podspec")
-warn("RxSwift.podspec changed") if modified_files.include?("RxSwift.podspec")
-warn("RxTests.podspec changed") if modified_files.include?("RxTests.podspec")
-warn("RxBlocking.podspec changed") if modified_files.include?("RxBlocking.podspec")
+warn("RxCocoa.podspec changed") if git.modified_files.include?("RxCocoa.podspec")
+warn("RxSwift.podspec changed") if git.modified_files.include?("RxSwift.podspec")
+warn("RxTests.podspec changed") if git.modified_files.include?("RxTests.podspec")
+warn("RxBlocking.podspec changed") if git.modified_files.include?("RxBlocking.podspec")
 
 # Warn summary on pull request
-if pr_body.length < 5
+if github.pr_body.length < 5
   warn "Please provide a summary in the Pull Request description"
 end
 
 # If these are all empty something has gone wrong, better to raise it in a comment
-if modified_files.empty? && added_files.empty? && deleted_files.empty?
+if git.modified_files.empty? && git.added_files.empty? && git.deleted_files.empty?
   fail "This PR has no changes at all, this is likely a developer issue."
 end
 
 # Warn when there is a big PR
-warn("Big PR") if lines_of_code > 500
-
+warn("Big PR") if git.lines_of_code > 500

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,46 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.8)
-    claide (1.0.0)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    claide (1.0.1)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
     colored (1.2)
-    danger (0.7.4)
-      claide
+    colored2 (3.1.2)
+    cork (0.2.0)
       colored (~> 1.2)
-      faraday
-      git
+    danger (4.3.3)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1)
+      kramdown (~> 1.5)
       octokit (~> 4.2)
-      redcarpet (~> 3.3)
       terminal-table (~> 1)
-    faraday (0.9.1)
+    faraday (0.12.0.1)
       multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
     git (1.3.0)
+    kramdown (1.13.2)
     multipart-post (2.0.0)
-    octokit (4.3.0)
-      sawyer (~> 0.7.0, >= 0.5.3)
-    redcarpet (3.3.4)
-    sawyer (0.7.0)
-      addressable (>= 2.3.5, < 2.5)
-      faraday (~> 0.8, < 0.10)
-    terminal-table (1.4.5)
+    nap (1.1.0)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    public_suffix (2.0.5)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    terminal-table (1.7.3)
+      unicode-display_width (~> 1.1.1)
+    unicode-display_width (1.1.3)
 
 PLATFORMS
   ruby
@@ -31,4 +49,4 @@ DEPENDENCIES
   danger
 
 BUNDLED WITH
-   1.12.5
+   1.14.6


### PR DESCRIPTION
## Description
- This fixes the issues when the bot comments on pull requests.

Screenshot of issue:
![screenshot from 2017-04-05 16-59-54](https://cloud.githubusercontent.com/assets/2777576/24714793/6d50c738-1a21-11e7-9a9a-58909b10ae3a.png)
