### PR TITLE
Implement DelegateProxy factory for Swift 4.0

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -175,6 +175,7 @@ custom_categories:
   children:
   - ControlTarget
   - DelegateProxy
+  - DelegateProxyFactory
   - DelegateProxyType
   - NSLayoutConstraint+Rx
   - Observable+Bind

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1394,6 +1394,10 @@
 		D2138C881BB9BEBE00339B5C /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093E8B1B8A732E0088E94D /* DelegateProxy.swift */; };
 		D2138C891BB9BEBE00339B5C /* DelegateProxyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093E8C1B8A732E0088E94D /* DelegateProxyType.swift */; };
 		D2138C991BB9BEEE00339B5C /* RxTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093E9C1B8A732E0088E94D /* RxTarget.swift */; };
+		D29E23191EF4B93D006E295D /* DelegateProxyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29E23171EF4B92E006E295D /* DelegateProxyFactory.swift */; };
+		D29E231A1EF4B93E006E295D /* DelegateProxyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29E23171EF4B92E006E295D /* DelegateProxyFactory.swift */; };
+		D29E231B1EF4B93E006E295D /* DelegateProxyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29E23171EF4B92E006E295D /* DelegateProxyFactory.swift */; };
+		D29E231C1EF4B93F006E295D /* DelegateProxyFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D29E23171EF4B92E006E295D /* DelegateProxyFactory.swift */; };
 		D2EBEADC1BB9B697003A27DC /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C491B8A72BE0088E94D /* Cancelable.swift */; };
 		D2EBEADD1BB9B697003A27DC /* ConnectableObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C4D1B8A72BE0088E94D /* ConnectableObservableType.swift */; };
 		D2EBEADE1BB9B697003A27DC /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C521B8A72BE0088E94D /* Disposable.swift */; };
@@ -2136,6 +2140,7 @@
 		CB883B441BE256D4000AC2EE /* BooleanDisposable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BooleanDisposable.swift; sourceTree = "<group>"; };
 		CDDEF1691D4FB40000CA8546 /* Disposables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Disposables.swift; sourceTree = "<group>"; };
 		D2138C751BB9BE9800339B5C /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D29E23171EF4B92E006E295D /* DelegateProxyFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateProxyFactory.swift; sourceTree = "<group>"; };
 		D2EA280C1BB9B5A200880ED3 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2EBEB811BB9B99D003A27DC /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxNavigationControllerDelegateProxy.swift; sourceTree = "<group>"; };
@@ -2523,6 +2528,7 @@
 				C80D338E1B91EF9E0014629D /* Observable+Bind.swift */,
 				C8093E8B1B8A732E0088E94D /* DelegateProxy.swift */,
 				C8093E8C1B8A732E0088E94D /* DelegateProxyType.swift */,
+				D29E23171EF4B92E006E295D /* DelegateProxyFactory.swift */,
 				C8093E9C1B8A732E0088E94D /* RxTarget.swift */,
 				C89AB1711DAAC1680065FBE6 /* ControlTarget.swift */,
 				C8BCD3F31C14B6D1005F1280 /* NSLayoutConstraint+Rx.swift */,
@@ -4048,6 +4054,7 @@
 				C882542B1B8A752B00B02D69 /* UIDatePicker+Rx.swift in Sources */,
 				C88254221B8A752B00B02D69 /* RxTableViewDataSourceProxy.swift in Sources */,
 				C8BCD3F41C14B6D1005F1280 /* NSLayoutConstraint+Rx.swift in Sources */,
+				D29E23191EF4B93D006E295D /* DelegateProxyFactory.swift in Sources */,
 				C882542C1B8A752B00B02D69 /* UIGestureRecognizer+Rx.swift in Sources */,
 				C89AB1D21DAAC3350065FBE6 /* ControlProperty+Driver.swift in Sources */,
 				C8093EE11B8A732E0088E94D /* DelegateProxy.swift in Sources */,
@@ -4115,6 +4122,7 @@
 				C89AB1F31DAAC3350065FBE6 /* SharedSequence+Operators.swift in Sources */,
 				C86781A61DB823B500B2029A /* NSSlider+Rx.swift in Sources */,
 				C89AB2231DAAC3350065FBE6 /* URLSession+Rx.swift in Sources */,
+				D29E231A1EF4B93E006E295D /* DelegateProxyFactory.swift in Sources */,
 				C86781A11DB823B500B2029A /* NSImageView+Rx.swift in Sources */,
 				C89AB2281DAAC33F0065FBE6 /* RxCocoa.swift in Sources */,
 				C8D132451C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */,
@@ -5241,6 +5249,7 @@
 				C8F0C03B1BBBFBB9001B112F /* UISearchBar+Rx.swift in Sources */,
 				C89AB2431DAAC3A60065FBE6 /* _RXDelegateProxy.m in Sources */,
 				C8F0C03C1BBBFBB9001B112F /* ItemEvents.swift in Sources */,
+				D29E231C1EF4B93F006E295D /* DelegateProxyFactory.swift in Sources */,
 				7EDBAEBF1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */,
 				C8F0C03D1BBBFBB9001B112F /* RxTableViewDataSourceType.swift in Sources */,
 				C89AB1FD1DAAC3350065FBE6 /* Variable+SharedSequence.swift in Sources */,
@@ -5302,6 +5311,7 @@
 				C89AB1751DAAC1680065FBE6 /* ControlTarget.swift in Sources */,
 				D203C4FB1BB9C53700D02D00 /* RxCollectionViewDelegateProxy.swift in Sources */,
 				D203C5031BB9C53E00D02D00 /* UIBarButtonItem+Rx.swift in Sources */,
+				D29E231B1EF4B93E006E295D /* DelegateProxyFactory.swift in Sources */,
 				C89AB1EC1DAAC3350065FBE6 /* SharedSequence+Operators+arity.swift in Sources */,
 				D203C4FC1BB9C53700D02D00 /* RxScrollViewDelegateProxy.swift in Sources */,
 				C89AB1F81DAAC3350065FBE6 /* SharedSequence.swift in Sources */,

--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -188,13 +188,6 @@ open class DelegateProxy : _RXDelegateProxy {
         return delegateAssociatedTag
     }
     
-    /// Initializes new instance of delegate proxy.
-    ///
-    /// - returns: Initialized instance of `self`.
-    open class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        return self.init(parentObject: object)
-    }
-    
     /// Returns assigned proxy for object.
     ///
     /// - parameter object: Object that can have assigned delegate proxy.

--- a/RxCocoa/Common/DelegateProxyFactory.swift
+++ b/RxCocoa/Common/DelegateProxyFactory.swift
@@ -1,0 +1,66 @@
+//
+//  DelegateProxyFactory.swift
+//  RxCocoa
+//
+//  Created by tarunon on 2017/06/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+#if !os(Linux)
+    
+#if !RX_NO_MODULE
+    import RxSwift
+#endif
+
+/**
+Define `DelegateProxy.init` for a specific object type.
+For example, in RxScrollViewDelegateProxy
+
+
+    class RxScrollViewDelegateProxy: DelegateProxy {
+        static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIScrollView) in
+            RxScrollViewDelegateProxy(parentObject: parentObject)
+        }
+    ...
+
+
+If need to extend them, chain `extended` after DelegateProxyFactory.init
+
+    class RxScrollViewDelegateProxy: DelegateProxy {
+        static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIScrollView) in
+                RxScrollViewDelegateProxy(parentObject: parentObject)
+            }
+            .extended { (parentObject: UITableView) in
+                RxTableViewDelegateProxy(parentObject: parentObject)
+            }
+    ...
+ 
+ 
+ */
+public class DelegateProxyFactory {
+    var factories: [ObjectIdentifier: ((AnyObject) -> AnyObject)]
+    public init<Object: AnyObject>(factory: @escaping (Object) -> AnyObject) {
+        factories = [ObjectIdentifier(Object.self): { factory(castOrFatalError($0)) }]
+    }
+    
+    public func extended<Object: AnyObject>(factory: @escaping (Object) -> AnyObject) -> DelegateProxyFactory {
+        guard factories[ObjectIdentifier(Object.self)] == nil else {
+            rxFatalError("The factory of \(Object.self) is duplicated. DelegateProxy is not allowed of duplicated base object type.")
+        }
+        factories[ObjectIdentifier(Object.self)] = { factory(castOrFatalError($0)) }
+        return self
+    }
+    
+    func createProxy(for object: AnyObject) -> AnyObject {
+        var mirror: Mirror? = Mirror(reflecting: object)
+        while mirror != nil {
+            if let factory = factories[ObjectIdentifier(mirror!.subjectType)] {
+                return factory(object)
+            }
+            mirror = mirror?.superclassMirror
+        }
+        rxFatalError("DelegateProxy has no factory of \(object). Call 'DelegateProxy.extend' first.")
+    }
+}
+    
+#endif

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -69,13 +69,17 @@ every view has a corresponding delegate virtual factory method.
 
 In case of UITableView / UIScrollView, there is
 
