### PR TITLE
[WIP] Math Operators - min(), max(), sum()

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -79,7 +79,9 @@ custom_categories:
   - Just
   - Map
   - Materialize
+  - Max
   - Merge
+  - Min
   - Multicast
   - Never
   - ObserveOn
@@ -100,6 +102,7 @@ custom_categories:
   - SkipWhile
   - StartWith
   - SubscribeOn
+  - Sum
   - Switch
   - SwitchIfEmpty
   - Take

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -51,6 +51,13 @@
 		782E80C01F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */; };
 		782E80C11F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */; };
 		782E80C21F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */; };
+		782E80C41F48A22900CDB4D2 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80C31F48A22900CDB4D2 /* Sum.swift */; };
+		782E80C51F48A22900CDB4D2 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80C31F48A22900CDB4D2 /* Sum.swift */; };
+		782E80C61F48A22900CDB4D2 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80C31F48A22900CDB4D2 /* Sum.swift */; };
+		782E80C71F48A22900CDB4D2 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80C31F48A22900CDB4D2 /* Sum.swift */; };
+		782E80C91F48A40100CDB4D2 /* Observable+SumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80C81F48A40100CDB4D2 /* Observable+SumTests.swift */; };
+		782E80CA1F48A40100CDB4D2 /* Observable+SumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80C81F48A40100CDB4D2 /* Observable+SumTests.swift */; };
+		782E80CB1F48A40100CDB4D2 /* Observable+SumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80C81F48A40100CDB4D2 /* Observable+SumTests.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEBE1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
@@ -1715,6 +1722,8 @@
 		782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+MaxTests.swift"; sourceTree = "<group>"; };
 		782E80BA1F48A18E00CDB4D2 /* Min.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Min.swift; sourceTree = "<group>"; };
 		782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+MinTests.swift"; sourceTree = "<group>"; };
+		782E80C31F48A22900CDB4D2 /* Sum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sum.swift; sourceTree = "<group>"; };
+		782E80C81F48A40100CDB4D2 /* Observable+SumTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+SumTests.swift"; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -2476,6 +2485,7 @@
 				C820A7F81EB4DA5900D431BC /* SkipWhile.swift */,
 				C820A8021EB4DA5900D431BC /* StartWith.swift */,
 				C820A8191EB4DA5900D431BC /* SubscribeOn.swift */,
+				782E80C31F48A22900CDB4D2 /* Sum.swift */,
 				C820A7E71EB4DA5900D431BC /* Switch.swift */,
 				C820A80A1EB4DA5900D431BC /* SwitchIfEmpty.swift */,
 				C820A7EE1EB4DA5900D431BC /* Take.swift */,
@@ -2765,6 +2775,7 @@
 				C820A9C51EB50A4200D431BC /* Observable+SkipWhileTests.swift */,
 				C820A9651EB4F39500D431BC /* Observable+SubscribeOnTests.swift */,
 				C83509161C38706D0027C24C /* Observable+SubscriptionTest.swift */,
+				782E80C81F48A40100CDB4D2 /* Observable+SumTests.swift */,
 				C820A9911EB4FD1400D431BC /* Observable+SwitchIfEmptyTests.swift */,
 				C820A98D1EB4FCC400D431BC /* Observable+SwitchTests.swift */,
 				C820A9BD1EB509B500D431BC /* Observable+TakeLastTests.swift */,
@@ -4354,6 +4365,7 @@
 				C8C4F1671DE9D44600003FA7 /* UISegmentedControl+RxTests.swift in Sources */,
 				C820A9661EB4F39500D431BC /* Observable+SubscribeOnTests.swift in Sources */,
 				C820A9EE1EB50EA100D431BC /* Observable+ScanTests.swift in Sources */,
+				782E80C91F48A40100CDB4D2 /* Observable+SumTests.swift in Sources */,
 				C820A96A1EB4F64800D431BC /* Observable+JustTests.swift in Sources */,
 				C820A98E1EB4FCC400D431BC /* Observable+SwitchTests.swift in Sources */,
 				C81B6AAA1DB2C15C0047CF86 /* Platform.Darwin.swift in Sources */,
@@ -4400,6 +4412,7 @@
 				C8C4F1811DE9DF0200003FA7 /* UIScrollView+RxTests.swift in Sources */,
 				54700CA11CE37E1900EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */,
 				C8350A191C38756A0027C24C /* VirtualSchedulerTest.swift in Sources */,
+				782E80CA1F48A40100CDB4D2 /* Observable+SumTests.swift in Sources */,
 				C820A9E71EB50DB900D431BC /* Observable+TimerTests.swift in Sources */,
 				C820A97F1EB4FA5A00D431BC /* Observable+RepeatTests.swift in Sources */,
 				C8C4F1781DE9DF0200003FA7 /* UIActivityIndicatorView+RxTests.swift in Sources */,
@@ -4624,6 +4637,7 @@
 				C8C4F1731DE9D7A300003FA7 /* NSTextField+RxTests.swift in Sources */,
 				C820A9641EB4EFD300D431BC /* Observable+ObserveOnTests.swift in Sources */,
 				C83509E41C3875580027C24C /* MockDisposable.swift in Sources */,
+				782E80CB1F48A40100CDB4D2 /* Observable+SumTests.swift in Sources */,
 				C83509D51C38753E0027C24C /* RxObjCRuntimeState.swift in Sources */,
 				1AF67DA81CED430100C310FA /* ReplaySubjectTest.swift in Sources */,
 				C820A9801EB4FA5A00D431BC /* Observable+RepeatTests.swift in Sources */,
@@ -4693,6 +4707,7 @@
 				C820A8A51EB4DA5A00D431BC /* DistinctUntilChanged.swift in Sources */,
 				C8093CD41B8A72BE0088E94D /* Disposable.swift in Sources */,
 				C820A8351EB4DA5900D431BC /* Delay.swift in Sources */,
