### PR TITLE
Duplication of words in traits documentation

### DIFF
--- a/Documentation/Traits.md
+++ b/Documentation/Traits.md
@@ -129,7 +129,7 @@ A Completable is a variation of Observable that can only _complete_ or _emit an 
 * Doesn't share side effects
 
 A useful use case for Completable would be to model any case where we only care for the fact an operation has completed, but don't care about a element resulted by that completion.
-You could compare it to using using an `Observable<Void>` that can't emit elements.
+You could compare it to using an `Observable<Void>` that can't emit elements.
 
 #### Creating a Completable
 Creating a Completable is similar to creating an Observable. A simple example would look like this:


### PR DESCRIPTION
Removed words duplication in traits documentation.