-    RxScrollViewDelegateProxy has factories that contains RxScrollViewDelegateProxy(parentObject: parentObject)
+    class RxScrollViewDelegateProxy: DelegateProxy {
+        static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIScrollView) in
+            RxScrollViewDelegateProxy(parentObject: parentObject)
+        }
+    }
     ....
 
 
 and extend it
 
-    RxScrollViewDelegateProxy.extend { (parentObject: UITableView) in
+    RxScrollViewDelegateProxy.extendProxy { (parentObject: UITableView) in
        RxTableViewDelegateProxy(parentObject: parentObject)
     }
 
@@ -83,10 +87,10 @@ and extend it
 */
 public protocol DelegateProxyType : AnyObject {
     /// DelegateProxy factory
-    static var factories: [((AnyObject) -> AnyObject?)] { get set }
+    static var delegateProxyFactory: DelegateProxyFactory { get }
     
     /// Extend DelegateProxy for specific subclass
-    static func extend<Object: AnyObject>(with factory: @escaping ((Object) -> AnyObject))
+    static func extendProxy<Object: AnyObject>(with creation: @escaping ((Object) -> AnyObject))
     
     /// Creates new proxy for target object.
     static func createProxyForObject(_ object: AnyObject) -> AnyObject
@@ -214,12 +218,14 @@ extension DelegateProxyType {
         }
     }
     
-    public static func extend<Object: AnyObject>(with factory: @escaping ((Object) -> AnyObject)) {
-        factories.append({ ($0 as? Object).map(factory) })
+    public static func extendProxy<Object: AnyObject>(with factory: @escaping ((Object) -> AnyObject)) {
+        MainScheduler.ensureExecutingOnScheduler()
+        _ = delegateProxyFactory.extended(factory: factory)
     }
     
     public static func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        return factories.reversed().reduce(AnyObject?.none) { $0 ?? $1(object) }!
+        MainScheduler.ensureExecutingOnScheduler()
+        return delegateProxyFactory.createProxy(for: object)
     }
 }
 

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -70,7 +70,7 @@ every view has a corresponding delegate virtual factory method.
 In case of UITableView / UIScrollView, there is
 
     class RxScrollViewDelegateProxy: DelegateProxy {
-        static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIScrollView) in
+        static var factory = DelegateProxyFactory { (parentObject: UIScrollView) in
             RxScrollViewDelegateProxy(parentObject: parentObject)
         }
     }
@@ -87,9 +87,10 @@ and extend it
 */
 public protocol DelegateProxyType : AnyObject {
     /// DelegateProxy factory
-    static var delegateProxyFactory: DelegateProxyFactory { get }
+    static var factory: DelegateProxyFactory { get }
     
     /// Extend DelegateProxy for specific subclass
+    /// See 'DelegateProxyFactory.extendedProxy'
     static func extendProxy<Object: AnyObject>(with creation: @escaping ((Object) -> AnyObject))
     
     /// Creates new proxy for target object.
@@ -218,14 +219,15 @@ extension DelegateProxyType {
         }
     }
     
-    public static func extendProxy<Object: AnyObject>(with factory: @escaping ((Object) -> AnyObject)) {
-        MainScheduler.ensureExecutingOnScheduler()
-        _ = delegateProxyFactory.extended(factory: factory)
+    /// Extend DelegateProxy for specific subclass
+    /// See 'DelegateProxyFactory.extendedProxy'
+    public static func extendProxy<Object: AnyObject>(with creation: @escaping ((Object) -> AnyObject)) {
+        _ = factory.extended(factory: creation)
     }
     
+    /// Creates new proxy for target object.
     public static func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        MainScheduler.ensureExecutingOnScheduler()
-        return delegateProxyFactory.createProxy(for: object)
+        return factory.createProxy(for: object)
     }
 }
 

--- a/RxCocoa/iOS/NSTextStorage+Rx.swift
+++ b/RxCocoa/iOS/NSTextStorage+Rx.swift
@@ -11,15 +11,6 @@
     import RxSwift
 #endif
     import UIKit
-
-    extension NSTextStorage {
-        /// Factory method that enables subclasses to implement their own `delegate`.
-        ///
-        /// - returns: Instance of delegate proxy that wraps `delegate`.
-        public func createRxDelegateProxy() -> RxTextStorageDelegateProxy {
-            return RxTextStorageDelegateProxy(parentObject: self)
-        }
-    }
     
     extension Reactive where Base: NSTextStorage {
 

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
@@ -35,7 +35,11 @@ final class CollectionViewDataSourceNotSet
 public class RxCollectionViewDataSourceProxy
     : DelegateProxy
     , UICollectionViewDataSource
-    , DelegateProxyType {
+, DelegateProxyType {
+    
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxCollectionViewDataSourceProxy(parentObject: $0) }
+    ]
 
     /// Typed parent object.
     public weak private(set) var collectionView: UICollectionView?
@@ -63,12 +67,6 @@ public class RxCollectionViewDataSourceProxy
     }
     
     // MARK: proxy
-
-    /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let collectionView: UICollectionView = castOrFatalError(object)
-        return collectionView.createRxDataSourceProxy()
-    }
 
     /// For more information take a look at `DelegateProxyType`.
     public override class func delegateAssociatedObjectTag() -> UnsafeRawPointer {

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
@@ -37,9 +37,9 @@ public class RxCollectionViewDataSourceProxy
     , UICollectionViewDataSource
 , DelegateProxyType {
     
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxCollectionViewDataSourceProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UICollectionView) in
+        RxCollectionViewDataSourceProxy(parentObject: parentObject)
+    }
 
     /// Typed parent object.
     public weak private(set) var collectionView: UICollectionView?

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
@@ -37,7 +37,7 @@ public class RxCollectionViewDataSourceProxy
     , UICollectionViewDataSource
 , DelegateProxyType {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UICollectionView) in
+    public static var factory = DelegateProxyFactory { (parentObject: UICollectionView) in
         RxCollectionViewDataSourceProxy(parentObject: parentObject)
     }
 

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -18,6 +18,10 @@
         : DelegateProxy
         , UINavigationControllerDelegate
         , DelegateProxyType {
+        
+        public static var factories: [((AnyObject) -> AnyObject?)] = [
+            { RxNavigationControllerDelegateProxy(parentObject: $0) }
+        ]
 
         /// For more information take a look at `DelegateProxyType`.
         public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
@@ -29,12 +33,6 @@
         public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {
             let navigationController: UINavigationController = castOrFatalError(object)
             navigationController.delegate = castOptionalOrFatalError(delegate)
-        }
-
-        /// For more information take a look at `DelegateProxyType`.
-        open override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-            let navigationController: UINavigationController = castOrFatalError(object)
-            return navigationController.createRxDelegateProxy()
         }
     }
 

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -19,10 +19,10 @@
         , UINavigationControllerDelegate
         , DelegateProxyType {
         
-        public static var factories: [((AnyObject) -> AnyObject?)] = [
-            { RxNavigationControllerDelegateProxy(parentObject: $0) }
-        ]
-
+        public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UINavigationController) in
+            RxNavigationControllerDelegateProxy(parentObject: parentObject)
+        }
+        
         /// For more information take a look at `DelegateProxyType`.
         public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
             let navigationController: UINavigationController = castOrFatalError(object)

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -19,7 +19,7 @@
         , UINavigationControllerDelegate
         , DelegateProxyType {
         
-        public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UINavigationController) in
+        public static var factory = DelegateProxyFactory { (parentObject: UINavigationController) in
             RxNavigationControllerDelegateProxy(parentObject: parentObject)
         }
         

--- a/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
@@ -18,7 +18,7 @@
         , DelegateProxyType
         , UIPickerViewDelegate {
         
-        public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIPickerView) in
+        public static var factory = DelegateProxyFactory { (parentObject: UIPickerView) in
             RxPickerViewDelegateProxy(parentObject: parentObject)
         }
         

--- a/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
@@ -17,12 +17,10 @@
         : DelegateProxy
         , DelegateProxyType
         , UIPickerViewDelegate {
-
-        /// For more information take a look at `DelegateProxyType`.
-        public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-            let pickerView: UIPickerView = castOrFatalError(object)
-            return pickerView.createRxDelegateProxy()
-        }
+        
+        public static var factories: [((AnyObject) -> AnyObject?)] = [
+            { RxPickerViewDelegateProxy(parentObject: $0) }
+        ]
         
         /// For more information take a look at `DelegateProxyType`.
         public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {

--- a/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
@@ -18,9 +18,9 @@
         , DelegateProxyType
         , UIPickerViewDelegate {
         
-        public static var factories: [((AnyObject) -> AnyObject?)] = [
-            { RxPickerViewDelegateProxy(parentObject: $0) }
-        ]
+        public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIPickerView) in
+            RxPickerViewDelegateProxy(parentObject: parentObject)
+        }
         
         /// For more information take a look at `DelegateProxyType`.
         public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {

--- a/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
@@ -19,7 +19,7 @@ public class RxScrollViewDelegateProxy
     , UIScrollViewDelegate
     , DelegateProxyType {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIScrollView) in
+    public static var factory = DelegateProxyFactory { (parentObject: UIScrollView) in
             RxScrollViewDelegateProxy(parentObject: parentObject)
         }
         .extended { (parentObject: UITableView) in

--- a/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
@@ -19,12 +19,19 @@ public class RxScrollViewDelegateProxy
     , UIScrollViewDelegate
     , DelegateProxyType {
     
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxScrollViewDelegateProxy(parentObject: $0) },
-        { ($0 as? UITableView).map { RxTableViewDelegateProxy(parentObject: $0) } },
-        { ($0 as? UICollectionView).map { RxCollectionViewDelegateProxy(parentObject: $0) } },
-        { ($0 as? UITextView).map { RxTextViewDelegateProxy(parentObject: $0) } }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIScrollView) in
+            RxScrollViewDelegateProxy(parentObject: parentObject)
+        }
+        .extended { (parentObject: UITableView) in
+            RxTableViewDelegateProxy(parentObject: parentObject)
+        }
+        .extended { (parentObject: UICollectionView) in
+            RxCollectionViewDelegateProxy(parentObject: parentObject)
+        }
+        .extended { (parentObject: UITextView) in
+            RxTextViewDelegateProxy(parentObject: parentObject)
+        }
+
 
     fileprivate var _contentOffsetBehaviorSubject: BehaviorSubject<CGPoint>?
     fileprivate var _contentOffsetPublishSubject: PublishSubject<()>?