+				782E80C51F48A22900CDB4D2 /* Sum.swift in Sources */,
 				C8093CEE1B8A72BE0088E94D /* SingleAssignmentDisposable.swift in Sources */,
 				C849BE2C1BAB5D070019AD27 /* ObservableConvertibleType.swift in Sources */,
 				C8093D9C1B8A72BE0088E94D /* SchedulerServices+Emulation.swift in Sources */,
@@ -4930,6 +4945,7 @@
 				C820A8A41EB4DA5A00D431BC /* DistinctUntilChanged.swift in Sources */,
 				C8093CED1B8A72BE0088E94D /* SingleAssignmentDisposable.swift in Sources */,
 				C820A8341EB4DA5900D431BC /* Delay.swift in Sources */,
+				782E80C41F48A22900CDB4D2 /* Sum.swift in Sources */,
 				C89814781E75A7D70035949C /* PrimitiveSequence+Zip+arity.swift in Sources */,
 				C849BE2B1BAB5D070019AD27 /* ObservableConvertibleType.swift in Sources */,
 				C8093D9B1B8A72BE0088E94D /* SchedulerServices+Emulation.swift in Sources */,
@@ -5091,6 +5107,7 @@
 				C820A8A71EB4DA5A00D431BC /* DistinctUntilChanged.swift in Sources */,
 				C8F0BF961BBBFB8B001B112F /* Disposable.swift in Sources */,
 				C820A8371EB4DA5900D431BC /* Delay.swift in Sources */,
+				782E80C71F48A22900CDB4D2 /* Sum.swift in Sources */,
 				C8F0BF971BBBFB8B001B112F /* SingleAssignmentDisposable.swift in Sources */,
 				C89461751BC6C1210055219D /* ObservableConvertibleType.swift in Sources */,
 				C8F0BF991BBBFB8B001B112F /* SchedulerServices+Emulation.swift in Sources */,
@@ -5452,6 +5469,7 @@
 				C820A8A61EB4DA5A00D431BC /* DistinctUntilChanged.swift in Sources */,
 				C86781761DB8129E00B2029A /* InfiniteSequence.swift in Sources */,
 				C820A8361EB4DA5900D431BC /* Delay.swift in Sources */,
+				782E80C61F48A22900CDB4D2 /* Sum.swift in Sources */,
 				D2EBEB3E1BB9B6D8003A27DC /* SerialDispatchQueueScheduler.swift in Sources */,
 				C89461761BC6C1220055219D /* ObservableConvertibleType.swift in Sources */,
 				D2EBEAF71BB9B6B2003A27DC /* ScheduledDisposable.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -44,6 +44,13 @@
 		782E80B71F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */; };
 		782E80B81F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */; };
 		782E80B91F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */; };
+		782E80BB1F48A18F00CDB4D2 /* Min.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BA1F48A18E00CDB4D2 /* Min.swift */; };
+		782E80BC1F48A18F00CDB4D2 /* Min.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BA1F48A18E00CDB4D2 /* Min.swift */; };
+		782E80BD1F48A18F00CDB4D2 /* Min.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BA1F48A18E00CDB4D2 /* Min.swift */; };
+		782E80BE1F48A18F00CDB4D2 /* Min.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BA1F48A18E00CDB4D2 /* Min.swift */; };
+		782E80C01F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */; };
+		782E80C11F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */; };
+		782E80C21F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEBE1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
@@ -1706,6 +1713,8 @@
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		782E80B11F48A0A200CDB4D2 /* Max.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Max.swift; sourceTree = "<group>"; };
 		782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+MaxTests.swift"; sourceTree = "<group>"; };
+		782E80BA1F48A18E00CDB4D2 /* Min.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Min.swift; sourceTree = "<group>"; };
+		782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+MinTests.swift"; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -2446,6 +2455,7 @@
 				C820A7FD1EB4DA5900D431BC /* Materialize.swift */,
 				782E80B11F48A0A200CDB4D2 /* Max.swift */,
 				C820A7F71EB4DA5900D431BC /* Merge.swift */,
+				782E80BA1F48A18E00CDB4D2 /* Min.swift */,
 				C820A81D1EB4DA5900D431BC /* Multicast.swift */,
 				C820A8161EB4DA5900D431BC /* Never.swift */,
 				C820A81A1EB4DA5900D431BC /* ObserveOn.swift */,
@@ -2737,6 +2747,7 @@
 				C820A9F91EB510D500D431BC /* Observable+MaterializeTests.swift */,
 				782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */,
 				C820A9991EB5001C00D431BC /* Observable+MergeTests.swift */,
+				782E80BF1F48A1A800CDB4D2 /* Observable+MinTests.swift */,
 				C820A9551EB4ED7C00D431BC /* Observable+MulticastTests.swift */,
 				C820A9611EB4EFD300D431BC /* Observable+ObserveOnTests.swift */,
 				C820A9711EB4F84000D431BC /* Observable+OptionalTests.swift */,
@@ -4281,6 +4292,7 @@
 				C820A9F21EB5109300D431BC /* Observable+DefaultIfEmpty.swift in Sources */,
 				C820AA0E1EB5140100D431BC /* Observable+TimeoutTests.swift in Sources */,
 				C8F03F411DBB98DB00AECC4C /* Anomalies.swift in Sources */,
+				782E80C11F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */,
 				C820A9561EB4ED7C00D431BC /* Observable+MulticastTests.swift in Sources */,
 				C820A9E61EB50DB900D431BC /* Observable+TimerTests.swift in Sources */,
 				C8353CE91DA19BC500BE3F5C /* TestErrors.swift in Sources */,
@@ -4482,6 +4494,7 @@
 				C83509DC1C38754C0027C24C /* ElementIndexPair.swift in Sources */,
 				C8845ADB1EDB607800B36836 /* Observable+ShareReplayScopeTests.swift in Sources */,
 				C8350A171C38756A0027C24C /* SubjectConcurrencyTest.swift in Sources */,
