### PR TITLE
Enumerated

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -71,6 +71,7 @@ custom_categories:
   - Do
   - ElementAt
   - Empty
+  - Enumerated
   - Error
   - Filter
   - Generate

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1247,6 +1247,13 @@
 		C8D132451C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D132431C42D15E00B59FFF /* SectionedViewDataSourceType.swift */; };
 		C8D132461C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D132431C42D15E00B59FFF /* SectionedViewDataSourceType.swift */; };
 		C8D132471C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D132431C42D15E00B59FFF /* SectionedViewDataSourceType.swift */; };
+		C8E390631F379041004FC993 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390621F379041004FC993 /* Enumerated.swift */; };
+		C8E390641F379041004FC993 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390621F379041004FC993 /* Enumerated.swift */; };
+		C8E390651F379041004FC993 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390621F379041004FC993 /* Enumerated.swift */; };
+		C8E390661F379041004FC993 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390621F379041004FC993 /* Enumerated.swift */; };
+		C8E390681F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
+		C8E390691F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
+		C8E3906A1F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
 		C8E8BA401E2BBDC800A4AC2C /* (null) in Sources */ = {isa = PBXBuildFile; };
 		C8E8BA5A1E2C181A00A4AC2C /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8A56AD71AD7424700B4673B /* RxSwift.framework */; };
 		C8E8BA641E2C186200A4AC2C /* Benchmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E8BA621E2C186200A4AC2C /* Benchmarks.swift */; };
@@ -2116,6 +2123,8 @@
 		C8D132431C42D15E00B59FFF /* SectionedViewDataSourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SectionedViewDataSourceType.swift; sourceTree = "<group>"; };
 		C8D132521C42DA7F00B59FFF /* SectionedViewDataSourceMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SectionedViewDataSourceMock.swift; sourceTree = "<group>"; };
 		C8D2C1501D4F3CD6006E2431 /* Rx.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Rx.playground; sourceTree = "<group>"; };
+		C8E390621F379041004FC993 /* Enumerated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Enumerated.swift; sourceTree = "<group>"; };
+		C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+EnumeratedTests.swift"; sourceTree = "<group>"; };
 		C8E8BA551E2C181A00A4AC2C /* Benchmarks.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Benchmarks.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C8E8BA621E2C186200A4AC2C /* Benchmarks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Benchmarks.swift; sourceTree = "<group>"; };
 		C8E8BA631E2C186200A4AC2C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -2399,6 +2408,7 @@
 				C820A8031EB4DA5900D431BC /* Do.swift */,
 				C820A7F61EB4DA5900D431BC /* ElementAt.swift */,
 				C820A8171EB4DA5900D431BC /* Empty.swift */,
+				C8E390621F379041004FC993 /* Enumerated.swift */,
 				C820A8141EB4DA5900D431BC /* Error.swift */,
 				C820A7FB1EB4DA5900D431BC /* Filter.swift */,
 				C820A7F31EB4DA5900D431BC /* Generate.swift */,
@@ -2688,6 +2698,7 @@
 				C820A9D51EB50C5C00D431BC /* Observable+DistinctUntilChangedTests.swift */,
 				C820A9D91EB50CAA00D431BC /* Observable+DoOnTests.swift */,
 				C820A9C91EB50A7100D431BC /* Observable+ElementAtTests.swift */,
+				C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */,
 				C820A9AD1EB5073E00D431BC /* Observable+FilterTests.swift */,
 				C820A9751EB4F92100D431BC /* Observable+GenerateTests.swift */,
 				C820A9D11EB50B0900D431BC /* Observable+GroupByTests.swift */,
@@ -4256,6 +4267,7 @@
 				C835092D1C38706E0027C24C /* Control+RxTests.swift in Sources */,
 				C834F6C21DB394E100C29244 /* Observable+BlockingTest.swift in Sources */,
 				C8BAA78D1E34F8D400EEC727 /* RecursiveLockTest.swift in Sources */,
