### PR TITLE
New materialize() operator over `BlockingObservable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 * Adds `UIScrollView.willEndDragging` extension. #1365
+* Adds `materialize()` operator for RxBlocking's `BlockingObservable`. #1383
 
 ## [3.6.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.6.1)
 

--- a/Documentation/UnitTests.md
+++ b/Documentation/UnitTests.md
@@ -86,7 +86,7 @@ It's easy to define `RxTests` extensions so you can write your tests in a readab
 
 It is also possible to write integration tests by using `RxBlocking` operators.
 
-Importing operators from the `RxBlocking` library will enable blocking the current thread and wait for sequence results.
+Using `RxBlocking`'s `toBlocking()` method, you can block the current thread and wait for the sequence to complete, allowing you to synchronously access its result.
 
 A simple way to test the result of your sequence is using the `toArray` method. It will return an array of all elements emitted once a sequence has completed successfully, or `throw` if an error caused the sequence to terminate.
 
@@ -98,7 +98,7 @@ let result = try fetchResource(location)
 XCTAssertEqual(result, expectedResult)
 ```
 
-Another option is to use the `materialize` operator which allows you to more granularly examine your sequence. It will return a `MaterializedSequenceResult` enumeration that could be either `.completed` along with the emitted elements if the sequence completed successfully, or `failed` if the sequence terminated with an error, along with the emitted error.
+Another option would be to use the `materialize` operator which lets you more granularly examine your sequence. It will return a `MaterializedSequenceResult` enumeration that could be either `.completed` along with the emitted elements if the sequence completed successfully, or `failed` if the sequence terminated with an error, along with the emitted error.
 
 ```swift
 let result = try fetchResource(location)

--- a/Documentation/UnitTests.md
+++ b/Documentation/UnitTests.md
@@ -88,10 +88,28 @@ It is also possible to write integration tests by using `RxBlocking` operators.
 
 Importing operators from `RxBlocking` library will enable blocking the current thread and wait for sequence results.
 
+If the squence succeeds, you can extract the array of results using `toArray()`, or `throw` if there's an error.
+
 ```swift
 let result = try fetchResource(location)
         .toBlocking()
         .toArray()
 
 XCTAssertEqual(result, expectedResult)
+```
+
+To extract a result representing the array of results _and_ an error if it occurred, the `materialize()` extension can be used.
+
+```swift
+let result = try fetchResource(location)
+        .toBlocking()
+        .materialize()
+
+switch result {
+        case .completed:
+            XCTFail("Expected result to be complete eith error, but result was successful.")
+        case .failed(let elements, let error):
+            XCTAssertEqual(elements, expectedResult)
+            XCTAssertErrorEqual(error, expectedError)
+        }
 ```

--- a/Documentation/UnitTests.md
+++ b/Documentation/UnitTests.md
@@ -86,9 +86,9 @@ It's easy to define `RxTests` extensions so you can write your tests in a readab
 
 It is also possible to write integration tests by using `RxBlocking` operators.
 
-Importing operators from `RxBlocking` library will enable blocking the current thread and wait for sequence results.
+Importing operators from the `RxBlocking` library will enable blocking the current thread and wait for sequence results.
 
-If the squence succeeds, you can extract the array of results using `toArray()`, or `throw` if there's an error.
+A simple way to test the result of your sequence is using the `toArray` method. It will return an array of all elements emitted once a sequence has completed successfully, or `throw` if an error caused the sequence to terminate.
 
 ```swift
 let result = try fetchResource(location)
@@ -98,7 +98,7 @@ let result = try fetchResource(location)
 XCTAssertEqual(result, expectedResult)
 ```
 
-To extract a result representing the array of results _and_ an error if it occurred, the `materialize()` extension can be used.
+Another option is to use the `materialize` operator which allows you to more granularly examine your sequence. It will return a `MaterializedSequenceResult` enumeration that could be either `.completed` along with the emitted elements if the sequence completed successfully, or `failed` if the sequence terminated with an error, along with the emitted error.
 
 ```swift
 let result = try fetchResource(location)

