### PR TITLE
Add a documentation for SPM TEST=1 env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ let package = Package(
 $ swift build
 ```
 
+To build or test a module with RxTest dependency, set `TEST=1`. ([RxSwift >= 3.4.2](https://github.com/ReactiveX/RxSwift/releases/tag/3.4.2))
+
+```bash
+$ TEST=1 swift test
+```
+
 ### Manually using git submodules
 
 * Add RxSwift as a submodule


### PR DESCRIPTION
Targeting `develop` branch since 3.4.2 isn't released yet.

Related links:

* #1215 No such module 'RxTest' with Swift Package Manager
* 102424379fb8d6c69b33b95c67504679042f44cc Adds RxTest only if `TEST=1` environmental variable is set.
* Example: [RxExpect's .travis.yml](https://github.com/devxoul/RxExpect/blob/38d55d148387c47f9f270da118ebf1003ef9107c/.travis.yml#L22)