+				C8E390681F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */,
 				C835093F1C38706E0027C24C /* ElementIndexPair.swift in Sources */,
 				C820A9CA1EB50A7100D431BC /* Observable+ElementAtTests.swift in Sources */,
 				C83509381C38706E0027C24C /* NSObject+RxTests.swift in Sources */,
@@ -4431,6 +4443,7 @@
 				C8C4F18A1DE9DFA400003FA7 /* UISearchBar+RxTests.swift in Sources */,
 				C8323A8F1E33FD5200CC0C7F /* Resources.swift in Sources */,
 				C8F03F421DBB98DB00AECC4C /* Anomalies.swift in Sources */,
+				C8E390691F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */,
 				C820A9A71EB5056C00D431BC /* Observable+SkipUntilTests.swift in Sources */,
 				C83509DC1C38754C0027C24C /* ElementIndexPair.swift in Sources */,
 				C8845ADB1EDB607800B36836 /* Observable+ShareReplayScopeTests.swift in Sources */,
@@ -4527,6 +4540,7 @@
 				C83509BE1C3875100027C24C /* DelegateProxyTest+Cocoa.swift in Sources */,
 				C820A9F41EB5109300D431BC /* Observable+DefaultIfEmpty.swift in Sources */,
 				C820AA041EB5134000D431BC /* Observable+DelaySubscriptionTests.swift in Sources */,
+				C8E3906A1F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */,
 				C8353CEB1DA19BC500BE3F5C /* TestErrors.swift in Sources */,
 				C8B2908B1C94D64700E923D0 /* RxTest+Controls.swift in Sources */,
 				C8C4F1751DE9D80A00003FA7 /* NSSlider+RxTests.swift in Sources */,
@@ -4644,6 +4658,7 @@
 				C8093D6A1B8A72BE0088E94D /* AnyObserver.swift in Sources */,
 				C820A9191EB4DA5A00D431BC /* AsMaybe.swift in Sources */,
 				C8B144FC1BD2D44500267DCE /* ConcurrentMainScheduler.swift in Sources */,
+				C8E390641F379041004FC993 /* Enumerated.swift in Sources */,
 				C820A8CD1EB4DA5A00D431BC /* Optional.swift in Sources */,
 				0BA949681E224B7E0036DD06 /* AsyncSubject.swift in Sources */,
 				C8FA89181C30409900CD3A17 /* HistoricalScheduler.swift in Sources */,
@@ -4877,6 +4892,7 @@
 				C8B144FB1BD2D44500267DCE /* ConcurrentMainScheduler.swift in Sources */,
 				C820A9181EB4DA5A00D431BC /* AsMaybe.swift in Sources */,
 				0BA949671E224B7E0036DD06 /* AsyncSubject.swift in Sources */,
+				C8E390631F379041004FC993 /* Enumerated.swift in Sources */,
 				C820A8CC1EB4DA5A00D431BC /* Optional.swift in Sources */,
 				C8093D871B8A72BE0088E94D /* RxMutableBox.swift in Sources */,
 				C8093D931B8A72BE0088E94D /* MainScheduler.swift in Sources */,
@@ -5034,6 +5050,7 @@
 				C8F0BF9A1BBBFB8B001B112F /* AnyObserver.swift in Sources */,
 				C820A91B1EB4DA5A00D431BC /* AsMaybe.swift in Sources */,
 				C8B144FE1BD2D44500267DCE /* ConcurrentMainScheduler.swift in Sources */,
+				C8E390661F379041004FC993 /* Enumerated.swift in Sources */,
 				C820A8CF1EB4DA5A00D431BC /* Optional.swift in Sources */,
 				0BA9496A1E224B7E0036DD06 /* AsyncSubject.swift in Sources */,
 				C8FA891A1C30409900CD3A17 /* HistoricalScheduler.swift in Sources */,
@@ -5389,6 +5406,7 @@
 				C80DA33A1C30B20B00C588B9 /* VirtualTimeScheduler.swift in Sources */,
 				C820A91A1EB4DA5A00D431BC /* AsMaybe.swift in Sources */,
 				D2EBEAF11BB9B6AE003A27DC /* BinaryDisposable.swift in Sources */,
