### PR TITLE
Add missing collectionview delegate control events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 * Adds `modelDeleted` to `UITableView`
+* Adds `itemHighlighted` to `UICollectionView`
+* Adds `itemUnhighlighted` to `UICollectionView`
+* Adds `willDisplayCell` to `UICollectionView`
+* Adds `didEndDisplayingCell` to `UICollectionView`
+* Adds `willDisplaySupplementaryView` to `UICollectionView`
+* Adds `didEndDisplayingSupplementaryView` to `UICollectionView`
 
 #### Anomalies
 

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -179,8 +179,8 @@ extension UICollectionView {
 }
 
 extension Reactive where Base: UICollectionView {
-    public typealias DisplayCollectionViewCellEvent = (cell: UICollectionViewCell, indexPath: IndexPath)
-    public typealias DisplayCollectionReusableViewEvent = (reuseableView: UICollectionReusableView, elementKind: String, indexPath: IndexPath)
+    public typealias DisplayCollectionViewCellEvent = (cell: UICollectionViewCell, at: IndexPath)
+    public typealias DisplayCollectionViewSupplementaryViewEvent = (supplementaryView: UICollectionReusableView, elementKind: String, at: IndexPath)
 
     /// Reactive wrapper for `dataSource`.
     ///
@@ -252,8 +252,8 @@ extension Reactive where Base: UICollectionView {
     }
 
     /// Reactive wrapper for `delegate` message `collectionView(_:willDisplaySupplementaryView:forElementKind:at:)`.
-    public var willDisplaySupplementaryView: ControlEvent<DisplayCollectionReusableViewEvent> {
-        let source: Observable<DisplayCollectionReusableViewEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:willDisplaySupplementaryView:forElementKind:at:)))
+    public var willDisplaySupplementaryView: ControlEvent<DisplayCollectionViewSupplementaryViewEvent> {
+        let source: Observable<DisplayCollectionViewSupplementaryViewEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:willDisplaySupplementaryView:forElementKind:at:)))
             .map { a in
                 return (try castOrThrow(UICollectionReusableView.self, a[1]),
                         try castOrThrow(String.self, a[2]),
@@ -274,8 +274,8 @@ extension Reactive where Base: UICollectionView {
     }
 
     /// Reactive wrapper for `delegate` message `collectionView(_:didEndDisplayingSupplementaryView:forElementOfKind:at:)`.
-    public var didEndDisplayingSupplementaryView: ControlEvent<DisplayCollectionReusableViewEvent> {
-        let source: Observable<DisplayCollectionReusableViewEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didEndDisplayingSupplementaryView:forElementOfKind:at:)))
+    public var didEndDisplayingSupplementaryView: ControlEvent<DisplayCollectionViewSupplementaryViewEvent> {
+        let source: Observable<DisplayCollectionViewSupplementaryViewEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didEndDisplayingSupplementaryView:forElementOfKind:at:)))
             .map { a in
                 return (try castOrThrow(UICollectionReusableView.self, a[1]),
                         try castOrThrow(String.self, a[2]),

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -179,6 +179,8 @@ extension UICollectionView {
 }
 
 extension Reactive where Base: UICollectionView {
+    public typealias DisplayCollectionViewCellEvent = (cell: UICollectionViewCell, indexPath: IndexPath)
+    public typealias DisplayCollectionReusableViewEvent = (reuseableView: UICollectionReusableView, elementKind: String, indexPath: IndexPath)
 
     /// Reactive wrapper for `dataSource`.
     ///
@@ -219,6 +221,70 @@ extension Reactive where Base: UICollectionView {
         return ControlEvent(events: source)
     }
 
+    /// Reactive wrapper for `delegate` message `collectionView:didHighlightItemAt:`.
+    public var itemHighlighted: ControlEvent<IndexPath> {
+        let source = delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didHighlightItemAt:)))
+            .map { a in
+                return try castOrThrow(IndexPath.self, a[1])
+            }
+        
+        return ControlEvent(events: source)
+    }
+
+    /// Reactive wrapper for `delegate` message `collectionView:didUnhighlightItemAt:`.
+    public var itemUnhighlighted: ControlEvent<IndexPath> {
+        let source = delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didUnhighlightItemAt:)))
+            .map { a in
+                return try castOrThrow(IndexPath.self, a[1])
+            }
+        
+        return ControlEvent(events: source)
+    }
+
+    /// Reactive wrapper for `delegate` message `collectionView:willDisplay:forItemAt:`.
+    public var willDisplayCell: ControlEvent<DisplayCollectionViewCellEvent> {
+        let source: Observable<DisplayCollectionViewCellEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:willDisplay:forItemAt:)))
+            .map { a in
+                return (try castOrThrow(UICollectionViewCell.self, a[1]), try castOrThrow(IndexPath.self, a[2]))
+            }
+        
+        return ControlEvent(events: source)
+    }
+
+    /// Reactive wrapper for `delegate` message `collectionView:willDisplaySupplementaryView:forElementKind:at:`.
+    public var willDisplaySupplementaryView: ControlEvent<DisplayCollectionReusableViewEvent> {
+        let source: Observable<DisplayCollectionReusableViewEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:willDisplaySupplementaryView:forElementKind:at:)))
+            .map { a in
+                return (try castOrThrow(UICollectionReusableView.self, a[1]),
+                        try castOrThrow(String.self, a[2]),
+                        try castOrThrow(IndexPath.self, a[3]))
+            }
+
+        return ControlEvent(events: source)
+    }
+
+    /// Reactive wrapper for `delegate` message `collectionView:didEndDisplaying:forItemAt:`.
+    public var didEndDisplayingCell: ControlEvent<DisplayCollectionViewCellEvent> {
+        let source: Observable<DisplayCollectionViewCellEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didEndDisplaying:forItemAt:)))
+            .map { a in
+                return (try castOrThrow(UICollectionViewCell.self, a[1]), try castOrThrow(IndexPath.self, a[2]))
+            }
+
+        return ControlEvent(events: source)
+    }
+
+    /// Reactive wrapper for `delegate` message `collectionView:didEndDisplayingSupplementaryView:forElementOfKind:at:`.
+    public var didEndDisplayingSupplementaryView: ControlEvent<DisplayCollectionReusableViewEvent> {
+        let source: Observable<DisplayCollectionReusableViewEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didEndDisplayingSupplementaryView:forElementOfKind:at:)))
+            .map { a in
+                return (try castOrThrow(UICollectionReusableView.self, a[1]),
+                        try castOrThrow(String.self, a[2]),
+                        try castOrThrow(IndexPath.self, a[3]))
+            }
+
+        return ControlEvent(events: source)
+    }
+    
     /// Reactive wrapper for `delegate` message `collectionView:didSelectItemAtIndexPath:`.
     ///
     /// It can be only used when one of the `rx.itemsWith*` methods is used to bind observable sequence,

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -201,7 +201,7 @@ extension Reactive where Base: UICollectionView {
         return RxCollectionViewDataSourceProxy.installForwardDelegate(dataSource, retainDelegate: false, onProxyForObject: self.base)
     }
    
