### PR TITLE
Fix UISwitch documentation referencing UIButton

### DIFF
--- a/RxCocoa/iOS/UISwitch+Rx.swift
+++ b/RxCocoa/iOS/UISwitch+Rx.swift
@@ -24,7 +24,7 @@ extension Reactive where Base: UISwitch {
     /**
     Reactive wrapper for `isOn` property.
     
-    **⚠️ Versions prior to iOS 10.2 were leaking `UIButton`s, so on those versions
+    **⚠️ Versions prior to iOS 10.2 were leaking `UISwitch`s, so on those versions
      underlying observable sequence won't complete when nothing holds a strong reference
      to UISwitch.⚠️**
     */


### PR DESCRIPTION
As title specifies, I believe `UISwitch` documentation note should reference `UISwitch` in the version warning instead of `UIButton`.