+				C8E390651F379041004FC993 /* Enumerated.swift in Sources */,
 				C820A8CE1EB4DA5A00D431BC /* Optional.swift in Sources */,
 				C8B144FD1BD2D44500267DCE /* ConcurrentMainScheduler.swift in Sources */,
 				0BA949691E224B7E0036DD06 /* AsyncSubject.swift in Sources */,

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -35,6 +35,75 @@ extension Observable {
     }
 }
 
+extension ObservableType {
+    /**
+
+    ** @available(*, deprecated, message: "Please use enumerated().map()", renamed: "enumerated().map()") **
+
+     Projects each element of an observable sequence into a new form by incorporating the element's index.
+
+     - seealso: [map operator on reactivex.io](http://reactivex.io/documentation/operators/map.html)
+
+     - parameter selector: A transform function to apply to each source element; the second parameter of the function represents the index of the source element.
+     - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
+     */
+    public func mapWithIndex<R>(_ selector: @escaping (E, Int) throws -> R)
+        -> Observable<R> {
+        return enumerated().map { try selector($0.element, $0.index) }
+    }
+
+
+    /**
+
+     ** @available(*, deprecated, message: "Please use enumerated().flatMap()", renamed: "enumerated().flatMap()") **
+
+     Projects each element of an observable sequence to an observable sequence by incorporating the element's index and merges the resulting observable sequences into one observable sequence.
+
+     - seealso: [flatMap operator on reactivex.io](http://reactivex.io/documentation/operators/flatmap.html)
+
+     - parameter selector: A transform function to apply to each element; the second parameter of the function represents the index of the source element.
+     - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
+     */
+    public func flatMapWithIndex<O: ObservableConvertibleType>(_ selector: @escaping (E, Int) throws -> O)
+        -> Observable<O.E> {
+        return enumerated().flatMap { try selector($0.element, $0.index) }
+    }
+
+    /**
+
+     ** @available(*, deprecated, message: "Please use enumerated().skipWhile().map()", renamed: "enumerated().skipWhile().map()") **
+     
+     Bypasses elements in an observable sequence as long as a specified condition is true and then returns the remaining elements.
+     The element's index is used in the logic of the predicate function.
+
+     - seealso: [skipWhile operator on reactivex.io](http://reactivex.io/documentation/operators/skipwhile.html)
+
+     - parameter predicate: A function to test each element for a condition; the second parameter of the function represents the index of the source element.
+     - returns: An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
+     */
+    public func skipWhileWithIndex(_ predicate: @escaping (E, Int) throws -> Bool) -> Observable<E> {
+        return enumerated().skipWhile { try predicate($0.element, $0.index) }.map { $0.element }
+    }
+
+
+    /**
+     
+     ** @available(*, deprecated, message: "Please use enumerated().takeWhile().map()", renamed: "enumerated().takeWhile().map()") **
+     
+     Returns elements from an observable sequence as long as a specified condition is true.
+
+     The element's index is used in the logic of the predicate function.
+
+     - seealso: [takeWhile operator on reactivex.io](http://reactivex.io/documentation/operators/takewhile.html)
+
+     - parameter predicate: A function to test each element for a condition; the second parameter of the function represents the index of the source element.
+     - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test no longer passes.
+     */
+    public func takeWhileWithIndex(_ predicate: @escaping (E, Int) throws -> Bool) -> Observable<E> {
+        return enumerated().takeWhile { try predicate($0.element, $0.index) }.map { $0.element }
+    }
+}
+
 extension Disposable {
     /// Deprecated in favor of `disposed(by:)`
     ///

--- a/RxSwift/Observables/Enumerated.swift
+++ b/RxSwift/Observables/Enumerated.swift
@@ -1,0 +1,62 @@
+//
+//  Enumerated.swift
+//  RxSwift
+//
+//  Created by Krunoslav Zaher on 8/6/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+extension ObservableType {
+
+    /**
+     Enumerates the elements of an observable sequence.
+
+     - seealso: [map operator on reactivex.io](http://reactivex.io/documentation/operators/map.html)
+
+     - returns: An observable sequence that contains tuples of source sequence elements and their indexes.
+     */
+    public func enumerated()
+        -> Observable<(index: Int, element: E)> {
+        return Enumerated(source: self.asObservable())
+    }
+}
+
+final fileprivate class EnumeratedSink<Element, O : ObserverType>: Sink<O>, ObserverType where O.E == (index: Int, element: Element) {
+    typealias E = Element
+    var index = 0
+    
+    func on(_ event: Event<Element>) {
+        switch event {
+        case .next(let value):
+            do {
+                let nextIndex = try incrementChecked(&index)
+                let next = (index: nextIndex, element: value)
+                forwardOn(.next(next))
+            }
+            catch let e {
+                forwardOn(.error(e))
+                dispose()
+            }
+        case .completed:
+            forwardOn(.completed)
+            dispose()
+        case .error(let error):
+            forwardOn(.error(error))
+            dispose()
+        }
+    }
+}
+
+final fileprivate class Enumerated<Element> : Producer<(index: Int, element: Element)> {
+    private let _source: Observable<Element>
+
+    init(source: Observable<Element>) {
+        _source = source
+    }
+
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == (index: Int, element: Element) {
+        let sink = EnumeratedSink<Element, O>(observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+}

--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -21,19 +21,6 @@ extension ObservableType {
         -> Observable<R> {
         return self.asObservable().composeMap(transform)
     }
-
-    /**
-     Projects each element of an observable sequence into a new form by incorporating the element's index.
-
-     - seealso: [map operator on reactivex.io](http://reactivex.io/documentation/operators/map.html)
-
-     - parameter selector: A transform function to apply to each source element; the second parameter of the function represents the index of the source element.
-     - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
-     */
-    public func mapWithIndex<R>(_ selector: @escaping (E, Int) throws -> R)
-        -> Observable<R> {
-        return MapWithIndex(source: asObservable(), selector: selector)
-    }
 }
 
 final fileprivate class MapSink<SourceType, O : ObserverType> : Sink<O>, ObserverType {
@@ -67,62 +54,6 @@ final fileprivate class MapSink<SourceType, O : ObserverType> : Sink<O>, Observe
             forwardOn(.completed)
             dispose()
         }
-    }
-}
-
-final fileprivate class MapWithIndexSink<SourceType, O : ObserverType> : Sink<O>, ObserverType {
-    typealias Selector = (SourceType, Int) throws -> ResultType
-
-    typealias ResultType = O.E
-    typealias Element = SourceType
-    typealias Parent = MapWithIndex<SourceType, ResultType>
-    
-    private let _selector: Selector
-
-    private var _index = 0
-
-    init(selector: @escaping Selector, observer: O, cancel: Cancelable) {
-        _selector = selector
-        super.init(observer: observer, cancel: cancel)
-    }
-
-    func on(_ event: Event<SourceType>) {
-        switch event {
-        case .next(let element):
-            do {
-                let mappedElement = try _selector(element, try incrementChecked(&_index))
-                forwardOn(.next(mappedElement))
-            }
-            catch let e {
-                forwardOn(.error(e))
-                dispose()
-            }
-        case .error(let error):
-            forwardOn(.error(error))
-            dispose()
-        case .completed:
-            forwardOn(.completed)
-            dispose()
-        }
-    }
-}
-
-final fileprivate class MapWithIndex<SourceType, ResultType> : Producer<ResultType> {
-    typealias Selector = (SourceType, Int) throws -> ResultType
-
-    private let _source: Observable<SourceType>
-
-    private let _selector: Selector
-
-    init(source: Observable<SourceType>, selector: @escaping Selector) {
-        _source = source
-        _selector = selector
-    }
-
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == ResultType {
-        let sink = MapWithIndexSink(selector: _selector, observer: observer, cancel: cancel)
-        let subscription = _source.subscribe(sink)
-        return (sink: sink, subscription: subscription)
     }
 }
 

