### PR TITLE
Remove nested subscribe "tip"

### DIFF
--- a/Documentation/Tips.md
+++ b/Documentation/Tips.md
@@ -22,29 +22,3 @@ extension ObservableType where E: MaybeCool {
   * Rx operators are as general as possible, but there will always be edge cases that will be hard to model. In those cases you can just create your own operator and possibly use one of the built-in operators as a reference.
 
   * Always use operators to compose subscriptions.
-
-  **Avoid nesting subscribe calls at all cost. This is a code smell.**
-
-  ```swift
-  textField.rx.text.subscribe(onNext: { text in
-      performURLRequest(text).subscribe(onNext: { result in
-          ...
-      })
-      .addDisposableTo(disposeBag)
-  })
-  .addDisposableTo(disposeBag)
-  ```
-
-  **Preferred way of chaining disposables by using operators.**
-
-  ```swift
-  textField.rx.text
-      .flatMapLatest { text in
-          // Assuming this doesn't fail and returns result on main scheduler,
-          // otherwise `catchError` and `observeOn(MainScheduler.instance)` can be used to
-          // correct this.
-          return performURLRequest(text)
-      }
-      ...
-      .addDisposableTo(disposeBag) // only one top most disposable
-  ```


### PR DESCRIPTION
I removed the section about nesting subscribe because it leads to more problems than it fixes.

### Nested subscribes are ok:

- **The lifecycle of the Observables can be different.** Disposing the text change Observable doesn't mean I wan't to cancel the network request in one of my services. The lifecycle of my service and the ViewController can be totally different. This also means I have different disposeBags
- **Handling errors is different for Observables which never complete and Observables which complete/error normally. Don't combine them.** When flatmapping the network request to the text change stream one must be very careful to catch all possible errors. Worst case scenario: The network request fails and the textField stops emitting text changes.