+				782E80C01F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */,
 				C83509EA1C3875580027C24C /* BackgroundThreadPrimitiveHotObservable.swift in Sources */,
 				C84CB1721C3876B800EB63CC /* UIView+RxTests.swift in Sources */,
 				C8353CEA1DA19BC500BE3F5C /* TestErrors.swift in Sources */,
@@ -4563,6 +4576,7 @@
 				C820A9981EB4FF7000D431BC /* Observable+ConcatTests.swift in Sources */,
 				C820A9901EB4FCC400D431BC /* Observable+SwitchTests.swift in Sources */,
 				C8845ADC1EDB607800B36836 /* Observable+ShareReplayScopeTests.swift in Sources */,
+				782E80C21F48A1A900CDB4D2 /* Observable+MinTests.swift in Sources */,
 				C834F6C61DB3950600C29244 /* NSControl+RxTests.swift in Sources */,
 				C83509D61C3875420027C24C /* SentMessageTest.swift in Sources */,
 				C81A097F1E6C27A100900B3B /* Observable+ZipTests.swift in Sources */,
@@ -4810,6 +4824,7 @@
 				C820A89D1EB4DA5A00D431BC /* StartWith.swift in Sources */,
 				C820A8FD1EB4DA5A00D431BC /* ObserveOn.swift in Sources */,
 				C8093CF61B8A72BE0088E94D /* Event.swift in Sources */,
+				782E80BE1F48A18F00CDB4D2 /* Min.swift in Sources */,
 				C83D73C51C1DBAEE003DC470 /* ScheduledItem.swift in Sources */,
 				C820A8A91EB4DA5A00D431BC /* WithLatestFrom.swift in Sources */,
 				C867817D1DB8129E00B2029A /* Queue.swift in Sources */,
@@ -5046,6 +5061,7 @@
 				C820A89C1EB4DA5A00D431BC /* StartWith.swift in Sources */,
 				C820A8FC1EB4DA5A00D431BC /* ObserveOn.swift in Sources */,
 				C8093CF51B8A72BE0088E94D /* Event.swift in Sources */,
+				782E80BB1F48A18F00CDB4D2 /* Min.swift in Sources */,
 				C83D73C41C1DBAEE003DC470 /* ScheduledItem.swift in Sources */,
 				C820A8A81EB4DA5A00D431BC /* WithLatestFrom.swift in Sources */,
 				C867817C1DB8129E00B2029A /* Queue.swift in Sources */,
@@ -5206,6 +5222,7 @@
 				C820A89F1EB4DA5A00D431BC /* StartWith.swift in Sources */,
 				C820A8FF1EB4DA5A00D431BC /* ObserveOn.swift in Sources */,
 				C8F0BFF91BBBFB8B001B112F /* Event.swift in Sources */,
+				782E80BD1F48A18F00CDB4D2 /* Min.swift in Sources */,
 				C83D73C71C1DBAEE003DC470 /* ScheduledItem.swift in Sources */,
 				C820A8AB1EB4DA5A00D431BC /* WithLatestFrom.swift in Sources */,
 				C867817F1DB8129E00B2029A /* Queue.swift in Sources */,
@@ -5566,6 +5583,7 @@
 				C820A89E1EB4DA5A00D431BC /* StartWith.swift in Sources */,
 				C820A8FE1EB4DA5A00D431BC /* ObserveOn.swift in Sources */,
 				C84CC5691BDD08A500E06A64 /* SubscriptionDisposable.swift in Sources */,
+				782E80BC1F48A18F00CDB4D2 /* Min.swift in Sources */,
 				C83D73C61C1DBAEE003DC470 /* ScheduledItem.swift in Sources */,
 				C820A8AA1EB4DA5A00D431BC /* WithLatestFrom.swift in Sources */,
 				C867817E1DB8129E00B2029A /* Queue.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -37,6 +37,13 @@
 		601AE3DB1EE24E5A00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DC1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DD1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
+		782E80B21F48A0A200CDB4D2 /* Max.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B11F48A0A200CDB4D2 /* Max.swift */; };
+		782E80B31F48A0A200CDB4D2 /* Max.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B11F48A0A200CDB4D2 /* Max.swift */; };
+		782E80B41F48A0A200CDB4D2 /* Max.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B11F48A0A200CDB4D2 /* Max.swift */; };
+		782E80B51F48A0A200CDB4D2 /* Max.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B11F48A0A200CDB4D2 /* Max.swift */; };
+		782E80B71F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */; };
+		782E80B81F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */; };
+		782E80B91F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEBE1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
@@ -1697,6 +1704,8 @@
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
+		782E80B11F48A0A200CDB4D2 /* Max.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Max.swift; sourceTree = "<group>"; };
+		782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+MaxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -2435,6 +2444,7 @@
 				C820A8151EB4DA5900D431BC /* Just.swift */,
 				C820A7E61EB4DA5900D431BC /* Map.swift */,
 				C820A7FD1EB4DA5900D431BC /* Materialize.swift */,
+				782E80B11F48A0A200CDB4D2 /* Max.swift */,
 				C820A7F71EB4DA5900D431BC /* Merge.swift */,
 				C820A81D1EB4DA5900D431BC /* Multicast.swift */,
 				C820A8161EB4DA5900D431BC /* Never.swift */,
@@ -2725,6 +2735,7 @@
 				C820A9691EB4F64800D431BC /* Observable+JustTests.swift */,
 				C820A9B51EB5081400D431BC /* Observable+MapTests.swift */,
 				C820A9F91EB510D500D431BC /* Observable+MaterializeTests.swift */,
+				782E80B61F48A0BC00CDB4D2 /* Observable+MaxTests.swift */,
 				C820A9991EB5001C00D431BC /* Observable+MergeTests.swift */,
 				C820A9551EB4ED7C00D431BC /* Observable+MulticastTests.swift */,
 				C820A9611EB4EFD300D431BC /* Observable+ObserveOnTests.swift */,
@@ -4294,6 +4305,7 @@
 				C820A9CA1EB50A7100D431BC /* Observable+ElementAtTests.swift in Sources */,
 				C83509381C38706E0027C24C /* NSObject+RxTests.swift in Sources */,
 				C820AA061EB5139C00D431BC /* Observable+BufferTests.swift in Sources */,
