### PR TITLE
rxcocoa build fix on xcode 9

### DIFF
--- a/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
+++ b/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
@@ -31,12 +31,12 @@ private class RxPickerViewArrayDataSource<T>: NSObject, UIPickerViewDataSource, 
     }
 }
 
-public class RxPickerViewSequenceDataSource<S: Sequence>
+class RxPickerViewSequenceDataSource<S: Sequence>
     : RxPickerViewArrayDataSource<S.Iterator.Element>
     , RxPickerViewDataSourceType {
-    public typealias Element = S
+    typealias Element = S
 
-    public func pickerView(_ pickerView: UIPickerView, observedEvent: Event<S>) {
+    func pickerView(_ pickerView: UIPickerView, observedEvent: Event<S>) {
         UIBindingObserver(UIElement: self) { dataSource, items in
             dataSource.items = items
             pickerView.reloadAllComponents()

--- a/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
+++ b/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
@@ -31,12 +31,12 @@ private class RxPickerViewArrayDataSource<T>: NSObject, UIPickerViewDataSource, 
     }
 }
 
-private class RxPickerViewSequenceDataSource<S: Sequence>
+public class RxPickerViewSequenceDataSource<S: Sequence>
     : RxPickerViewArrayDataSource<S.Iterator.Element>
     , RxPickerViewDataSourceType {
-    typealias Element = S
+    public typealias Element = S
 
-    func pickerView(_ pickerView: UIPickerView, observedEvent: Event<S>) {
+    public func pickerView(_ pickerView: UIPickerView, observedEvent: Event<S>) {
         UIBindingObserver(UIElement: self) { dataSource, items in
             dataSource.items = items
             pickerView.reloadAllComponents()

--- a/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
+++ b/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
@@ -12,7 +12,7 @@
     import RxSwift
 #endif
 
-private class RxPickerViewArrayDataSource<T>: NSObject, UIPickerViewDataSource, SectionedViewDataSourceType {
+class RxPickerViewArrayDataSource<T>: NSObject, UIPickerViewDataSource, SectionedViewDataSourceType {
     fileprivate var items: [T] = []
     
     func model(at indexPath: IndexPath) throws -> Any {


### PR DESCRIPTION
I am not sure about other classes and their visibility but the RxPickerViewSequenceDataSource being private doesn't work on XCode 9. Actually I don't understand how it could build at all without being public.