--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -21,18 +21,6 @@ extension ObservableType {
             return FlatMap(source: asObservable(), selector: selector)
     }
 
-    /**
-     Projects each element of an observable sequence to an observable sequence by incorporating the element's index and merges the resulting observable sequences into one observable sequence.
-
-     - seealso: [flatMap operator on reactivex.io](http://reactivex.io/documentation/operators/flatmap.html)
-
-     - parameter selector: A transform function to apply to each element; the second parameter of the function represents the index of the source element.
-     - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
-     */
-    public func flatMapWithIndex<O: ObservableConvertibleType>(_ selector: @escaping (E, Int) throws -> O)
-        -> Observable<O.E> {
-            return FlatMapWithIndex(source: asObservable(), selector: selector)
-    }
 }
 
 extension ObservableType {
@@ -367,22 +355,6 @@ fileprivate final class FlatMapSink<SourceElement, SourceSequence: ObservableCon
     }
 }
 
-fileprivate final class FlatMapWithIndexSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.E == SourceSequence.E {
-    typealias Selector = (SourceElement, Int) throws -> SourceSequence
-
-    private var _index = 0
-    private let _selector: Selector
-
-    init(selector: @escaping Selector, observer: Observer, cancel: Cancelable) {
-        _selector = selector
-        super.init(observer: observer, cancel: cancel)
-    }
-
-    override func performMap(_ element: SourceElement) throws -> SourceSequence {
-        return try _selector(element, try incrementChecked(&_index))
-    }
-}
-
 // MARK: FlatMapFirst
 
 fileprivate final class FlatMapFirstSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.E == SourceSequence.E {
@@ -560,26 +532,6 @@ final fileprivate class FlatMap<SourceElement, SourceSequence: ObservableConvert
         let subscription = sink.run(_source)
         return (sink: sink, subscription: subscription)
     }
