### PR TITLE
Tone down warning about swift 3.0 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 ## About Rx
 
-**:warning: This readme describes RxSwift 3.0 version that requires Swift 3.0.**
-
 **:warning: If you are looking for Swift 2.3 compatible version, please take a look at RxSwift ~> 2.0 versions and [swift-2.3](https://github.com/ReactiveX/RxSwift/tree/rxswift-2.0) branch.**
 
 Rx is a [generic abstraction of computation](https://youtu.be/looJcaeboBY) expressed through `Observable<Element>` interface.


### PR DESCRIPTION
With Swift 4.0 out in preview I think it is safe to say most people have moved past swift 2.x. 