### PR TITLE
forward RxTextFieldDelegateProxy.controlTextDidChange to underlying delegate

### DIFF
--- a/RxCocoa/macOS/NSTextField+Rx.swift
+++ b/RxCocoa/macOS/NSTextField+Rx.swift
@@ -40,6 +40,7 @@ public class RxTextFieldDelegateProxy
         let textField: NSTextField = castOrFatalError(notification.object)
         let nextValue = textField.stringValue
         self.textSubject.on(.next(nextValue))
+        _forwardToDelegate?.controlTextDidChange(notification)
     }
 
     // MARK: Delegate proxy methods

--- a/Tests/RxCocoaTests/NSTextField+RxTests.swift
+++ b/Tests/RxCocoaTests/NSTextField+RxTests.swift
@@ -20,4 +20,47 @@ extension NSTextFieldTests {
         let createView: () -> NSTextField = { NSTextField(frame: CGRect(x: 0, y: 0, width: 1, height: 1)) }
         ensurePropertyDeallocated(createView, "a") { (view: NSTextField) in view.rx.text.orEmpty }
     }
+
+    func testTextField_ControlTextDidChange_ForwardsToDelegates() {
+
+        var completed = false
+
+        autoreleasepool {
+            let textField = NSTextField()
+            let delegate = TextFieldDelegate()
+            textField.delegate = delegate
+            var rxDidChange = false
+
+            _ = textField.rx.text
+                .skip(1) // Initial value
+                .subscribe(onNext: { _ in
+                    rxDidChange = true
+                }, onCompleted: {
+                    completed = true
+                })
+
+            XCTAssertFalse(rxDidChange)
+            XCTAssertFalse(delegate.didChange)
+
+            let notification = Notification(
+                name: .NSControlTextDidChange,
+                object: textField,
+                userInfo: ["NSFieldEditor" : NSText()])
+            (textField.delegate as! NSObject).controlTextDidChange(notification)
+
+            XCTAssertTrue(rxDidChange)
+            XCTAssertTrue(delegate.didChange)
+        }
+
+        XCTAssertTrue(completed)
+    }
+
+}
+
+fileprivate final class TextFieldDelegate: NSObject, NSTextFieldDelegate {
+
+    var didChange = false
+    override func controlTextDidChange(_ notification: Notification) {
+        didChange = true
+    }
 }


### PR DESCRIPTION
Although this method is not part of the `NSTextFieldDelegate` protocol, and although the docs say this is part of a `NSControl`, in fact this method is available on `NSObject`s, view controllers, and the like and is the standard typing observation mechanism.

Since the `RxTextFieldDelegateProxy` hooked itself onto this without forwarding, existing delegates in the rest of the app become deactivated.