-    /// Reactive wrapper for `delegate` message `collectionView:didSelectItemAtIndexPath:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:didSelectItemAtIndexPath:)`.
     public var itemSelected: ControlEvent<IndexPath> {
         let source = delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didSelectItemAt:)))
             .map { a in
@@ -211,7 +211,7 @@ extension Reactive where Base: UICollectionView {
         return ControlEvent(events: source)
     }
 
-    /// Reactive wrapper for `delegate` message `collectionView:didSelectItemAtIndexPath:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:didSelectItemAtIndexPath:)`.
     public var itemDeselected: ControlEvent<IndexPath> {
         let source = delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didDeselectItemAt:)))
             .map { a in
@@ -221,7 +221,7 @@ extension Reactive where Base: UICollectionView {
         return ControlEvent(events: source)
     }
 
-    /// Reactive wrapper for `delegate` message `collectionView:didHighlightItemAt:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:didHighlightItemAt:)`.
     public var itemHighlighted: ControlEvent<IndexPath> {
         let source = delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didHighlightItemAt:)))
             .map { a in
@@ -231,7 +231,7 @@ extension Reactive where Base: UICollectionView {
         return ControlEvent(events: source)
     }
 
-    /// Reactive wrapper for `delegate` message `collectionView:didUnhighlightItemAt:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:didUnhighlightItemAt:)`.
     public var itemUnhighlighted: ControlEvent<IndexPath> {
         let source = delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didUnhighlightItemAt:)))
             .map { a in
@@ -251,7 +251,7 @@ extension Reactive where Base: UICollectionView {
         return ControlEvent(events: source)
     }
 
-    /// Reactive wrapper for `delegate` message `collectionView:willDisplaySupplementaryView:forElementKind:at:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:willDisplaySupplementaryView:forElementKind:at:)`.
     public var willDisplaySupplementaryView: ControlEvent<DisplayCollectionReusableViewEvent> {
         let source: Observable<DisplayCollectionReusableViewEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:willDisplaySupplementaryView:forElementKind:at:)))
             .map { a in
@@ -273,7 +273,7 @@ extension Reactive where Base: UICollectionView {
         return ControlEvent(events: source)
     }
 
-    /// Reactive wrapper for `delegate` message `collectionView:didEndDisplayingSupplementaryView:forElementOfKind:at:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:didEndDisplayingSupplementaryView:forElementOfKind:at:)`.
     public var didEndDisplayingSupplementaryView: ControlEvent<DisplayCollectionReusableViewEvent> {
         let source: Observable<DisplayCollectionReusableViewEvent> = self.delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didEndDisplayingSupplementaryView:forElementOfKind:at:)))
             .map { a in
@@ -285,7 +285,7 @@ extension Reactive where Base: UICollectionView {
         return ControlEvent(events: source)
     }
     
-    /// Reactive wrapper for `delegate` message `collectionView:didSelectItemAtIndexPath:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:didSelectItemAtIndexPath:)`.
     ///
     /// It can be only used when one of the `rx.itemsWith*` methods is used to bind observable sequence,
     /// or any other data source conforming to `SectionedViewDataSourceType` protocol.
@@ -306,7 +306,7 @@ extension Reactive where Base: UICollectionView {
         return ControlEvent(events: source)
     }
 
-    /// Reactive wrapper for `delegate` message `collectionView:didSelectItemAtIndexPath:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:didSelectItemAtIndexPath:)`.
     ///
     /// It can be only used when one of the `rx.itemsWith*` methods is used to bind observable sequence,
     /// or any other data source conforming to `SectionedViewDataSourceType` protocol.
@@ -342,7 +342,7 @@ extension Reactive where Base: UICollectionView {
 
 extension Reactive where Base: UICollectionView {
     
-    /// Reactive wrapper for `delegate` message `collectionView:didUpdateFocusInContext:withAnimationCoordinator:`.
+    /// Reactive wrapper for `delegate` message `collectionView(_:didUpdateFocusInContext:withAnimationCoordinator:)`.
     public var didUpdateFocusInContextWithAnimationCoordinator: ControlEvent<(context: UICollectionViewFocusUpdateContext, animationCoordinator: UIFocusAnimationCoordinator)> {
 
         let source = delegate.methodInvoked(#selector(UICollectionViewDelegate.collectionView(_:didUpdateFocusIn:with:)))

--- a/Tests/RxCocoaTests/UICollectionView+RxTests.swift
+++ b/Tests/RxCocoaTests/UICollectionView+RxTests.swift
@@ -108,11 +108,11 @@ final class UICollectionViewTests : RxTest {
             })
 
         let testCell = UICollectionViewCell(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
-        let testRow = IndexPath(row: 1, section: 0)
-        collectionView.delegate!.collectionView!(collectionView, willDisplay: testCell, forItemAt: testRow)
+        let testIndexPath = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, willDisplay: testCell, forItemAt: testIndexPath)
 
         XCTAssertEqual(resultCell, testCell)
-        XCTAssertEqual(resultIndexPath, testRow)
+        XCTAssertEqual(resultIndexPath, testIndexPath)
         subscription.dispose()
     }
 
@@ -120,25 +120,25 @@ final class UICollectionViewTests : RxTest {
         let layout = UICollectionViewFlowLayout()
         let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), collectionViewLayout: layout)
 
-        var resultReuseableView: UICollectionReusableView? = nil
+        var resultSupplementaryView: UICollectionReusableView? = nil
         var resultElementKind: String? = nil
         var resultIndexPath: IndexPath? = nil
 
         let subscription = collectionView.rx.willDisplaySupplementaryView
             .subscribe(onNext: { (reuseableView, elementKind, indexPath) in
-                resultReuseableView = reuseableView
+                resultSupplementaryView = reuseableView
                 resultElementKind = elementKind
                 resultIndexPath = indexPath
             })
 
-        let testReuseableView = UICollectionReusableView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        let testSupplementaryView = UICollectionReusableView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
         let testElementKind = UICollectionElementKindSectionHeader
-        let testRow = IndexPath(row: 1, section: 0)
-        collectionView.delegate!.collectionView!(collectionView, willDisplaySupplementaryView: testReuseableView, forElementKind: testElementKind, at: testRow)
+        let testIndexPath = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, willDisplaySupplementaryView: testSupplementaryView, forElementKind: testElementKind, at: testIndexPath)
 
-        XCTAssertEqual(resultReuseableView, testReuseableView)
+        XCTAssertEqual(resultSupplementaryView, testSupplementaryView)
         XCTAssertEqual(resultElementKind, testElementKind)
-        XCTAssertEqual(resultIndexPath, testRow)
+        XCTAssertEqual(resultIndexPath, testIndexPath)
         subscription.dispose()
     }
 
