### PR TITLE
Add "Playground" page to Rx.playground

### DIFF
--- a/Rx.playground/Pages/Playground.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Playground.xcplaygroundpage/Contents.swift
@@ -1,0 +1,22 @@
+/*:
+ > # IMPORTANT: To use **Rx.playground**:
+ 1. Open **Rx.xcworkspace**.
+ 1. Build the **RxSwift-macOS** scheme (**Product** → **Build**).
+ 1. Open **Rx** playground in the **Project navigator**.
+ 1. Show the Debug Area (**View** → **Debug Area** → **Show Debug Area**).
+ */
+import RxSwift
+/*:
+ # Try Yourself
+ 
+ It's time to play with Rx 🎉
+ */
+playgroundShouldContinueIndefinitely()
+
+example("Try yourself") {
+  // let disposeBag = DisposeBag()
+  _ = Observable.just("Hello, RxSwift!")
+    .debug("Observable")
+    .subscribe()
+    // .disposed(by: disposeBag) // If dispose bag is used instead, sequence will terminate on scope exit
+}

--- a/Rx.playground/contents.xcplayground
+++ b/Rx.playground/contents.xcplayground
@@ -13,5 +13,6 @@
         <page name='Error_Handling_Operators'/>
         <page name='Debugging_Operators'/>
         <page name='Enable_RxSwift.resourceCount'/>
+        <page name='Playground'/>
     </pages>
 </playground>


### PR DESCRIPTION
## Background

I frequently use Rx.playground. I thought that it would be great if we have an empty playground page.

## Description

Use this page

* ... to prototype your observable streams and custom operators
* ... to write an answer for Rx questions
* ... for whatever you want!

<img width="1436" alt="screen shot 2017-04-27 at 3 45 05 pm" src="https://cloud.githubusercontent.com/assets/931655/25471132/9ae793d4-2b60-11e7-96d2-f70513dbaaee.png">
