### PR TITLE
Add UIBindingObserver for updating UIButton's image

### DIFF
--- a/RxCocoa/iOS/UIButton+Rx.swift
+++ b/RxCocoa/iOS/UIButton+Rx.swift
@@ -50,7 +50,7 @@ extension Reactive where Base: UIButton {
 
 extension Reactive where Base: UIButton {
     
-    /// Reactive wrapper for `setTitle(_:controlState:)`
+    /// Reactive wrapper for `setTitle(_:for:)`
     public func title(for controlState: UIControlState = []) -> UIBindingObserver<Base, String?> {
         return UIBindingObserver<Base, String?>(UIElement: self.base) { (button, title) -> () in
             button.setTitle(title, for: controlState)

--- a/RxCocoa/iOS/UIButton+Rx.swift
+++ b/RxCocoa/iOS/UIButton+Rx.swift
@@ -56,6 +56,20 @@ extension Reactive where Base: UIButton {
             button.setTitle(title, for: controlState)
         }
     }
+
+    /// Reactive wrapper for `setImage(_:for:)`
+    public func image(for controlState: UIControlState = []) -> UIBindingObserver<Base, UIImage?> {
+        return UIBindingObserver<Base, UIImage?>(UIElement: self.base) { (button, image) -> () in
+            button.setImage(image, for: controlState)
+        }
+    }
+
+    /// Reactive wrapper for `setBackgroundImage(_:for:)`
+    public func backgroundImage(for controlState: UIControlState = []) -> UIBindingObserver<Base, UIImage?> {
+        return UIBindingObserver<Base, UIImage?>(UIElement: self.base) { (button, image) -> () in
+            button.setBackgroundImage(image, for: controlState)
+        }
+    }
     
 }
 #endif

--- a/Tests/RxCocoaTests/UIButton+RxTests.swift
+++ b/Tests/RxCocoaTests/UIButton+RxTests.swift
@@ -72,6 +72,60 @@ extension UIButtonTests {
             let createView: () -> UIButton = { UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1)) }
             ensureEventDeallocated(createView) { (view: UIButton) in view.rx.tap }
         }
+
+        func testImageNormal() {
+            let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+            let image = UIImage()
+
+            XCTAssertFalse(button.image(for: .normal) == image)
+            _ = Observable.just(image).subscribe(button.rx.image(for: .normal))
+            XCTAssertTrue(button.image(for: .normal) == image)
+        }
+
+        func testImageSelected() {
+            let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+            let image = UIImage()
+
+            XCTAssertFalse(button.image(for: .selected) == image)
+            _ = Observable.just(image).subscribe(button.rx.image(for: .selected))
+            XCTAssertTrue(button.image(for: .selected) == image)
+        }
+
+        func testImageDefault() {
+            let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+            let image = UIImage()
+
+            XCTAssertFalse(button.image(for: []) == image)
+            _ = Observable.just(image).subscribe(button.rx.image())
+            XCTAssertTrue(button.image(for: []) == image)
+        }
+
+        func testBackgroundImageNormal() {
+            let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+            let image = UIImage()
+
+            XCTAssertFalse(button.backgroundImage(for: .normal) == image)
+            _ = Observable.just(image).subscribe(button.rx.backgroundImage(for: .normal))
+            XCTAssertTrue(button.backgroundImage(for: .normal) == image)
+        }
+
+        func testBackgroundImageSelected() {
+            let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+            let image = UIImage()
+
+            XCTAssertFalse(button.backgroundImage(for: .selected) == image)
+            _ = Observable.just(image).subscribe(button.rx.backgroundImage(for: .selected))
+            XCTAssertTrue(button.backgroundImage(for: .selected) == image)
+        }
+
+        func testBackgroundImageDefault() {
+            let button = UIButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+            let image = UIImage()
+
+            XCTAssertFalse(button.backgroundImage(for: []) == image)
+            _ = Observable.just(image).subscribe(button.rx.backgroundImage())
+            XCTAssertTrue(button.backgroundImage(for: []) == image)
+        }
     }
 
 #endif


### PR DESCRIPTION
Since updating title and attributed title are supported in `Reactive<UIButton>`, I reckon it's sensible that adding supports for updating image and background image.