+				782E80B81F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */,
 				C820A96E1EB4F7AC00D431BC /* Observable+SequenceTests.swift in Sources */,
 				C8A9B6F41DAD752200C9B027 /* Observable+BindTests.swift in Sources */,
 				271A97441CFC9F7B00D64125 /* UIViewController+RxTests.swift in Sources */,
@@ -4501,6 +4513,7 @@
 				C8F27DC11CE68DA700D5FB4F /* UITextView+RxTests.swift in Sources */,
 				C86B1E231D42BF5200130546 /* SchedulerTests.swift in Sources */,
 				C860EC961C42E26100A664B3 /* SectionedViewDataSourceMock.swift in Sources */,
+				782E80B71F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */,
 				C820AA071EB5139C00D431BC /* Observable+BufferTests.swift in Sources */,
 				C8350A0F1C3875630027C24C /* Observable+ZipTests+arity.swift in Sources */,
 			);
@@ -4603,6 +4616,7 @@
 				C8350A001C38755E0027C24C /* Observable+Tests.swift in Sources */,
 				C83509E91C3875580027C24C /* TestConnectableObservable.swift in Sources */,
 				C820A97C1EB4FA0800D431BC /* Observable+RangeTests.swift in Sources */,
+				782E80B91F48A0BD00CDB4D2 /* Observable+MaxTests.swift in Sources */,
 				C83509DF1C38754F0027C24C /* TestVirtualScheduler.swift in Sources */,
 				C820A9DC1EB50CAA00D431BC /* Observable+DoOnTests.swift in Sources */,
 				C83509CD1C3875230027C24C /* NotificationCenterTests.swift in Sources */,
@@ -4704,6 +4718,7 @@
 				C83D73C11C1DBAEE003DC470 /* InvocableType.swift in Sources */,
 				C820A9151EB4DA5A00D431BC /* ToArray.swift in Sources */,
 				C820A8751EB4DA5A00D431BC /* SkipWhile.swift in Sources */,
+				782E80B51F48A0A200CDB4D2 /* Max.swift in Sources */,
 				C820A91D1EB4DA5A00D431BC /* AsSingle.swift in Sources */,
 				C8093D741B8A72BE0088E94D /* ObserverBase.swift in Sources */,
 				C85106891C2D550E0075150C /* String+Rx.swift in Sources */,
@@ -4939,6 +4954,7 @@
 				C85106881C2D550E0075150C /* String+Rx.swift in Sources */,
 				C820A9141EB4DA5A00D431BC /* ToArray.swift in Sources */,
 				C820A8741EB4DA5A00D431BC /* SkipWhile.swift in Sources */,
+				782E80B21F48A0A200CDB4D2 /* Max.swift in Sources */,
 				C820A91C1EB4DA5A00D431BC /* AsSingle.swift in Sources */,
 				C8BF34CF1C2E426800416CAE /* Platform.Linux.swift in Sources */,
 				C8093D791B8A72BE0088E94D /* TailRecursiveSink.swift in Sources */,
@@ -5098,6 +5114,7 @@
 				C83D73C31C1DBAEE003DC470 /* InvocableType.swift in Sources */,
 				C820A9171EB4DA5A00D431BC /* ToArray.swift in Sources */,
 				C820A8771EB4DA5A00D431BC /* SkipWhile.swift in Sources */,
+				782E80B41F48A0A200CDB4D2 /* Max.swift in Sources */,
 				C820A91F1EB4DA5A00D431BC /* AsSingle.swift in Sources */,
 				C8F0BFAF1BBBFB8B001B112F /* ObserverBase.swift in Sources */,
 				C851068B1C2D550E0075150C /* String+Rx.swift in Sources */,
@@ -5457,6 +5474,7 @@
 				C820A89A1EB4DA5A00D431BC /* Catch.swift in Sources */,
 				D2EBEB421BB9B6DE003A27DC /* ReplaySubject.swift in Sources */,
 				C820A9161EB4DA5A00D431BC /* ToArray.swift in Sources */,
+				782E80B31F48A0A200CDB4D2 /* Max.swift in Sources */,
 				C820A8761EB4DA5A00D431BC /* SkipWhile.swift in Sources */,
 				C820A91E1EB4DA5A00D431BC /* AsSingle.swift in Sources */,
 				D2EBEB381BB9B6D8003A27DC /* ConcurrentDispatchQueueScheduler.swift in Sources */,

