### PR TITLE
Add missing syntax highlighting

### DIFF
--- a/Documentation/Traits.md
+++ b/Documentation/Traits.md
@@ -379,7 +379,7 @@ Any observable sequence can be converted to `Driver` trait, as long as it satisf
 
 So how do you make sure those properties are satisfied? Just use normal Rx operators. `asDriver(onErrorJustReturn: [])` is equivalent to following code.
 
-```
+```swift
 let safeSequence = xs
   .observeOn(MainScheduler.instance)       // observe events on main scheduler
   .catchErrorJustReturn(onErrorJustReturn) // can't error out


### PR DESCRIPTION
This commit adds missing `Swift` syntax highlighting in `Documentation/Traits.md` file.