### PR TITLE
Fixed issue with NSControl.rx.value multiple observers

### DIFF
--- a/Tests/RxCocoaTests/NSButton+RxTests.swift
+++ b/Tests/RxCocoaTests/NSButton+RxTests.swift
@@ -39,4 +39,23 @@ extension NSButtonTests {
 
         XCTAssertEqual(button.state, NSControl.StateValue.off)
     }
+	
+	func testButton_multipleObservers() {
+		let button = NSButton(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+		var value1: NSControl.StateValue? = nil
+		var value2: NSControl.StateValue? = nil
+
+		_ = Observable.just(NSControl.StateValue.off).bind(to: button.rx.state)
+		_ = button.rx.state.subscribe(onNext: { value1 = $0 })
+		_ = button.rx.state.subscribe(onNext: { value2 = $0 })
+		_ = Observable.just(NSControl.StateValue.on).bind(to: button.rx.state)
+
+		if let target = button.target, let action = button.action {
+			_ = target.perform(action, with: button)
+		}
+
+		XCTAssertEqual(button.state, NSControl.StateValue.on)
+		XCTAssertEqual(value1, NSControl.StateValue.on)
+		XCTAssertEqual(value2, NSControl.StateValue.on)
+	}
 }


### PR DESCRIPTION
When multiple observers want to look at NSControl.rx.value, only one would get updates because
the returned observable wasn't shared(). This is examplified by the new test added to NSButton

This also solves the issue of observers with varying types

Relates to issue #1398 