### PR TITLE
[Proposal] Use `@autoclosure` on `catchErrorJustReturn`

### DIFF
--- a/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
+++ b/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
@@ -17,7 +17,7 @@ extension ObservableConvertibleType {
     - parameter onErrorJustReturn: Element to return in case of error and after that complete the sequence.
     - returns: Driving observable sequence.
     */
-    public func asDriver(onErrorJustReturn: E) -> Driver<E> {
+    public func asDriver(onErrorJustReturn: @autoclosure @escaping () -> E) -> Driver<E> {
         let source = self
             .asObservable()
             .observeOn(DriverSharingStrategy.scheduler)

--- a/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
@@ -17,7 +17,7 @@ extension ObservableConvertibleType {
     - parameter onErrorJustReturn: Element to return in case of error and after that complete the sequence.
     - returns: Driving observable sequence.
     */
-    public func asSharedSequence<S: SharingStrategyProtocol>(sharingStrategy: S.Type = S.self, onErrorJustReturn: E) -> SharedSequence<S, E> {
+    public func asSharedSequence<S: SharingStrategyProtocol>(sharingStrategy: S.Type = S.self, onErrorJustReturn: @autoclosure @escaping () -> E) -> SharedSequence<S, E> {
         let source = self
             .asObservable()
             .observeOn(S.scheduler)

--- a/RxSwift/Observables/Catch.swift
+++ b/RxSwift/Observables/Catch.swift
@@ -29,9 +29,9 @@ extension ObservableType {
      - parameter element: Last element in an observable sequence in case error occurs.
      - returns: An observable sequence containing the source sequence's elements, followed by the `element` in case an error occurred.
      */
-    public func catchErrorJustReturn(_ element: E)
+    public func catchErrorJustReturn(_ element: @autoclosure @escaping () -> E)
         -> Observable<E> {
-        return Catch(source: asObservable(), handler: { _ in Observable.just(element) })
+        return Catch(source: asObservable(), handler: { _ in Observable.just(element()) })
     }
     
 }


### PR DESCRIPTION
Hello, this pr is a proposal that use swift `@autoclosure` feature on `catchErrorJustReturn` operator and their families.

## Motivation
In my opinion, `catchErrorJustReturn` is desirable that lazy evaluate their argument value, because it may be correct that the argument is never used at all.
Some times I want to make `Driver`/`SharedSequence` from `Observable` that will never take any error.
For example, I know two cases,
```swift
let button = UIButton()
button.rx.tap
  .take(1) // or some of unsupported operator on SharedSequence
  .asDriver(onErrorJustReturn:())
```
```swift
observable // Observable<Int>
  .retry()
  .asDriver(onErrorJustReturn: -1)
```
In this case, I call `asDriver(onErrorJustReturn:)`, but the observable will never take an error to `asDriver(onErrorJustReturn:)` operator.
I hope to use function that contains `assert` or their family in `.asDriver(onErrorJustReturn:)` if observable will never take any Error.
```swift
func neverHappen<T>(_ value: T) -> T {
  precondition(false)
  return value
}

observable // Observable<Int>
  .retry()
  .asDriver(onErrorJustReturn: neverHappen(-1))
```
We can understand this code is clearly indicates that never happen any error.
But now, `catchErrorJustReturn` evaluate them argument immediately, so we cannot write this code.

## Pros
`catchErrorJustReturn` will evaluate their argument when ocurred an error. We can clarify our intention throwing never error happen.

## Cons
If some-guys take the class property on `catchErrorJustReturn` argument, it may make cycling reference.
Auto-closure may be a bit tricky.

## Other methods
I think there are means that add `.asDriverUnsafe` and` .asSharedSequenceUnsafe` instead of, but it may be dangerous. 🤔