### PR TITLE
adding unavailable messages for Swift 4.0

### DIFF
--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -132,3 +132,109 @@ extension ObservableType {
         })
     }
 }
+
+#if os(iOS) || os(tvOS)
+    import UIKit
+
+    extension NSTextStorage {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxTextStorageDelegateProxy {
+            fatalError()
+        }
+    }
+
+    extension UIScrollView {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxScrollViewDelegateProxy {
+            fatalError()
+        }
+    }
+
+    extension UICollectionView {
+        @available(*, unavailable, message: "createRxDataSourceProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDataSourceProxy() -> RxCollectionViewDataSourceProxy {
+            fatalError()
+        }
+    }
+
+    extension UITableView {
+        @available(*, unavailable, message: "createRxDataSourceProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDataSourceProxy() -> RxTableViewDataSourceProxy {
+            fatalError()
+        }
+    }
+
+    extension UINavigationBar {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxNavigationControllerDelegateProxy {
+            fatalError()
+        }
+    }
+
+    extension UINavigationController {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxNavigationControllerDelegateProxy {
+            fatalError()
+        }
+    }
+
+    extension UITabBar {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxTabBarDelegateProxy {
+            fatalError()
+        }
+    }
+
+    extension UITabBarController {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxTabBarControllerDelegateProxy {
+            fatalError()
+        }
+    }
+
+    extension UISearchBar {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxSearchBarDelegateProxy {
+            fatalError()
+        }
+    }
+
+#endif
+
+#if os(iOS)
+    extension UISearchController {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxSearchControllerDelegateProxy {
+            fatalError()
+        }
+    }
+
+    extension UIPickerView {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxPickerViewDelegateProxy {
+            fatalError()
+        }
+
+        @available(*, unavailable, message: "createRxDataSourceProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDataSourceProxy() -> RxPickerViewDataSourceProxy {
+            fatalError()
+        }
+    }
+    extension UIWebView {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxWebViewDelegateProxy {
+            fatalError()
+        }
+    }
+#endif
+
+#if os(macOS)
+    import Cocoa
+
+    extension NSTextField {
+        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
+        public func createRxDelegateProxy() -> RxTextFieldDelegateProxy {
+            fatalError()
+        }
+    }
+#endif


### PR DESCRIPTION
Hello @kzaher ,
I'm sorry it's my mistaking, I forgot adding unavailable messages for old API.
If some guy override `createRxDelegateProxy`, then they can see unavailable messages.