### PR TITLE
	Improves locking behavior of `merge` and `switch` operators.

### DIFF
--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -56,6 +56,7 @@ final class AnomaliesTest_ : AnomaliesTest, RxTestCase {
     static var allTests: [(String, (AnomaliesTest_) -> () -> ())] { return [
     ("test936", AnomaliesTest.test936),
     ("test1323", AnomaliesTest.test1323),
+    ("test1344", AnomaliesTest.test1344),
     ("testSeparationBetweenOnAndSubscriptionLocks", AnomaliesTest.testSeparationBetweenOnAndSubscriptionLocks),
     ] }
 }

--- a/Tests/RxSwiftTests/Anomalies.swift
+++ b/Tests/RxSwiftTests/Anomalies.swift
@@ -101,6 +101,30 @@ extension AnomaliesTest {
         }
     }
 
+    func test1344(){
+        let disposeBag = DisposeBag()
+        let foo = Observable<Int>.create({ observer in
+                observer.on(.next(1))
+                Thread.sleep(forTimeInterval: 0.1)
+                observer.on(.completed)
+                return Disposables.create()
+            })
+            .flatMap { (int) -> Observable<[Int]> in
+                return Observable.create { (observer) -> Disposable in
+                    DispatchQueue.global().async {
+                        observer.onNext([int])
+                    }
+                    self.sleep(0.1)
+                    return Disposables.create()
+                }
+            }
+
+        Observable.merge(foo, .just([42]))
+            .subscribe { (e) in
+            }
+            .disposed(by: disposeBag)
+    }
+
     func testSeparationBetweenOnAndSubscriptionLocks() {
         func performSharingOperatorsTest(share: @escaping (Observable<Int>) -> Observable<Int>) {
             for i in 0 ..< 1 {


### PR DESCRIPTION
Hi @MartinMoizard,

I've found an issue in an optimized array version of `Observable.merge`. Could you please verify this solves your issue?

