### PR TITLE
Add forwarding delegate implementation in RxSearchBarDelegateProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## Master
 
+* Add forwarding delegate implementation in RxSearchBarDelegateProxy
+
 ## [3.6.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.6.1)
 
 #### Anomalies

--- a/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
@@ -40,7 +40,17 @@ public class RxSearchBarDelegateProxy
         return searchBar.createRxDelegateProxy()
     }
 #endif
-    
+
+    public func searchBar(_ searchBar: UISearchBar, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        /**
+         We've had some issues with observing text changes. This is here just in case we need the same hack in future and that
+         we wouldn't need to change the public interface.
+         */
+        let forwardToDelegate = self.forwardToDelegate() as? UISearchBarDelegate
+        return forwardToDelegate?.searchBar?(searchBar,
+                                             shouldChangeTextIn: range,
+                                             replacementText: text) ?? true
+    }
 }
 
 #endif


### PR DESCRIPTION
I had UISearchBar issue related to Japanese Kanji conversion.
I need a extension point to the DelegateProxy to get around it, so adding this anyways.
For now I can extend RxSearchBarDelegateProxy like this and it works, so I'm not in hurry.

```swift
// TODO: This should be implemented in RxSwift.
extension RxSearchBarDelegateProxy {
    public func searchBar(_ searchBar: UISearchBar, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
        /**
         We've had some issues with observing text changes. This is here just in case we need the same hack in future and that
         we wouldn't need to change the public interface.
         */
        let forwardToDelegate = self.forwardToDelegate() as? UISearchBarDelegate
        return forwardToDelegate?.searchBar?(searchBar,
                                            shouldChangeTextIn: range,
                                            replacementText: text) ?? true
    }
}
```
```swift
extension Reactive where Base: UISearchBar {
    private final class SearchBarDelegate: NSObject, UISearchBarDelegate {
        func searchBar(_ searchBar: UISearchBar, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
            return true
        }
    }
```
```swift
    searchBar.rx.delegate.setForwardToDelegate(MySearchBarDelegate(), retainDelegate: true)
    let shouldChange = searchBar.rx.delegate.rx
        .methodInvoked(#selector(UISearchBarDelegate.searchBar(_:shouldChangeTextIn:replacementText:)))
```