### PR TITLE
Introduce `Sink` using nested class

### DIFF
--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -74,7 +74,7 @@ final fileprivate class Map<SourceType, ResultType>: Producer<ResultType> {
 }
 
 extension Map {
-    private class Sink<O: ObserverType>: RxSwift.Sink<O>, ObserverType where O.E == ResultType {
+    fileprivate class Sink<O: ObserverType>: RxSwift.Sink<O>, ObserverType where O.E == ResultType {
         private let _transform: Transform
         
         init(transform: @escaping Transform, observer: O, cancel: Cancelable) {


### PR DESCRIPTION
Hi there.

I proposed same topic when swift 3.1 released. #1157 
Maybe now is good, I propose it again.
I wish make same changes to every operator.

## Pros
* Can eliminate many duplicate type defines and use same generics type and `typealias` between `Sink` and their parent.
* Can increase `Sink`s confidentiality.

## Cons
* Make many code differences, several other improvements may affected by this proposal.
* In the past, `Sink` was always written before their parent, cannot do that anymore. (Can write at `extension`, we need to write after their parent.)
* If there are shared `Sink` class, this proposal might be a not good way in shared `Sink` class.

## Benchmark
This is my benchmark score.

|BenchmarkMethod|swift4.0|proposal/nested_sink|
|---|---|---|
|testMapFilterCreating|0.766sec|0.787sec|
|testMapFilterPumping|3.132sec|3.155sec|