--- a/RxSwift/Observables/Max.swift
+++ b/RxSwift/Observables/Max.swift
@@ -1,0 +1,87 @@
+//
+//  Max.swift
+//  RxSwift
+//
+//  Created by Shai Mishali on 8/19/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+extension ObservableType {
+
+    /**
+     Emits the item from the source Observable that had the maximum value using a provided comparator closure.
+
+     - parameter comparator: A comparator method expected to return true if the first element has a greater value then the second element.
+     - returns: An observable sequence containing the specified number of elements from the end of the source sequence.
+    */
+    public func max(_ comparator: @escaping (E, E) -> Bool)
+        -> Observable<E> {
+            return Max(source: asObservable(), comparator: comparator)
+    }
+}
+
+extension ObservableType where E: Comparable {
+
+    /**
+     Emits the item from the source Observable that had the maximum value.
+
+     - returns: An observable sequence containing the specified number of elements from the end of the source sequence.
+     */
+    public func max()
+        -> Observable<E> {
+            return Max(source: asObservable()) { $0 > $1 }
+    }
+}
+
+final fileprivate class MaxSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias E = O.E
+    typealias Comparator = (E, E) -> Bool
+
+    private let _comparator: Comparator
+    private var _max: E?
+
+    init(comparator: @escaping Comparator, observer: O, cancel: Cancelable) {
+        _comparator = comparator
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ event: Event<E>) {
+        switch event {
+        case .next(let value):
+            guard let max = _max else {
+                _max = value
+                return
+            }
+
+            _max = _comparator(max, value) ? _max : value
+        case .error:
+            forwardOn(event)
+            dispose()
+        case .completed:
+            if let max = _max {
+                forwardOn(.next(max))
+            }
+
+            forwardOn(.completed)
+            dispose()
+        }
+    }
+}
+
+final fileprivate class Max<Element>: Producer<Element> {
+    typealias Comparator = (E, E) -> Bool
+
+    private let _source: Observable<Element>
+    private let _comparator: Comparator
+
+    init(source: Observable<Element>, comparator: @escaping Comparator) {
+        _source = source
+        _comparator = comparator
+    }
+
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+        let sink = MaxSink(comparator: _comparator, observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+}

--- a/RxSwift/Observables/Min.swift
+++ b/RxSwift/Observables/Min.swift
@@ -1,0 +1,86 @@
+//
+//  Min.swift
+//  RxSwift
+//
+//  Created by Shai Mishali on 8/19/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+extension ObservableType {
+
+    /**
+     Emits the item from the source Observable that had the minimum value using a provided comparator closure.
+
+     - parameter comparator: A comparator method expected to return true if the first element has a lower value then the second element.
+     - returns: An observable sequence containing the specified number of elements from the end of the source sequence.
+    */
+    public func min(_ comparator: @escaping (E, E) -> Bool)
+        -> Observable<E> {
+            return Min(source: asObservable(), comparator: comparator)
+    }
+}
+
+extension ObservableType where E: Comparable {
+    /**
+     Emits the item from the source Observable that had the minimum value.
+
+     - returns: An observable sequence containing the specified number of elements from the end of the source sequence.
+     */
+    public func min()
+        -> Observable<E> {
+            return Min(source: asObservable()) { $0 < $1 }
+    }
+}
+
+final fileprivate class MinSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias E = O.E
+    typealias Comparator = (E, E) -> Bool
+
+    private let _comparator: Comparator
+    private var _min: E?
+
+    init(comparator: @escaping Comparator, observer: O, cancel: Cancelable) {
+        _comparator = comparator
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ event: Event<E>) {
+        switch event {
+        case .next(let value):
+            guard let min = _min else {
+                _min = value
+                return
+            }
+
+            _min = _comparator(min, value) ? _min : value
+        case .error:
+            forwardOn(event)
+            dispose()
+        case .completed:
+            if let min = _min {
+                forwardOn(.next(min))
+            }
+
+            forwardOn(.completed)
+            dispose()
+        }
+    }
+}
+
+final fileprivate class Min<Element>: Producer<Element> {
+    typealias Comparator = (E, E) -> Bool
+
+    private let _source: Observable<Element>
+    private let _comparator: Comparator
+
+    init(source: Observable<Element>, comparator: @escaping Comparator) {
+        _source = source
+        _comparator = comparator
+    }
+
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+        let sink = MinSink(comparator: _comparator, observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+}

--- a/RxSwift/Observables/Sum.swift
+++ b/RxSwift/Observables/Sum.swift
@@ -1,0 +1,86 @@
+//
+//  Sum.swift
+//  RxSwift
+//
+//  Created by Shai Mishali on 8/19/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+extension ObservableType {
+
+    /**
+     Emits the sum of all elements emitted from the source Observable using a provided accumulator closure and seed value.
+
+     - parameter seed: Seed value.
+     - parameter accumulator: A closure returning the sum of two elements.
+     - returns: An observable sequence containing the specified number of elements from the end of the source sequence.
+     */
+    public func sum(seed: E, _ accumulator: @escaping (E, E) -> E)
+        -> Observable<E> {
+            return Sum(source: asObservable(), seed: seed, accumulator: accumulator)
+    }
+}
+
+extension ObservableType where E: Numeric {
+
+    /**
+     Emits the sum of all elements emitted from the source Observable.
+
+     - returns: An observable sequence containing the specified number of elements from the end of the source sequence.
+     */
+    public func sum()
+        -> Observable<E> {
+            return Sum(source: asObservable(), seed: 0) { $0 + $1 }
+    }
+}
+
+final fileprivate class SumSink<O: ObserverType> : Sink<O>, ObserverType {
+    typealias E = O.E
+    typealias Parent = Sum<E>
+    typealias Accumulated = E
+
+    private var _parent: Parent
+    private var _accumulated: Accumulated
+
+    init(parent: Parent, observer: O, cancel: Cancelable) {
+        _parent = parent
+        _accumulated = parent._accumulated
+
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ event: Event<E>) {
+        switch event {
+        case .next(let value):
+            _accumulated = _parent._accumulator(_accumulated, value)
+        case .error:
+            forwardOn(event)
+            dispose()
+        case .completed:
+            forwardOn(.next(_accumulated))
+            forwardOn(.completed)
+            dispose()
+        }
+    }
+}
+
+final fileprivate class Sum<Element>: Producer<Element> {
+    typealias Accumulator = (E, E) -> E
+    typealias Accumulated = E
+
+    private let _source: Observable<Element>
+    fileprivate let _accumulator: Accumulator
+    fileprivate let _accumulated: Accumulated
+
+    init(source: Observable<Element>, seed: Element, accumulator: @escaping Accumulator) {
+        _source = source
+        _accumulator = accumulator
+        _accumulated = seed
+    }
+
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+        let sink = SumSink(parent: self, observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+}

--- a/Sources/AllTestz/Observable+MaxTests.swift
+++ b/Sources/AllTestz/Observable+MaxTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Observable+MaxTests.swift

--- a/Sources/AllTestz/Observable+MinTests.swift
+++ b/Sources/AllTestz/Observable+MinTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Observable+MinTests.swift

--- a/Sources/AllTestz/Observable+SumTests.swift
+++ b/Sources/AllTestz/Observable+SumTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Observable+SumTests.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -241,6 +241,22 @@ final class ObservableBlockingTest_ : ObservableBlockingTest, RxTestCase {
     ] }
 }
 