-}
-
-final fileprivate class FlatMapWithIndex<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.E> {
-    typealias Selector = (SourceElement, Int) throws -> SourceSequence
-
-    private let _source: Observable<SourceElement>
-    
-    private let _selector: Selector
-
-    init(source: Observable<SourceElement>, selector: @escaping Selector) {
-        _source = source
-        _selector = selector
-    }
-    
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == SourceSequence.E {
-        let sink = FlatMapWithIndexSink<SourceElement, SourceSequence, O>(selector: _selector, observer: observer, cancel: cancel)
-        let subscription = sink.run(_source)
-        return (sink: sink, subscription: subscription)
-    }
-
 }
 
 final fileprivate class FlatMapFirst<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.E> {

--- a/RxSwift/Observables/SkipWhile.swift
+++ b/RxSwift/Observables/SkipWhile.swift
@@ -19,19 +19,6 @@ extension ObservableType {
     public func skipWhile(_ predicate: @escaping (E) throws -> Bool) -> Observable<E> {
         return SkipWhile(source: asObservable(), predicate: predicate)
     }
-
-    /**
-     Bypasses elements in an observable sequence as long as a specified condition is true and then returns the remaining elements.
-     The element's index is used in the logic of the predicate function.
-
-     - seealso: [skipWhile operator on reactivex.io](http://reactivex.io/documentation/operators/skipwhile.html)
-
-     - parameter predicate: A function to test each element for a condition; the second parameter of the function represents the index of the source element.
-     - returns: An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
-     */
-    public func skipWhileWithIndex(_ predicate: @escaping (E, Int) throws -> Bool) -> Observable<E> {
-        return SkipWhile(source: asObservable(), predicate: predicate)
-    }
 }
 
 final fileprivate class SkipWhileSink<O: ObserverType> : Sink<O>, ObserverType {
@@ -70,74 +57,21 @@ final fileprivate class SkipWhileSink<O: ObserverType> : Sink<O>, ObserverType {
     }
 }
 
-final fileprivate class SkipWhileSinkWithIndex<O: ObserverType> : Sink<O>, ObserverType {
-
-    typealias Element = O.E
-    typealias Parent = SkipWhile<Element>
-
-    fileprivate let _parent: Parent
-    fileprivate var _index = 0
-    fileprivate var _running = false
-
-    init(parent: Parent, observer: O, cancel: Cancelable) {
-        _parent = parent
-        super.init(observer: observer, cancel: cancel)
-    }
-
-    func on(_ event: Event<Element>) {
-        switch event {
-        case .next(let value):
-            if !_running {
-                do {
-                    _running = try !_parent._predicateWithIndex(value, _index)
-                    let _ = try incrementChecked(&_index)
-                } catch let e {
-                    forwardOn(.error(e))
-                    dispose()
-                    return
-                }
-            }
-
-            if _running {
-                forwardOn(.next(value))
-            }
-        case .error, .completed:
-            forwardOn(event)
-            dispose()
-        }
-    }
-}
-
 final fileprivate class SkipWhile<Element>: Producer<Element> {
     typealias Predicate = (Element) throws -> Bool
     typealias PredicateWithIndex = (Element, Int) throws -> Bool
 
     fileprivate let _source: Observable<Element>
-    fileprivate let _predicate: Predicate!
-    fileprivate let _predicateWithIndex: PredicateWithIndex!
+    fileprivate let _predicate: Predicate
 
     init(source: Observable<Element>, predicate: @escaping Predicate) {
         _source = source
         _predicate = predicate
-        _predicateWithIndex = nil
-    }
-
-    init(source: Observable<Element>, predicate: @escaping PredicateWithIndex) {
-        _source = source
-        _predicate = nil
-        _predicateWithIndex = predicate
     }
 
     override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
-        if let _ = _predicate {
-            let sink = SkipWhileSink(parent: self, observer: observer, cancel: cancel)
-            let subscription = _source.subscribe(sink)
-            return (sink: sink, subscription: subscription)
-        }
-        else {
-            let sink = SkipWhileSinkWithIndex(parent: self, observer: observer, cancel: cancel)
-            let subscription = _source.subscribe(sink)
-            return (sink: sink, subscription: subscription)
-        }
+        let sink = SkipWhileSink(parent: self, observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
     }
 }

--- a/RxSwift/Observables/TakeWhile.swift
+++ b/RxSwift/Observables/TakeWhile.swift
@@ -20,21 +20,6 @@ extension ObservableType {
         -> Observable<E> {
         return TakeWhile(source: asObservable(), predicate: predicate)
     }
-
-    /**
-     Returns elements from an observable sequence as long as a specified condition is true.
-
-     The element's index is used in the logic of the predicate function.
-
-     - seealso: [takeWhile operator on reactivex.io](http://reactivex.io/documentation/operators/takewhile.html)
-
-     - parameter predicate: A function to test each element for a condition; the second parameter of the function represents the index of the source element.
-     - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test no longer passes.
-     */
-    public func takeWhileWithIndex(_ predicate: @escaping (E, Int) throws -> Bool)
-        -> Observable<E> {
-        return TakeWhile(source: asObservable(), predicate: predicate)
-    }
 }
 
 final fileprivate class TakeWhileSink<O: ObserverType>
@@ -81,81 +66,20 @@ final fileprivate class TakeWhileSink<O: ObserverType>
     
 }
 
