### PR TITLE
`UINavigationController` delegate proxy

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -230,6 +230,7 @@ custom_categories:
   - UIGestureRecognizer+Rx
   - UIImageView+Rx
   - UILabel+Rx
+  - UINavigationController+Rx
   - UINavigationItem+Rx
   - UIPageControl+Rx
   - UIPickerView+Rx
@@ -259,6 +260,7 @@ custom_categories:
   children:
   - RxCollectionViewDataSourceProxy
   - RxCollectionViewDelegateProxy
+  - RxNavigationControllerDelegateProxy
   - RxPickerViewDelegateProxy
   - RxScrollViewDelegateProxy
   - RxSearchBarDelegateProxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## Master
 
+* Adds `UINavigationController` delegate proxy and extensions:
+    * `willShow`
+    * `didShow`
 
 ## [3.4](https://github.com/ReactiveX/RxSwift/releases/tag/3.4) (Xcode 8.3.1 / Swift 3.1 compatible)
 

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1357,6 +1357,12 @@
 		D2FC15B31BCB95E5007361FF /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */; };
 		D2FC15B41BCB95E7007361FF /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */; };
 		D2FC15B51BCB95E8007361FF /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22B6D251BC8504A00BCE0AB /* SkipWhile.swift */; };
+		D9080ACF1EA05AE0002B433B /* RxNavigationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */; };
+		D9080AD01EA05AF7002B433B /* RxNavigationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */; };
+		D9080AD11EA05DA2002B433B /* RxNavigationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */; };
+		D9080AD41EA05DE9002B433B /* UINavigationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */; };
+		D9080AD51EA05DEB002B433B /* UINavigationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */; };
+		D9080AD61EA05DEC002B433B /* UINavigationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */; };
 		EB15145D1DFFAACB00555E2C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB15145C1DFFAACB00555E2C /* Optional.swift */; };
 		EB15145E1DFFAACB00555E2C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB15145C1DFFAACB00555E2C /* Optional.swift */; };
 		EB15145F1DFFAACB00555E2C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB15145C1DFFAACB00555E2C /* Optional.swift */; };
@@ -2030,6 +2036,8 @@
 		D285BAC31BC0231000B3F602 /* SkipUntil.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SkipUntil.swift; sourceTree = "<group>"; };
 		D2EA280C1BB9B5A200880ED3 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2EBEB811BB9B99D003A27DC /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxNavigationControllerDelegateProxy.swift; sourceTree = "<group>"; };
+		D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Rx.swift"; sourceTree = "<group>"; };
 		EB15145C1DFFAACB00555E2C /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Rx.swift"; sourceTree = "<group>"; };
 		ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTabBarControllerDelegateProxy.swift; sourceTree = "<group>"; };
@@ -2761,6 +2769,7 @@
 				7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */,
 				C882540D1B8A752B00B02D69 /* UIScrollView+Rx.swift */,
 				C882540E1B8A752B00B02D69 /* UISearchBar+Rx.swift */,
+				D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */,
 				C882540F1B8A752B00B02D69 /* UISegmentedControl+Rx.swift */,
 				C88254101B8A752B00B02D69 /* UISlider+Rx.swift */,
 				F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */,
@@ -2824,6 +2833,7 @@
 				84C225A21C33F00B008724EC /* RxTextStorageDelegateProxy.swift */,
 				846436E11C9AF64C0035B40D /* RxSearchControllerDelegateProxy.swift */,
 				844BC8AA1CE4FA5600F5C7CB /* RxPickerViewDelegateProxy.swift */,
+				D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */,
 				4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */,
 			);
 			path = Proxies;
@@ -3896,6 +3906,7 @@
 				C89AB2061DAAC3350065FBE6 /* KVORepresentable+Swift.swift in Sources */,
 				C89AB1E21DAAC3350065FBE6 /* Variable+Driver.swift in Sources */,
 				C89AB1DE1DAAC3350065FBE6 /* ObservableConvertibleType+Driver.swift in Sources */,
+				D9080ACF1EA05AE0002B433B /* RxNavigationControllerDelegateProxy.swift in Sources */,
 				C88254271B8A752B00B02D69 /* UIBarButtonItem+Rx.swift in Sources */,
 				C89AB2161DAAC3350065FBE6 /* NSObject+Rx+KVORepresentable.swift in Sources */,
 				C882542B1B8A752B00B02D69 /* UIDatePicker+Rx.swift in Sources */,
