### PR TITLE
Fix typo: so -> do

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -699,7 +699,7 @@ Every time you do this, somebody will probably write this code somewhere:
 ```swift
   kittens
     .subscribe(onNext: { kitten in
-      // so something with kitten
+      // do something with kitten
     })
     .disposed(by: disposeBag)
 ```


### PR DESCRIPTION
Thank you for developing this great library.
I fixed a typo on documentation `GettingStarted.md` for you!
If this is not a typo, close this PR.