### PR TITLE
[Feature] - Add RepeatWhen operator to Observable

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -89,6 +89,7 @@ custom_categories:
   - Range
   - Reduce
   - Repeat
+  - RepeatWhen
   - RetryWhen
   - Sample
   - Scan

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -21,6 +21,13 @@
 		1AF67DA61CED430100C310FA /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
 		1AF67DA71CED430100C310FA /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
 		1AF67DA81CED430100C310FA /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
+		25872F681ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25872F671ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift */; };
+		25872F691ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25872F671ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift */; };
+		25872F6A1ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25872F671ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift */; };
+		259598291EC646E500F698FF /* RepeatWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259598281EC646E500F698FF /* RepeatWhen.swift */; };
+		2595982A1EC646E500F698FF /* RepeatWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259598281EC646E500F698FF /* RepeatWhen.swift */; };
+		2595982B1EC646E500F698FF /* RepeatWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259598281EC646E500F698FF /* RepeatWhen.swift */; };
+		2595982C1EC646E500F698FF /* RepeatWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 259598281EC646E500F698FF /* RepeatWhen.swift */; };
 		271A97411CFC996B00D64125 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
 		271A97441CFC9F7B00D64125 /* UIViewControler+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewControler+RxTests.swift */; };
 		4613456F1D9A4467001ABAF2 /* UIWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */; };
@@ -1676,6 +1683,8 @@
 		0BA9496B1E224B9C0036DD06 /* AsyncSubjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AsyncSubjectTests.swift; sourceTree = "<group>"; };
 		1AF67DA11CED420A00C310FA /* PublishSubjectTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PublishSubjectTest.swift; sourceTree = "<group>"; };
 		1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReplaySubjectTest.swift; sourceTree = "<group>"; };
+		25872F671ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+RepeatWhenTests.swift"; sourceTree = "<group>"; };
+		259598281EC646E500F698FF /* RepeatWhen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepeatWhen.swift; sourceTree = "<group>"; };
 		271A97401CFC996B00D64125 /* UIViewController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
 		271A97421CFC99FE00D64125 /* UIViewControler+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewControler+RxTests.swift"; sourceTree = "<group>"; };
 		4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+RxTests.swift"; sourceTree = "<group>"; };
@@ -2451,6 +2460,7 @@
 				C820A82A1EB4DA5900D431BC /* Zip+arity.swift */,
 				C820A82B1EB4DA5900D431BC /* Zip+arity.tt */,
 				C820A80B1EB4DA5900D431BC /* Zip+Collection.swift */,
+				259598281EC646E500F698FF /* RepeatWhen.swift */,
 			);
 			path = Observables;
 			sourceTree = "<group>";
@@ -2749,6 +2759,7 @@
 				C835091A1C38706D0027C24C /* SubjectConcurrencyTest.swift */,
 				C835091B1C38706D0027C24C /* VariableTest.swift */,
 				C835091C1C38706D0027C24C /* VirtualSchedulerTest.swift */,
+				25872F671ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift */,
 			);
 			path = RxSwiftTests;
 			sourceTree = "<group>";
@@ -4167,6 +4178,7 @@
 				C8F03F4F1DBBAE9400AECC4C /* DispatchQueue+Extensions.swift in Sources */,
 				C835094B1C38706E0027C24C /* Observable+Tests.swift in Sources */,
 				C8C217D51CB7100E0038A2E6 /* UITableView+RxTests.swift in Sources */,
+				25872F681ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift in Sources */,
 				C835092E1C38706E0027C24C /* ControlEventTests.swift in Sources */,
 				844BC8BB1CE5024500F5C7CB /* UIPickerView+RxTests.swift in Sources */,
 				C896A68B1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift in Sources */,
@@ -4343,6 +4355,7 @@
 				C8350A191C38756A0027C24C /* VirtualSchedulerTest.swift in Sources */,
 				C820A9E71EB50DB900D431BC /* Observable+TimerTests.swift in Sources */,
 				C820A97F1EB4FA5A00D431BC /* Observable+RepeatTests.swift in Sources */,
+				25872F691ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift in Sources */,
 				C8C4F1781DE9DF0200003FA7 /* UIActivityIndicatorView+RxTests.swift in Sources */,
 				C83509BF1C3875220027C24C /* DelegateProxyTest+UIKit.swift in Sources */,
 				C820A94B1EB4E75E00D431BC /* Observable+AmbTests.swift in Sources */,
@@ -4479,6 +4492,7 @@
 				1AF67DA41CED427D00C310FA /* PublishSubjectTest.swift in Sources */,
 				C820A9781EB4F92100D431BC /* Observable+GenerateTests.swift in Sources */,
 				0BA9496E1E224B9C0036DD06 /* AsyncSubjectTests.swift in Sources */,
