### PR TITLE
Add a possibility to use XCTAssertEqual with elements of type [Record…

### DIFF
--- a/RxTest/Event+Equatable.swift
+++ b/RxTest/Event+Equatable.swift
@@ -36,6 +36,29 @@ public func == <Element: Equatable>(lhs: Event<Element>, rhs: Event<Element>) ->
 ///
 /// In case `Error` events are being compared, they are equal in case their `NSError` representations are equal (domain and code)
 /// and their string representations are equal.
+public func == <Element: Equatable>(lhs: Event<[Element]>, rhs: Event<[Element]>) -> Bool {
+    switch (lhs, rhs) {
+    case (.completed, .completed): return true
+    case (.error(let e1), .error(let e2)):
+        #if os(Linux)
+            return  "\(e1)" == "\(e2)"
+        #else
+            let error1 = e1 as NSError
+            let error2 = e2 as NSError
+            
+            return error1.domain == error2.domain
+                && error1.code == error2.code
+                && "\(e1)" == "\(e2)"
+        #endif
+    case (.next(let v1), .next(let v2)): return v1 == v2
+    default: return false
+    }
+}
+
+/// Compares two events. They are equal if they are both the same member of `Event` enumeration.
+///
+/// In case `Error` events are being compared, they are equal in case their `NSError` representations are equal (domain and code)
+/// and their string representations are equal.
 public func == <Element: Equatable>(lhs: SingleEvent<Element>, rhs: SingleEvent<Element>) -> Bool {
     switch (lhs, rhs) {
     case (.error(let e1), .error(let e2)):

--- a/RxTest/Recorded.swift
+++ b/RxTest/Recorded.swift
@@ -39,3 +39,7 @@ public func == <T: Equatable>(lhs: Recorded<T>, rhs: Recorded<T>) -> Bool {
 public func == <T: Equatable>(lhs: Recorded<Event<T>>, rhs: Recorded<Event<T>>) -> Bool {
     return lhs.time == rhs.time && lhs.value == rhs.value
 }
+
+public func == <T: Equatable>(lhs: Recorded<Event<[T]>>, rhs: Recorded<Event<[T]>>) -> Bool {
+    return lhs.time == rhs.time && lhs.value == rhs.value
+}

--- a/RxTest/XCTest+Rx.swift
+++ b/RxTest/XCTest+Rx.swift
@@ -179,6 +179,36 @@ public func XCTAssertEqual<T: Equatable>(_ lhs: [Recorded<Event<T>>], _ rhs: [Re
     printSequenceDifferences(lhs, rhs, ==)
 }
 
+/**
+ Asserts two lists of Recorded events are equal.
+ 
+ Recorded events are equal if times are equal and recoreded events are equal.
+ 
+ Event is considered equal if:
+ * `Next` events are equal if they have equal corresponding elements.
+ * `Error` events are equal if errors have same domain and code for `NSError` representation and have equal descriptions.
+ * `Completed` events are always equal.
+ 
+ - parameter lhs: first set of events.
+ - parameter lhs: second set of events.
+ */
+
+public func XCTAssertEqual<T: Equatable>(_ lhs: [Recorded<Event<[T]>>], _ rhs: [Recorded<Event<[T]>>], file: StaticString = #file, line: UInt = #line) {
+    let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }
+    let rightEquatable = rhs.map { AnyEquatable(target: $0, comparer: ==) }
+    #if os(Linux)
+        XCTAssertEqual(leftEquatable, rightEquatable)
+    #else
+        XCTAssertEqual(leftEquatable, rightEquatable, file: file, line: line)
+    #endif
+    
+    if leftEquatable == rightEquatable {
+        return
+    }
+    
+    printSequenceDifferences(lhs, rhs, ==)
+}
+
 func printSequenceDifferences<E>(_ lhs: [E], _ rhs: [E], _ equal: (E, E) -> Bool) {
     print("Differences:")
     for (index, elements) in zip(lhs, rhs).enumerated() {


### PR DESCRIPTION
The problem appears if a stream of events sends arrays. Due to swift 3 limitations it's not possible to write yet
```
extension Array: Equatable where Element: Equatable .
```
Assertion function is unavailable. Check the example below:

```
class FooTests: XCTestCase {
    
    let scheduler = TestScheduler(initialClock: 0)
    let disposeBag = DisposeBag()
       
    func testBar() {
        let observable = Observable.from([[1], [2], [3], [4]])
        let expected = [next(0, [1]), next(0, [2]), next(0, [3]), next(0, [4]), completed(0)]
        let observer = scheduler.createObserver([Int].self)
        observable.subscribe(observer).addDisposableTo(disposeBag)
        scheduler.start()
        XCTAssertEqual(observer.events, expected)
    }
}

```
It rises:

> Cannot invoke 'XCTAssertEqual' with an argument list of type '([Recorded<Event<[Int]>>], [Recorded<Event<[Int]>>])'