### PR TITLE
Fix CLLocationManager extension example

### DIFF
--- a/RxExample/Extensions/CLLocationManager+Rx.swift
+++ b/RxExample/Extensions/CLLocationManager+Rx.swift
@@ -29,30 +29,24 @@ extension Reactive where Base: CLLocationManager {
     Reactive wrapper for `delegate` message.
     */
     public var didUpdateLocations: Observable<[CLLocation]> {
-        return delegate.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didUpdateLocations:)))
-            .map { a in
-                return try castOrThrow([CLLocation].self, a[1])
-            }
+        return (delegate as! RxCLLocationManagerDelegateProxy).didUpdateLocationsSubject.asObservable()
     }
 
     /**
     Reactive wrapper for `delegate` message.
     */
-    public var didFailWithError: Observable<NSError> {
-        return delegate.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didFailWithError:)))
-            .map { a in
-                return try castOrThrow(NSError.self, a[1])
-            }
+    public var didFailWithError: Observable<Error> {
+        return (delegate as! RxCLLocationManagerDelegateProxy).didFailWithErrorSubject.asObservable()
     }
 
     #if os(iOS) || os(macOS)
     /**
     Reactive wrapper for `delegate` message.
     */
-    public var didFinishDeferredUpdatesWithError: Observable<NSError?> {
+    public var didFinishDeferredUpdatesWithError: Observable<Error?> {
         return delegate.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didFinishDeferredUpdatesWithError:)))
             .map { a in
-                return try castOptionalOrThrow(NSError.self, a[1])
+                return try castOptionalOrThrow(Error.self, a[1])
             }
     }
     #endif
@@ -118,7 +112,7 @@ extension Reactive where Base: CLLocationManager {
     #endif
 
     #if os(iOS) || os(macOS)
-    
+
     /**
     Reactive wrapper for `delegate` message.
     */
@@ -136,11 +130,11 @@ extension Reactive where Base: CLLocationManager {
     /**
     Reactive wrapper for `delegate` message.
     */
-    public var monitoringDidFailForRegionWithError: Observable<(region: CLRegion?, error: NSError)> {
+    public var monitoringDidFailForRegionWithError: Observable<(region: CLRegion?, error: Error)> {
         return delegate.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:monitoringDidFailFor:withError:)))
             .map { a in
                 let region = try castOptionalOrThrow(CLRegion.self, a[1])
-                let error = try castOrThrow(NSError.self, a[2])
+                let error = try castOrThrow(Error.self, a[2])
                 return (region: region, error: error)
             }
     }
@@ -176,11 +170,11 @@ extension Reactive where Base: CLLocationManager {
     /**
     Reactive wrapper for `delegate` message.
     */
-    public var rangingBeaconsDidFailForRegionWithError: Observable<(region: CLBeaconRegion, error: NSError)> {
+    public var rangingBeaconsDidFailForRegionWithError: Observable<(region: CLBeaconRegion, error: Error)> {
         return delegate.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:rangingBeaconsDidFailFor:withError:)))
             .map { a in
                 let region = try castOrThrow(CLBeaconRegion.self, a[1])
-                let error = try castOrThrow(NSError.self, a[2])
+                let error = try castOrThrow(Error.self, a[2])
                 return (region: region, error: error)
             }
     }
@@ -212,9 +206,6 @@ extension Reactive where Base: CLLocationManager {
                 return CLAuthorizationStatus(rawValue: Int32(number.intValue)) ?? .notDetermined
             }
     }
-
-
-
 }
 
 

--- a/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
+++ b/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
@@ -34,10 +34,12 @@ class RxCLLocationManagerDelegateProxy : DelegateProxy
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        _forwardToDelegate?.locationManager(manager, didUpdateLocations: locations)
         didUpdateLocationsSubject.onNext(locations)
     }
 
     public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        _forwardToDelegate?.locationManager(manager, didFailWithError: error)
         didFailWithErrorSubject.onNext(error)
     }
 }

--- a/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
+++ b/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
@@ -15,14 +15,29 @@ import CoreLocation
 class RxCLLocationManagerDelegateProxy : DelegateProxy
                                        , CLLocationManagerDelegate
                                        , DelegateProxyType {
-    
+
+    internal lazy var didUpdateLocationsSubject = PublishSubject<[CLLocation]>()
+    internal lazy var didFailWithErrorSubject = PublishSubject<Error>()
+
     class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
         let locationManager: CLLocationManager = object as! CLLocationManager
         return locationManager.delegate
     }
-    
+
     class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {
         let locationManager: CLLocationManager = object as! CLLocationManager
-        locationManager.delegate = delegate as? CLLocationManagerDelegate
+        if let delegate = delegate {
+            locationManager.delegate = (delegate as! CLLocationManagerDelegate)
+        } else {
+            locationManager.delegate = nil
+        }
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        didUpdateLocationsSubject.onNext(locations)
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        didFailWithErrorSubject.onNext(error)
     }
 }


### PR DESCRIPTION
Replaces PR 1027, which targeted master instead of develop.
Should fix #1136. This uses a similar method as RxScrollViewDelegateProxy.swift.