+final class ObservableMinTest_ : ObservableMinTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableMinTest_) -> () -> ())] { return [
+    ("test_minInt", ObservableMinTest.test_minInt),
+    ("test_minFloat", ObservableMinTest.test_minFloat),
+    ("test_minClosure", ObservableMinTest.test_minClosure),
+    ("test_minError", ObservableMinTest.test_minError),
+    ("test_minDisposed", ObservableMinTest.test_minDisposed),
+    ] }
+}
+
 final class ObservableRetryWhenTest_ : ObservableRetryWhenTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -260,6 +276,22 @@ final class ObservableRetryWhenTest_ : ObservableRetryWhenTest, RxTestCase {
     ("testRetryWhen_Incremental_BackOff", ObservableRetryWhenTest.testRetryWhen_Incremental_BackOff),
     ("testRetryWhen_IgnoresDifferentErrorTypes", ObservableRetryWhenTest.testRetryWhen_IgnoresDifferentErrorTypes),
     ("testRetryWhen_tailRecursiveOptimizationsTest", ObservableRetryWhenTest.testRetryWhen_tailRecursiveOptimizationsTest),
+    ] }
+}
+
+final class ObservableSumTest_ : ObservableSumTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSumTest_) -> () -> ())] { return [
+    ("test_sumInt", ObservableSumTest.test_sumInt),
+    ("test_sumDouble", ObservableSumTest.test_sumDouble),
+    ("test_sumClosure", ObservableSumTest.test_sumClosure),
+    ("test_sumError", ObservableSumTest.test_sumError),
+    ("test_sumDisposed", ObservableSumTest.test_sumDisposed),
     ] }
 }
 
@@ -1630,6 +1662,22 @@ final class ObservableGroupByTest_ : ObservableGroupByTest, RxTestCase {
     ] }
 }
 