-final fileprivate class TakeWhileSinkWithIndex<O: ObserverType>
-    : Sink<O>
-    , ObserverType {
-    typealias Element = O.E
-    typealias Parent = TakeWhile<Element>
-    
-    fileprivate let _parent: Parent
-    
-    fileprivate var _running = true
-    fileprivate var _index = 0
-    
-    init(parent: Parent, observer: O, cancel: Cancelable) {
-        _parent = parent
-        super.init(observer: observer, cancel: cancel)
-    }
-    
-    func on(_ event: Event<Element>) {
-        switch event {
-        case .next(let value):
-            if !_running {
-                return
-            }
-            
-            do {
-                _running = try _parent._predicateWithIndex(value, _index)
-                let _ = try incrementChecked(&_index)
-            } catch let e {
-                forwardOn(.error(e))
-                dispose()
-                return
-            }
-            
-            if _running {
-                forwardOn(.next(value))
-            } else {
-                forwardOn(.completed)
-                dispose()
-            }
-        case .error, .completed:
-            forwardOn(event)
-            dispose()
-        }
-    }
-    
-}
-
 final fileprivate class TakeWhile<Element>: Producer<Element> {
     typealias Predicate = (Element) throws -> Bool
-    typealias PredicateWithIndex = (Element, Int) throws -> Bool
 
     fileprivate let _source: Observable<Element>
-    fileprivate let _predicate: Predicate!
-    fileprivate let _predicateWithIndex: PredicateWithIndex!
+    fileprivate let _predicate: Predicate
 
     init(source: Observable<Element>, predicate: @escaping Predicate) {
         _source = source
         _predicate = predicate
-        _predicateWithIndex = nil
     }
-    
-    init(source: Observable<Element>, predicate: @escaping PredicateWithIndex) {
-        _source = source
-        _predicate = nil
-        _predicateWithIndex = predicate
-    }
-    
+
     override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
-        if let _ = _predicate {
-            let sink = TakeWhileSink(parent: self, observer: observer, cancel: cancel)
-            let subscription = _source.subscribe(sink)
-            return (sink: sink, subscription: subscription)
-        } else {
-            let sink = TakeWhileSinkWithIndex(parent: self, observer: observer, cancel: cancel)
-            let subscription = _source.subscribe(sink)
-            return (sink: sink, subscription: subscription)
-        }
+        let sink = TakeWhileSink(parent: self, observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
     }
 }

