### PR TITLE
fix compilation error on linux

### DIFF
--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -141,7 +141,7 @@ extension Reactive where Base: URLSession {
                 if Logging.URLRequests(request) {
                     let interval = Date().timeIntervalSince(d ?? Date())
                     print(convertURLRequestToCurlCommand(request))
-                    print(convertResponseToString(response, error.map { $0 as NSError }, interval))
+                    print(convertResponseToString(response, error.map { $0 as! NSError }, interval))
                 }
                 
                 guard let response = response, let data = data else {


### PR DESCRIPTION
I was getting this error compiling on linux with swift 3.1.1:
Sources/RxCocoa/URLSession+Rx.swift:144:76: error: 'Error' is not convertible to 'NSError'; did you mean to use 'as!' to force downcast?
                    print(convertResponseToString(response, error.map { $0 as NSError }, interval))
                                                                        ~~~^~~~~~~~~~
                                                                           as!
<unknown>:0: error: build had 1 command failures