--- a/Documentation/UnitTests.md
+++ b/Documentation/UnitTests.md
@@ -105,11 +105,20 @@ let result = try fetchResource(location)
         .toBlocking()
         .materialize()
 
+// For testing the results or error in the case of terminating with error
 switch result {
         case .completed:
-            XCTFail("Expected result to be complete eith error, but result was successful.")
+            XCTFail("Expected result to complete with error, but result was successful.")
         case .failed(let elements, let error):
             XCTAssertEqual(elements, expectedResult)
             XCTAssertErrorEqual(error, expectedError)
+        }
+
+// For testing the results in the case of termination with completion
+switch result {
+        case .completed(let elements):
+            XCTAssertEqual(elements, expectedResult)
+        case .failed(_, let error):
+            XCTFail("Expected result to complete without error, but received \(error).")
         }
 ```

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -10,6 +10,14 @@
     import RxSwift
 #endif
 
+/// The `MaterializedSequenceResult` enum represents the materialized
+/// output of a BlockingObservable.
+///
+/// If the sequence terminates successfully, the result is represented
+/// by `.completed` with the array of elements.
+///
+/// If the sequene terminates with error, the result is represented
+/// by `.failed` with both the array of elements and the terminating error.
 public enum MaterializedSequenceResult<T> {
     case completed(elements: [T])
     case failed(elements: [T], error: Error)

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -10,7 +10,7 @@
     import RxSwift
 #endif
 
-public enum SequenceMaterializeResult<T> {
+public enum MaterializedSequenceResult<T> {
     case completed(elements: [T])
     case failed(elements: [T], error: Error)
 }
@@ -88,13 +88,13 @@ extension BlockingObservable {
     /// The sequence is materialized as a result type capturing how the sequence terminated (completed or error), along with any elements up to that point.
     ///
     /// - returns: On completion, returns the list of elements in the sequence. On error, returns the list of elements up to that point, along with the error itself.
-    public func materialize() -> SequenceMaterializeResult<E> {
+    public func materialize() -> MaterializedSequenceResult<E> {
         return materializeResult()
     }
 }
 
 extension BlockingObservable {
-    fileprivate func materializeResult(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) -> SequenceMaterializeResult<E> {
+    fileprivate func materializeResult(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) -> MaterializedSequenceResult<E> {
         var elements: [E] = Array<E>()
         var error: Swift.Error?
         
@@ -146,13 +146,13 @@ extension BlockingObservable {
         }
         
         if let error = error {
-            return SequenceMaterializeResult.failed(elements: elements, error: error)
+            return MaterializedSequenceResult.failed(elements: elements, error: error)
         }
         
-        return SequenceMaterializeResult.completed(elements: elements)
+        return MaterializedSequenceResult.completed(elements: elements)
     }
     
-    fileprivate func elementsOrThrow(_ results: SequenceMaterializeResult<E>) throws -> [E] {
+    fileprivate func elementsOrThrow(_ results: MaterializedSequenceResult<E>) throws -> [E] {
         switch results {
         case .failed(_, let error):
             throw error

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -10,6 +10,11 @@
     import RxSwift
 #endif
 
+enum SequenceMaterializeResult<T> {
+    case completed(elements: [T])
+    case failed(elements: [T], error: Error)
+}
+
 extension BlockingObservable {
     /// Blocks current thread until sequence terminates.
     ///
@@ -17,7 +22,8 @@ extension BlockingObservable {
     ///
     /// - returns: All elements of sequence.
     public func toArray() throws -> [E] {
-        return try convertToArray()
+        let results = convertToArray()
+        return try elementsOrThrow(results)
     }
 }
 
@@ -28,7 +34,8 @@ extension BlockingObservable {
     ///
     /// - returns: First element of sequence. If sequence is empty `nil` is returned.
     public func first() throws -> E? {
-        return try convertToArray(max: 1).first
+        let results = convertToArray(max: 1)
+        return try elementsOrThrow(results).first
     }
 }
 
@@ -39,7 +46,8 @@ extension BlockingObservable {
     ///
     /// - returns: Last element in the sequence. If sequence is empty `nil` is returned.
     public func last() throws -> E? {
-        return try convertToArray().last
+        let results = convertToArray()
+        return try elementsOrThrow(results).last
     }
 }
 
@@ -60,7 +68,8 @@ extension BlockingObservable {
     /// - parameter predicate: A function to test each source element for a condition.
     /// - returns: Returns the only element of an sequence that satisfies the condition in the predicate, and reports an error if there is not exactly one element in the sequence.
     public func single(_ predicate: @escaping (E) throws -> Bool) throws -> E? {
-        let elements = try convertToArray(max: 2, predicate: predicate)
+        let results = convertToArray(max: 2, predicate: predicate)
+        let elements = try elementsOrThrow(results)
         
         switch elements.count {
         case 0:
@@ -74,9 +83,8 @@ extension BlockingObservable {
 }
 
 extension BlockingObservable {
-    fileprivate func convertToArray(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) throws -> [E] {
+    fileprivate func convertToArray(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) -> SequenceMaterializeResult<E> {
         var elements: [E] = Array<E>()
-        
         var error: Swift.Error?
         
         let lock = RunLoopLock(timeout: timeout)
@@ -127,9 +135,18 @@ extension BlockingObservable {
         }
         
         if let error = error {
-            throw error
+            return SequenceMaterializeResult.failed(elements: elements, error: error)
         }
         
-        return elements
+        return SequenceMaterializeResult.completed(elements: elements)
+    }
+    
+    fileprivate func elementsOrThrow(_ results: SequenceMaterializeResult<E>) throws -> [E] {
+        switch results {
+        case .failed(_, let error):
+            throw error
+        case .completed(let elements):
+            return elements
+        }
     }
 }

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -22,7 +22,7 @@ extension BlockingObservable {
     ///
     /// - returns: All elements of sequence.
     public func toArray() throws -> [E] {
-        let results = convertToArray()
+        let results = materializeResult()
         return try elementsOrThrow(results)
     }
 }
@@ -34,7 +34,7 @@ extension BlockingObservable {
     ///
     /// - returns: First element of sequence. If sequence is empty `nil` is returned.
     public func first() throws -> E? {
-        let results = convertToArray(max: 1)
+        let results = materializeResult(max: 1)
         return try elementsOrThrow(results).first
     }
 }
@@ -46,7 +46,7 @@ extension BlockingObservable {
     ///
     /// - returns: Last element in the sequence. If sequence is empty `nil` is returned.
     public func last() throws -> E? {
-        let results = convertToArray()
+        let results = materializeResult()
         return try elementsOrThrow(results).last
     }
 }
@@ -68,7 +68,7 @@ extension BlockingObservable {
     /// - parameter predicate: A function to test each source element for a condition.
     /// - returns: Returns the only element of an sequence that satisfies the condition in the predicate, and reports an error if there is not exactly one element in the sequence.
     public func single(_ predicate: @escaping (E) throws -> Bool) throws -> E? {
-        let results = convertToArray(max: 2, predicate: predicate)
+        let results = materializeResult(max: 2, predicate: predicate)
         let elements = try elementsOrThrow(results)
         
         switch elements.count {
@@ -89,12 +89,12 @@ extension BlockingObservable {
     ///
     /// - returns: On completion, returns the list of elements in the sequence. On error, returns the list of elements up to that point, along with the error itself.
     public func materialize() -> SequenceMaterializeResult<E> {
-        return convertToArray()
+        return materializeResult()
     }
 }
 
 extension BlockingObservable {
-    fileprivate func convertToArray(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) -> SequenceMaterializeResult<E> {
+    fileprivate func materializeResult(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) -> SequenceMaterializeResult<E> {
         var elements: [E] = Array<E>()
         var error: Swift.Error?
         

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -10,7 +10,7 @@
     import RxSwift
 #endif
 
-enum SequenceMaterializeResult<T> {
+public enum SequenceMaterializeResult<T> {
     case completed(elements: [T])
     case failed(elements: [T], error: Error)
 }
@@ -79,6 +79,17 @@ extension BlockingObservable {
         default:
             throw RxError.moreThanOneElement
         }
+    }
+}
+
+extension BlockingObservable {
+    /// Blocks current thread until sequence terminates.
+    ///
+    /// The sequence is materialized as a result type capturing how the sequence terminated (completed or error), along with any elements up to that point.
+    ///
+    /// - returns: On completion, returns the list of elements in the sequence. On error, returns the list of elements up to that point, along with the error itself.
+    public func materialize() -> SequenceMaterializeResult<E> {
+        return convertToArray()
     }
 }
 

--- a/RxBlocking/README.md
+++ b/RxBlocking/README.md
@@ -23,6 +23,10 @@ extension BlockingObservable {
     public func single() throws -> E? {}
     public func single(_ predicate: @escaping (E) throws -> Bool) throws -> E? {}
 }
+
+extension BlockingObservable {
+    public func materialize() -> MaterializedSequenceResult<E>
+}
 ```
 
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -238,6 +238,10 @@ final class ObservableBlockingTest_ : ObservableBlockingTest, RxTestCase {
     ("testSingle_independent", ObservableBlockingTest.testSingle_independent),
     ("testSingle_timeout", ObservableBlockingTest.testSingle_timeout),
     ("testSinglePredicate_timeout", ObservableBlockingTest.testSinglePredicate_timeout),
+    ("testMaterialize_empty", ObservableBlockingTest.testMaterialize_empty),
+    ("testMaterialize_empty_fail", ObservableBlockingTest.testMaterialize_empty_fail),
+    ("testMaterialize_someData", ObservableBlockingTest.testMaterialize_someData),
+    ("testMaterialize_someData_fail", ObservableBlockingTest.testMaterialize_someData_fail),
     ] }
 }
 

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -337,3 +337,54 @@ extension ObservableBlockingTest {
         }
     }
 }
