### PR TITLE
Update RxSwift for Xcode 9b4

### DIFF
--- a/Platform/DataStructures/PriorityQueue.swift
+++ b/Platform/DataStructures/PriorityQueue.swift
@@ -52,7 +52,11 @@ struct PriorityQueue<Element> {
     private mutating func removeAt(_ index: Int) {
         let removingLast = index == _elements.count - 1
         if !removingLast {
+            #if swift(>=3.2)
+            _elements.swapAt(index, _elements.count - 1)
+            #else
             swap(&_elements[index], &_elements[_elements.count - 1])
+            #endif
         }
 
         _ = _elements.popLast()
@@ -72,8 +76,11 @@ struct PriorityQueue<Element> {
         while unbalancedIndex > 0 {
             let parentIndex = (unbalancedIndex - 1) / 2
             guard _hasHigherPriority(_elements[unbalancedIndex], _elements[parentIndex]) else { break }
-            
+            #if swift(>=3.2)
+            _elements.swapAt(unbalancedIndex, parentIndex)
+            #else
             swap(&_elements[unbalancedIndex], &_elements[parentIndex])
+            #endif
             unbalancedIndex = parentIndex
         }
     }
@@ -99,7 +106,11 @@ struct PriorityQueue<Element> {
 
             guard highestPriorityIndex != unbalancedIndex else { break }
 
+            #if swift(>=3.2)
+            _elements.swapAt(highestPriorityIndex, unbalancedIndex)
+            #else
             swap(&_elements[highestPriorityIndex], &_elements[unbalancedIndex])
+            #endif
             unbalancedIndex = highestPriorityIndex
         }
     }

--- a/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
@@ -31,6 +31,17 @@ extension ObservableConvertibleType {
     - parameter onErrorDriveWith: SharedSequence that provides elements of the sequence in case of error.
     - returns: Driving observable sequence.
     */
+    #if swift(>=3.2)
+    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorDriveWith: SharedSequence<S, E>) -> SharedSequence<S, E> {
+        let source = self
+            .asObservable()
+            .observeOn(S.scheduler)
+            .catchError { _ in
+                onErrorDriveWith.asObservable()
+        }
+        return SharedSequence(source)
+    }
+    #else
     public func asSharedSequence<S: SharingStrategyProtocol>(sharingStrategy: S.Type = S.self, onErrorDriveWith: SharedSequence<S, E>) -> SharedSequence<S, E> {
         let source = self
             .asObservable()
@@ -40,6 +51,7 @@ extension ObservableConvertibleType {
             }
         return SharedSequence(source)
     }
+    #endif
 
     /**
     Converts anything convertible to `Observable` to `SharedSequence` unit.
@@ -47,6 +59,17 @@ extension ObservableConvertibleType {
     - parameter onErrorRecover: Calculates driver that continues to drive the sequence in case of error.
     - returns: Driving observable sequence.
     */
+    #if swift(>=3.2)
+    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorRecover: @escaping (_ error: Swift.Error) -> SharedSequence<S, E>) -> SharedSequence<S, E> {
+        let source = self
+            .asObservable()
+            .observeOn(S.scheduler)
+            .catchError { error in
+                onErrorRecover(error).asObservable()
+        }
+        return SharedSequence(source)
+    }
+    #else
     public func asSharedSequence<S: SharingStrategyProtocol>(sharingStrategy: S.Type = S.self, onErrorRecover: @escaping (_ error: Swift.Error) -> SharedSequence<S, E>) -> SharedSequence<S, E> {
         let source = self
             .asObservable()
@@ -56,4 +79,5 @@ extension ObservableConvertibleType {
             }
         return SharedSequence(source)
     }
+    #endif
 }

--- a/RxSwift/ObservableType.swift
+++ b/RxSwift/ObservableType.swift
@@ -8,8 +8,10 @@
 
 /// Represents a push style sequence.
 public protocol ObservableType : ObservableConvertibleType {
+    #if !swift(>=3.2)
     /// Type of elements in sequence.
     associatedtype E
+    #endif
     
     /**
     Subscribes `observer` to receive events for this sequence.

--- a/RxSwift/ObserverType.swift
+++ b/RxSwift/ObserverType.swift
@@ -23,18 +23,36 @@ extension ObserverType {
     /// Convenience method equivalent to `on(.next(element: E))`
     ///
     /// - parameter element: Next element to send to observer(s)
+    #if swift(>=3.2)
+    public func onNext(_ element: E) {
+        on(.next(element))
+    }
+    #else
     public final func onNext(_ element: E) {
         on(.next(element))
     }
+    #endif
     
     /// Convenience method equivalent to `on(.completed)`
+    #if swift(>=3.2)
+    public func onCompleted() {
+        on(.completed)
+    }
+    #else
     public final func onCompleted() {
         on(.completed)
     }
+    #endif
     
     /// Convenience method equivalent to `on(.error(Swift.Error))`
     /// - parameter error: Swift.Error to send to observer(s)
+    #if swift(>=3.2)
+    public func onError(_ error: Swift.Error) {
+        on(.error(error))
+    }
+    #else
     public final func onError(_ error: Swift.Error) {
         on(.error(error))
     }
+    #endif
 }


### PR DESCRIPTION
I checked out the develop branch, saw a number of warnings. Since we use `SWIFT_WARNINGS_AS_ERRORS` (i.e., `-Werror`) I had to resolve them in our fork.