### PR TITLE
Update throttle of SharedSequence to support `latest` parameter

### DIFF
--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -302,10 +302,10 @@ extension SharedSequenceConvertibleType {
      - parameter latest: Should latest element received in a dueTime wide time window since last element emission be emitted.
      - returns: The throttled sequence.
     */
-    public func throttle(_ dueTime: RxTimeInterval)
+    public func throttle(_ dueTime: RxTimeInterval, latest: Bool = true)
         -> SharedSequence<SharingStrategy, E> {
         let source = self.asObservable()
-            .throttle(dueTime, scheduler: SharingStrategy.scheduler)
+            .throttle(dueTime, latest: latest, scheduler: SharingStrategy.scheduler)
 
         return SharedSequence(source)
     }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1215,6 +1215,7 @@ final class DriverTest_ : DriverTest, RxTestCase {
     ("testAsDriver_merge2", DriverTest.testAsDriver_merge2),
     ("testAsDriver_debounce", DriverTest.testAsDriver_debounce),
     ("testAsDriver_throttle", DriverTest.testAsDriver_throttle),
+    ("testAsDriver_throttle2", DriverTest.testAsDriver_throttle2),
     ("testAsDriver_scan", DriverTest.testAsDriver_scan),
     ("testAsDriver_concat_sequenceType", DriverTest.testAsDriver_concat_sequenceType),
     ("testAsDriver_concat", DriverTest.testAsDriver_concat),

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -813,6 +813,23 @@ extension DriverTest {
         XCTAssertEqual(results, [1, -1])
     }
 
+    func testAsDriver_throttle2() {
+        let hotObservable = BackgroundThreadPrimitiveHotObservable<Int>()
+        let driver = hotObservable.asDriver(onErrorJustReturn: -1).throttle(0.5, latest: false)
+
+        let results = subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription(driver) {
+            XCTAssertTrue(hotObservable.subscriptions == [SubscribedToHotObservable])
+
+            hotObservable.on(.next(1))
+            hotObservable.on(.next(2))
+            hotObservable.on(.error(testError))
+
+            XCTAssertTrue(hotObservable.subscriptions == [UnsunscribedFromHotObservable])
+        }
+
+        XCTAssertEqual(results, [1])
+    }
+
 }
 
 // MARK: scan


### PR DESCRIPTION
The `latest` parameter is in the documentation but it's not implemented.