--- a/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
@@ -18,6 +18,13 @@ public class RxScrollViewDelegateProxy
     : DelegateProxy
     , UIScrollViewDelegate
     , DelegateProxyType {
+    
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxScrollViewDelegateProxy(parentObject: $0) },
+        { ($0 as? UITableView).map { RxTableViewDelegateProxy(parentObject: $0) } },
+        { ($0 as? UICollectionView).map { RxCollectionViewDelegateProxy(parentObject: $0) } },
+        { ($0 as? UITextView).map { RxTextViewDelegateProxy(parentObject: $0) } }
+    ]
 
     fileprivate var _contentOffsetBehaviorSubject: BehaviorSubject<CGPoint>?
     fileprivate var _contentOffsetPublishSubject: PublishSubject<()>?
@@ -71,12 +78,6 @@ public class RxScrollViewDelegateProxy
     }
     
     // MARK: delegate proxy
-
-    /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let scrollView: UIScrollView = castOrFatalError(object)
-        return scrollView.createRxDelegateProxy()
-    }
 
     /// For more information take a look at `DelegateProxyType`.
     public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {

--- a/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
@@ -21,9 +21,9 @@ public class RxSearchBarDelegateProxy
 
     // MARK: Delegate proxy methods
 
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxSearchBarDelegateProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UISearchBar) in
+        RxSearchBarDelegateProxy(parentObject: parentObject)
+    }
     
     /// For more information take a look at `DelegateProxyType`.
     public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {

--- a/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
@@ -21,7 +21,7 @@ public class RxSearchBarDelegateProxy
 
     // MARK: Delegate proxy methods
 
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UISearchBar) in
+    public static var factory = DelegateProxyFactory { (parentObject: UISearchBar) in
         RxSearchBarDelegateProxy(parentObject: parentObject)
     }
     

--- a/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
@@ -19,6 +19,12 @@ public class RxSearchBarDelegateProxy
     , UISearchBarDelegate
     , DelegateProxyType {
 
+    // MARK: Delegate proxy methods
+
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxSearchBarDelegateProxy(parentObject: $0) }
+    ]
+    
     /// For more information take a look at `DelegateProxyType`.
     public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
         let searchBar: UISearchBar = castOrFatalError(object)
@@ -30,17 +36,6 @@ public class RxSearchBarDelegateProxy
         let searchBar: UISearchBar = castOrFatalError(object)
         searchBar.delegate = castOptionalOrFatalError(delegate)
     }
-
-    // MARK: Delegate proxy methods
-    
-#if os(iOS)
-    /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let searchBar: UISearchBar = castOrFatalError(object)
-        return searchBar.createRxDelegateProxy()
-    }
-#endif
-    
 }
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
@@ -20,7 +20,7 @@ public class RxSearchControllerDelegateProxy
     , DelegateProxyType
 , UISearchControllerDelegate {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UISearchController) in
+    public static var factory = DelegateProxyFactory { (parentObject: UISearchController) in
         RxSearchControllerDelegateProxy(parentObject: parentObject)
     }
     

--- a/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
@@ -20,9 +20,9 @@ public class RxSearchControllerDelegateProxy
     , DelegateProxyType
 , UISearchControllerDelegate {
     
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxSearchControllerDelegateProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UISearchController) in
+        RxSearchControllerDelegateProxy(parentObject: parentObject)
+    }
     
     /// For more information take a look at `DelegateProxyType`.
     public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {

--- a/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
@@ -18,13 +18,11 @@
 public class RxSearchControllerDelegateProxy
     : DelegateProxy
     , DelegateProxyType
-    , UISearchControllerDelegate {
-
-    /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let pickerView: UISearchController = castOrFatalError(object)
-        return pickerView.createRxDelegateProxy()
-    }
+, UISearchControllerDelegate {
+    
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxSearchControllerDelegateProxy(parentObject: $0) }
+    ]
     
     /// For more information take a look at `DelegateProxyType`.
     public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {

--- a/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
@@ -19,6 +19,10 @@ public class RxTabBarControllerDelegateProxy
     , UITabBarControllerDelegate
     , DelegateProxyType {
     
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxTabBarControllerDelegateProxy(parentObject: $0) }
+    ]
+    
     /// For more information take a look at `DelegateProxyType`.
     public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
         let tabBarController: UITabBarController = castOrFatalError(object)
@@ -29,12 +33,6 @@ public class RxTabBarControllerDelegateProxy
     public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {
         let tabBarController: UITabBarController = castOrFatalError(object)
         tabBarController.delegate = castOptionalOrFatalError(delegate)
-    }
-    
-    /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let tabBarController: UITabBarController = castOrFatalError(object)
-        return tabBarController.createRxDelegateProxy()
     }
 }
 

--- a/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
@@ -19,9 +19,9 @@ public class RxTabBarControllerDelegateProxy
     , UITabBarControllerDelegate
     , DelegateProxyType {
     
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxTabBarControllerDelegateProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UITabBarController) in
+        RxTabBarControllerDelegateProxy(parentObject: parentObject)
+    }
     
     /// For more information take a look at `DelegateProxyType`.
     public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {

--- a/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
@@ -19,7 +19,7 @@ public class RxTabBarControllerDelegateProxy
     , UITabBarControllerDelegate
     , DelegateProxyType {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UITabBarController) in
+    public static var factory = DelegateProxyFactory { (parentObject: UITabBarController) in
         RxTabBarControllerDelegateProxy(parentObject: parentObject)
     }
     

--- a/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
@@ -19,9 +19,9 @@ public class RxTabBarDelegateProxy
     , UITabBarDelegate
     , DelegateProxyType {
     
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxTabBarDelegateProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UITabBar) in
+        RxTabBarDelegateProxy(parentObject: parentObject)
+    }
 
     /// For more information take a look at `DelegateProxyType`.
     public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {

--- a/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
@@ -18,6 +18,10 @@ public class RxTabBarDelegateProxy
     : DelegateProxy
     , UITabBarDelegate
     , DelegateProxyType {
+    
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxTabBarDelegateProxy(parentObject: $0) }
+    ]
 
     /// For more information take a look at `DelegateProxyType`.
     public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
@@ -30,13 +34,6 @@ public class RxTabBarDelegateProxy
         let tabBar: UITabBar = castOrFatalError(object)
         tabBar.delegate = castOptionalOrFatalError(delegate)
     }
-
-    /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let tabBar: UITabBar = castOrFatalError(object)
-        return tabBar.createRxDelegateProxy()
-    }
-
 }
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
@@ -19,7 +19,7 @@ public class RxTabBarDelegateProxy
     , UITabBarDelegate
     , DelegateProxyType {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UITabBar) in
+    public static var factory = DelegateProxyFactory { (parentObject: UITabBar) in
         RxTabBarDelegateProxy(parentObject: parentObject)
     }
 

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
@@ -34,9 +34,9 @@ public class RxTableViewDataSourceProxy
     , UITableViewDataSource
     , DelegateProxyType {
     
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxTableViewDataSourceProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UITableView) in
+        RxTableViewDataSourceProxy(parentObject: parentObject)
+    }
 
     /// Typed parent object.
     public weak fileprivate(set) var tableView: UITableView?

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
@@ -33,6 +33,10 @@ public class RxTableViewDataSourceProxy
     : DelegateProxy
     , UITableViewDataSource
     , DelegateProxyType {
+    
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxTableViewDataSourceProxy(parentObject: $0) }
+    ]
 
     /// Typed parent object.
     public weak fileprivate(set) var tableView: UITableView?
@@ -60,12 +64,6 @@ public class RxTableViewDataSourceProxy
     }
     
     // MARK: proxy
