### PR TITLE
Rx blocking remove duplicate code

### DIFF
--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -74,29 +74,7 @@ extension BlockingObservable {
 }
 
 extension BlockingObservable {
-    /// Blocks current thread until sequence terminates.
-    ///
-    /// If sequence terminates with error, that error is returned. Otherwise, if there is no error, it returns nil
-    ///
-    /// - returns: Returns the terminating error of the sequence if it occurs, and nil otherwise.
-    public func toError() -> Swift.Error? {
-        let (_, error) = convertToArrayResult()
-        return error
-    }
-}
-
-extension BlockingObservable {
     fileprivate func convertToArray(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) throws -> [E] {
-        let (elements, error) = convertToArrayResult(max: max, predicate: predicate)
-        
-        if let error = error {
-            throw error
-        }
-        
-        return elements
-    }
-    
-    fileprivate func convertToArrayResult(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) -> ([E], Swift.Error?) {
         var elements: [E] = Array<E>()
         
         var error: Swift.Error?
@@ -148,6 +126,10 @@ extension BlockingObservable {
             error = err
         }
         
-        return (elements, error)
+        if let error = error {
+            throw error
+        }
+        
+        return elements
     }
 }

--- a/RxBlocking/README.md
+++ b/RxBlocking/README.md
@@ -18,6 +18,15 @@ extension ObservableType {
 extension ObservableType {
     public func last() throws -> E? {}
 }
+
+extension Observableype {
+    public func single() throws -> E? {}
+    public func single(_ predicate: @escaping (E) throws -> Bool) throws -> E? {}
+}
+
+extension ObservableType {
+    public func toError() -> Swift.Error? {}
+}
 ```
 
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -238,6 +238,8 @@ final class ObservableBlockingTest_ : ObservableBlockingTest, RxTestCase {
     ("testSingle_independent", ObservableBlockingTest.testSingle_independent),
     ("testSingle_timeout", ObservableBlockingTest.testSingle_timeout),
     ("testSinglePredicate_timeout", ObservableBlockingTest.testSinglePredicate_timeout),
+    ("testToError_success", ObservableBlockingTest.testToError_success),
+    ("testToError_fail", ObservableBlockingTest.testToError_fail),
     ] }
 }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -238,8 +238,6 @@ final class ObservableBlockingTest_ : ObservableBlockingTest, RxTestCase {
     ("testSingle_independent", ObservableBlockingTest.testSingle_independent),
     ("testSingle_timeout", ObservableBlockingTest.testSingle_timeout),
     ("testSinglePredicate_timeout", ObservableBlockingTest.testSinglePredicate_timeout),
-    ("testToError_success", ObservableBlockingTest.testToError_success),
-    ("testToError_fail", ObservableBlockingTest.testToError_fail),
     ] }
 }
 

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -436,3 +436,17 @@ extension ObservableBlockingTest {
         }
     }
 }
+
+// toError
+
+extension ObservableBlockingTest {
+    func testToError_success() {
+        XCTAssertNil(Observable.just(42).toBlocking().toError())
+    }
+    
+    func testToError_fail() {
+        let error = Observable<Int>.error(testError).toBlocking().toError()
+        XCTAssertNotNil(error)
+        XCTAssertErrorEqual(error!, testError)
+    }
+}

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -304,8 +304,10 @@ extension ObservableBlockingTest {
     }
     
     func testSingle_predicate_someData_one_match() {
+        var predicateVals = [Int]()
         do {
             let element = try Observable.of(42, 43, 44, 45).toBlocking().single( { e in
+                predicateVals.append(e)
                 return e == 44
             } )
             XCTAssertEqual(element, 44)
@@ -313,11 +315,14 @@ extension ObservableBlockingTest {
         catch _ {
             XCTFail()
         }
+        XCTAssertEqual(predicateVals, [42, 43, 44, 45])
     }
 
     func testSingle_predicate_someData_two_match() {
+        var predicateVals = [Int]()
         do {
             _ = try Observable.of(42, 43, 44, 45).toBlocking().single( { e in
+                predicateVals.append(e)
                 return e >= 43
             } )
             XCTFail()
@@ -325,12 +330,15 @@ extension ObservableBlockingTest {
         catch let e {
             XCTAssertEqual((e as! RxError)._code, RxError.moreThanOneElement._code)
         }
+        XCTAssertEqual(predicateVals, [42, 43, 44])
     }
 
     
     func testSingle_predicate_none() {
+        var predicateVals = [Int]()
         do {
             _ = try Observable.of(42, 43, 44, 45).toBlocking().single( { e in
+                predicateVals.append(e)
                 return e > 50
             } )
             XCTFail()
@@ -338,11 +346,14 @@ extension ObservableBlockingTest {
         catch let e {
             XCTAssertEqual((e as! RxError)._code, RxError.noElements._code)
         }
+        XCTAssertEqual(predicateVals, [42, 43, 44, 45])
     }
 
     func testSingle_predicate_throws() {
+        var predicateVals = [Int]()
         do {
             _ = try Observable.of(42, 43, 44, 45, scheduler: CurrentThreadScheduler.instance).toBlocking().single( { e in
+                predicateVals.append(e)
                 if e < 43 { return false }
                 throw testError
             } )
@@ -351,6 +362,7 @@ extension ObservableBlockingTest {
         catch let e {
             XCTAssertErrorEqual(e, testError)
         }
+        XCTAssertEqual(predicateVals, [42, 43])
     }
     
     func testSingle_predicate_fail() {

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -304,10 +304,8 @@ extension ObservableBlockingTest {
     }
     
     func testSingle_predicate_someData_one_match() {
-        var predicateVals = [Int]()
         do {
             let element = try Observable.of(42, 43, 44, 45).toBlocking().single( { e in
-                predicateVals.append(e)
                 return e == 44
             } )
             XCTAssertEqual(element, 44)
@@ -315,14 +313,11 @@ extension ObservableBlockingTest {
         catch _ {
             XCTFail()
         }
-        XCTAssertEqual(predicateVals, [42, 43, 44, 45])
     }
 
     func testSingle_predicate_someData_two_match() {
-        var predicateVals = [Int]()
         do {
             _ = try Observable.of(42, 43, 44, 45).toBlocking().single( { e in
-                predicateVals.append(e)
                 return e >= 43
             } )
             XCTFail()
@@ -330,15 +325,12 @@ extension ObservableBlockingTest {
         catch let e {
             XCTAssertEqual((e as! RxError)._code, RxError.moreThanOneElement._code)
         }
-        XCTAssertEqual(predicateVals, [42, 43, 44])
     }
 
     
     func testSingle_predicate_none() {
-        var predicateVals = [Int]()
         do {
             _ = try Observable.of(42, 43, 44, 45).toBlocking().single( { e in
-                predicateVals.append(e)
                 return e > 50
             } )
             XCTFail()
@@ -346,14 +338,11 @@ extension ObservableBlockingTest {
         catch let e {
             XCTAssertEqual((e as! RxError)._code, RxError.noElements._code)
         }
-        XCTAssertEqual(predicateVals, [42, 43, 44, 45])
     }
 
     func testSingle_predicate_throws() {
-        var predicateVals = [Int]()
         do {
             _ = try Observable.of(42, 43, 44, 45, scheduler: CurrentThreadScheduler.instance).toBlocking().single( { e in
-                predicateVals.append(e)
                 if e < 43 { return false }
                 throw testError
             } )
@@ -362,7 +351,6 @@ extension ObservableBlockingTest {
         catch let e {
             XCTAssertErrorEqual(e, testError)
         }
-        XCTAssertEqual(predicateVals, [42, 43])
     }
     
     func testSingle_predicate_fail() {

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -17,11 +17,11 @@ class ObservableBlockingTest : RxTest {
 
 extension ObservableBlockingTest {
     func testToArray_empty() {
-        XCTAssert(try! Observable<Int>.empty().toBlocking().toArray() == [])
+        XCTAssertEqual(try! Observable<Int>.empty().toBlocking().toArray(), [])
     }
     
     func testToArray_return() {
-        XCTAssert(try! Observable.just(42).toBlocking().toArray() == [42])
+        XCTAssertEqual(try! Observable.just(42).toBlocking().toArray(), [42])
     }
     
     func testToArray_fail() {
@@ -35,7 +35,7 @@ extension ObservableBlockingTest {
     }
     
     func testToArray_someData() {
-        XCTAssert(try! Observable.of(42, 43, 44, 45).toBlocking().toArray() == [42, 43, 44, 45])
+        XCTAssertEqual(try! Observable.of(42, 43, 44, 45).toBlocking().toArray(), [42, 43, 44, 45])
     }
     
     func testToArray_withRealScheduler() {
@@ -46,7 +46,7 @@ extension ObservableBlockingTest {
             .toBlocking()
             .toArray()
         
-        XCTAssert(array == Array(0..<10))
+        XCTAssertEqual(array, Array(0..<10))
     }
 
     func testToArray_independent() {
@@ -89,11 +89,11 @@ extension ObservableBlockingTest {
 
 extension ObservableBlockingTest {
     func testFirst_empty() {
-        XCTAssert(try! Observable<Int>.empty().toBlocking().first() == nil)
+        XCTAssertNil(try! Observable<Int>.empty().toBlocking().first())
     }
     
     func testFirst_return() {
-        XCTAssert(try! Observable.just(42).toBlocking().first() == 42)
+        XCTAssertEqual(try! Observable.just(42).toBlocking().first(), 42)
     }
     
     func testFirst_fail() {
@@ -107,18 +107,18 @@ extension ObservableBlockingTest {
     }
     
     func testFirst_someData() {
-        XCTAssert(try! Observable.of(42, 43, 44, 45).toBlocking().first() == 42)
+        XCTAssertEqual(try! Observable.of(42, 43, 44, 45).toBlocking().first(), 42)
     }
     
     func testFirst_withRealScheduler() {
         let scheduler = ConcurrentDispatchQueueScheduler(qos: .default)
         
-        let array = try! Observable<Int64>.interval(0.001, scheduler: scheduler)
+        let element = try! Observable<Int64>.interval(0.001, scheduler: scheduler)
             .take(10)
             .toBlocking()
             .first()
         
-        XCTAssert(array == 0)
+        XCTAssertEqual(element, 0)
     }
 
     func testFirst_independent() {
@@ -161,11 +161,11 @@ extension ObservableBlockingTest {
 
 extension ObservableBlockingTest {
     func testLast_empty() {
-        XCTAssert(try! Observable<Int>.empty().toBlocking().last() == nil)
+        XCTAssertNil(try! Observable<Int>.empty().toBlocking().last())
     }
     
     func testLast_return() {
-        XCTAssert(try! Observable.just(42).toBlocking().last() == 42)
+        XCTAssertEqual(try! Observable.just(42).toBlocking().last(), 42)
     }
     
     func testLast_fail() {
@@ -179,18 +179,18 @@ extension ObservableBlockingTest {
     }
     
     func testLast_someData() {
-        XCTAssert(try! Observable.of(42, 43, 44, 45).toBlocking().last() == 45)
+        XCTAssertEqual(try! Observable.of(42, 43, 44, 45).toBlocking().last(), 45)
     }
     
     func testLast_withRealScheduler() {
         let scheduler = ConcurrentDispatchQueueScheduler(qos: .default)
         
-        let array = try! Observable<Int64>.interval(0.001, scheduler: scheduler)
+        let element = try! Observable<Int64>.interval(0.001, scheduler: scheduler)
             .take(10)
             .toBlocking()
             .last()
         
-        XCTAssert(array == 9)
+        XCTAssertEqual(element, 9)
     }
 
     func testLast_independent() {
@@ -239,12 +239,12 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertTrue((e as! RxError)._code == RxError.noElements._code)
+            XCTAssertEqual((e as! RxError)._code, RxError.noElements._code)
         }
     }
     
     func testSingle_return() {
-        XCTAssert(try! Observable.just(42).toBlocking().single() == 42)
+        XCTAssertEqual(try! Observable.just(42).toBlocking().single(), 42)
     }
 
     func testSingle_two() {
@@ -253,7 +253,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertTrue((e as! RxError)._code == RxError.moreThanOneElement._code)
+            XCTAssertEqual((e as! RxError)._code, RxError.moreThanOneElement._code)
         }
     }
 
@@ -263,7 +263,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertTrue((e as! RxError)._code == RxError.moreThanOneElement._code)
+            XCTAssertEqual((e as! RxError)._code, RxError.moreThanOneElement._code)
         }
     }
     
@@ -280,12 +280,12 @@ extension ObservableBlockingTest {
     func testSingle_withRealScheduler() {
         let scheduler = ConcurrentDispatchQueueScheduler(qos: .default)
         
-        let array = try! Observable<Int64>.interval(0.001, scheduler: scheduler)
+        let element = try! Observable<Int64>.interval(0.001, scheduler: scheduler)
             .take(1)
             .toBlocking()
             .single()
         
-        XCTAssert(array == 0)
+        XCTAssertEqual(element, 0)
     }
 
     
@@ -295,21 +295,22 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertTrue((e as! RxError)._code == RxError.noElements._code)
+            XCTAssertEqual((e as! RxError)._code, RxError.noElements._code)
         }
     }
     
     func testSingle_predicate_return() {
-        XCTAssert(try! Observable.just(42).toBlocking().single( { _ in true } ) == 42)
+        XCTAssertEqual(try! Observable.just(42).toBlocking().single( { _ in true } ), 42)
     }
     
     func testSingle_predicate_someData_one_match() {
         var predicateVals = [Int]()
         do {
-            _ = try Observable.of(42, 43, 44, 45).toBlocking().single( { e in
+            let element = try Observable.of(42, 43, 44, 45).toBlocking().single( { e in
                 predicateVals.append(e)
                 return e == 44
             } )
+            XCTAssertEqual(element, 44)
         }
         catch _ {
             XCTFail()
@@ -327,7 +328,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertTrue((e as! RxError)._code == RxError.moreThanOneElement._code)
+            XCTAssertEqual((e as! RxError)._code, RxError.moreThanOneElement._code)
         }
         XCTAssertEqual(predicateVals, [42, 43, 44])
     }
@@ -343,7 +344,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertTrue((e as! RxError)._code == RxError.noElements._code)
+            XCTAssertEqual((e as! RxError)._code, RxError.noElements._code)
         }
         XCTAssertEqual(predicateVals, [42, 43, 44, 45])
     }
@@ -377,12 +378,12 @@ extension ObservableBlockingTest {
     func testSingle_predicate_withRealScheduler() {
         let scheduler = ConcurrentDispatchQueueScheduler(qos: .default)
         
-        let array = try! Observable<Int64>.interval(0.001, scheduler: scheduler)
+        let element = try! Observable<Int64>.interval(0.001, scheduler: scheduler)
             .take(4)
             .toBlocking()
             .single( { $0 == 3 } )
         
-        XCTAssert(array == 3)
+        XCTAssertEqual(element, 3)
     }
 
     func testSingle_independent() {

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -436,17 +436,3 @@ extension ObservableBlockingTest {
         }
     }
 }
-
-// toError
-
-extension ObservableBlockingTest {
-    func testToError_success() {
-        XCTAssertNil(Observable.just(42).toBlocking().toError())
-    }
-    
-    func testToError_fail() {
-        let error = Observable<Int>.error(testError).toBlocking().toError()
-        XCTAssertNotNil(error)
-        XCTAssertErrorEqual(error!, testError)
-    }
-}

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -239,7 +239,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertEqual((e as! RxError)._code, RxError.noElements._code)
+            XCTAssertErrorEqual(e, RxError.noElements)
         }
     }
     
@@ -253,7 +253,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertEqual((e as! RxError)._code, RxError.moreThanOneElement._code)
+            XCTAssertErrorEqual(e, RxError.moreThanOneElement)
         }
     }
 
@@ -263,7 +263,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertEqual((e as! RxError)._code, RxError.moreThanOneElement._code)
+            XCTAssertErrorEqual(e, RxError.moreThanOneElement)
         }
     }
     
@@ -295,7 +295,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertEqual((e as! RxError)._code, RxError.noElements._code)
+            XCTAssertErrorEqual(e, RxError.noElements)
         }
     }
     
@@ -328,7 +328,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertEqual((e as! RxError)._code, RxError.moreThanOneElement._code)
+            XCTAssertErrorEqual(e, RxError.moreThanOneElement)
         }
         XCTAssertEqual(predicateVals, [42, 43, 44])
     }
@@ -344,7 +344,7 @@ extension ObservableBlockingTest {
             XCTFail()
         }
         catch let e {
-            XCTAssertEqual((e as! RxError)._code, RxError.noElements._code)
+            XCTAssertErrorEqual(e, RxError.noElements)
         }
         XCTAssertEqual(predicateVals, [42, 43, 44, 45])
     }


### PR DESCRIPTION
I've just discovered `asBlocking()` and it's so useful for unit testing observables, thanks.

At a first glance, the code in each of `toArray`, `first`, `last` and `single` is really similar. This PR combines them all into one to share the `toArray` implementation.

I initially thought testing the `predicateVals` callbacks was an unnecessary implementation detail, however, I've now realised it's basically testing that the sequence is terminated as soon as the conditions fail, so it wont keep observing forever.

UPDATE: I added a general purpose array converter that has the same behaviour around terminating as soon as it's got the values it needs, or breaks an expected precondition (eg. `single`), but it can still share the same code.

~Do you think `asBlocking()` is used on eg. infinite or ongoing observables, where the lazy evaluation is important?~

~Assuming that's the case, I'm playing with some ways of keeping the minimal code and also not evaluating the entire sequence, but haven't nailed it yet, in which case this PR might not be useful.~