### PR TITLE
Add missing scrollview delegate control events

### DIFF
--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -26,6 +26,7 @@
     }
 
     extension Reactive where Base: UIScrollView {
+        public typealias EndZoomEvent = (view: UIView?, scale: CGFloat)
 
         /// Reactive wrapper for `delegate`.
         ///
@@ -57,6 +58,12 @@
             let source = RxScrollViewDelegateProxy.proxyForObject(base).contentOffsetPublishSubject
             return ControlEvent(events: source)
         }
+        
+        /// Reactive wrapper for delegate method `scrollViewWillBeginDecelerating`
+        public var willBeginDecelerating: ControlEvent<Void> {
+            let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewWillBeginDecelerating(_:))).map { _ in }
+            return ControlEvent(events: source)
+        }
     	
     	/// Reactive wrapper for delegate method `scrollViewDidEndDecelerating`
     	public var didEndDecelerating: ControlEvent<Void> {
@@ -64,6 +71,12 @@
     		return ControlEvent(events: source)
     	}
     	
+        /// Reactive wrapper for delegate method `scrollViewWillBeginDragging`
+        public var willBeginDragging: ControlEvent<Void> {
+            let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewWillBeginDragging(_:))).map { _ in }
+            return ControlEvent(events: source)
+        }
+        
     	/// Reactive wrapper for delegate method `scrollViewDidEndDragging(_:willDecelerate:)`
     	public var didEndDragging: ControlEvent<Bool> {
     		let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidEndDragging(_:willDecelerate:))).map { value -> Bool in
@@ -88,6 +101,22 @@
         /// Reactive wrapper for delegate method `scrollViewDidEndScrollingAnimation`
         public var didEndScrollingAnimation: ControlEvent<Void> {
             let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidEndScrollingAnimation(_:))).map { _ in }
+            return ControlEvent(events: source)
+        }
+        
+        /// Reactive wrapper for delegate method `scrollViewWillBeginZooming(_:with:)`
+        public var willBeginZooming: ControlEvent<UIView?> {
+            let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewWillBeginZooming(_:with:))).map { value -> UIView? in
+                return try castOptionalOrThrow(UIView.self, value[1] as AnyObject)
+            }
+            return ControlEvent(events: source)
+        }
+        
+        /// Reactive wrapper for delegate method `scrollViewDidEndZooming(_:with:atScale:)`
+        public var didEndZooming: ControlEvent<EndZoomEvent> {
+            let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewDidEndZooming(_:with:atScale:))).map { value -> EndZoomEvent in
+                return (try castOptionalOrThrow(UIView.self, value[1] as AnyObject), try castOrThrow(CGFloat.self, value[2]))
+            }
             return ControlEvent(events: source)
         }
 

--- a/Tests/RxCocoaTests/UIScrollView+RxTests.swift
+++ b/Tests/RxCocoaTests/UIScrollView+RxTests.swift
@@ -62,6 +62,28 @@ extension UIScrollViewTests {
         XCTAssertTrue(completed)
     }
 	
+    func testScrollViewWillBeginDecelerating() {
+        var completed = false
+
+        autoreleasepool {
+            let scrollView = UIScrollView()
+            var willBeginDecelerating = false
+
+            _ = scrollView.rx.willBeginDecelerating.subscribe(onNext: {
+                willBeginDecelerating = true
+            }, onCompleted: {
+                completed = true
+            })
+
+            XCTAssertFalse(willBeginDecelerating)
+
+            scrollView.delegate!.scrollViewWillBeginDecelerating!(scrollView)
+
+            XCTAssertTrue(willBeginDecelerating)
+        }
+
+        XCTAssertTrue(completed)
+    }
 	
 	func testScrollViewDidEndDecelerating() {
 		var completed = false
@@ -85,6 +107,29 @@ extension UIScrollViewTests {
 		
 		XCTAssertTrue(completed)
 	}
+
+    func testScrollViewWillBeginDragging() {
+        var completed = false
+
+        autoreleasepool {
+            let scrollView = UIScrollView()
+            var willBeginDragging = false
+
+            _ = scrollView.rx.willBeginDragging.subscribe(onNext: {
+                willBeginDragging = true
+            }, onCompleted: {
+                completed = true
+            })
+
+            XCTAssertFalse(willBeginDragging)
+
+            scrollView.delegate!.scrollViewWillBeginDragging!(scrollView)
+
+            XCTAssertTrue(willBeginDragging)
+        }
+
+        XCTAssertTrue(completed)
+    }
 	
 	func testScrollViewDidEndDragging() {
 		var completed = false
@@ -189,6 +234,62 @@ extension UIScrollViewTests {
             XCTAssertTrue(didEndScrollingAnimation)
         }
         
+        XCTAssertTrue(completed)
+    }
+
+    func testScrollViewWillBeginZooming() {
+        var completed = false
+
+        autoreleasepool {
+            let scrollView = UIScrollView()
+            let zoomView = UIView()
+            var results: [UIView?] = []
+
+            _ = scrollView.rx.willBeginZooming.subscribe(onNext: { value in
+                results.append(value)
+            }, onCompleted: {
+                completed = true
+            })
+
+            XCTAssertTrue(results.isEmpty)
+
+            scrollView.delegate!.scrollViewWillBeginZooming!(scrollView, with: zoomView)
+            scrollView.delegate!.scrollViewWillBeginZooming!(scrollView, with: nil)
+
+            XCTAssertEqual(results[0], zoomView)
+            XCTAssertNil(results[1])
+        }
+
+        XCTAssertTrue(completed)
+    }
+
+    func testScrollViewDidEndZooming() {
+        var completed = false
+
+        autoreleasepool {
+            let scrollView = UIScrollView()
+            let zoomView = UIView()
+            var viewResults: [UIView?] = []
+            var scaleResults: [CGFloat] = []
+
+            _ = scrollView.rx.didEndZooming.subscribe(onNext: { (view, scale) in
+                viewResults.append(view)
+                scaleResults.append(scale)
+            }, onCompleted: {
+                completed = true
+            })
+
+            XCTAssertTrue(viewResults.isEmpty)
+            XCTAssertTrue(scaleResults.isEmpty)
+
+            scrollView.delegate!.scrollViewDidEndZooming!(scrollView, with: zoomView, atScale: 0)
+            scrollView.delegate!.scrollViewDidEndZooming!(scrollView, with: nil, atScale: 2)
+
+            XCTAssertEqual(viewResults[0], zoomView)
+            XCTAssertNil(viewResults[1])
+            XCTAssertEqual(scaleResults, [0, 2])
+        }
+
         XCTAssertTrue(completed)
     }
 }


### PR DESCRIPTION
Hello,

This PR adds control events that were not implemented for UIScrollViewDelegate. I'm not sure if these were intentionally left unimplemented, but I have implemented these in extensions in a project I work on and thought it would be useful if they were part of RxCocoa, so others could use them as well.

If this all works out, I plan on submitting another PR to add functionality to UICollectionViewDelegate as well.

Thanks!