### PR TITLE
Remove duplicated protocol adoption

### DIFF
--- a/RxSwift/Disposables/BooleanDisposable.swift
+++ b/RxSwift/Disposables/BooleanDisposable.swift
@@ -7,7 +7,7 @@
 //
 
 /// Represents a disposable resource that can be checked for disposal status.
-public final class BooleanDisposable : Disposable, Cancelable {
+public final class BooleanDisposable : Cancelable {
 
     internal static let BooleanDisposableTrue = BooleanDisposable(isDisposed: true)
     private var _isDisposed = false

--- a/RxSwift/Disposables/CompositeDisposable.swift
+++ b/RxSwift/Disposables/CompositeDisposable.swift
@@ -7,7 +7,7 @@
 //
 
 /// Represents a group of disposable resources that are disposed together.
-public final class CompositeDisposable : DisposeBase, Disposable, Cancelable {
+public final class CompositeDisposable : DisposeBase, Cancelable {
     /// Key used to remove disposable from composite disposable
     public struct DisposeKey {
         fileprivate let key: BagKey

--- a/RxSwift/Disposables/SingleAssignmentDisposable.swift
+++ b/RxSwift/Disposables/SingleAssignmentDisposable.swift
@@ -11,7 +11,7 @@ Represents a disposable resource which only allows a single assignment of its un
 
 If an underlying disposable resource has already been set, future attempts to set the underlying disposable resource will throw an exception.
 */
-public final class SingleAssignmentDisposable : DisposeBase, Disposable, Cancelable {
+public final class SingleAssignmentDisposable : DisposeBase, Cancelable {
 
     fileprivate enum DisposeState: UInt32 {
         case disposed = 1


### PR DESCRIPTION
I found that `BooleanDisposable`, `CompositeDisposable` and `SingleAssignmentDisposable` adopt to the two protocols `Disposable` and `Cancelable` whereas `Cancelable` inherits `Disposable` and there is no need to do so. Is there any reason for this and if not, can we remove the `Disposable` from their adoption?