+
+// materialize
+
+extension ObservableBlockingTest {
+    func testMaterialize_empty() {
+        let result = Observable<Int>.empty().toBlocking().materialize()
+        
+        switch result {
+        case .completed(let elements):
+            XCTAssertEqual(elements, [])
+        case .failed:
+            XCTFail("Expected result to be complete successfully, but result was failed.")
+        }
+    }
+    
+    func testMaterialize_empty_fail() {
+        let result = Observable<Int>.error(testError).toBlocking().materialize()
+        
+        switch result {
+        case .completed:
+            XCTFail("Expected result to be complete eith error, but result was successful.")
+        case .failed(let elements, let error):
+            XCTAssertEqual(elements, [])
+            XCTAssertErrorEqual(error, testError)
+        }
+    }
+    
+    func testMaterialize_someData() {
+        let result = Observable.of(42, 43, 44, 45).toBlocking().materialize()
+        
+        switch result {
+        case .completed(let elements):
+            XCTAssertEqual(elements, [42, 43, 44, 45])
+        case .failed:
+            XCTFail("Expected result to be complete successfully, but result was failed.")
+        }
+    }
+    
+    func testMaterialize_someData_fail() {
+        let sequence = Observable.concat(Observable.of(42, 43, 44, 45), Observable<Int>.error(testError))
+        let result = sequence.toBlocking().materialize()
+        
+        switch result {
+        case .completed:
+            XCTFail("Expected result to be complete eith error, but result was successful.")
+        case .failed(let elements, let error):
+            XCTAssertEqual(elements, [42, 43, 44, 45])
+            XCTAssertErrorEqual(error, testError)
+        }
+    }
+}


### PR DESCRIPTION
This is based on a discussion in #1355 and on previous changes in #1354.

We introduce new extension to `BlockingObservable` called `materialize()` which returns a result type capturing the completed/failed status of the sequence, along with and elements and the error. The result type looks like this:

```
public enum SequenceMaterializeResult<T> {
    case completed(elements: [T])
    case failed(elements: [T], error: Error)
}
```

Internally, the rest of the `BlockingObservable+Operators` use `SequenceMaterializeResult`, and only `throw` at the last minute if an unexpected error occurs. This is mostly to maintain a backwards compatible interface for the existing operators, so it's a non-breaking change.