### PR TITLE
Fix/1252 driver scheduling

### DIFF
--- a/RxCocoa/Traits/Driver/Driver.swift
+++ b/RxCocoa/Traits/Driver/Driver.swift
@@ -37,7 +37,7 @@
 public typealias Driver<E> = SharedSequence<DriverSharingStrategy, E>
 
 public struct DriverSharingStrategy: SharingStrategyProtocol {
-    public static var scheduler: SchedulerType { return driverObserveOnScheduler }
+    public static var scheduler: SchedulerType { return driverObserveOnScheduler() }
     public static func share<E>(_ source: Observable<E>) -> Observable<E> {
         return source.shareReplayLatestWhileConnected()
     }
@@ -58,12 +58,12 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
 */
 public func driveOnScheduler(_ scheduler: SchedulerType, action: () -> ()) {
     let originalObserveOnScheduler = driverObserveOnScheduler
-    driverObserveOnScheduler = scheduler
+    driverObserveOnScheduler = { return scheduler }
 
     action()
 
     // If you remove this line , compiler buggy optimizations will change behavior of this code
-    _forceCompilerToStopDoingInsaneOptimizationsThatBreakCode(driverObserveOnScheduler)
+    _forceCompilerToStopDoingInsaneOptimizationsThatBreakCode(scheduler)
     // Scary, I know
 
     driverObserveOnScheduler = originalObserveOnScheduler
@@ -87,4 +87,4 @@ func _forceCompilerToStopDoingInsaneOptimizationsThatBreakCode(_ scheduler: Sche
     }
 }
 
-fileprivate var driverObserveOnScheduler: SchedulerType = MainScheduler.instance
+fileprivate var driverObserveOnScheduler: () -> SchedulerType = { MainScheduler() }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -573,6 +573,7 @@ final class DriverTest_ : DriverTest, RxTestCase {
     ("testDriverFromOptionalWhenNil", DriverTest.testDriverFromOptionalWhenNil),
     ("testDriverFromSequence", DriverTest.testDriverFromSequence),
     ("testDriverFromArray", DriverTest.testDriverFromArray),
+    ("testDrivingOrderOfSynchronousSubscriptions", DriverTest.testDrivingOrderOfSynchronousSubscriptions),
     ] }
 }
 

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -1159,7 +1159,7 @@ extension DriverTest {
 
             XCTAssertTrue(hotObservable1.subscriptions == [UnsunscribedFromHotObservable])
         }
-        
+
         XCTAssertEqual(results, [2, -1])
     }
 }
@@ -1375,7 +1375,7 @@ extension DriverTest {
                 ])
         }
     }
-    
+
     func testDriverFromArray() {
         let scheduler = TestScheduler(initialClock: 0)
 
@@ -1386,5 +1386,41 @@ extension DriverTest {
                 completed(202)
                 ])
         }
+    }
+}
+
+// MARK: correct order of sync subscriptions
+
+extension DriverTest {
+    func testDrivingOrderOfSynchronousSubscriptions() {
+        var disposeBag = DisposeBag()
+        let scheduler = TestScheduler(initialClock: 0)
+        let observer = scheduler.createObserver(String.self)
+        let variable = Variable("initial")
+
+        variable.asDriver()
+            .drive(observer)
+            .disposed(by: disposeBag)
+
+        Driver.just("first")
+            .drive(variable)
+            .disposed(by: disposeBag)
+
+        Driver.just("second")
+            .drive(variable)
+            .disposed(by: disposeBag)
+
+        Observable.just("third")
+            .bind(to: variable)
+            .disposed(by: disposeBag)
+
+        XCTAssertEqual(observer.events, [
+            next(0, "initial"),
+            next(0, "first"),
+            next(0, "second"),
+            next(0, "third")
+        ])
+
+        disposeBag = DisposeBag()
     }
 }

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -1402,11 +1402,11 @@ extension DriverTest {
             .drive(observer)
             .disposed(by: disposeBag)
 
-        Driver.just("first")
+        prepareSampleDriver(with: "first")
             .drive(variable)
             .disposed(by: disposeBag)
 
-        Driver.just("second")
+        prepareSampleDriver(with: "second")
             .drive(variable)
             .disposed(by: disposeBag)
 
@@ -1419,8 +1419,17 @@ extension DriverTest {
             next(0, "first"),
             next(0, "second"),
             next(0, "third")
-        ])
+            ])
 
         disposeBag = DisposeBag()
+    }
+
+    func prepareSampleDriver(with item: String) -> Driver<String> {
+        return Observable.create { observer in
+            observer.onNext(item)
+            observer.onCompleted()
+            return Disposables.create()
+            }
+            .asDriver(onErrorJustReturn: "")
     }
 }


### PR DESCRIPTION
This is the PR which fixes #1252 

As we discussed the issue on RxSwift's slack, the reason of the issue is all the Drivers share the same instance of `MainScheduler`.

The solution is to use different scheduler instances for Drivers.

`MainScheduler.instance` still returns a shared instance of the scheduler, so it is possible to have similar issue if people will use `observeOn(MainScheduler.instance)` on Observables. @kzaher I'm thinking if this is ok 🤔 