### PR TITLE
Fixes a typo.

### DIFF
--- a/RxSwift/Rx.swift
+++ b/RxSwift/Rx.swift
@@ -72,8 +72,8 @@ func decrementChecked(_ i: inout Int) throws -> Int {
         private let _lock = RecursiveLock()
 
         public enum SychronizationErrorMessages: String {
-            case variable = "Two different threads are trying to assign the same `Variable.value` unsynchronized.\n    This is undefined behavior because the end result (variable value) is nondetermininstic and depends on the \n    operating system thread scheduler. This will cause random behavior of your program.\n"
-            case `default` = "Two different unsynchronized threads are trying to send some event simultaneously.\n    This is undefined behavior because the ordering of the effects caused by these events is nondetermininstic and depends on the \n    operating system thread scheduler. This will result in a random behavior of your program.\n"
+            case variable = "Two different threads are trying to assign the same `Variable.value` unsynchronized.\n    This is undefined behavior because the end result (variable value) is nondeterministic and depends on the \n    operating system thread scheduler. This will cause random behavior of your program.\n"
+            case `default` = "Two different unsynchronized threads are trying to send some event simultaneously.\n    This is undefined behavior because the ordering of the effects caused by these events is nondeterministic and depends on the \n    operating system thread scheduler. This will result in a random behavior of your program.\n"
         }
 
         private var _threads = Dictionary<UnsafeMutableRawPointer, Int>()


### PR DESCRIPTION
Hello!
This commits fixes a typo where the word nondeterministic was spelled
nondetermininstic.
Thanks.