+				25872F6A1ECB8AED003B0F60 /* Observable+RepeatWhenTests.swift in Sources */,
 				C83509E71C3875580027C24C /* PrimitiveHotObservable.swift in Sources */,
 				C850F3D61E749F5C006C417C /* PrimitiveSequenceTest.swift in Sources */,
 				C83509CE1C3875230027C24C /* NSObject+RxTests.swift in Sources */,
@@ -4694,6 +4708,7 @@
 				C8C3DA101B939767004D233E /* CurrentThreadScheduler.swift in Sources */,
 				C820A9351EB4DA5A00D431BC /* Sink.swift in Sources */,
 				C8093D861B8A72BE0088E94D /* Rx.swift in Sources */,
+				2595982A1EC646E500F698FF /* RepeatWhen.swift in Sources */,
 				C820A87D1EB4DA5A00D431BC /* TakeWhile.swift in Sources */,
 				C8093DA61B8A72BE0088E94D /* SubjectType.swift in Sources */,
 				C8093D6C1B8A72BE0088E94D /* AnonymousObserver.swift in Sources */,
@@ -4931,6 +4946,7 @@
 				C8093DA51B8A72BE0088E94D /* SubjectType.swift in Sources */,
 				C820A9341EB4DA5A00D431BC /* Sink.swift in Sources */,
 				C8FA89171C30409900CD3A17 /* HistoricalScheduler.swift in Sources */,
+				259598291EC646E500F698FF /* RepeatWhen.swift in Sources */,
 				C820A87C1EB4DA5A00D431BC /* TakeWhile.swift in Sources */,
 				C8093D6B1B8A72BE0088E94D /* AnonymousObserver.swift in Sources */,
 				C8093DA11B8A72BE0088E94D /* PublishSubject.swift in Sources */,
@@ -5092,6 +5108,7 @@
 				C8F0BFBB1BBBFB8B001B112F /* CurrentThreadScheduler.swift in Sources */,
 				C820A9371EB4DA5A00D431BC /* Sink.swift in Sources */,
 				C8F0BFBC1BBBFB8B001B112F /* Rx.swift in Sources */,
+				2595982C1EC646E500F698FF /* RepeatWhen.swift in Sources */,
 				C820A87F1EB4DA5A00D431BC /* TakeWhile.swift in Sources */,
 				C8F0BFBE1BBBFB8B001B112F /* SubjectType.swift in Sources */,
 				C8F0BFC11BBBFB8B001B112F /* AnonymousObserver.swift in Sources */,
@@ -5444,6 +5461,7 @@
 				C84CC5501BDCF48200E06A64 /* LockOwnerType.swift in Sources */,
 				C820A9361EB4DA5A00D431BC /* Sink.swift in Sources */,
 				C84CC5551BDCF49300E06A64 /* SynchronizedOnType.swift in Sources */,
+				2595982B1EC646E500F698FF /* RepeatWhen.swift in Sources */,
 				C820A87E1EB4DA5A00D431BC /* TakeWhile.swift in Sources */,
 				D2EBEB351BB9B6D2003A27DC /* ObserverBase.swift in Sources */,
 				D2EBEADE1BB9B697003A27DC /* Disposable.swift in Sources */,

