### PR TITLE
`do` operator make memory leaking

### DIFF
--- a/RxSwift/Observables/Implementations/Do.swift
+++ b/RxSwift/Observables/Implementations/Do.swift
@@ -8,18 +8,18 @@
 
 final class DoSink<O: ObserverType> : Sink<O>, ObserverType {
     typealias Element = O.E
-    typealias Parent = Do<Element>
+    typealias EventHandler = (Event<Element>) throws -> Void
     
-    private let _parent: Parent
+    private let _eventHandler: EventHandler
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
-        _parent = parent
+    init(eventHandler: @escaping EventHandler, observer: O, cancel: Cancelable) {
+        _eventHandler = eventHandler
         super.init(observer: observer, cancel: cancel)
     }
     
     func on(_ event: Event<Element>) {
         do {
-            try _parent._eventHandler(event)
+            try _eventHandler(event)
             forwardOn(event)
             if event.isStopEvent {
                 dispose()
@@ -51,7 +51,7 @@ final class Do<Element> : Producer<Element> {
     
     override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
         _onSubscribe?()
-        let sink = DoSink(parent: self, observer: observer, cancel: cancel)
+        let sink = DoSink(eventHandler: _eventHandler, observer: observer, cancel: cancel)
         let subscription = _source.subscribe(sink)
         _onSubscribed?()
         let onDispose = _onDispose


### PR DESCRIPTION
I found a serious memory leaking bug when using `flatMap`, `do` and `rx.deallocated`.

Minimum code is here,
```swift
Observable.just(NSObject())
  .flatMap { $0.rx.deallocated }
  .map { _ in }
  .subscribe { print($0) } // called `next`, `completed` immediately
  .disposed(by: disposeBag)

Observable.just(NSObject())
  .flatMap { $0.rx.deallocated }
  .do()
  .subscribe { print($0) } // nothing.
  .disposed(by: disposeBag)
```

Maybe it's caused a cycling reference between `Do`, `DoSink` and `Do.source`.

I try to fix cycling reference, and seems work well now.

I'd add test case for avoid these bug.

@kzaher Is it really bug? I wish hearing your opinion.