--- a/Sources/AllTestz/Observable+EnumeratedTests.swift
+++ b/Sources/AllTestz/Observable+EnumeratedTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Observable+EnumeratedTests.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -504,6 +504,20 @@ final class RecursiveLockTests_ : RecursiveLockTests, RxTestCase {
     ] }
 }
 
+final class ObservableEnumeratedTest_ : ObservableEnumeratedTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableEnumeratedTest_) -> () -> ())] { return [
+    ("test_Infinite", ObservableEnumeratedTest.test_Infinite),
+    ("test_Completed", ObservableEnumeratedTest.test_Completed),
+    ("test_Error", ObservableEnumeratedTest.test_Error),
+    ] }
+}
+
 final class QueueTest_ : QueueTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1822,6 +1836,7 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(DisposableTest_.allTests),
         testCase(CompletableAndThenTest_.allTests),
         testCase(RecursiveLockTests_.allTests),
+        testCase(ObservableEnumeratedTest_.allTests),
         testCase(QueueTest_.allTests),
         testCase(ObservableSequenceTest_.allTests),
         testCase(DriverTest_.allTests),

--- a/Sources/RxSwift/Enumerated.swift
+++ b/Sources/RxSwift/Enumerated.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/Enumerated.swift

--- a/Tests/RxSwiftTests/Observable+EnumeratedTests.swift
+++ b/Tests/RxSwiftTests/Observable+EnumeratedTests.swift
@@ -54,9 +54,9 @@ extension ObservableEnumeratedTest {
         }
 
         XCTAssertArraysEqual(res.events, [
-            next(210, (0, "a")),
-            next(220, (1, "b")),
-            next(280, (2, "c")),
+            next(210, (index: 0, element: "a")),
+            next(220, (index: 1, element: "b")),
+            next(280, (index: 2, element: "c")),
             completed(300)
         ] as [Recorded<Event<(index: Int, element: String)>>], compareRecordedEvents)
 
@@ -80,9 +80,9 @@ extension ObservableEnumeratedTest {
         }
 
         XCTAssertArraysEqual(res.events, [
-            next(210, (0, "a")),
-            next(220, (1, "b")),
-            next(280, (2, "c")),
+            next(210, (index: 0, element: "a")),
+            next(220, (index: 1, element: "b")),
+            next(280, (index: 2, element: "c")),
             error(300, testError)
             ] as [Recorded<Event<(index: Int, element: String)>>], compareRecordedEvents)
 