@@ -3906,6 +3917,7 @@
 				C8093EE11B8A732E0088E94D /* DelegateProxy.swift in Sources */,
 				C89AB2501DAAC3A60065FBE6 /* _RXObjCRuntime.m in Sources */,
 				C89AB21E1DAAC3350065FBE6 /* NSObject+Rx.swift in Sources */,
+				D9080AD41EA05DE9002B433B /* UINavigationController+Rx.swift in Sources */,
 				88718CFE1CE5D80000D88D60 /* UITabBar+Rx.swift in Sources */,
 				88D98F2E1CE7549A00D50457 /* RxTabBarDelegateProxy.swift in Sources */,
 				C88254331B8A752B00B02D69 /* UISwitch+Rx.swift in Sources */,
@@ -4997,8 +5009,10 @@
 				C89AB1D91DAAC3350065FBE6 /* Driver+Subscription.swift in Sources */,
 				91BE429F1CBF7F3D00F6B062 /* UIPageControl+Rx.swift in Sources */,
 				846436E61C9AF6670035B40D /* RxSearchControllerDelegateProxy.swift in Sources */,
+				D9080AD11EA05DA2002B433B /* RxNavigationControllerDelegateProxy.swift in Sources */,
 				C89AB2111DAAC3350065FBE6 /* Logging.swift in Sources */,
 				C89AB1761DAAC1680065FBE6 /* ControlTarget.swift in Sources */,
+				D9080AD61EA05DEC002B433B /* UINavigationController+Rx.swift in Sources */,
 				C89AB21D1DAAC3350065FBE6 /* NSObject+Rx+RawRepresentable.swift in Sources */,
 				C89AB2191DAAC3350065FBE6 /* NSObject+Rx+KVORepresentable.swift in Sources */,
 				C89AB2531DAAC3A60065FBE6 /* _RXObjCRuntime.m in Sources */,
@@ -5051,8 +5065,10 @@
 				C89AB1D01DAAC3350065FBE6 /* ControlEvent+Driver.swift in Sources */,
 				84C225A41C33F00B008724EC /* RxTextStorageDelegateProxy.swift in Sources */,
 				C89AB2081DAAC3350065FBE6 /* KVORepresentable+Swift.swift in Sources */,
+				D9080AD01EA05AF7002B433B /* RxNavigationControllerDelegateProxy.swift in Sources */,
 				D203C5131BB9C53E00D02D00 /* UITextView+Rx.swift in Sources */,
 				D203C4F41BB9C52400D02D00 /* RxTableViewReactiveArrayDataSource.swift in Sources */,
+				D9080AD51EA05DEB002B433B /* UINavigationController+Rx.swift in Sources */,
 				7F600F401C5D0C6D00535B1D /* UIRefreshControl+Rx.swift in Sources */,
 				C89AB1D81DAAC3350065FBE6 /* Driver+Subscription.swift in Sources */,
 				C89AB1DC1DAAC3350065FBE6 /* Driver.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1363,6 +1363,8 @@
 		D9080AD41EA05DE9002B433B /* UINavigationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */; };
 		D9080AD51EA05DEB002B433B /* UINavigationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */; };
 		D9080AD61EA05DEC002B433B /* UINavigationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */; };
+		D9080AD81EA06189002B433B /* UINavigationController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */; };
+		D9080AD91EA06189002B433B /* UINavigationController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */; };
 		EB15145D1DFFAACB00555E2C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB15145C1DFFAACB00555E2C /* Optional.swift */; };
 		EB15145E1DFFAACB00555E2C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB15145C1DFFAACB00555E2C /* Optional.swift */; };
 		EB15145F1DFFAACB00555E2C /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB15145C1DFFAACB00555E2C /* Optional.swift */; };
@@ -2038,6 +2040,7 @@
 		D2EBEB811BB9B99D003A27DC /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxNavigationControllerDelegateProxy.swift; sourceTree = "<group>"; };
 		D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Rx.swift"; sourceTree = "<group>"; };
+		D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+RxTests.swift"; sourceTree = "<group>"; };
 		EB15145C1DFFAACB00555E2C /* Optional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Optional.swift; sourceTree = "<group>"; };
 		ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Rx.swift"; sourceTree = "<group>"; };
 		ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTabBarControllerDelegateProxy.swift; sourceTree = "<group>"; };
@@ -2548,6 +2551,7 @@
 				C8C4F16C1DE9D4F400003FA7 /* UIDatePicker+RxTests.swift */,
 				C8C4F1641DE9D3FB00003FA7 /* UIGestureRecognizer+RxTests.swift */,
 				C8C4F1601DE9CD1600003FA7 /* UILabel+RxTests.swift */,