--- a/RxSwift/Observables/RepeatWhen.swift
+++ b/RxSwift/Observables/RepeatWhen.swift
@@ -1,0 +1,147 @@
+//
+//  RepeatWhen.swift
+//  Rx
+//
+//  Created by sergdort on 12/05/2017.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+extension ObservableType {
+    /**
+    Returns an Observable that emits the same values as the source Observable with the exception of an onCompleted. An onCompleted notification from the source will result in the emission of a void item to the Observable provided as an argument to the notificationHandler function. If that Observable calls onComplete or onError then repeatWhen will call onCompleted or onError on the child subscription. Otherwise, this Observable will resubscribe to the source observable.
+     
+     - parameter notificationHandler: receives an Observable of notifications with which a user can complete or error, aborting the repeat.
+     
+     - returns: An observable sequence producing the elements of the given sequence repeatedly
+    */
+    public func repeatWhen<TriggerObservable: ObservableType>(_ notificationHandler: @escaping (Observable<Void>) -> TriggerObservable)
+        -> Observable<E> {
+            return RepeatWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
+    }
+}
+
+final fileprivate class RepeatWhenSequence<S: Sequence, TriggerObservable: ObservableType> : Producer<S.Iterator.Element.E> where S.Iterator.Element : ObservableType {
+    typealias Element = S.Iterator.Element.E
+    
+    fileprivate let _sources: S
+    fileprivate let _notificationHandler: (Observable<Void>) -> TriggerObservable
+    
+    init(sources: S, notificationHandler: @escaping (Observable<Void>) -> TriggerObservable) {
+        _sources = sources
+        _notificationHandler = notificationHandler
+    }
+    
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+        let sink = RepeatWhenSequenceSink<S, O, TriggerObservable>(parent: self, observer: observer, cancel: cancel)
+        let subscription = sink.run((self._sources.makeIterator(), nil))
+        return (sink: sink, subscription: subscription)
+    }
+}
+
+final fileprivate class RepeatWhenSequenceSink<S: Sequence, O: ObserverType, TriggerObservable: ObservableType>
+    : TailRecursiveSink<S, O> where S.Iterator.Element : ObservableType, S.Iterator.Element.E == O.E {
+    typealias Element = O.E
+    typealias Parent = RepeatWhenSequence<S, TriggerObservable>
+    
+    let _lock = RecursiveLock()
+    
+    fileprivate let _parent: Parent
+    fileprivate let _completeSubject = PublishSubject<Void>()
+    fileprivate let _handler: Observable<TriggerObservable.E>
+    fileprivate let _notifier = PublishSubject<TriggerObservable.E>()
+    
+    init(parent: Parent, observer: O, cancel: Cancelable) {
+        _parent = parent
+        _handler = parent._notificationHandler(_completeSubject).asObservable()
+        super.init(observer: observer, cancel: cancel)
+    }
+    
+    override func done() {
+        forwardOn(.completed)
+        dispose()
+    }
+    
+    override func extract(_ observable: Observable<E>) -> SequenceGenerator? {
+        // It is important to always return `nil` here because there are sideffects in the `run` method
+        // that are dependant on particular `retryWhen` operator so single operator stack can't be reused in this
+        // case.
+        return nil
+    }
+    
+    override func subscribeToNext(_ source: Observable<E>) -> Disposable {
+        let subscription = SingleAssignmentDisposable()
+        let iter = RepeatWhenSequenceSinkIter(parent: self, subscription: subscription)
+        subscription.setDisposable(source.subscribe(iter))
+        return iter
+    }
+    
+    override func run(_ sources: SequenceGenerator) -> Disposable {
+        let triggerSubscription = _handler.subscribe(_notifier.asObserver())
+        let superSubscription = super.run(sources)
+        return Disposables.create(superSubscription, triggerSubscription)
+    }
+}
+
+final fileprivate class RepeatWhenSequenceSinkIter<S: Sequence, O: ObserverType, TriggerObservable: ObservableType>
+    : ObserverType
+    , Disposable where S.Iterator.Element : ObservableType, S.Iterator.Element.E == O.E {
+    typealias E = O.E
+    typealias Parent = RepeatWhenSequenceSink<S, O, TriggerObservable>
+    
+    fileprivate let _parent: Parent
+    fileprivate let _completeHandlerSubscription = SingleAssignmentDisposable()
+    fileprivate let _subscription: Disposable
+    
+    init(parent: Parent, subscription: Disposable) {
+        _parent = parent
+        _subscription = subscription
+    }
+    
+    func on(_ event: Event<E>) {
+        switch event {
+        case .next:
+            _parent.forwardOn(event)
+        case .error(let error):
+            _subscription.dispose()
+            _parent.forwardOn(.error(error))
+            _parent.dispose()
+        case .completed:
+            _subscription.dispose()
+            let completeHandlerSubscription = _parent._notifier.subscribe(RepeatTriggerSink(parent: self))
+            _completeHandlerSubscription.setDisposable(completeHandlerSubscription)
+            _parent._completeSubject.on(.next())
+        }
+    }
+    
+    final func dispose() {
+        _subscription.dispose()
+        _completeHandlerSubscription.dispose()
+    }
+}
+
+final fileprivate class RepeatTriggerSink<S: Sequence, O: ObserverType, TriggerObservable: ObservableType>
+    : ObserverType where S.Iterator.Element : ObservableType, S.Iterator.Element.E == O.E {
+    typealias E = TriggerObservable.E
+    
+    typealias Parent = RepeatWhenSequenceSinkIter<S, O, TriggerObservable>
+    
+    fileprivate let _parent: Parent
+    
+    init(parent: Parent) {
+        _parent = parent
+    }
+    
+    func on(_ event: Event<E>) {
+        switch event {
+        case .next:
+            _parent._parent.schedule(.moveNext)
+        case .error(let e):
+            _parent._parent.forwardOn(.error(e))
+            _parent._parent.dispose()
+        case .completed:
+            _parent._parent.forwardOn(.completed)
+            _parent._parent.dispose()
+        }
+    }
+}
+

