### PR TITLE
Fix an exception caused by calling an optional delegate method

### DIFF
--- a/RxCocoa/macOS/NSTextField+Rx.swift
+++ b/RxCocoa/macOS/NSTextField+Rx.swift
@@ -40,7 +40,7 @@ public class RxTextFieldDelegateProxy
         let textField: NSTextField = castOrFatalError(notification.object)
         let nextValue = textField.stringValue
         self.textSubject.on(.next(nextValue))
-        _forwardToDelegate?.controlTextDidChange(notification)
+        _forwardToDelegate?.controlTextDidChange?(notification)
     }
 
     // MARK: Delegate proxy methods


### PR DESCRIPTION
This fixes an exception when the forwarded delegate does not implement the `controlTextDidChange(…)` method. Fixes #1405. 