### PR TITLE
Adds UITableView.rx.modelDeleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## Master
 
-#### Anomalies
+* Adds `modelDeleted` to `UITableView`
 
+#### Anomalies
 
 ## [3.5.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.5.0)
 

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -360,6 +360,29 @@ extension Reactive where Base: UITableView {
 
         return ControlEvent(events: source)
     }
+    
+    /**
+     Reactive wrapper for `delegate` message `tableView:commitEditingStyle:forRowAtIndexPath:`.
+     
+     It can be only used when one of the `rx.itemsWith*` methods is used to bind observable sequence,
+     or any other data source conforming to `SectionedViewDataSourceType` protocol.
+     
+     ```
+        tableView.rx.modelDeleted(MyModel.self)
+            .map { ...
+     ```
+     */
+    public func modelDeleted<T>(_ modelType: T.Type) -> ControlEvent<T> {
+        let source: Observable<T> = self.itemDeleted.flatMap { [weak view = self.base as UITableView] indexPath -> Observable<T> in
+            guard let view = view else {
+                return Observable.empty()
+            }
+            
+            return Observable.just(try view.rx.model(at: indexPath))
+        }
+        
+        return ControlEvent(events: source)
+    }
 
     /**
      Synchronous helper method for retrieving a model at indexPath through a reactive data source.


### PR DESCRIPTION
This PR adds `UITableView.rx.modelDeleted`, that is in the spirit of, say, `modelSelected`.

This is my first PR to RxSwift, so my apologies if I've missed anything. Please don't hesitate to correct me!

**Changes Made**
* Added [`UITableView.rx.modelDeleted`](https://github.com/cliss/RxSwift/blob/c2a5f614c7e31a3a7c39b4ad171b164ee81ec5aa/RxCocoa/iOS/UITableView%2BRx.swift#L375-L385)
* Added [unit test](https://github.com/cliss/RxSwift/blob/c2a5f614c7e31a3a7c39b4ad171b164ee81ec5aa/Tests/RxCocoaTests/UITableView%2BRxTests.swift#L347-L374)
* Updated [`CHANGELOG.md`](https://github.com/cliss/RxSwift/blob/c2a5f614c7e31a3a7c39b4ad171b164ee81ec5aa/CHANGELOG.md#master), though I may not have done that in the appropriate place

**Test Script**

I *did* run `all-tests.sh` and it failed, however, it was due to tvOS issues, which don't relate to this PR. So... ¯\\_(ツ)_/¯