+				D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */,
 				54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */,
 				914FCD661CCDB82E0058B304 /* UIPageControl+RxTest.swift */,
 				844BC8B71CE5023200F5C7CB /* UIPickerView+RxTests.swift */,
@@ -4066,6 +4070,7 @@
 				C83509311C38706E0027C24C /* DelegateProxyTest+UIKit.swift in Sources */,
 				C83509481C38706E0027C24C /* TestConnectableObservable.swift in Sources */,
 				C8353CEC1DA19BC500BE3F5C /* XCTest+AllTests.swift in Sources */,
+				D9080AD81EA06189002B433B /* UINavigationController+RxTests.swift in Sources */,
 				C8353CE61DA19BC500BE3F5C /* Recorded+Timeless.swift in Sources */,
 				C83509371C38706E0027C24C /* NotificationCenterTests.swift in Sources */,
 				C835095C1C38706E0027C24C /* Observable+MultipleTest.swift in Sources */,
@@ -4184,6 +4189,7 @@
 				C8350A111C38756A0027C24C /* Observable+SingleTest.swift in Sources */,
 				C8E9E42C1D43B26C0049644E /* Observable+DebugTest.swift in Sources */,
 				C8350A2A1C3875B50027C24C /* RxMutableBox.swift in Sources */,
+				D9080AD91EA06189002B433B /* UINavigationController+RxTests.swift in Sources */,
 				C8C4F17A1DE9DF0200003FA7 /* UIBarButtonItem+RxTests.swift in Sources */,
 				C8350A151C38756A0027C24C /* ObserverTests.swift in Sources */,
 				1AF67DA71CED430100C310FA /* ReplaySubjectTest.swift in Sources */,

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -14,7 +14,7 @@ import UIKit
 #endif
 
 /// For more information take a look at `DelegateProxyType`.
-public class RxNavigationControllerDelegateProxy
+open class RxNavigationControllerDelegateProxy
     : DelegateProxy
     , UINavigationControllerDelegate
     , DelegateProxyType {
@@ -32,7 +32,7 @@ public class RxNavigationControllerDelegateProxy
     }
 
     /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
+    open override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
         let navigationController: UINavigationController = castOrFatalError(object)
         return navigationController.createRxDelegateProxy()
     }

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -1,0 +1,41 @@
+//
+//  RxNavigationControllerDelegateProxy.swift
+//  Rx
+//
+//  Created by Diogo on 13/04/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+import UIKit
+#if !RX_NO_MODULE
+    import RxSwift
+#endif
+
+/// For more information take a look at `DelegateProxyType`.
+public class RxNavigationControllerDelegateProxy
+    : DelegateProxy
+    , UINavigationControllerDelegate
+    , DelegateProxyType {
+
+    /// For more information take a look at `DelegateProxyType`.
+    public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
+        let navigationController: UINavigationController = castOrFatalError(object)
+        return navigationController.delegate
+    }
+
+    /// For more information take a look at `DelegateProxyType`.
+    public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {
+        let navigationController: UINavigationController = castOrFatalError(object)
+        navigationController.delegate = castOptionalOrFatalError(delegate)
+    }
+
+    /// For more information take a look at `DelegateProxyType`.
+    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
+        let navigationController: UINavigationController = castOrFatalError(object)
+        return navigationController.createRxDelegateProxy()
+    }
+}
+
+#endif

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -1,6 +1,6 @@
 //
 //  RxNavigationControllerDelegateProxy.swift
-//  Rx
+//  RxCocoa
 //
 //  Created by Diogo on 13/04/17.
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.

--- a/RxCocoa/iOS/UINavigationController+Rx.swift
+++ b/RxCocoa/iOS/UINavigationController+Rx.swift
@@ -1,6 +1,6 @@
 //
 //  UINavigationController+Rx.swift
-//  Rx
+//  RxCocoa
 //
 //  Created by Diogo on 13/04/17.
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.

