### PR TITLE
Rx blocking tidy test assertions

### DIFF
--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -17,11 +17,11 @@ class ObservableBlockingTest : RxTest {
 
 extension ObservableBlockingTest {
     func testToArray_empty() {
-        XCTAssertEqual(try! Observable<Int>.empty().toBlocking().toArray(), [])
+        XCTAssertEqual(try Observable<Int>.empty().toBlocking().toArray(), [])
     }
     
     func testToArray_return() {
-        XCTAssertEqual(try! Observable.just(42).toBlocking().toArray(), [42])
+        XCTAssertEqual(try Observable.just(42).toBlocking().toArray(), [42])
     }
     
     func testToArray_fail() {
@@ -29,7 +29,7 @@ extension ObservableBlockingTest {
     }
     
     func testToArray_someData() {
-        XCTAssertEqual(try! Observable.of(42, 43, 44, 45).toBlocking().toArray(), [42, 43, 44, 45])
+        XCTAssertEqual(try Observable.of(42, 43, 44, 45).toBlocking().toArray(), [42, 43, 44, 45])
     }
     
     func testToArray_withRealScheduler() {
@@ -64,7 +64,6 @@ extension ObservableBlockingTest {
     }
 
     func testToArray_timeout() {
-        
         do {
             _ = try Observable<Int>.never().toBlocking(timeout: 0.01).toArray()
             XCTFail("It should fail")
@@ -84,11 +83,11 @@ extension ObservableBlockingTest {
 
 extension ObservableBlockingTest {
     func testFirst_empty() {
-        XCTAssertNil(try! Observable<Int>.empty().toBlocking().first())
+        XCTAssertNil(try Observable<Int>.empty().toBlocking().first())
     }
     
     func testFirst_return() {
-        XCTAssertEqual(try! Observable.just(42).toBlocking().first(), 42)
+        XCTAssertEqual(try Observable.just(42).toBlocking().first(), 42)
     }
     
     func testFirst_fail() {
@@ -96,7 +95,7 @@ extension ObservableBlockingTest {
     }
     
     func testFirst_someData() {
-        XCTAssertEqual(try! Observable.of(42, 43, 44, 45).toBlocking().first(), 42)
+        XCTAssertEqual(try Observable.of(42, 43, 44, 45).toBlocking().first(), 42)
     }
     
     func testFirst_withRealScheduler() {
@@ -150,11 +149,11 @@ extension ObservableBlockingTest {
 
 extension ObservableBlockingTest {
     func testLast_empty() {
-        XCTAssertNil(try! Observable<Int>.empty().toBlocking().last())
+        XCTAssertNil(try Observable<Int>.empty().toBlocking().last())
     }
     
     func testLast_return() {
-        XCTAssertEqual(try! Observable.just(42).toBlocking().last(), 42)
+        XCTAssertEqual(try Observable.just(42).toBlocking().last(), 42)
     }
     
     func testLast_fail() {
@@ -162,7 +161,7 @@ extension ObservableBlockingTest {
     }
     
     func testLast_someData() {
-        XCTAssertEqual(try! Observable.of(42, 43, 44, 45).toBlocking().last(), 45)
+        XCTAssertEqual(try Observable.of(42, 43, 44, 45).toBlocking().last(), 45)
     }
     
     func testLast_withRealScheduler() {
@@ -221,7 +220,7 @@ extension ObservableBlockingTest {
     }
     
     func testSingle_return() {
-        XCTAssertEqual(try! Observable.just(42).toBlocking().single(), 42)
+        XCTAssertEqual(try Observable.just(42).toBlocking().single(), 42)
     }
 
     func testSingle_two() {
@@ -253,7 +252,7 @@ extension ObservableBlockingTest {
     }
     
     func testSingle_predicate_return() {
-        XCTAssertEqual(try! Observable.just(42).toBlocking().single( { _ in true } ), 42)
+        XCTAssertEqual(try Observable.just(42).toBlocking().single( { _ in true } ), 42)
     }
     
     func testSingle_predicate_someData_one_match() {

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -64,17 +64,8 @@ extension ObservableBlockingTest {
     }
 
     func testToArray_timeout() {
-        do {
-            _ = try Observable<Int>.never().toBlocking(timeout: 0.01).toArray()
-            XCTFail("It should fail")
-        }
-        catch let e {
-            if case .timeout = e as! RxError {
-
-            }
-            else {
-                XCTFail()
-            }
+        XCTAssertThrowsError(try Observable<Int>.never().toBlocking(timeout: 0.01).toArray()) { error in
+            XCTAssertErrorEqual(error, RxError.timeout)
         }
     }
 }
@@ -130,17 +121,8 @@ extension ObservableBlockingTest {
     }
 
     func testFirst_timeout() {
-        do {
-            _ = try Observable<Int>.never().toBlocking(timeout: 0.01).first()
-            XCTFail("It should fail")
-        }
-        catch let e {
-            if case .timeout = e as! RxError {
-
-            }
-            else {
-                XCTFail()
-            }
+        XCTAssertThrowsError(try Observable<Int>.never().toBlocking(timeout: 0.01).first()) { error in
+            XCTAssertErrorEqual(error, RxError.timeout)
         }
     }
 }
@@ -196,17 +178,8 @@ extension ObservableBlockingTest {
     }
 
     func testLast_timeout() {
-        do {
-            _ = try Observable<Int>.never().toBlocking(timeout: 0.01).last()
-            XCTFail("It should fail")
-        }
-        catch let e {
-            if case .timeout = e as! RxError {
-
-            }
-            else {
-                XCTFail()
-            }
+        XCTAssertThrowsError(try Observable<Int>.never().toBlocking(timeout: 0.01).last()) { error in
+            XCTAssertErrorEqual(error, RxError.timeout)
         }
     }
 }
@@ -353,32 +326,14 @@ extension ObservableBlockingTest {
     }
 
     func testSingle_timeout() {
-        do {
-            _ = try Observable<Int>.never().toBlocking(timeout: 0.01).single()
-            XCTFail("It should fail")
-        }
-        catch let e {
-            if case .timeout = e as! RxError {
-
-            }
-            else {
-                XCTFail()
-            }
+        XCTAssertThrowsError(try Observable<Int>.never().toBlocking(timeout: 0.01).single()) { error in
+            XCTAssertErrorEqual(error, RxError.timeout)
         }
     }
 
     func testSinglePredicate_timeout() {
-        do {
-            _ = try Observable<Int>.never().toBlocking(timeout: 0.01).single { _ in true }
-            XCTFail("It should fail")
-        }
-        catch let e {
-            if case .timeout = e as! RxError {
-
-            }
-            else {
-                XCTFail()
-            }
+        XCTAssertThrowsError(try Observable<Int>.never().toBlocking(timeout: 0.01).single { _ in true }) { error in
+            XCTAssertErrorEqual(error, RxError.timeout)
         }
     }
 }

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -25,13 +25,7 @@ extension ObservableBlockingTest {
     }
     
     func testToArray_fail() {
-        do {
-            _ = try Observable<Int>.error(testError).toBlocking().toArray()
-            XCTFail("It should fail")
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, testError)
-        }
+        XCTAssertThrowsErrorEqual(try Observable<Int>.error(testError).toBlocking().toArray(), testError)
     }
     
     func testToArray_someData() {
@@ -70,6 +64,7 @@ extension ObservableBlockingTest {
     }
 
     func testToArray_timeout() {
+        
         do {
             _ = try Observable<Int>.never().toBlocking(timeout: 0.01).toArray()
             XCTFail("It should fail")
@@ -97,13 +92,7 @@ extension ObservableBlockingTest {
     }
     
     func testFirst_fail() {
-        do {
-            _ = try Observable<Int>.error(testError).toBlocking().first()
-            XCTFail()
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, testError)
-        }
+        XCTAssertThrowsErrorEqual(try Observable<Int>.error(testError).toBlocking().first(), testError)
     }
     
     func testFirst_someData() {
@@ -169,13 +158,7 @@ extension ObservableBlockingTest {
     }
     
     func testLast_fail() {
-        do {
-            _ = try Observable<Int>.error(testError).toBlocking().last()
-            XCTFail()
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, testError)
-        }
+        XCTAssertThrowsErrorEqual(try Observable<Int>.error(testError).toBlocking().last(), testError)
     }
     
     func testLast_someData() {
@@ -234,13 +217,7 @@ extension ObservableBlockingTest {
 
 extension ObservableBlockingTest {
     func testSingle_empty() {
-        do {
-            _ = try Observable<Int>.empty().toBlocking().single()
-            XCTFail()
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, RxError.noElements)
-        }
+        XCTAssertThrowsErrorEqual(try Observable<Int>.empty().toBlocking().single(), RxError.noElements)
     }
     
     func testSingle_return() {
@@ -248,33 +225,15 @@ extension ObservableBlockingTest {
     }
 
     func testSingle_two() {
-        do {
-            _ = try Observable.of(42, 43).toBlocking().single()
-            XCTFail()
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, RxError.moreThanOneElement)
-        }
+        XCTAssertThrowsErrorEqual(try Observable.of(42, 43).toBlocking().single(), RxError.moreThanOneElement)
     }
 
     func testSingle_someData() {
-        do {
-            _ = try Observable.of(42, 43, 44, 45).toBlocking().single()
-            XCTFail()
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, RxError.moreThanOneElement)
-        }
+        XCTAssertThrowsErrorEqual(try Observable.of(42, 43, 44, 45).toBlocking().single(), RxError.moreThanOneElement)
     }
     
     func testSingle_fail() {
-        do {
-            _ = try Observable<Int>.error(testError).toBlocking().single()
-            XCTFail()
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, testError)
-        }
+        XCTAssertThrowsErrorEqual(try Observable<Int>.error(testError).toBlocking().single(), testError)
     }
     
     func testSingle_withRealScheduler() {
@@ -290,13 +249,7 @@ extension ObservableBlockingTest {
 
     
     func testSingle_predicate_empty() {
-        do {
-            _ = try Observable<Int>.empty().toBlocking().single { _ in true }
-            XCTFail()
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, RxError.noElements)
-        }
+        XCTAssertThrowsErrorEqual(try Observable<Int>.empty().toBlocking().single { _ in true }, RxError.noElements)
     }
     
     func testSingle_predicate_return() {
@@ -366,13 +319,7 @@ extension ObservableBlockingTest {
     }
     
     func testSingle_predicate_fail() {
-        do {
-            _ = try Observable<Int>.error(testError).toBlocking().single( { _ in true } )
-            XCTFail()
-        }
-        catch let e {
-            XCTAssertErrorEqual(e, testError)
-        }
+        XCTAssertThrowsErrorEqual(try Observable<Int>.error(testError).toBlocking().single { _ in true }, testError)
     }
     
     func testSingle_predicate_withRealScheduler() {

--- a/Tests/XCTest+AllTests.swift
+++ b/Tests/XCTest+AllTests.swift
@@ -22,6 +22,12 @@ func XCTAssertErrorEqual(_ lhs: Swift.Error, _ rhs: Swift.Error, file: StaticStr
     XCTAssertTrue(event1 == event2, file: file, line: line)
 }
 
+func XCTAssertThrowsErrorEqual<T>(_ expression: @autoclosure () throws -> T, _ expectedError: Error, file: StaticString = #file, line: UInt = #line) {
+    XCTAssertThrowsError(expression, file: file, line: line) { actualError in
+        XCTAssertErrorEqual(actualError, expectedError, file: file, line: line)
+    }
+}
+
 func NSValuesAreEqual(_ lhs: Any, _ rhs: Any) -> Bool {
     if let lhsValue = lhs as? NSValue, let rhsValue = rhs as? NSValue {
         #if os(Linux)

--- a/Tests/XCTest+AllTests.swift
+++ b/Tests/XCTest+AllTests.swift
@@ -16,10 +16,10 @@ import class Foundation.NSObject
 import struct Foundation.Date
 
 func XCTAssertErrorEqual(_ lhs: Swift.Error, _ rhs: Swift.Error, file: StaticString = #file, line: UInt = #line) {
-    let event1: Event<Int> = .error(lhs)
-    let event2: Event<Int> = .error(rhs)
+    let lhsEvent: Event<Int> = .error(lhs)
+    let rhsEvent: Event<Int> = .error(rhs)
     
-    XCTAssertTrue(event1 == event2, file: file, line: line)
+    XCTAssertTrue(lhsEvent == rhsEvent, "expected \(rhsEvent) but received \(lhsEvent)", file: file, line: line)
 }
 
 func XCTAssertThrowsErrorEqual<T>(_ expression: @autoclosure () throws -> T, _ expectedError: Error, file: StaticString = #file, line: UInt = #line) {


### PR DESCRIPTION
In the discussion in #1355, @kzaher showed me a cleaner way to test throwing errors in XCTest. I never knew this built in assertion function existed!

To get a feel for it, I rolled it through the RxBlocking unit tests. It tests the same functionality with less code, and seems more readable as well, so felt like it was worth contributing back. I introduced another error helper `XCTAssertThrowsErrorEqual` that wraps the existing one to do the common assertions in one line.

I also removed a few force unwrapped errors, where the `XCTAssertEqual` matcher handles errors more gracefully and reports errors rather than crashing (I couldn't easily change all `try!` to `try` so only changed the low hanging fruit.