--- a/Tests/RxSwiftTests/Observable+EnumeratedTests.swift
+++ b/Tests/RxSwiftTests/Observable+EnumeratedTests.swift
@@ -1,0 +1,122 @@
+//
+//  Observable+EnumeratedTests.swift
+//  Tests
+//
+//  Created by Krunoslav Zaher on 8/6/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+class ObservableEnumeratedTest : RxTest {
+}
+
+extension ObservableEnumeratedTest {
+
+    func test_Infinite() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(210, "a"),
+            next(220, "b"),
+            next(280, "c")
+            ])
+
+        let res = scheduler.start {
+            xs.enumerated()
+        }
+
+        XCTAssertArraysEqual(res.events, [
+            next(210, (index: 0, element: "a")),
+            next(220, (index: 1, element: "b")),
+            next(280, (index: 2, element: "c"))
+        ] as [Recorded<Event<(index: Int, element: String)>>], compareRecordedEvents)
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 1000)
+            ])
+    }
+
+    func test_Completed() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(210, "a"),
+            next(220, "b"),
+            next(280, "c"),
+            completed(300)
+            ])
+
+        let res = scheduler.start {
+            xs.enumerated()
+        }
+
+        XCTAssertArraysEqual(res.events, [
+            next(210, (0, "a")),
+            next(220, (1, "b")),
+            next(280, (2, "c")),
+            completed(300)
+        ] as [Recorded<Event<(index: Int, element: String)>>], compareRecordedEvents)
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 300)
+            ])
+    }
+
+    func test_Error() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(210, "a"),
+            next(220, "b"),
+            next(280, "c"),
+            error(300, testError)
+            ])
+
+        let res = scheduler.start {
+            xs.enumerated()
+        }
+
+        XCTAssertArraysEqual(res.events, [
+            next(210, (0, "a")),
+            next(220, (1, "b")),
+            next(280, (2, "c")),
+            error(300, testError)
+            ] as [Recorded<Event<(index: Int, element: String)>>], compareRecordedEvents)
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 300)
+            ])
+    }
+
+    #if TRACE_RESOURCES
+        func testEnumeratedReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).enumerated().subscribe()
+        }
+
+        func testEnumeratedReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).enumerated().subscribe()
+        }
+    #endif
+}
+
+fileprivate func compareRecordedEvents(lhs: Recorded<Event<(index: Int, element: String)>>, rhs: Recorded<Event<(index: Int, element: String)>>) -> Bool {
+    return lhs.time == rhs.time && { (lhs: Event<(index: Int, element: String)>, rhs: Event<(index: Int, element: String)>) in
+        switch (lhs, rhs) {
+        case (.next(let lhs), .next(let rhs)):
+            return lhs == rhs
+        case (.next, _):
+            return false
+        case (.error(let lhs), .error(let rhs)):
+            return Event<Int>.error(lhs) == Event<Int>.error(rhs)
+        case (.error, _):
+            return false
+        case (.completed, .completed):
+            return true
+        case (.completed, _):
+            return false
+        }
+    }(lhs.value, rhs.value)
+}

--- a/Tests/RxSwiftTests/Observable+GroupByTests.swift
+++ b/Tests/RxSwiftTests/Observable+GroupByTests.swift
@@ -32,7 +32,7 @@ extension ObservableGroupByTest {
         
         let res = scheduler.start { () -> Observable<String> in
             let group: Observable<GroupedObservable<Int, Int>> = xs.groupBy { x in x % 2 }
-            let mappedWithIndex = group.mapWithIndex { (go: GroupedObservable<Int, Int>, i: Int) -> Observable<String> in
+            let mappedWithIndex = group.enumerated().map { (i: Int, go: GroupedObservable<Int, Int>) -> Observable<String> in
                 return go.map { (e: Int) -> String in
                     return "\(i) \(e)"
                 }


### PR DESCRIPTION
We would like to clean up our public interface a bit.

Instead of having:
* `mapWithIndex`
* `flatMapWithIndex`
* `skipWhileWithIndex`
* `takeWhileWithIndex`

we would have single `enumerated` operator equivalent that could be combined with:
* `map`
* `flatMap`
* `skipWhile`
* `takeWhile`

We will mark those operators deprecated in 4.0. I'm curious, is anyone extensively using them?