### PR TITLE
Adds `isEnabled` property for UILabel extension

### DIFF
--- a/RxCocoa/iOS/UILabel+Rx.swift
+++ b/RxCocoa/iOS/UILabel+Rx.swift
@@ -29,6 +29,13 @@ extension Reactive where Base: UILabel {
         }
     }
     
+    /// Bindable sink for `isEnabled` property.
+    public var isEnabled: UIBindingObserver<Base, Bool> {
+        return UIBindingObserver(UIElement: self.base) { control, value in
+            control.isEnabled = value
+        }
+    }
+    
 }
 
 #endif

--- a/RxCocoa/iOS/UILabel+Rx.swift
+++ b/RxCocoa/iOS/UILabel+Rx.swift
@@ -31,8 +31,8 @@ extension Reactive where Base: UILabel {
     
     /// Bindable sink for `isEnabled` property.
     public var isEnabled: UIBindingObserver<Base, Bool> {
-        return UIBindingObserver(UIElement: self.base) { control, value in
-            control.isEnabled = value
+        return UIBindingObserver(UIElement: self.base) { label, value in
+            label.isEnabled = value
         }
     }
     


### PR DESCRIPTION
Despite the fact that `UILabel` is not an `UIControl`, it has an `isEnabled` property. Just out of curiosity, according to the docs (https://developer.apple.com/reference/uikit/uilabel/1620530-isenabled), "This property determines only how the label is drawn. Disabled text is dimmed somewhat to indicate it is not active. This property is set to true by default".