+final class ObservableMaxTest_ : ObservableMaxTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableMaxTest_) -> () -> ())] { return [
+    ("test_maxInt", ObservableMaxTest.test_maxInt),
+    ("test_maxFloat", ObservableMaxTest.test_maxFloat),
+    ("test_maxClosure", ObservableMaxTest.test_maxClosure),
+    ("test_maxError", ObservableMaxTest.test_maxError),
+    ("test_maxDisposed", ObservableMaxTest.test_maxDisposed),
+    ] }
+}
+
 final class ObservableSwitchIfEmptyTest_ : ObservableSwitchIfEmptyTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1644,6 +1692,29 @@ final class ObservableSwitchIfEmptyTest_ : ObservableSwitchIfEmptyTest, RxTestCa
     ("testSwitchIfEmpty_SourceEmpty_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceEmpty_SwitchCompletes),
     ("testSwitchIfEmpty_SourceEmpty_SwitchError", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceEmpty_SwitchError),
     ("testSwitchIfEmpty_Never", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_Never),
+    ] }
+}
+
+final class ObservableTakeUntilTest_ : ObservableTakeUntilTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableTakeUntilTest_) -> () -> ())] { return [
+    ("testTakeUntil_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntil_Preempt_SomeData_Next),
+    ("testTakeUntil_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntil_Preempt_SomeData_Error),
+    ("testTakeUntil_NoPreempt_SomeData_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_SomeData_Empty),
+    ("testTakeUntil_NoPreempt_SomeData_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_SomeData_Never),
+    ("testTakeUntil_Preempt_Never_Next", ObservableTakeUntilTest.testTakeUntil_Preempt_Never_Next),
+    ("testTakeUntil_Preempt_Never_Error", ObservableTakeUntilTest.testTakeUntil_Preempt_Never_Error),
+    ("testTakeUntil_NoPreempt_Never_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Empty),
+    ("testTakeUntil_NoPreempt_Never_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Never),
+    ("testTakeUntil_Preempt_BeforeFirstProduced", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced),
+    ("testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed),
+    ("testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna", ObservableTakeUntilTest.testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna),
+    ("testTakeUntil_Error_Some", ObservableTakeUntilTest.testTakeUntil_Error_Some),
     ] }
 }
 
@@ -1668,29 +1739,6 @@ final class ObservableThrottleTest_ : ObservableThrottleTest, RxTestCase {
     ("test_ThrottleTimeSpan_Error", ObservableThrottleTest.test_ThrottleTimeSpan_Error),
     ("test_ThrottleTimeSpan_NoEnd", ObservableThrottleTest.test_ThrottleTimeSpan_NoEnd),
     ("test_ThrottleTimeSpan_WithRealScheduler", ObservableThrottleTest.test_ThrottleTimeSpan_WithRealScheduler),
-    ] }
-}
-
-final class ObservableTakeUntilTest_ : ObservableTakeUntilTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableTakeUntilTest_) -> () -> ())] { return [
-    ("testTakeUntil_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntil_Preempt_SomeData_Next),
-    ("testTakeUntil_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntil_Preempt_SomeData_Error),
-    ("testTakeUntil_NoPreempt_SomeData_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_SomeData_Empty),
-    ("testTakeUntil_NoPreempt_SomeData_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_SomeData_Never),
-    ("testTakeUntil_Preempt_Never_Next", ObservableTakeUntilTest.testTakeUntil_Preempt_Never_Next),
-    ("testTakeUntil_Preempt_Never_Error", ObservableTakeUntilTest.testTakeUntil_Preempt_Never_Error),
-    ("testTakeUntil_NoPreempt_Never_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Empty),
-    ("testTakeUntil_NoPreempt_Never_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Never),
-    ("testTakeUntil_Preempt_BeforeFirstProduced", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced),
-    ("testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed),
-    ("testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna", ObservableTakeUntilTest.testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna),
-    ("testTakeUntil_Error_Some", ObservableTakeUntilTest.testTakeUntil_Error_Some),
     ] }
 }
 
@@ -1822,7 +1870,9 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(PrimitiveSequenceTest_.allTests),
         testCase(VirtualSchedulerTest_.allTests),
         testCase(ObservableBlockingTest_.allTests),
+        testCase(ObservableMinTest_.allTests),
         testCase(ObservableRetryWhenTest_.allTests),
+        testCase(ObservableSumTest_.allTests),
         testCase(ObservableDelaySubscriptionTest_.allTests),
         testCase(ObservableDistinctUntilChangedTest_.allTests),
         testCase(ObservableObserveOnTest_.allTests),
@@ -1887,9 +1937,10 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(ObservableDoOnTest_.allTests),
         testCase(ObservableElementAtTest_.allTests),
         testCase(ObservableGroupByTest_.allTests),
+        testCase(ObservableMaxTest_.allTests),
         testCase(ObservableSwitchIfEmptyTest_.allTests),
-        testCase(ObservableThrottleTest_.allTests),
         testCase(ObservableTakeUntilTest_.allTests),
+        testCase(ObservableThrottleTest_.allTests),
         testCase(ObservableMergeTest_.allTests),
         testCase(ObservableReduceTest_.allTests),
     ])

--- a/Sources/RxSwift/Max.swift
+++ b/Sources/RxSwift/Max.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/Max.swift

--- a/Sources/RxSwift/Min.swift
+++ b/Sources/RxSwift/Min.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/Min.swift

--- a/Sources/RxSwift/Sum.swift
+++ b/Sources/RxSwift/Sum.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/Sum.swift

--- a/Tests/RxSwiftTests/Observable+MaxTests.swift
+++ b/Tests/RxSwiftTests/Observable+MaxTests.swift
@@ -1,0 +1,168 @@
+//
+//  Observable+MaxTests.swift
+//  Tests
+//
+//  Created by Shai Mishali on 8/19/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+import RxSwift
+import RxTest
+
+#if os(Linux)
+    import Glibc
+#endif
+
+class ObservableMaxTest : RxTest {
+}
+
+extension ObservableMaxTest {
+    func test_maxInt() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 160),
+            next(270, 40),
+            next(340, 111),
+            next(380, 1),
+            next(390, 111),
+            next(450, 40),
+            next(470, 270),
+            next(560, 271),
+            next(580, 11),
+            next(600, 269),
+            completed(610)
+            ])
+
+        let res = scheduler.start { xs.max() }
+
+        XCTAssertEqual(res.events, [
+            next(610, 271),
+            completed(610)
+            ])
+    }
+
+    func test_maxFloat() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 0.71),
+            next(180, 0.709),
+            next(230, 0.6),
+            next(270, 0.888),
+            next(340, 1.45),
+            next(380, 8),
+            next(390, 8.35),
+            next(450, 24.55),
+            next(470, 0.44),
+            next(560, 0.05),
+            next(580, 29.1579),
+            next(600, 29.1577),
+            completed(610)
+            ])
+
+        let res = scheduler.start { xs.max() }
+
+        XCTAssertEqual(res.events, [
+            next(610, 29.1579),
+            completed(610)
+            ])
+    }
+
+    func test_maxClosure() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, "h"),
+            next(180, "a"),
+            next(230, "hello"),
+            next(270, "hello world"),
+            next(340, "encyclopedia"),
+            next(380, "very very long string"),
+            next(390, "sho"),
+            next(450, "short"),
+            completed(470)
+            ])
+
+        let res = scheduler.start { xs.max { $0.characters.count > $1.characters.count } }
+
+        XCTAssertEqual(res.events, [
+            next(470, "very very long string"),
+            completed(470)
+            ])
+    }
+
+    func test_maxError() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 160),
+            next(270, 40),
+            next(340, 111),
+            next(380, 1),
+            error(385, TestError.dummyError),
+            next(390, 111),
+            next(450, 40),
+            next(470, 270),
+            next(560, 271),
+            next(580, 11),
+            next(600, 269),
+            completed(610)
+            ])
+
+        let res = scheduler.start() { xs.max() }
+
+        XCTAssertEqual(res.events, [
+            error(385, TestError.dummyError)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 385)
+        ])
+    }
+
+    func test_maxDisposed() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 160),
+            next(270, 40),
+            next(340, 111),
+            next(380, 1),
+            next(390, 111),
+            next(450, 40),
+            next(470, 270),
+            next(560, 271),
+            next(580, 11),
+            next(600, 269),
+            completed(610)
+            ])
+
+        let res = scheduler.start(disposed: 350) { xs.max() }
+
+        XCTAssertEqual(res.events, [])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 350)
+            ])
+    }
+
+    #if TRACE_RESOURCES
+    func testFilterReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).max().subscribe()
+    }
+
+    func testFilter1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).max().subscribe()
+    }
+    #endif
+}