@@ -168,25 +168,25 @@ final class UICollectionViewTests : RxTest {
         let layout = UICollectionViewFlowLayout()
         let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), collectionViewLayout: layout)
 
-        var resultReuseableView: UICollectionReusableView? = nil
+        var resultSupplementaryView: UICollectionReusableView? = nil
         var resultElementKind: String? = nil
         var resultIndexPath: IndexPath? = nil
 
         let subscription = collectionView.rx.didEndDisplayingSupplementaryView
             .subscribe(onNext: { (reuseableView, elementKind, indexPath) in
-                resultReuseableView = reuseableView
+                resultSupplementaryView = reuseableView
                 resultElementKind = elementKind
                 resultIndexPath = indexPath
             })
 
-        let testReuseableView = UICollectionReusableView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        let testSupplementaryView = UICollectionReusableView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
         let testElementKind = UICollectionElementKindSectionHeader
-        let testRow = IndexPath(row: 1, section: 0)
-        collectionView.delegate!.collectionView!(collectionView, didEndDisplayingSupplementaryView: testReuseableView, forElementOfKind: testElementKind, at: testRow)
+        let testIndexPath = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, didEndDisplayingSupplementaryView: testSupplementaryView, forElementOfKind: testElementKind, at: testIndexPath)
 
-        XCTAssertEqual(resultReuseableView, testReuseableView)
+        XCTAssertEqual(resultSupplementaryView, testSupplementaryView)
         XCTAssertEqual(resultElementKind, testElementKind)
