### PR TITLE
use Xcode 8.0 to test Swift 3.0 building for swift source compatibility suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode8.3
+osx_image: xcode8.0
 env:
   - DANGER=1
   - TEST=iOS


### PR DESCRIPTION
*DO NOT MERGE*

This PR has been opened to test if the project builds on Swift 3.0 so we can add the project to the Swift Source Compatibility Suite.