### PR TITLE
Fixed a problem where the TableViewWithEditingCommands example died.

### DIFF
--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/RandomUserAPI.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/RandomUserAPI.swift
@@ -29,6 +29,9 @@ class RandomUserAPI {
                 
                 return try self.parseJSON(json)
             }
+            .catchError { error in
+                return Observable.empty()
+            }
     }
     
     private func parseJSON(_ json: [String: AnyObject]) throws -> [User] {


### PR DESCRIPTION
If "Allow Arbitrary Loads" is set to No in Info.plist, the "TableViewWithEditingCommands" example will exit as soon as you run it.

So, need to add a catchError inside the getExampleUserResultSet() function.