-        XCTAssertEqual(resultIndexPath, testRow)
+        XCTAssertEqual(resultIndexPath, testIndexPath)
         subscription.dispose()
     }
 

--- a/Tests/RxCocoaTests/UICollectionView+RxTests.swift
+++ b/Tests/RxCocoaTests/UICollectionView+RxTests.swift
@@ -58,6 +58,137 @@ final class UICollectionViewTests : RxTest {
         subscription.dispose()
     }
 
+    func testCollectionView_itemHighlighted() {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), collectionViewLayout: layout)
+
+        var resultIndexPath: IndexPath? = nil
+
+        let subscription = collectionView.rx.itemHighlighted
+            .subscribe(onNext: { indexPath in
+                resultIndexPath = indexPath
+            })
+
+        let testRow = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, didHighlightItemAt: testRow)
+
+        XCTAssertEqual(resultIndexPath, testRow)
+        subscription.dispose()
+    }
+
+    func testCollectionView_itemUnhighlighted() {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), collectionViewLayout: layout)
+
+        var resultIndexPath: IndexPath? = nil
+
+        let subscription = collectionView.rx.itemUnhighlighted
+            .subscribe(onNext: { indexPath in
+                resultIndexPath = indexPath
+            })
+
+        let testRow = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, didUnhighlightItemAt: testRow)
+
+        XCTAssertEqual(resultIndexPath, testRow)
+        subscription.dispose()
+    }
+
+    func testCollectionView_willDisplayCell() {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), collectionViewLayout: layout)
+
+        var resultCell: UICollectionViewCell? = nil
+        var resultIndexPath: IndexPath? = nil
+
+        let subscription = collectionView.rx.willDisplayCell
+            .subscribe(onNext: { (cell, indexPath) in
+                resultCell = cell
+                resultIndexPath = indexPath
+            })
+
+        let testCell = UICollectionViewCell(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        let testRow = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, willDisplay: testCell, forItemAt: testRow)
+
+        XCTAssertEqual(resultCell, testCell)
+        XCTAssertEqual(resultIndexPath, testRow)
+        subscription.dispose()
+    }
+
+    func testCollectionView_willDisplaySupplementaryView() {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), collectionViewLayout: layout)
+
+        var resultReuseableView: UICollectionReusableView? = nil
+        var resultElementKind: String? = nil
+        var resultIndexPath: IndexPath? = nil
+
+        let subscription = collectionView.rx.willDisplaySupplementaryView
+            .subscribe(onNext: { (reuseableView, elementKind, indexPath) in
+                resultReuseableView = reuseableView
+                resultElementKind = elementKind
+                resultIndexPath = indexPath
+            })
+
+        let testReuseableView = UICollectionReusableView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        let testElementKind = UICollectionElementKindSectionHeader
+        let testRow = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, willDisplaySupplementaryView: testReuseableView, forElementKind: testElementKind, at: testRow)
+
+        XCTAssertEqual(resultReuseableView, testReuseableView)
+        XCTAssertEqual(resultElementKind, testElementKind)
+        XCTAssertEqual(resultIndexPath, testRow)
+        subscription.dispose()
+    }
+
+    func testCollectionView_didEndDisplayingCell() {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), collectionViewLayout: layout)
+
+        var resultCell: UICollectionViewCell? = nil
+        var resultIndexPath: IndexPath? = nil
+
+        let subscription = collectionView.rx.didEndDisplayingCell
+            .subscribe(onNext: { (cell, indexPath) in
+                resultCell = cell
+                resultIndexPath = indexPath
+            })
+
+        let testCell = UICollectionViewCell(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        let testRow = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, didEndDisplaying: testCell, forItemAt: testRow)
+
+        XCTAssertEqual(resultCell, testCell)
+        XCTAssertEqual(resultIndexPath, testRow)
+        subscription.dispose()
+    }
+
+    func testCollectionView_didEndDisplayingSupplementaryView() {
+        let layout = UICollectionViewFlowLayout()
+        let collectionView = UICollectionView(frame: CGRect(x: 0, y: 0, width: 1, height: 1), collectionViewLayout: layout)
+
+        var resultReuseableView: UICollectionReusableView? = nil
+        var resultElementKind: String? = nil
+        var resultIndexPath: IndexPath? = nil
+
+        let subscription = collectionView.rx.didEndDisplayingSupplementaryView
+            .subscribe(onNext: { (reuseableView, elementKind, indexPath) in
+                resultReuseableView = reuseableView
+                resultElementKind = elementKind
+                resultIndexPath = indexPath
+            })
+
+        let testReuseableView = UICollectionReusableView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        let testElementKind = UICollectionElementKindSectionHeader
+        let testRow = IndexPath(row: 1, section: 0)
+        collectionView.delegate!.collectionView!(collectionView, didEndDisplayingSupplementaryView: testReuseableView, forElementOfKind: testElementKind, at: testRow)
+
+        XCTAssertEqual(resultReuseableView, testReuseableView)
+        XCTAssertEqual(resultElementKind, testElementKind)
+        XCTAssertEqual(resultIndexPath, testRow)
+        subscription.dispose()
+    }
 
     func testCollectionView_DelegateEventCompletesOnDealloc1() {
         let items: Observable<[Int]> = Observable.just([1, 2, 3])


### PR DESCRIPTION
This PR:

- Adds control events that were not implemented for UICollectionViewDelegate.
- Updates the method prototype syntax in UICollectionView+Rx comments

Please let me know if you need anything modified.

Thanks!