### PR TITLE
Fixed a problem where the TableViewWithEditingCommands example died.

### DIFF
--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/DetailViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/DetailViewController.swift
@@ -33,6 +33,7 @@ class DetailViewController: ViewController {
                 UIImage(data: data)
             }
             .observeOn($.mainScheduler)
+            .catchErrorJustReturn(nil)
             .subscribe(imageView.rx.image)
             .disposed(by: disposeBag)
         

--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/TableViewWithEditingCommandsViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/TableViewWithEditingCommandsViewController.swift
@@ -76,8 +76,9 @@ class TableViewWithEditingCommandsViewController: ViewController, UITableViewDel
         )
 
         let loadFavoriteUsers = RandomUserAPI.sharedAPI
-                .getExampleUserResultSet()
-                .map(TableViewEditingCommand.setUsers)
+            .getExampleUserResultSet()
+            .map(TableViewEditingCommand.setUsers)
+            .catchErrorJustReturn(TableViewEditingCommand.setUsers(users: []))
 
         let initialLoadCommand = Observable.just(TableViewEditingCommand.setFavoriteUsers(favoriteUsers: [superMan, watMan]))
                 .concat(loadFavoriteUsers)
@@ -103,10 +104,6 @@ class TableViewWithEditingCommandsViewController: ViewController, UITableViewDel
                     SectionModel(model: "Favorite Users", items: $0.favoriteUsers),
                     SectionModel(model: "Normal Users", items: $0.users)
                 ]
-            }
-            .catchError { (error) in
-                showAlert(error.localizedDescription)
-                return Observable.empty()
             }
             .bind(to: tableView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)

--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/TableViewWithEditingCommandsViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/TableViewWithEditingCommandsViewController.swift
@@ -104,6 +104,10 @@ class TableViewWithEditingCommandsViewController: ViewController, UITableViewDel
                     SectionModel(model: "Normal Users", items: $0.users)
                 ]
             }
+            .catchError { (error) in
+                showAlert(error.localizedDescription)
+                return Observable.empty()
+            }
             .bind(to: tableView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
When the user list can not be obtained due to a network error, the "TableViewWithEditingCommands" example will exit as soon as you run it.
So, added a catchErrorJustReturn.