-
-    /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let tableView: UITableView = castOrFatalError(object)
-        return tableView.createRxDataSourceProxy()
-    }
 
     /// For more information take a look at `DelegateProxyType`.
     public override class func delegateAssociatedObjectTag() -> UnsafeRawPointer {

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
@@ -34,7 +34,7 @@ public class RxTableViewDataSourceProxy
     , UITableViewDataSource
     , DelegateProxyType {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UITableView) in
+    public static var factory = DelegateProxyFactory { (parentObject: UITableView) in
         RxTableViewDataSourceProxy(parentObject: parentObject)
     }
 

--- a/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
@@ -16,13 +16,11 @@
     public class RxTextStorageDelegateProxy
         : DelegateProxy
         , DelegateProxyType
-        , NSTextStorageDelegate {
-
-        /// For more information take a look at `DelegateProxyType`.
-        public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-            let pickerView: NSTextStorage = castOrFatalError(object)
-            return pickerView.createRxDelegateProxy()
-        }
+    , NSTextStorageDelegate {
+        
+        public static var factories: [((AnyObject) -> AnyObject?)] = [
+            { RxTextStorageDelegateProxy(parentObject: $0) }
+        ]
         
         /// For more information take a look at `DelegateProxyType`.
         public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {

--- a/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
@@ -18,9 +18,9 @@
         , DelegateProxyType
     , NSTextStorageDelegate {
         
-        public static var factories: [((AnyObject) -> AnyObject?)] = [
-            { RxTextStorageDelegateProxy(parentObject: $0) }
-        ]
+        public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: NSTextStorage) in
+            RxTextStorageDelegateProxy(parentObject: parentObject)
+        }
         
         /// For more information take a look at `DelegateProxyType`.
         public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {

--- a/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
@@ -18,7 +18,7 @@
         , DelegateProxyType
     , NSTextStorageDelegate {
         
-        public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: NSTextStorage) in
+        public static var factory = DelegateProxyFactory { (parentObject: NSTextStorage) in
             RxTextStorageDelegateProxy(parentObject: parentObject)
         }
         

--- a/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
@@ -17,13 +17,11 @@ public class RxWebViewDelegateProxy
     : DelegateProxy
     , DelegateProxyType
     , UIWebViewDelegate {
-
-    /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let pickerView: UIWebView = castOrFatalError(object)
-        return pickerView.createRxDelegateProxy()
-    }
     
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxWebViewDelegateProxy(parentObject: $0) }
+    ]
+
     /// For more information take a look at `DelegateProxyType`.
     public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {
         let webView: UIWebView = castOrFatalError(object)

--- a/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
@@ -18,7 +18,7 @@ public class RxWebViewDelegateProxy
     , DelegateProxyType
     , UIWebViewDelegate {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIWebView) in
+    public static var factory = DelegateProxyFactory { (parentObject: UIWebView) in
         RxWebViewDelegateProxy(parentObject: parentObject)
     }
 

--- a/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
@@ -18,9 +18,9 @@ public class RxWebViewDelegateProxy
     , DelegateProxyType
     , UIWebViewDelegate {
     
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxWebViewDelegateProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: UIWebView) in
+        RxWebViewDelegateProxy(parentObject: parentObject)
+    }
 
     /// For more information take a look at `DelegateProxyType`.
     public class func setCurrentDelegate(_ delegate: AnyObject?, toObject object: AnyObject) {

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -160,17 +160,6 @@ extension Reactive where Base: UICollectionView {
     }
 }
 
-extension UICollectionView {
-   
-    /// Factory method that enables subclasses to implement their own `rx.dataSource`.
-    ///
-    /// - returns: Instance of delegate proxy that wraps `dataSource`.
-    public func createRxDataSourceProxy() -> RxCollectionViewDataSourceProxy {
-        return RxCollectionViewDataSourceProxy(parentObject: self)
-    }
-
-}
-
 extension Reactive where Base: UICollectionView {
 
     /// Reactive wrapper for `dataSource`.

--- a/RxCocoa/iOS/UINavigationController+Rx.swift
+++ b/RxCocoa/iOS/UINavigationController+Rx.swift
@@ -13,15 +13,6 @@ import RxSwift
 #endif
 import UIKit
 
-extension UINavigationController {
-    /// Factory method that enables subclasses to implement their own `delegate`.
-    ///
-    /// - returns: Instance of delegate proxy that wraps `delegate`.
-    public func createRxDelegateProxy() -> RxNavigationControllerDelegateProxy {
-        return RxNavigationControllerDelegateProxy(parentObject: self)
-    }
-}
-
 extension Reactive where Base: UINavigationController {
     public typealias ShowEvent = (viewController: UIViewController, animated: Bool)
 

--- a/RxCocoa/iOS/UIPickerView+Rx.swift
+++ b/RxCocoa/iOS/UIPickerView+Rx.swift
@@ -13,17 +13,6 @@
 #endif
     import UIKit
 
-    extension UIPickerView {
-
-        /// Factory method that enables subclasses to implement their own `delegate`.
-        ///
-        /// - returns: Instance of delegate proxy that wraps `delegate`.
-        public func createRxDelegateProxy() -> RxPickerViewDelegateProxy {
-            return RxPickerViewDelegateProxy(parentObject: self)
-        }
-        
-    }
-    
     extension Reactive where Base: UIPickerView {
 
         /// Reactive wrapper for `delegate`.

--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -14,26 +14,6 @@
 
     import UIKit
 
-    extension UIScrollView {
-        
-        /// Factory method that enables subclasses to implement their own `delegate`.
-        ///
-        /// - returns: Instance of delegate proxy that wraps `delegate`.
-        public func createRxDelegateProxy() -> RxScrollViewDelegateProxy {
-            switch self {
-            case self as UICollectionView:
-              return RxCollectionViewDelegateProxy(parentObject: self)
-            case self as UITableView:
-                return RxTableViewDelegateProxy(parentObject: self)
-            case self as UITextView:
-                return RxTextViewDelegateProxy(parentObject: self)
-            default:
-                return RxScrollViewDelegateProxy(parentObject: self)
-            }
-        }
-        
-    }
-
     extension Reactive where Base: UIScrollView {
 
         /// Reactive wrapper for `delegate`.

--- a/RxCocoa/iOS/UISearchBar+Rx.swift
+++ b/RxCocoa/iOS/UISearchBar+Rx.swift
@@ -13,19 +13,6 @@ import RxSwift
 #endif
 import UIKit
 
-
-#if os(iOS)
-    extension UISearchBar {
-        /// Factory method that enables subclasses to implement their own `delegate`.
-        ///
-        /// - returns: Instance of delegate proxy that wraps `delegate`.
-        public func createRxDelegateProxy() -> RxSearchBarDelegateProxy {
-            return RxSearchBarDelegateProxy(parentObject: self)
-        }
-        
-    }
-#endif
-
 extension Reactive where Base: UISearchBar {
 
     /// Reactive wrapper for `delegate`.

--- a/RxCocoa/iOS/UISearchController+Rx.swift
+++ b/RxCocoa/iOS/UISearchController+Rx.swift
@@ -12,15 +12,6 @@
     import RxSwift
 #endif
     import UIKit
-
-    extension UISearchController {
-        /// Factory method that enables subclasses to implement their own `delegate`.
-        ///
-        /// - returns: Instance of delegate proxy that wraps `delegate`.
-        public func createRxDelegateProxy() -> RxSearchControllerDelegateProxy {
-            return RxSearchControllerDelegateProxy(parentObject: self)
-        }
-    }
     
     @available(iOS 8.0, *)
     extension Reactive where Base: UISearchController {

--- a/RxCocoa/iOS/UITabBar+Rx.swift
+++ b/RxCocoa/iOS/UITabBar+Rx.swift
@@ -70,17 +70,7 @@ extension Reactive where Base: UITabBar {
 /**
  iOS and tvOS
  */
-extension UITabBar {
     
-    /// Factory method that enables subclasses to implement their own `delegate`.
-    ///
-    /// - returns: Instance of delegate proxy that wraps `delegate`.
-    public func createRxDelegateProxy() -> RxTabBarDelegateProxy {
-        return RxTabBarDelegateProxy(parentObject: self)
-    }
-
-}
-
 extension Reactive where Base: UITabBar {
     /// Reactive wrapper for `delegate`.
     ///

--- a/RxCocoa/iOS/UITabBarController+Rx.swift
+++ b/RxCocoa/iOS/UITabBarController+Rx.swift
@@ -58,16 +58,6 @@ extension Reactive where Base: UITabBarController {
 /**
  iOS and tvOS
  */
-extension UITabBarController {
-    
-    /// Factory method that enables subclasses to implement their own `delegate`.
-    ///
-    /// - returns: Instance of delegate proxy that wraps `delegate`.
-    public func createRxDelegateProxy() -> RxTabBarControllerDelegateProxy {
-        return RxTabBarControllerDelegateProxy(parentObject: self)
-    }
-    
-}
     
 extension Reactive where Base: UITabBarController {
     /// Reactive wrapper for `delegate`.

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -165,19 +165,6 @@ extension Reactive where Base: UITableView {
 
 }
 
-extension UITableView {
- 
-    /**
-    Factory method that enables subclasses to implement their own `rx.dataSource`.
-    
-    - returns: Instance of delegate proxy that wraps `dataSource`.
-    */
-    public func createRxDataSourceProxy() -> RxTableViewDataSourceProxy {
-        return RxTableViewDataSourceProxy(parentObject: self)
-    }
-
-}
-
 extension Reactive where Base: UITableView {
     /**
     Reactive wrapper for `dataSource`.

--- a/RxCocoa/iOS/UIWebView+Rx.swift
+++ b/RxCocoa/iOS/UIWebView+Rx.swift
@@ -14,17 +14,6 @@ import UIKit
 import RxSwift
 #endif
 
-    extension UIWebView {
-
-        /// Factory method that enables subclasses to implement their own `delegate`.
-        ///
-        /// - returns: Instance of delegate proxy that wraps `delegate`.
-        public func createRxDelegateProxy() -> RxWebViewDelegateProxy {
-            return RxWebViewDelegateProxy(parentObject: self)
-        }
-
-    }
-    
     extension Reactive where Base: UIWebView {
 
         /// Reactive wrapper for `delegate`.

--- a/RxCocoa/macOS/NSTextField+Rx.swift
+++ b/RxCocoa/macOS/NSTextField+Rx.swift
@@ -20,6 +20,10 @@ public class RxTextFieldDelegateProxy
     : DelegateProxy
     , NSTextFieldDelegate
     , DelegateProxyType {
+    
+    public static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxTextFieldDelegateProxy(parentObject: $0) }
+    ]
 
     fileprivate let textSubject = PublishSubject<String?>()
 
@@ -46,12 +50,6 @@ public class RxTextFieldDelegateProxy
     // MARK: Delegate proxy methods
 
     /// For more information take a look at `DelegateProxyType`.
-    public override class func createProxyForObject(_ object: AnyObject) -> AnyObject {
-        let control: NSTextField = castOrFatalError(object)
-        return control.createRxDelegateProxy()
-    }
-
-    /// For more information take a look at `DelegateProxyType`.
     public class func currentDelegateFor(_ object: AnyObject) -> AnyObject? {
         let textField: NSTextField = castOrFatalError(object)
         return textField.delegate
@@ -63,16 +61,6 @@ public class RxTextFieldDelegateProxy
         textField.delegate = castOptionalOrFatalError(delegate)
     }
     
-}
-
-extension NSTextField {
-
-    /// Factory method that enables subclasses to implement their own `delegate`.
-    ///
-    /// - returns: Instance of delegate proxy that wraps `delegate`.
-    public func createRxDelegateProxy() -> RxTextFieldDelegateProxy {
-        return RxTextFieldDelegateProxy(parentObject: self)
-    }
 }
 
 extension Reactive where Base: NSTextField {

--- a/RxCocoa/macOS/NSTextField+Rx.swift
+++ b/RxCocoa/macOS/NSTextField+Rx.swift
@@ -21,9 +21,9 @@ public class RxTextFieldDelegateProxy
     , NSTextFieldDelegate
     , DelegateProxyType {
     
-    public static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxTextFieldDelegateProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: NSTextField) in
+        RxTextFieldDelegateProxy(parentObject: parentObject)
+    }
 
     fileprivate let textSubject = PublishSubject<String?>()
 

--- a/RxCocoa/macOS/NSTextField+Rx.swift
+++ b/RxCocoa/macOS/NSTextField+Rx.swift
@@ -21,7 +21,7 @@ public class RxTextFieldDelegateProxy
     , NSTextFieldDelegate
     , DelegateProxyType {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: NSTextField) in
+    public static var factory = DelegateProxyFactory { (parentObject: NSTextField) in
         RxTextFieldDelegateProxy(parentObject: parentObject)
     }
 

--- a/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
+++ b/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
@@ -16,7 +16,7 @@ class RxCLLocationManagerDelegateProxy : DelegateProxy
                                        , CLLocationManagerDelegate
                                        , DelegateProxyType {
     
-    static var delegateProxyFactory = DelegateProxyFactory { (parentObject: CLLocationManager) in
+    static var factory = DelegateProxyFactory { (parentObject: CLLocationManager) in
         RxCLLocationManagerDelegateProxy(parentObject: parentObject)
     }
 

--- a/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
+++ b/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
@@ -15,6 +15,10 @@ import CoreLocation
 class RxCLLocationManagerDelegateProxy : DelegateProxy
                                        , CLLocationManagerDelegate
                                        , DelegateProxyType {
+    
+    static var factories: [((AnyObject) -> AnyObject?)] = [
+        { RxCLLocationManagerDelegateProxy(parentObject: $0) }
+    ]
 
     internal lazy var didUpdateLocationsSubject = PublishSubject<[CLLocation]>()
     internal lazy var didFailWithErrorSubject = PublishSubject<Error>()

--- a/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
+++ b/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
@@ -16,9 +16,9 @@ class RxCLLocationManagerDelegateProxy : DelegateProxy
                                        , CLLocationManagerDelegate
                                        , DelegateProxyType {
     
-    static var factories: [((AnyObject) -> AnyObject?)] = [
-        { RxCLLocationManagerDelegateProxy(parentObject: $0) }
-    ]
+    static var delegateProxyFactory = DelegateProxyFactory { (parentObject: CLLocationManager) in
+        RxCLLocationManagerDelegateProxy(parentObject: parentObject)
+    }
 
     internal lazy var didUpdateLocationsSubject = PublishSubject<[CLLocation]>()
     internal lazy var didFailWithErrorSubject = PublishSubject<Error>()

--- a/Sources/RxCocoa/DelegateProxyFactory.swift
+++ b/Sources/RxCocoa/DelegateProxyFactory.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/Common/DelegateProxyFactory.swift

--- a/Tests/RxCocoaTests/DelegateProxyTest+Cocoa.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+Cocoa.swift
@@ -15,7 +15,7 @@ import XCTest
 
 extension DelegateProxyTest {
     func test_NSTextFieldDelegateExtension() {
-        performDelegateTest(NSTextFieldSubclass(frame: CGRect.zero))
+        performDelegateTest(NSTextFieldSubclass(frame: CGRect.zero), proxyType: ExtendNSTextFieldDelegateProxy.self)
     }
 }
 

--- a/Tests/RxCocoaTests/DelegateProxyTest+Cocoa.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+Cocoa.swift
@@ -32,10 +32,6 @@ class ExtendNSTextFieldDelegateProxy
 final class NSTextFieldSubclass
     : NSTextField
     , TestDelegateControl {
-    override func createRxDelegateProxy() -> RxTextFieldDelegateProxy {
-        return ExtendNSTextFieldDelegateProxy(parentObject: self)
-    }
-
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }

--- a/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
@@ -16,11 +16,11 @@ import XCTest
 
 extension DelegateProxyTest {
     func test_UITableViewDelegateExtension() {
-        performDelegateTest(UITableViewSubclass1(frame: CGRect.zero))
+        performDelegateTest(UITableViewSubclass1(frame: CGRect.zero), proxyType: ExtendTableViewDelegateProxy.self)
     }
 
     func test_UITableViewDataSourceExtension() {
-        performDelegateTest(UITableViewSubclass2(frame: CGRect.zero))
+        performDelegateTest(UITableViewSubclass2(frame: CGRect.zero), proxyType: ExtendTableViewDataSourceProxy.self)
     }
 }
 
@@ -28,51 +28,51 @@ extension DelegateProxyTest {
 
     func test_UICollectionViewDelegateExtension() {
         let layout = UICollectionViewFlowLayout()
-        performDelegateTest(UICollectionViewSubclass1(frame: CGRect.zero, collectionViewLayout: layout))
+        performDelegateTest(UICollectionViewSubclass1(frame: CGRect.zero, collectionViewLayout: layout), proxyType: ExtendCollectionViewDelegateProxy.self)
     }
 
     func test_UICollectionViewDataSourceExtension() {
         let layout = UICollectionViewFlowLayout()
-        performDelegateTest(UICollectionViewSubclass2(frame: CGRect.zero, collectionViewLayout: layout))
+        performDelegateTest(UICollectionViewSubclass2(frame: CGRect.zero, collectionViewLayout: layout), proxyType: ExtendCollectionViewDataSourceProxy.self)
     }
 }
 
 extension DelegateProxyTest {
     func test_UINavigationControllerDelegateExtension() {
-        performDelegateTest(UINavigationControllerSubclass())
+        performDelegateTest(UINavigationControllerSubclass(), proxyType: ExtendNavigationControllerDelegateProxy.self)
     }
 }
 
 extension DelegateProxyTest {
     func test_UIScrollViewDelegateExtension() {
-        performDelegateTest(UIScrollViewSubclass1(frame: CGRect.zero))
+        performDelegateTest(UIScrollViewSubclass(frame: CGRect.zero), proxyType: ExtendScrollViewDelegateProxy.self)
     }
 }
 
 #if os(iOS)
 extension DelegateProxyTest {
     func test_UISearchBarDelegateExtension() {
-        performDelegateTest(UISearchBarSubclass(frame: CGRect.zero))
+        performDelegateTest(UISearchBarSubclass(frame: CGRect.zero), proxyType: ExtendSearchBarDelegateProxy.self)
     }
 }
 #endif
 
 extension DelegateProxyTest {
     func test_UITextViewDelegateExtension() {
-        performDelegateTest(UITextViewSubclass(frame: CGRect.zero))
+        performDelegateTest(UITextViewSubclass(frame: CGRect.zero), proxyType: ExtendTextViewDelegateProxy.self)
     }
 }
 
 #if os(iOS)
 extension DelegateProxyTest {
     func test_UISearchController() {
-        performDelegateTest(UISearchControllerSubclass())
+        performDelegateTest(UISearchControllerSubclass(), proxyType: ExtendSearchControllerDelegateProxy.self)
     }
 }
     
 extension DelegateProxyTest {
     func test_UIPickerViewExtension() {
-        performDelegateTest(UIPickerViewSubclass(frame: CGRect.zero))
+        performDelegateTest(UIPickerViewSubclass(frame: CGRect.zero), proxyType: ExtendPickerViewDelegateProxy.self)
     }
 }
 #endif
@@ -80,32 +80,20 @@ extension DelegateProxyTest {
 #if os(iOS)
 extension DelegateProxyTest {
     func test_UIWebViewDelegateExtension() {
-        performDelegateTest(UIWebViewSubclass(frame: CGRect.zero))
+        performDelegateTest(UIWebViewSubclass(frame: CGRect.zero), proxyType: ExtendWebViewDelegateProxy.self)
     }
 }
 #endif
 
 extension DelegateProxyTest {
     func test_UITabBarControllerDelegateExtension() {
-        performDelegateTest(UITabBarControllerSubclass())
+        performDelegateTest(UITabBarControllerSubclass(), proxyType: ExtendTabBarControllerDelegateProxy.self)
     }
 }
 
 extension DelegateProxyTest {
     func test_UITabBarDelegateExtension() {
-        performDelegateTest(UITabBarSubclass())
-    }
-}
-
-extension DelegateProxyTest {
-    func test_DelegateProxyExtendOrder() {
-        performDelegateTest(UIScrollViewSubclass2(frame: CGRect.zero))
-    }
-}
-
-extension DelegateProxyTest {
-    func test_DelegateProxyHasNoSpecificFactory() {
-        performDelegateTest(UIScrollViewSubclass3(frame: CGRect.zero))
+        performDelegateTest(UITabBarSubclass(), proxyType: ExtendTabBarDelegateProxy.self)
     }
 }
 
@@ -235,15 +223,15 @@ final class UICollectionViewSubclass2
 final class ExtendScrollViewDelegateProxy
     : RxScrollViewDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UIScrollViewSubclass1?
+    weak fileprivate(set) var control: UIScrollViewSubclass?
 
     required init(parentObject: AnyObject) {
-        self.control = (parentObject as! UIScrollViewSubclass1)
+        self.control = (parentObject as! UIScrollViewSubclass)
         super.init(parentObject: parentObject)
     }
 }
 
-class UIScrollViewSubclass1
+final class UIScrollViewSubclass
     : UIScrollView
     , TestDelegateControl {
     func doThatTest(_ value: Int) {
@@ -257,36 +245,6 @@ class UIScrollViewSubclass1
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
         return RxScrollViewDelegateProxy.installForwardDelegate(testDelegate, retainDelegate: false, onProxyForObject: self)
     }
-}
-
-final class ExtendScrollViewDelegateProxy2
-    : RxScrollViewDelegateProxy
-, TestDelegateProtocol {
-    weak fileprivate(set) var control: UIScrollViewSubclass2?
-    
-    required init(parentObject: AnyObject) {
-        self.control = (parentObject as! UIScrollViewSubclass2)
-        super.init(parentObject: parentObject)
-    }
-}
-
-final class UIScrollViewSubclass2
-    : UIScrollView
-, TestDelegateControl {
-    func doThatTest(_ value: Int) {
-        (delegate as! TestDelegateProtocol).testEventHappened?(value)
-    }
-    
-    var delegateProxy: DelegateProxy {
-        return self.rx.delegate
-    }
-    
-    func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
-        return RxScrollViewDelegateProxy.installForwardDelegate(testDelegate, retainDelegate: false, onProxyForObject: self)
-    }
-}
-
-final class UIScrollViewSubclass3: UIScrollViewSubclass1 {
 }
 
 #if os(iOS)

--- a/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
@@ -120,10 +120,6 @@ final class ExtendTableViewDelegateProxy
 final class UITableViewSubclass1
     : UITableView
     , TestDelegateControl {
-    override func createRxDelegateProxy() -> RxScrollViewDelegateProxy {
-        return ExtendTableViewDelegateProxy(parentObject: self)
-    }
-
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -151,10 +147,7 @@ final class ExtendTableViewDataSourceProxy
 final class UITableViewSubclass2
     : UITableView
     , TestDelegateControl {
-    override func createRxDataSourceProxy() -> RxTableViewDataSourceProxy {
-        return ExtendTableViewDataSourceProxy(parentObject: self)
-    }
-
+    
     func doThatTest(_ value: Int) {
         if dataSource != nil {
             (dataSource as! TestDelegateProtocol).testEventHappened?(value)
@@ -184,10 +177,6 @@ final class ExtendCollectionViewDelegateProxy
 final class UICollectionViewSubclass1
     : UICollectionView
     , TestDelegateControl {
-    override func createRxDelegateProxy() -> RxScrollViewDelegateProxy {
-        return ExtendCollectionViewDelegateProxy(parentObject: self)
-    }
-
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -215,9 +204,6 @@ final class ExtendCollectionViewDataSourceProxy
 final class UICollectionViewSubclass2
     : UICollectionView
     , TestDelegateControl {
-    override func createRxDataSourceProxy() -> RxCollectionViewDataSourceProxy {
-        return ExtendCollectionViewDataSourceProxy(parentObject: self)
-    }
 
     func doThatTest(_ value: Int) {
         if dataSource != nil {
@@ -248,10 +234,6 @@ final class ExtendScrollViewDelegateProxy
 final class UIScrollViewSubclass
     : UIScrollView
     , TestDelegateControl {
-    override func createRxDelegateProxy() -> RxScrollViewDelegateProxy {
-        return ExtendScrollViewDelegateProxy(parentObject: self)
-    }
-
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -280,11 +262,6 @@ final class ExtendSearchBarDelegateProxy
 final class UISearchBarSubclass
     : UISearchBar
     , TestDelegateControl {
-    
-    override func createRxDelegateProxy() -> RxSearchBarDelegateProxy {
-        return ExtendSearchBarDelegateProxy(parentObject: self)
-    }
-    
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -313,10 +290,6 @@ final class ExtendTextViewDelegateProxy
 final class UITextViewSubclass
     : UITextView
     , TestDelegateControl {
-    override func createRxDelegateProxy() -> RxScrollViewDelegateProxy {
-        return ExtendTextViewDelegateProxy(parentObject: self)
-    }
-
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -341,11 +314,6 @@ final class ExtendSearchControllerDelegateProxy
 final class UISearchControllerSubclass
     : UISearchController
     , TestDelegateControl {
-
-    override func createRxDelegateProxy() -> RxSearchControllerDelegateProxy {
-        return ExtendSearchControllerDelegateProxy(parentObject: self)
-    }
-    
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -371,11 +339,6 @@ final class ExtendPickerViewDelegateProxy
 final class UIPickerViewSubclass
     : UIPickerView
     , TestDelegateControl {
-
-    public override func createRxDelegateProxy() -> RxPickerViewDelegateProxy {
-        return ExtendPickerViewDelegateProxy(parentObject: self)
-    }
-
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -400,11 +363,6 @@ final class ExtendWebViewDelegateProxy
 }
 
 final class UIWebViewSubclass: UIWebView, TestDelegateControl {
-
-    override func createRxDelegateProxy() -> RxWebViewDelegateProxy {
-        return ExtendWebViewDelegateProxy(parentObject: self)
-    }
-    
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -437,11 +395,6 @@ final class ExtendTextStorageDelegateProxy
 final class NSTextStorageSubclass
     : NSTextStorage
     , TestDelegateControl {
-
-    override func createRxDelegateProxy() -> RxTextStorageDelegateProxy {
-        return ExtendTextStorageDelegateProxy(parentObject: self)
-    }
-
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -489,10 +442,6 @@ final class ExtendTabBarDelegateProxy
 }
 
 final class UINavigationControllerSubclass: UINavigationController, TestDelegateControl {
-    override func createRxDelegateProxy() -> RxNavigationControllerDelegateProxy {
-        return ExtendNavigationControllerDelegateProxy(parentObject: self)
-    }
-
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -511,10 +460,6 @@ final class UINavigationControllerSubclass: UINavigationController, TestDelegate
 final class UITabBarControllerSubclass
     : UITabBarController
     , TestDelegateControl {
-    override func createRxDelegateProxy() -> RxTabBarControllerDelegateProxy {
-        return ExtendTabBarControllerDelegateProxy(parentObject: self)
-    }
-    
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
@@ -529,10 +474,6 @@ final class UITabBarControllerSubclass
 }
 
 final class UITabBarSubclass: UITabBar, TestDelegateControl {
-    override func createRxDelegateProxy() -> RxTabBarDelegateProxy {
-        return ExtendTabBarDelegateProxy(parentObject: self)
-    }
-    
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }

--- a/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
@@ -45,7 +45,7 @@ extension DelegateProxyTest {
 
 extension DelegateProxyTest {
     func test_UIScrollViewDelegateExtension() {
-        performDelegateTest(UIScrollViewSubclass(frame: CGRect.zero))
+        performDelegateTest(UIScrollViewSubclass1(frame: CGRect.zero))
     }
 }
 
@@ -94,6 +94,18 @@ extension DelegateProxyTest {
 extension DelegateProxyTest {
     func test_UITabBarDelegateExtension() {
         performDelegateTest(UITabBarSubclass())
+    }
+}
+
+extension DelegateProxyTest {
+    func test_DelegateProxyExtendOrder() {
+        performDelegateTest(UIScrollViewSubclass2(frame: CGRect.zero))
+    }
+}
+
+extension DelegateProxyTest {
+    func test_DelegateProxyHasNoSpecificFactory() {
+        performDelegateTest(UIScrollViewSubclass3(frame: CGRect.zero))
     }
 }
 
@@ -223,15 +235,15 @@ final class UICollectionViewSubclass2
 final class ExtendScrollViewDelegateProxy
     : RxScrollViewDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UIScrollViewSubclass?
+    weak fileprivate(set) var control: UIScrollViewSubclass1?
 
     required init(parentObject: AnyObject) {
-        self.control = (parentObject as! UIScrollViewSubclass)
+        self.control = (parentObject as! UIScrollViewSubclass1)
         super.init(parentObject: parentObject)
     }
 }
 
-final class UIScrollViewSubclass
+class UIScrollViewSubclass1
     : UIScrollView
     , TestDelegateControl {
     func doThatTest(_ value: Int) {
@@ -245,6 +257,36 @@ final class UIScrollViewSubclass
     func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
         return RxScrollViewDelegateProxy.installForwardDelegate(testDelegate, retainDelegate: false, onProxyForObject: self)
     }
+}
+
+final class ExtendScrollViewDelegateProxy2
+    : RxScrollViewDelegateProxy
+, TestDelegateProtocol {
+    weak fileprivate(set) var control: UIScrollViewSubclass2?
+    
+    required init(parentObject: AnyObject) {
+        self.control = (parentObject as! UIScrollViewSubclass2)
+        super.init(parentObject: parentObject)
+    }
+}
+
+final class UIScrollViewSubclass2
+    : UIScrollView
+, TestDelegateControl {
+    func doThatTest(_ value: Int) {
+        (delegate as! TestDelegateProtocol).testEventHappened?(value)
+    }
+    
+    var delegateProxy: DelegateProxy {
+        return self.rx.delegate
+    }
+    
+    func setMineForwardDelegate(_ testDelegate: TestDelegateProtocol) -> Disposable {
+        return RxScrollViewDelegateProxy.installForwardDelegate(testDelegate, retainDelegate: false, onProxyForObject: self)
+    }
+}
+
+final class UIScrollViewSubclass3: UIScrollViewSubclass1 {
 }
 
 #if os(iOS)

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -56,60 +56,68 @@ extension TestDelegateControl {
 // MARK: Tests
 
 final class DelegateProxyTest : RxTest {
-    override func setUp() {
-        super.setUp()
+    
+    static var extendDelegateProxy: Void = {
         // setup extending of DelegateProxies
         #if os(iOS) || os(tvOS)
-            RxScrollViewDelegateProxy.extend { (parentObject: UIScrollViewSubclass) in
+            RxScrollViewDelegateProxy.extendProxy { (parentObject: UIScrollViewSubclass2) in
+                ExtendScrollViewDelegateProxy2(parentObject: parentObject)
+            }
+            RxScrollViewDelegateProxy.extendProxy { (parentObject: UIScrollViewSubclass1) in
                 ExtendScrollViewDelegateProxy(parentObject: parentObject)
             }
-            RxScrollViewDelegateProxy.extend { (parentObject: UITableViewSubclass1) in
+            RxScrollViewDelegateProxy.extendProxy { (parentObject: UITableViewSubclass1) in
                 ExtendTableViewDelegateProxy(parentObject: parentObject)
             }
-            RxTableViewDataSourceProxy.extend { (parentObject: UITableViewSubclass2) in
+            RxTableViewDataSourceProxy.extendProxy { (parentObject: UITableViewSubclass2) in
                 ExtendTableViewDataSourceProxy(parentObject: parentObject)
             }
-            RxScrollViewDelegateProxy.extend { (parentObject: UICollectionViewSubclass1) in
+            RxScrollViewDelegateProxy.extendProxy { (parentObject: UICollectionViewSubclass1) in
                 ExtendCollectionViewDelegateProxy(parentObject: parentObject)
             }
-            RxCollectionViewDataSourceProxy.extend { (parentObject: UICollectionViewSubclass2) in
+            RxCollectionViewDataSourceProxy.extendProxy { (parentObject: UICollectionViewSubclass2) in
                 ExtendCollectionViewDataSourceProxy(parentObject: parentObject)
             }
-            RxScrollViewDelegateProxy.extend { (parentObject: UITextViewSubclass) in
+            RxScrollViewDelegateProxy.extendProxy { (parentObject: UITextViewSubclass) in
                 ExtendTextViewDelegateProxy(parentObject: parentObject)
             }
-            RxTextStorageDelegateProxy.extend { (parentObject: NSTextStorageSubclass) in
+            RxTextStorageDelegateProxy.extendProxy { (parentObject: NSTextStorageSubclass) in
                 ExtendTextStorageDelegateProxy(parentObject: parentObject)
             }
-            RxNavigationControllerDelegateProxy.extend { (parentObject: UINavigationControllerSubclass) in
+            RxNavigationControllerDelegateProxy.extendProxy { (parentObject: UINavigationControllerSubclass) in
                 ExtendNavigationControllerDelegateProxy(parentObject: parentObject)
             }
-            RxTabBarControllerDelegateProxy.extend { (parentObject: UITabBarControllerSubclass) in
+            RxTabBarControllerDelegateProxy.extendProxy { (parentObject: UITabBarControllerSubclass) in
                 ExtendTabBarControllerDelegateProxy(parentObject: parentObject)
             }
-            RxTabBarDelegateProxy.extend { (parentObject: UITabBarSubclass) -> AnyObject in
+            RxTabBarDelegateProxy.extendProxy { (parentObject: UITabBarSubclass) -> AnyObject in
                 ExtendTabBarDelegateProxy(parentObject: parentObject)
             }
         #endif
         #if os(iOS)
-            RxSearchBarDelegateProxy.extend { (parentObject: UISearchBarSubclass) in
+            RxSearchBarDelegateProxy.extendProxy { (parentObject: UISearchBarSubclass) in
                 ExtendSearchBarDelegateProxy(parentObject: parentObject)
             }
-            RxSearchControllerDelegateProxy.extend { (parentObject: UISearchControllerSubclass) in
+            RxSearchControllerDelegateProxy.extendProxy { (parentObject: UISearchControllerSubclass) in
                 ExtendSearchControllerDelegateProxy(parentObject: parentObject)
             }
-            RxPickerViewDelegateProxy.extend { (parentObject: UIPickerViewSubclass) in
+            RxPickerViewDelegateProxy.extendProxy { (parentObject: UIPickerViewSubclass) in
                 ExtendPickerViewDelegateProxy(parentObject: parentObject)
             }
-            RxWebViewDelegateProxy.extend { (parentObject: UIWebViewSubclass) in
+            RxWebViewDelegateProxy.extendProxy { (parentObject: UIWebViewSubclass) in
                 ExtendWebViewDelegateProxy(parentObject: parentObject)
             }
         #endif
         #if os(macOS)
-            RxTextFieldDelegateProxy.extend { (parentObject: NSTextFieldSubclass) in
+            RxTextFieldDelegateProxy.extendProxy { (parentObject: NSTextFieldSubclass) in
                 ExtendNSTextFieldDelegateProxy(parentObject: parentObject)
             }
         #endif
+    }()
+    
+    override func setUp() {
+        super.setUp()
+        _ = DelegateProxyTest.extendDelegateProxy
     }
     
     func test_OnInstallDelegateIsRetained() {
@@ -476,9 +484,9 @@ final class ThreeDSectionedViewDelegateProxy : DelegateProxy
                                        , ThreeDSectionedViewProtocol
                                        , DelegateProxyType {
     
-    static var factories: [((AnyObject) -> AnyObject?)] = [
-        { ThreeDSectionedViewDelegateProxy(parentObject: $0) }
-    ]
+    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: ThreeDSectionedView) in
+        ThreeDSectionedViewDelegateProxy(parentObject: parentObject)
+    }
     
     required init(parentObject: AnyObject) {
         super.init(parentObject: parentObject)

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -56,6 +56,62 @@ extension TestDelegateControl {
 // MARK: Tests
 
 final class DelegateProxyTest : RxTest {
+    override func setUp() {
+        super.setUp()
+        // setup extending of DelegateProxies
+        #if os(iOS) || os(tvOS)
+            RxScrollViewDelegateProxy.extend { (parentObject: UIScrollViewSubclass) in
+                ExtendScrollViewDelegateProxy(parentObject: parentObject)
+            }
+            RxScrollViewDelegateProxy.extend { (parentObject: UITableViewSubclass1) in
+                ExtendTableViewDelegateProxy(parentObject: parentObject)
+            }
+            RxTableViewDataSourceProxy.extend { (parentObject: UITableViewSubclass2) in
+                ExtendTableViewDataSourceProxy(parentObject: parentObject)
+            }
+            RxScrollViewDelegateProxy.extend { (parentObject: UICollectionViewSubclass1) in
+                ExtendCollectionViewDelegateProxy(parentObject: parentObject)
+            }
+            RxCollectionViewDataSourceProxy.extend { (parentObject: UICollectionViewSubclass2) in
+                ExtendCollectionViewDataSourceProxy(parentObject: parentObject)
+            }
+            RxScrollViewDelegateProxy.extend { (parentObject: UITextViewSubclass) in
+                ExtendTextViewDelegateProxy(parentObject: parentObject)
+            }
+            RxTextStorageDelegateProxy.extend { (parentObject: NSTextStorageSubclass) in
+                ExtendTextStorageDelegateProxy(parentObject: parentObject)
+            }
+            RxNavigationControllerDelegateProxy.extend { (parentObject: UINavigationControllerSubclass) in
+                ExtendNavigationControllerDelegateProxy(parentObject: parentObject)
+            }
+            RxTabBarControllerDelegateProxy.extend { (parentObject: UITabBarControllerSubclass) in
+                ExtendTabBarControllerDelegateProxy(parentObject: parentObject)
+            }
+            RxTabBarDelegateProxy.extend { (parentObject: UITabBarSubclass) -> AnyObject in
+                ExtendTabBarDelegateProxy(parentObject: parentObject)
+            }
+        #endif
+        #if os(iOS)
+            RxSearchBarDelegateProxy.extend { (parentObject: UISearchBarSubclass) in
+                ExtendSearchBarDelegateProxy(parentObject: parentObject)
+            }
+            RxSearchControllerDelegateProxy.extend { (parentObject: UISearchControllerSubclass) in
+                ExtendSearchControllerDelegateProxy(parentObject: parentObject)
+            }
+            RxPickerViewDelegateProxy.extend { (parentObject: UIPickerViewSubclass) in
+                ExtendPickerViewDelegateProxy(parentObject: parentObject)
+            }
+            RxWebViewDelegateProxy.extend { (parentObject: UIWebViewSubclass) in
+                ExtendWebViewDelegateProxy(parentObject: parentObject)
+            }
+        #endif
+        #if os(macOS)
+            RxTextFieldDelegateProxy.extend { (parentObject: NSTextFieldSubclass) in
+                ExtendNSTextFieldDelegateProxy(parentObject: parentObject)
+            }
+        #endif
+    }
+    
     func test_OnInstallDelegateIsRetained() {
         let view = ThreeDSectionedView()
         let mock = MockThreeDSectionedViewProtocol()
@@ -419,6 +475,11 @@ final class ThreeDSectionedView: NSObject {
 final class ThreeDSectionedViewDelegateProxy : DelegateProxy
                                        , ThreeDSectionedViewProtocol
                                        , DelegateProxyType {
+    
+    static var factories: [((AnyObject) -> AnyObject?)] = [
+        { ThreeDSectionedViewDelegateProxy(parentObject: $0) }
+    ]
+    
     required init(parentObject: AnyObject) {
         super.init(parentObject: parentObject)
     }

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -56,70 +56,6 @@ extension TestDelegateControl {
 // MARK: Tests
 
 final class DelegateProxyTest : RxTest {
-    
-    static var extendDelegateProxy: Void = {
-        // setup extending of DelegateProxies
-        #if os(iOS) || os(tvOS)
-            RxScrollViewDelegateProxy.extendProxy { (parentObject: UIScrollViewSubclass2) in
-                ExtendScrollViewDelegateProxy2(parentObject: parentObject)
-            }
-            RxScrollViewDelegateProxy.extendProxy { (parentObject: UIScrollViewSubclass1) in
-                ExtendScrollViewDelegateProxy(parentObject: parentObject)
-            }
-            RxScrollViewDelegateProxy.extendProxy { (parentObject: UITableViewSubclass1) in
-                ExtendTableViewDelegateProxy(parentObject: parentObject)
-            }
-            RxTableViewDataSourceProxy.extendProxy { (parentObject: UITableViewSubclass2) in
-                ExtendTableViewDataSourceProxy(parentObject: parentObject)
-            }
-            RxScrollViewDelegateProxy.extendProxy { (parentObject: UICollectionViewSubclass1) in
-                ExtendCollectionViewDelegateProxy(parentObject: parentObject)
-            }
-            RxCollectionViewDataSourceProxy.extendProxy { (parentObject: UICollectionViewSubclass2) in
-                ExtendCollectionViewDataSourceProxy(parentObject: parentObject)
-            }
-            RxScrollViewDelegateProxy.extendProxy { (parentObject: UITextViewSubclass) in
-                ExtendTextViewDelegateProxy(parentObject: parentObject)
-            }
-            RxTextStorageDelegateProxy.extendProxy { (parentObject: NSTextStorageSubclass) in
-                ExtendTextStorageDelegateProxy(parentObject: parentObject)
-            }
-            RxNavigationControllerDelegateProxy.extendProxy { (parentObject: UINavigationControllerSubclass) in
-                ExtendNavigationControllerDelegateProxy(parentObject: parentObject)
-            }
-            RxTabBarControllerDelegateProxy.extendProxy { (parentObject: UITabBarControllerSubclass) in
-                ExtendTabBarControllerDelegateProxy(parentObject: parentObject)
-            }
-            RxTabBarDelegateProxy.extendProxy { (parentObject: UITabBarSubclass) -> AnyObject in
-                ExtendTabBarDelegateProxy(parentObject: parentObject)
-            }
-        #endif
-        #if os(iOS)
-            RxSearchBarDelegateProxy.extendProxy { (parentObject: UISearchBarSubclass) in
-                ExtendSearchBarDelegateProxy(parentObject: parentObject)
-            }
-            RxSearchControllerDelegateProxy.extendProxy { (parentObject: UISearchControllerSubclass) in
-                ExtendSearchControllerDelegateProxy(parentObject: parentObject)
-            }
-            RxPickerViewDelegateProxy.extendProxy { (parentObject: UIPickerViewSubclass) in
-                ExtendPickerViewDelegateProxy(parentObject: parentObject)
-            }
-            RxWebViewDelegateProxy.extendProxy { (parentObject: UIWebViewSubclass) in
-                ExtendWebViewDelegateProxy(parentObject: parentObject)
-            }
-        #endif
-        #if os(macOS)
-            RxTextFieldDelegateProxy.extendProxy { (parentObject: NSTextFieldSubclass) in
-                ExtendNSTextFieldDelegateProxy(parentObject: parentObject)
-            }
-        #endif
-    }()
-    
-    override func setUp() {
-        super.setUp()
-        _ = DelegateProxyTest.extendDelegateProxy
-    }
-    
     func test_OnInstallDelegateIsRetained() {
         let view = ThreeDSectionedView()
         let mock = MockThreeDSectionedViewProtocol()
@@ -386,7 +322,10 @@ extension DelegateProxyTest {
 // MARK: Testing extensions
 
 extension DelegateProxyTest {
-    func performDelegateTest<Control: TestDelegateControl>( _ createControl: @autoclosure() -> Control) {
+    func performDelegateTest<Control: TestDelegateControl, ExtendedProxy: DelegateProxyType>( _ createControl: @autoclosure() -> Control, proxyType: ExtendedProxy.Type) where ExtendedProxy: DelegateProxy {
+        ExtendedProxy.extendProxy { (parentObject: Control) in
+            ExtendedProxy(parentObject: parentObject)
+        }
         var control: TestDelegateControl!
 
         autoreleasepool {
@@ -484,7 +423,7 @@ final class ThreeDSectionedViewDelegateProxy : DelegateProxy
                                        , ThreeDSectionedViewProtocol
                                        , DelegateProxyType {
     
-    public static var delegateProxyFactory = DelegateProxyFactory { (parentObject: ThreeDSectionedView) in
+    public static var factory = DelegateProxyFactory { (parentObject: ThreeDSectionedView) in
         ThreeDSectionedViewDelegateProxy(parentObject: parentObject)
     }
     


### PR DESCRIPTION
It's based on discuss of #1287 

Notes:
- I made this more simply than discussions one.
- Maybe we don't need `func createProxyForObject(_ :)` specific implementation anymore.
- The performance is less than overriding way, but we cannot use overriding way anymore...
- I think I will separate type around `factory` from `DelegateProxy` when I implement `DelegateProxy` with generics type. Because we cannot make static property using generics type.