--- a/RxSwift/Observables/RepeatWhen.swift
+++ b/RxSwift/Observables/RepeatWhen.swift
@@ -1,6 +1,6 @@
 //
 //  RepeatWhen.swift
-//  Rx
+//  RxSwift
 //
 //  Created by sergdort on 12/05/2017.
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.

--- a/Sources/AllTestz/Observable+RepeatWhenTests.swift
+++ b/Sources/AllTestz/Observable+RepeatWhenTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Observable+RepeatWhenTests.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -637,6 +637,24 @@ final class ObservableSubscribeOnTest_ : ObservableSubscribeOnTest, RxTestCase {
     ] }
 }
 
+final class ObservableRepeatWhenTests_ : ObservableRepeatWhenTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableRepeatWhenTests_) -> () -> ())] { return [
+    ("testRepeatWhen_never", ObservableRepeatWhenTests.testRepeatWhen_never),
+    ("testRepeatWhen_Observable_Never", ObservableRepeatWhenTests.testRepeatWhen_Observable_Never),
+    ("testRepeatObservable_Empty", ObservableRepeatWhenTests.testRepeatObservable_Empty),
+    ("testRepeatWhenObservable_NextError", ObservableRepeatWhenTests.testRepeatWhenObservable_NextError),
+    ("testRepeatWhenObservable_Complete", ObservableRepeatWhenTests.testRepeatWhenObservable_Complete),
+    ("testRepeatWhenNextComplete", ObservableRepeatWhenTests.testRepeatWhenNextComplete),
+    ("testRepeatWhenInfinite", ObservableRepeatWhenTests.testRepeatWhenInfinite),
+    ] }
+}
+
 final class ObservableWindowTest_ : ObservableWindowTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1784,6 +1802,7 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(ObservableMapTest_.allTests),
         testCase(CurrentThreadSchedulerTest_.allTests),
         testCase(ObservableSubscribeOnTest_.allTests),
+        testCase(ObservableRepeatWhenTests_.allTests),
         testCase(ObservableWindowTest_.allTests),
         testCase(ObservableShareReplay1WhileConnectedTest_.allTests),
         testCase(ObservableZipTest_.allTests),

--- a/Sources/RxSwift/RepeatWhen.swift
+++ b/Sources/RxSwift/RepeatWhen.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/RepeatWhen.swift

--- a/Tests/RxSwiftTests/Observable+RepeatWhenTests.swift
+++ b/Tests/RxSwiftTests/Observable+RepeatWhenTests.swift
@@ -1,6 +1,6 @@
 //
 //  Observable+RepeatWhenTests.swift
-//  Rx
+//  Tests
 //
 //  Created by sergdort on 16/05/2017.
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.

--- a/Tests/RxSwiftTests/Observable+RepeatWhenTests.swift
+++ b/Tests/RxSwiftTests/Observable+RepeatWhenTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import RxSwift
 import RxTest
 