--- a/Tests/RxSwiftTests/Observable+MinTests.swift
+++ b/Tests/RxSwiftTests/Observable+MinTests.swift
@@ -1,0 +1,169 @@
+//
+//  Observable+MinTests.swift
+//  Tests
+//
+//  Created by Shai Mishali on 8/19/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+import XCTest
+import RxSwift
+import RxTest
+
+#if os(Linux)
+    import Glibc
+#endif
+
+class ObservableMinTest : RxTest {
+}
+
+extension ObservableMinTest {
+    func test_minInt() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 160),
+            next(270, 40),
+            next(340, 111),
+            next(380, 1),
+            next(390, 111),
+            next(450, 40),
+            next(470, 270),
+            next(560, 271),
+            next(580, 11),
+            next(600, 269),
+            completed(610)
+            ])
+
+        let res = scheduler.start { xs.min() }
+
+        XCTAssertEqual(res.events, [
+            next(610, 1),
+            completed(610)
+            ])
+    }
+
+    func test_minFloat() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 0.71),
+            next(180, 0.709),
+            next(230, 0.6),
+            next(270, 0.888),
+            next(340, 1.45),
+            next(380, 8),
+            next(390, 8.35),
+            next(450, 24.55),
+            next(470, 0.44),
+            next(560, 0.05),
+            next(580, 29.1579),
+            next(600, 29.1577),
+            completed(610)
+            ])
+
+        let res = scheduler.start { xs.min() }
+
+        XCTAssertEqual(res.events, [
+            next(610, 0.05),
+            completed(610)
+            ])
+    }
+
+    func test_minClosure() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, "h"),
+            next(180, "a"),
+            next(230, "hello"),
+            next(270, "hello world"),
+            next(285, "a"),
+            next(340, "encyclopedia"),
+            next(380, "very very long string"),
+            next(390, "sho"),
+            next(450, "short"),
+            completed(470)
+            ])
+
+        let res = scheduler.start { xs.min { $0.characters.count < $1.characters.count } }
+
+        XCTAssertEqual(res.events, [
+            next(470, "a"),
+            completed(470)
+            ])
+    }
+
+    func test_minError() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 160),
+            next(270, 40),
+            next(340, 111),
+            next(380, 1),
+            error(385, TestError.dummyError),
+            next(390, 111),
+            next(450, 40),
+            next(470, 270),
+            next(560, 271),
+            next(580, 11),
+            next(600, 269),
+            completed(610)
+            ])
+
+        let res = scheduler.start() { xs.min() }
+
+        XCTAssertEqual(res.events, [
+            error(385, TestError.dummyError)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 385)
+        ])
+    }
+
+    func test_minDisposed() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 160),
+            next(270, 40),
+            next(340, 111),
+            next(380, 1),
+            next(390, 111),
+            next(450, 40),
+            next(470, 270),
+            next(560, 271),
+            next(580, 11),
+            next(600, 269),
+            completed(610)
+            ])
+
+        let res = scheduler.start(disposed: 350) { xs.min() }
+
+        XCTAssertEqual(res.events, [])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 350)
+            ])
+    }
+
+    #if TRACE_RESOURCES
+    func testFilterReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).min().subscribe()
+    }
+
+    func testFilter1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).min().subscribe()
+    }
+    #endif
+}

--- a/Tests/RxSwiftTests/Observable+SumTests.swift
+++ b/Tests/RxSwiftTests/Observable+SumTests.swift
@@ -1,0 +1,150 @@
+//
+//  Observable+SumTests.swift
+//  Tests
+//
+//  Created by Shai Mishali on 8/19/17.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+#if os(Linux)
+    import Glibc
+#endif
+
+class ObservableSumTest : RxTest {
+}
+
+extension ObservableSumTest {
+    func test_sumInt() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 10),
+            next(270, 35),
+            next(340, 2000),
+            next(380, 1),
+            next(450, 271),
+            next(470, 4444),
+            completed(610)
+            ])
+
+        let res = scheduler.start { xs.sum() }
+
+        XCTAssertEqual(res.events, [
+            next(610, 6761),
+            completed(610)
+            ])
+    }
+
+    func test_sumDouble() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(200, 0.3),
+            next(210, 0.5),
+            next(230, 0.1),
+            next(270, 0.1),
+            next(340, 0.25),
+            next(380, 0.25),
+            completed(390)
+            ])
+
+        let res = scheduler.start { xs.sum() }
+
+        XCTAssertEqual(res.events, [
+            next(390, 1.2),
+            completed(390)
+            ])
+    }
+
+    func test_sumClosure() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(230, "eh"),
+            next(250, "ll"),
+            next(270, " o"),
+            next(290, "row"),
+            next(310, "dl"),
+            next(320, "!"),
+            completed(330)
+            ])
+
+        let res = scheduler.start { xs.sum(seed: "") { $0 + String($1.characters.reversed()) } }
+
+        XCTAssertEqual(res.events, [
+            next(330, "hello world!"),
+            completed(330)
+            ])
+    }
+
+    func test_sumError() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 160),
+            next(270, 40),
+            next(340, 111),
+            next(380, 1),
+            error(385, TestError.dummyError),
+            next(390, 111),
+            next(450, 40),
+            next(470, 270),
+            next(560, 271),
+            next(580, 11),
+            next(600, 269),
+            completed(610)
+            ])
+
+        let res = scheduler.start() { xs.sum() }
+
+        XCTAssertEqual(res.events, [
+            error(385, TestError.dummyError)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 385)
+            ])
+    }
+
+    func test_sumDisposed() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 80),
+            next(180, 140),
+            next(230, 10),
+            next(270, 35),
+            next(340, 2000),
+            next(380, 1),
+            next(450, 271),
+            next(470, 4444),
+            completed(480)
+            ])
+
+        let res = scheduler.start(disposed: 350) { xs.sum() }
+
+        XCTAssertEqual(res.events, [])
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 350)
+            ])
+    }
+
+    #if TRACE_RESOURCES
+    func testFilterReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).sum().subscribe()
+    }
+
+    func testFilter1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).sum().subscribe()
+    }
+    #endif
+}
+


### PR DESCRIPTION
Hey All :)
I noticed we’re missing [`min()`](http://reactivex.io/documentation/operators/min.html), [`max()`](http://reactivex.io/documentation/operators/max.html) and [`sum()`](http://reactivex.io/documentation/operators/sum.html) so thought it would be cool to try and add these. 😄 

I've pushed this PR onto the Swift 4 branch so it would be part of the new release, and also to take advantage of the new Numeric protocol for `sum()`. 

This is my first attempt at making an operator PR so I’m sure there are some things that can be done better, which is exactly why I’m sharing this with the community. Would love the feedback of those more experienced 🤓 

The operators are based off of ReactiveX and also more or less the way they're implemented in RxJava: 

`min()` and `max()` work "out of the box" for all `Comparable`s. You can also [provide a `comparator` callback](https://github.com/ReactiveX/RxSwift/blob/feature/math/Tests/RxSwiftTests/Observable%2BMaxTests.swift#L92) to all non-`Comparable`s to "decide" which elements are lesser or greater. 

`sum()` works "out of the box" for all `Numeric`s. You can also [provide a `seed` and `accumulator`](https://github.com/ReactiveX/RxSwift/blob/feature/math/Tests/RxSwiftTests/Observable%2BSumTests.swift#L78) for non-`Numeric`s to provide custom summing of the items.

Looking forward to your feedback and hope this makes sense to all :)

🎉 🎉 🐰 