### PR TITLE
Fix link to 3.4.0 tag in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 
-## [3.4](https://github.com/ReactiveX/RxSwift/releases/tag/3.4) (Xcode 8.3.1 / Swift 3.1 compatible)
+## [3.4.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.4.0) (Xcode 8.3.1 / Swift 3.1 compatible)
 
 * Xcode 8.3.1 / Swift 3.1 compatibility.
 * Add subscription closures for Single, Maybe and Completable (`onSuccess`, `onError`, `onCompleted`).


### PR DESCRIPTION
Current link points to 404 because tag is `3.4.0` and not just `3.4`