--- a/RxCocoa/iOS/UINavigationController+Rx.swift
+++ b/RxCocoa/iOS/UINavigationController+Rx.swift
@@ -1,0 +1,60 @@
+//
+//  UINavigationController+Rx.swift
+//  Rx
+//
+//  Created by Diogo on 13/04/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+#if !RX_NO_MODULE
+import RxSwift
+#endif
+import UIKit
+
+extension UINavigationController {
+    /// Factory method that enables subclasses to implement their own `delegate`.
+    ///
+    /// - returns: Instance of delegate proxy that wraps `delegate`.
+    public func createRxDelegateProxy() -> RxNavigationControllerDelegateProxy {
+        return RxNavigationControllerDelegateProxy(parentObject: self)
+    }
+}
+
+extension Reactive where Base: UINavigationController {
+    public typealias ShowEvent = (viewController: UIViewController, animated: Bool)
+
+    /// Reactive wrapper for `delegate`.
+    ///
+    /// For more information take a look at `DelegateProxyType` protocol documentation.
+    public var delegate: DelegateProxy {
+        return RxNavigationControllerDelegateProxy.proxyForObject(base)
+    }
+
+    /// Reactive wrapper for delegate method `navigationController(:willShow:animated:)`.
+    public var willShow: ControlEvent<ShowEvent> {
+        let source: Observable<ShowEvent> = delegate
+            .methodInvoked(#selector(UINavigationControllerDelegate.navigationController(_:willShow:animated:)))
+            .map { arg in
+                let viewController = try castOrThrow(UIViewController.self, arg[1])
+                let animated = try castOrThrow(Bool.self, arg[2])
+                return (viewController, animated)
+        }
+        return ControlEvent(events: source)
+    }
+
+    /// Reactive wrapper for delegate method `navigationController(:didShow:animated:)`.
+    public var didShow: ControlEvent<ShowEvent> {
+        let source: Observable<ShowEvent> = delegate
+            .methodInvoked(#selector(UINavigationControllerDelegate.navigationController(_:didShow:animated:)))
+            .map { arg in
+                let viewController = try castOrThrow(UIViewController.self, arg[1])
+                let animated = try castOrThrow(Bool.self, arg[2])
+                return (viewController, animated)
+        }
+        return ControlEvent(events: source)
+    }
+}
+
+#endif

--- a/RxExample/Extensions/RxImagePickerDelegateProxy.swift
+++ b/RxExample/Extensions/RxImagePickerDelegateProxy.swift
@@ -15,49 +15,9 @@
    import UIKit
 
 public class RxImagePickerDelegateProxy
-    : DelegateProxy
-    , DelegateProxyType
-    , UIImagePickerControllerDelegate
-    , UINavigationControllerDelegate {
+    : RxNavigationControllerDelegateProxy
+    , UIImagePickerControllerDelegate {
     
-    /**
-     For more information take a look at `DelegateProxyType`.
-     */
-    public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {
-        let imagePickerController: UIImagePickerController = castOrFatalError(object)
-        imagePickerController.delegate = castOptionalOrFatalError(delegate)
-    }
-    
-    /**
-     For more information take a look at `DelegateProxyType`.
-     */
-    public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
-        let imagePickerController: UIImagePickerController = castOrFatalError(object)
-        return imagePickerController.delegate
-    }
-
 }
 
-    private func castOrFatalError<T>(_ value: Any!) -> T {
-        let maybeResult: T? = value as? T
-        guard let result = maybeResult else {
-            rxFatalError("Failure converting from \(value) to \(T.self)")
-        }
-
-        return result
-    }
-
-    private func castOptionalOrFatalError<T>(_ value: AnyObject?) -> T? {
-        if value == nil {
-            return nil
-        }
-        let v: T = castOrFatalError(value)
-        return v
-    }
-
-    private func rxFatalError(_ lastMessage: String) -> Never {
-        // The temptation to comment this line is great, but please don't, it's for your own good. The choice is yours.
-        fatalError(lastMessage)
-    }
-    
 #endif

--- a/RxExample/Extensions/UIImagePickerController+Rx.swift
+++ b/RxExample/Extensions/UIImagePickerController+Rx.swift
@@ -18,15 +18,6 @@
     extension Reactive where Base: UIImagePickerController {
 
         /**
-         Reactive wrapper for `delegate`.
-
-         For more information take a look at `DelegateProxyType` protocol documentation.
-         */
-        public var delegate: DelegateProxy {
-            return RxImagePickerDelegateProxy.proxyForObject(base)
-        }
-
-        /**
          Reactive wrapper for `delegate` message.
          */
         public var didFinishPickingMediaWithInfo: Observable<[String : AnyObject]> {

--- a/Sources/RxCocoa/RxNavigationControllerDelegateProxy.swift
+++ b/Sources/RxCocoa/RxNavigationControllerDelegateProxy.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift

--- a/Sources/RxCocoa/UINavigationController+Rx.swift
+++ b/Sources/RxCocoa/UINavigationController+Rx.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/iOS/UINavigationController+Rx.swift

--- a/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
@@ -41,6 +41,14 @@ extension DelegateProxyTest {
     }
 }
 
+// MARK: UITabBarController
+
+extension DelegateProxyTest {
+    func test_UINavigationControllerDelegateExtension() {
+        performDelegateTest(UINavigationControllerSubclass())
+    }
+}
+
 // MARK: UIScrollView
 
 extension DelegateProxyTest {
@@ -467,7 +475,16 @@ final class NSTextStorageSubclass
     }
 }
 
+final class ExtendNavigationControllerDelegateProxy
+    : RxNavigationControllerDelegateProxy
+    , TestDelegateProtocol {
+    weak fileprivate(set) var control: UINavigationControllerSubclass?
 
+    required init(parentObject: AnyObject) {
+        self.control = (parentObject as! UINavigationControllerSubclass)
+        super.init(parentObject: parentObject)
+    }
+}
 
 final class ExtendTabBarControllerDelegateProxy
     : RxTabBarControllerDelegateProxy
@@ -488,6 +505,26 @@ final class ExtendTabBarDelegateProxy
     required init(parentObject: AnyObject) {
         self.control = (parentObject as! UITabBarSubclass)
         super.init(parentObject: parentObject)
+    }
+}
+
+final class UINavigationControllerSubclass: UINavigationController, TestDelegateControl {
+    override func createRxDelegateProxy() -> RxNavigationControllerDelegateProxy {
+        return ExtendNavigationControllerDelegateProxy(parentObject: self)
+    }
+
+    func doThatTest(_ value: Int) {
+        (delegate as! TestDelegateProtocol).testEventHappened?(value)
+    }
+
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
+    }
+
+    func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
+        return RxNavigationControllerDelegateProxy.installForwardDelegate(testDelegate,
+                                                                          retainDelegate: false,
+                                                                          onProxyForObject: self)
     }
 }
 

