### PR TITLE
[WIP] don't swallow NSControl events duplicates

### DIFF
--- a/RxCocoa/macOS/NSControl+Rx.swift
+++ b/RxCocoa/macOS/NSControl+Rx.swift
@@ -64,7 +64,6 @@ extension Reactive where Base: NSControl {
                 
                 return observer
             }
-            .distinctUntilChanged()
             .takeUntil((control as! NSObject).rx.deallocated)
         }
 


### PR DESCRIPTION
Found (and fixed) a problem:

* create a macOS app with a check box
* checkbox is ticked and bound to user defaults (see below)
* when the Rx binding from the defaults unticks the checkbox and the user ticks it again, the tick event is discarded (because the `ControlEvent` didn't recognize the unticking)

Sample wiring:

        bananaCheckbox.rx.state
            .asDriver()
            .map { $0 == NSOnState }
            .drive(onNext: updateWantsBananaUserDefaults)
            .disposed(by: disposeBag)

        wantsBananaUserDefaultsObservable
            .asDriver(onErrorJustReturn: false)
            .map { wantsBanana in
                if wantsBanana { return NSOnState } else { return NSOffState } }
            .drive(bananaCheckbox.rx.state)
            .disposed(by: disposeBag)

This is because the `.rx.state` `ControlEvent` suppressed duplicates. In principle, this made sense; but in practice it causes problems. Removing the line doesn't break any tests.

So the real question is: do we need tests for duplicate events, first, then flesh out edge cases?