### PR TITLE
Add rx.touchDown to UIButton

### DIFF
--- a/RxCocoa/iOS/UIButton+Rx.swift
+++ b/RxCocoa/iOS/UIButton+Rx.swift
@@ -15,9 +15,89 @@ import UIKit
 
 extension Reactive where Base: UIButton {
     
+    public var touchDown: ControlEvent<Void> {
+        return controlEvent(.touchDown)
+    }
+    
+    public var touchDownRepeat: ControlEvent<Void> {
+        return controlEvent(.touchDownRepeat)
+    }
+    
+    public var touchDragInside: ControlEvent<Void> {
+        return controlEvent(.touchDragInside)
+    }
+    
+    public var touchDragOutside: ControlEvent<Void> {
+        return controlEvent(.touchDragOutside)
+    }
+    
+    public var touchDragEnter: ControlEvent<Void> {
+        return controlEvent(.touchDragEnter)
+    }
+    
+    public var touchDragExit: ControlEvent<Void> {
+        return controlEvent(.touchDragExit)
+    }
+    
+    public var touchUpInside: ControlEvent<Void> {
+        return controlEvent(.touchUpInside)
+    }
+    
     /// Reactive wrapper for `TouchUpInside` control event.
     public var tap: ControlEvent<Void> {
         return controlEvent(.touchUpInside)
+    }
+    
+    public var touchUpOutside: ControlEvent<Void> {
+        return controlEvent(.touchUpOutside)
+    }
+    
+    public var touchCancel: ControlEvent<Void> {
+        return controlEvent(.touchCancel)
+    }
+    
+    public var valueChanged: ControlEvent<Void> {
+        return controlEvent(.valueChanged)
+    }
+    
+    public var primaryActionTriggered: ControlEvent<Void> {
+        return controlEvent(.primaryActionTriggered)
+    }
+    
+    public var editingDidBegin: ControlEvent<Void> {
+        return controlEvent(.editingDidBegin)
+    }
+    
+    public var editingChanged: ControlEvent<Void> {
+        return controlEvent(.editingChanged)
+    }
+    
+    public var editingDidEnd: ControlEvent<Void> {
+        return controlEvent(.editingDidEnd)
+    }
+    
+    public var editingDidEndOnExit: ControlEvent<Void> {
+        return controlEvent(.editingDidEndOnExit)
+    }
+    
+    public var allTouchEvents: ControlEvent<Void> {
+        return controlEvent(.allTouchEvents)
+    }
+    
+    public var allEditingEvents: ControlEvent<Void> {
+        return controlEvent(.allEditingEvents)
+    }
+    
+    public var applicationReserved: ControlEvent<Void> {
+        return controlEvent(.applicationReserved)
+    }
+    
+    public var systemReserved: ControlEvent<Void> {
+        return controlEvent(.systemReserved)
+    }
+    
+    public var allEvents: ControlEvent<Void> {
+        return controlEvent(.allEvents)
     }
 }
 


### PR DESCRIPTION
**Proposal**:
Currently, only `rx.tap` is implemented for `UIButton`. The _tap_ terminology is too vague. 
I think it's better to implement all UIControlEvents like `touchDown, touchUpInside, touchUpOutside` etc. 