--- a/Tests/RxCocoaTests/UINavigationController+RxTests.swift
+++ b/Tests/RxCocoaTests/UINavigationController+RxTests.swift
@@ -1,6 +1,6 @@
 //
 //  UINavigationController+RxTests.swift
-//  Rx
+//  Tests
 //
 //  Created by Diogo on 13/04/17.
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.

--- a/Tests/RxCocoaTests/UINavigationController+RxTests.swift
+++ b/Tests/RxCocoaTests/UINavigationController+RxTests.swift
@@ -1,0 +1,87 @@
+//
+//  UINavigationController+RxTests.swift
+//  Rx
+//
+//  Created by Diogo on 13/04/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS) || os(tvOS)
+
+import RxSwift
+import RxCocoa
+import UIKit
+import XCTest
+
+final class UINavigationControllerTests : RxTest {
+}
+
+extension UINavigationControllerTests {
+
+    func testWillShow() {
+        let navigationController = UINavigationController()
+
+        let viewController = UIViewController()
+        var presentedViewController = UIViewController()
+
+        XCTAssertNotEqual(viewController, presentedViewController)
+
+        let animated = true
+        var presentedAnimated = false
+
+        XCTAssertNotEqual(animated, presentedAnimated)
+
+        _ = navigationController.rx.willShow
+            .subscribe(onNext: { (viewController, animated) in
+                presentedViewController = viewController
+                presentedAnimated = animated
+            })
+
+        _ = navigationController.rx.didShow
+            .subscribe(onNext: { _ in
+                XCTFail("Should not be called")
+            })
+
+        navigationController.delegate!.navigationController!(navigationController,
+                                                             willShow: viewController,
+                                                             animated: animated)
+
+        XCTAssertEqual(viewController, presentedViewController)
+        XCTAssertEqual(animated, presentedAnimated)
+    }
+
+    func testDidShow() {
+        let navigationController = UINavigationController()
+
+        let viewController = UIViewController()
+        var presentedViewController = UIViewController()
+
+        XCTAssertNotEqual(viewController, presentedViewController)
+
+        let animated = true
+        var presentedAnimated = false
+
+        XCTAssertNotEqual(animated, presentedAnimated)
+
+        _ = navigationController.rx.willShow
+            .subscribe(onNext: { _ in
+                XCTFail("Should not be called")
+            })
+
+        _ = navigationController.rx.didShow
+            .subscribe(onNext: { (viewController, animated) in
+                presentedViewController = viewController
+                presentedAnimated = animated
+            })
+
+        navigationController.delegate!.navigationController!(navigationController,
+                                                             didShow: viewController,
+                                                             animated: animated)
+
+        XCTAssertEqual(viewController, presentedViewController)
+        XCTAssertEqual(animated, presentedAnimated)
+    }
+
+}
+
+#endif


### PR DESCRIPTION
Add extensions:
- `willShow`
- `didShow`

I had to make `RxNavigationControllerDelegateProxy` open, so I could subclass in `RxImagePickerDelegateProxy` that is in `RxExample`. Let me know if this is the recommended way to do it.