-final class ObservableRepeatWhenTests: RxTest {
+class ObservableRepeatWhenTests: RxTest {
     
     func testRepeatWhen_never() {
         let scheduler = TestScheduler(initialClock: 0)

--- a/Tests/RxSwiftTests/Observable+RepeatWhenTests.swift
+++ b/Tests/RxSwiftTests/Observable+RepeatWhenTests.swift
@@ -1,0 +1,237 @@
+//
+//  Observable+RepeatWhenTests.swift
+//  Rx
+//
+//  Created by sergdort on 16/05/2017.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+final class ObservableRepeatWhenTests: RxTest {
+    
+    func testRepeatWhen_never() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(150, 1),
+            completed(250)
+        ])
+        
+        let ys = scheduler.createColdObservable([
+            completed(1, Int.self)
+        ])
+        
+        let results = scheduler.start {
+            return xs.repeatWhen { _ in
+                return ys
+            }
+        }
+        
+        XCTAssertEqual(results.events, [
+            completed(250)
+        ])
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+        ])
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 201)
+        ])
+    }
+    
+    func testRepeatWhen_Observable_Never() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(150, 1),
+            next(210, 2),
+            next(220, 3),
+            next(230, 4),
+            next(240, 5),
+            completed(250)
+        ])
+        
+        let ys: TestableObservable<Int> = scheduler.createColdObservable([])
+        
+        let results = scheduler.start {
+            return xs.repeatWhen { _ in
+                return ys
+            }
+        }
+        
+        XCTAssertEqual(results.events, [
+            next(210, 2),
+            next(220, 3),
+            next(230, 4),
+            next(240, 5)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+        ])
+        
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 1000)
+        ])
+    }
+    
+    func testRepeatObservable_Empty() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createColdObservable([
+            next(100, 1),
+            next(150, 2),
+            next(200, 3),
+            completed(250)
+            ])
+        
+        let ys = scheduler.createColdObservable([
+            completed(1, Int.self)
+        ])
+        
+        let results = scheduler.start {
+            return xs.repeatWhen { _ in
+                return ys
+            }
+        }
+        
+        XCTAssertEqual(results.events, [
+            next(300, 1),
+            next(350, 2),
+            next(400, 3),
+            completed(450)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 450)
+        ])
+    }
+    
+    func testRepeatWhenObservable_NextError() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createColdObservable([
+            next(10, 1),
+            next(20, 2),
+            error(30, testError),
+            completed(40)
+        ])
+        
+        let results = scheduler.start {
+            return xs.repeatWhen { notifications in
+                return notifications.scan(0, accumulator: { (count, _) in
+                    if count == 2 {
+                        throw testError
+                    }
+                    return count + 1
+                })
+            }
+        }
+        
+        XCTAssertEqual(results.events, [
+            next(210, 1),
+            next(220, 2),
+            error(230, testError)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 230)
+        ])
+    }
+    
+    func testRepeatWhenObservable_Complete() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createColdObservable([
+            next(10, 1),
+            next(20, 2),
+            completed(30)
+        ])
+        
+        let ys = scheduler.createColdObservable([
+            completed(0, Int.self)
+        ])
+        
+        let results = scheduler.start {
+            return xs.repeatWhen { _ in
+                return ys
+            }
+        }
+
+        XCTAssertEqual(results.events, [
+            next(210, 1),
+            next(220, 2),
+            completed(230)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 230)
+        ])
+        
+        XCTAssertEqual(ys.subscriptions, [
+            Subscription(200, 200)
+        ])
+    }
+    
+    func testRepeatWhenNextComplete() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createColdObservable([
+            next(10, 1),
+                next(20, 2),
+                completed(30)
+        ])
+
+        let results = scheduler.start {
+            return xs.repeatWhen { notifications in
+                return notifications.scan(0) { (count, _) in
+                    return count + 1
+                }.takeWhile { count in
+                    return count < 2
+                }
+            }
+        }
+
+        XCTAssertEqual(results.events, [
+            next(210, 1),
+                next(220, 2),
+                next(240, 1),
+                next(250, 2),
+                completed(260)
+        ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 230),
+            Subscription(230, 260)
+        ])
+    }
+    
+    func testRepeatWhenInfinite() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createColdObservable([
+            next(10, 1),
+                next(20, 2),
+                completed(30)
+        ])
+
+        let ys: TestableObservable<Int> = scheduler.createColdObservable([])
+
+        let results = scheduler.start {
+            return xs.repeatWhen { _ in
+                return ys
+            }
+        }
+
+        XCTAssertEqual(results.events, [
+            next(210, 1),
+                next(220, 2)
+        ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 230)
+        ])
+    }
+}

--- a/Tests/RxSwiftTests/Observable+RepeatWhenTests.swift
+++ b/Tests/RxSwiftTests/Observable+RepeatWhenTests.swift
@@ -234,4 +234,20 @@ class ObservableRepeatWhenTests: RxTest {
             Subscription(200, 230)
         ])
     }
+    
+    #if TRACE_RESOURCES
+    func testRepeatWhen1ReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).repeatWhen { _ in Observable.just(1) }.subscribe()
+    }
+    
+    func testRepeatWhen1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).repeatWhen { _ in Observable.just(1) }.subscribe()
+    }
+    
+    func testRepeatWhen3ReleasesResourcesOnError() {
+        _ = Observable<Int>.just(1).repeatWhen { e in
+            return Observable<Int>.error(testError)
+        }.subscribe()
+    }
+    #endif
 }


### PR DESCRIPTION
This PR adds repeatWhen operator to observable sequence #396 

### Description of change

* Implement adopt almost all logic from the `RetryWhen` operator
* Add `RepeatWhenSequence`, `RepeatWhenSequenceSink`, `RepeatWhenSequenceSinkIter`, `RepeatTriggerSink`
* Add `repeatWhen` extension methods on `ObservableType`

### Questions

* Is it worth to include to the main repo? :) 
* I feel a little bit sorry for copy pasting almost everything from `RetryWhen`, so I'm thinking maybe there is a way to refactor so we can share logic between both of the operators ?


