### PR TITLE
Added pretty init for AnyObserver with closures for each event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## Master
-
+* Adds `init` for `AnyObserver` with closures for each event. #1408
 * Adds `UIScrollView.willEndDragging` extension. #1365
 * Adds `materialize()` operator for RxBlocking's `BlockingObservable`. #1383
 * Adds `first` operator to ObservableType.

--- a/RxSwift/AnyObserver.swift
+++ b/RxSwift/AnyObserver.swift
@@ -32,6 +32,22 @@ public struct AnyObserver<Element> : ObserverType {
         self.observer = observer.on
     }
     
+    /// Construct an instance whose `on(event)` calls specific closure for events.
+    ///
+    /// - parameter observer: Observer that receives sequence events.
+    public init(onNext: ((E) -> Swift.Void)? = nil, onError: ((Error) -> Swift.Void)? = nil, onCompleted: (() -> Swift.Void)? = nil) {
+        self.init { event in
+            switch event {
+            case .next(let element):
+                onNext?(element)
+            case .error(let error):
+                onError?(error)
+            case .completed:
+                onCompleted?()
+            }
+        }
+    }
+    
     /// Send `event` to this observer.
     ///
     /// - parameter event: Event instance.

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1458,6 +1458,8 @@ final class ObserverTests_ : ObserverTests, RxTestCase {
     ("testMapElementCompleted", ObserverTests.testMapElementCompleted),
     ("testMapElementError", ObserverTests.testMapElementError),
     ("testMapElementThrow", ObserverTests.testMapElementThrow),
+    ("testPrettyInitWithError", ObserverTests.testPrettyInitWithError),
+    ("testPrettyInitWithComplete", ObserverTests.testPrettyInitWithComplete),
     ] }
 }
 

--- a/Tests/RxSwiftTests/ObserverTests.swift
+++ b/Tests/RxSwiftTests/ObserverTests.swift
@@ -131,3 +131,47 @@ extension ObserverTests {
         XCTAssertEqual(observer.events, [error(testError)])
     }
 }
+
+extension ObserverTests {
+    func testPrettyInitWithError() {
+        var elements = [Int]()
+        var errorNotification: Error?
+        
+        let observer = AnyObserver<Int>(onNext: { element in
+            elements.append(element)
+        }, onError: { error in
+            errorNotification = error
+        })
+        
+        _ = Observable<Int>.create { observer -> Disposable in
+            observer.onNext(0)
+            observer.onError(testError)
+            observer.onNext(1)
+            return Disposables.create()
+        }.subscribe(observer)
+        
+        XCTAssertNotNil(errorNotification)
+        XCTAssertEqual(elements, [0])
+    }
+    
+    func testPrettyInitWithComplete() {
+        var elements = [Int]()
+        var onCompletedCall = false
+        
+        let observer = AnyObserver<Int>(onNext: { element in
+            elements.append(element)
+        }, onCompleted: {
+            onCompletedCall = true
+        })
+        
+        _ = Observable<Int>.create { observer -> Disposable in
+            observer.onNext(0)
+            observer.onCompleted()
+            observer.onNext(1)
+            return Disposables.create()
+        }.subscribe(observer)
+        
+        XCTAssertTrue(onCompletedCall)
+        XCTAssertEqual(elements, [0])
+    }
+}


### PR DESCRIPTION
**Added pretty init for AnyObserver with closures for each event.**
It's really simple for use:

```swift
let observer = AnyObserver<String>(onNext: { element in
    print(element)
}, onError: { error in
    print(error.localizedDescription)
}, onCompleted: {
    print("onCompleted")
})
```