### PR TITLE
Default implementation for DelegateProxy

### DIFF
--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -242,6 +242,36 @@ extension DelegateProxyType
     }
 }
 
+public protocol HasDelegate: AnyObject {
+    associatedtype Delegate: AnyObject
+    var delegate: Delegate? { get set }
+}
+
+extension DelegateProxyType where ParentObject: HasDelegate, Self.Delegate == ParentObject.Delegate {
+    public static func currentDelegate(for object: ParentObject) -> Delegate? {
+        return object.delegate
+    }
+
+    public static func setCurrentDelegate(_ delegate: Delegate?, to object: ParentObject) {
+        object.delegate = delegate
+    }
+}
+
+public protocol HasDataSource: AnyObject {
+    associatedtype DataSource: AnyObject
+    var dataSource: DataSource? { get set }
+}
+
+extension DelegateProxyType where ParentObject: HasDataSource, Self.Delegate == ParentObject.DataSource {
+    public static func currentDelegate(for object: ParentObject) -> Delegate? {
+        return object.dataSource
+    }
+
+    public static func setCurrentDelegate(_ delegate: Delegate?, to object: ParentObject) {
+        object.dataSource = delegate
+    }
+}
+
     #if os(iOS) || os(tvOS)
         import UIKit
 

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
@@ -13,6 +13,10 @@ import UIKit
 import RxSwift
 #endif
 
+extension UICollectionView: HasDataSource {
+    public typealias DataSource = UICollectionViewDataSource
+}
+
 let collectionViewDataSourceNotSet = CollectionViewDataSourceNotSet()
 
 final class CollectionViewDataSourceNotSet
@@ -63,18 +67,6 @@ open class RxCollectionViewDataSourceProxy
     /// Required delegate method implementation.
     public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         return (_requiredMethodsDataSource ?? collectionViewDataSourceNotSet).collectionView(collectionView, cellForItemAt: indexPath)
-    }
-    
-    // MARK: proxy
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func setCurrentDelegate(_ delegate: UICollectionViewDataSource?, to object: ParentObject) {
-        object.dataSource = delegate
-    }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func currentDelegate(for object: ParentObject) -> UICollectionViewDataSource? {
-        return object.dataSource
     }
 
     /// For more information take a look at `DelegateProxyType`.

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -13,6 +13,10 @@
         import RxSwift
     #endif
 
+    extension UINavigationController: HasDelegate {
+        public typealias Delegate = UINavigationControllerDelegate
+    }
+
     /// For more information take a look at `DelegateProxyType`.
     open class RxNavigationControllerDelegateProxy
         : DelegateProxy<UINavigationController, UINavigationControllerDelegate>
@@ -31,16 +35,6 @@
         // Register known implementations
         public static func registerKnownImplementations() {
             self.register { RxNavigationControllerDelegateProxy(parentObject: $0) }
-        }
-
-        /// For more information take a look at `DelegateProxyType`.
-        open class func currentDelegate(for object: ParentObject) -> UINavigationControllerDelegate? {
-            return object.delegate
-        }
-
-        /// For more information take a look at `DelegateProxyType`.
-        open class func setCurrentDelegate(_ delegate: UINavigationControllerDelegate?, to object: ParentObject) {
-            object.delegate = delegate
         }
     }
 #endif

--- a/RxCocoa/iOS/Proxies/RxPickerViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDataSourceProxy.swift
@@ -13,6 +13,10 @@
     import RxSwift
 #endif
 
+extension UIPickerView: HasDataSource {
+    public typealias DataSource = UIPickerViewDataSource
+}
+
 fileprivate let pickerViewDataSourceNotSet = PickerViewDataSourceNotSet()
 
 final fileprivate class PickerViewDataSourceNotSet: NSObject, UIPickerViewDataSource {
@@ -57,18 +61,6 @@ public class RxPickerViewDataSourceProxy
     /// Required delegate method implementation.
     public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         return (_requiredMethodsDataSource ?? pickerViewDataSourceNotSet).pickerView(pickerView, numberOfRowsInComponent: component)
-    }
-    
-    // MARK: proxy
-    
-    /// For more information take a look at `DelegateProxyType`.
-    public class func setCurrentDelegate(_ delegate: UIPickerViewDataSource?, to object: UIPickerView) {
-        object.dataSource = delegate
-    }
-    
-    /// For more information take a look at `DelegateProxyType`.
-    public class func currentDelegate(for object: UIPickerView) -> UIPickerViewDataSource? {
-        return object.dataSource
     }
     
     /// For more information take a look at `DelegateProxyType`.

--- a/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
@@ -13,6 +13,10 @@
 #endif
     import UIKit
 
+    extension UIPickerView: HasDelegate {
+        public typealias Delegate = UIPickerViewDelegate
+    }
+
     open class RxPickerViewDelegateProxy
         : DelegateProxy<UIPickerView, UIPickerViewDelegate>
         , DelegateProxyType 
@@ -30,16 +34,6 @@
         // Register known implementationss
         public static func registerKnownImplementations() {
             self.register { RxPickerViewDelegateProxy(parentObject: $0) }
-        }
-
-        /// For more information take a look at `DelegateProxyType`.
-        open class func setCurrentDelegate(_ delegate: UIPickerViewDelegate?, to object: ParentObject) {
-            object.delegate = delegate
-        }
-        
-        /// For more information take a look at `DelegateProxyType`.
-        open class func currentDelegate(for object: ParentObject) -> UIPickerViewDelegate? {
-            return object.delegate
         }
     }
 #endif

--- a/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
@@ -12,6 +12,10 @@
 import RxSwift
 #endif
 import UIKit
+    
+extension UIScrollView: HasDelegate {
+    public typealias Delegate = UIScrollViewDelegate
+}
 
 /// For more information take a look at `DelegateProxyType`.
 open class RxScrollViewDelegateProxy
@@ -74,18 +78,6 @@ open class RxScrollViewDelegateProxy
             subject.on(.next(()))
         }
         self._forwardToDelegate?.scrollViewDidScroll?(scrollView)
-    }
-    
-    // MARK: delegate proxy
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func setCurrentDelegate(_ delegate: UIScrollViewDelegate?, to object: ParentObject) {
-        object.delegate = delegate
-    }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func currentDelegate(for object: ParentObject) -> UIScrollViewDelegate? {
-        return object.delegate
     }
     
     deinit {

--- a/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
@@ -13,6 +13,10 @@ import UIKit
 import RxSwift
 #endif
 
+extension UISearchBar: HasDelegate {
+    public typealias Delegate = UISearchBarDelegate
+}
+
 /// For more information take a look at `DelegateProxyType`.
 open class RxSearchBarDelegateProxy
     : DelegateProxy<UISearchBar, UISearchBarDelegate>
@@ -31,18 +35,6 @@ open class RxSearchBarDelegateProxy
     // Register known implementations
     public static func registerKnownImplementations() {
         self.register { RxSearchBarDelegateProxy(parentObject: $0) }
-    }
-
-    // MARK: Delegate proxy methods
-    
-    /// For more information take a look at `DelegateProxyType`.
-    open class func currentDelegate(for object: ParentObject) -> UISearchBarDelegate? {
-        return object.delegate
-    }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func setCurrentDelegate(_ delegate: UISearchBarDelegate?, to object: ParentObject) {
-        object.delegate = delegate
     }
 }
 

--- a/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
@@ -13,6 +13,10 @@
 #endif
    import UIKit
 
+extension UISearchController: HasDelegate {
+    public typealias Delegate = UISearchControllerDelegate
+}
+
 /// For more information take a look at `DelegateProxyType`.
 @available(iOS 8.0, *)
 open class RxSearchControllerDelegateProxy
@@ -33,17 +37,6 @@ open class RxSearchControllerDelegateProxy
     public static func registerKnownImplementations() {
         self.register { RxSearchControllerDelegateProxy(parentObject: $0) }
     }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func setCurrentDelegate(_ delegate: UISearchControllerDelegate?, to object: ParentObject) {
-        object.delegate = delegate
-    }
-    
-    /// For more information take a look at `DelegateProxyType`.
-    open class func currentDelegate(for object: ParentObject) -> UISearchControllerDelegate? {
-        return object.delegate
-    }
-    
 }
    
 #endif

--- a/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
@@ -13,6 +13,10 @@ import UIKit
 import RxSwift
 #endif
 
+extension UITabBarController: HasDelegate {
+    public typealias Delegate = UITabBarControllerDelegate
+}
+
 /// For more information take a look at `DelegateProxyType`.
 open class RxTabBarControllerDelegateProxy
     : DelegateProxy<UITabBarController, UITabBarControllerDelegate>
@@ -31,16 +35,6 @@ open class RxTabBarControllerDelegateProxy
     // Register known implementations
     public static func registerKnownImplementations() {
         self.register { RxTabBarControllerDelegateProxy(parentObject: $0) }
-    }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func currentDelegate(for object: ParentObject) -> UITabBarControllerDelegate? {
-        return object.delegate
-    }
-    
-    /// For more information take a look at `DelegateProxyType`.
-    open class func setCurrentDelegate(_ delegate: UITabBarControllerDelegate?, to object: ParentObject) {
-        object.delegate = delegate
     }
 }
 

--- a/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
@@ -13,6 +13,10 @@ import UIKit
 import RxSwift
 #endif
 
+extension UITabBar: HasDelegate {
+    public typealias Delegate = UITabBarDelegate
+}
+
 /// For more information take a look at `DelegateProxyType`.
 open class RxTabBarDelegateProxy
     : DelegateProxy<UITabBar, UITabBarDelegate>

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
@@ -12,6 +12,10 @@ import UIKit
 #if !RX_NO_MODULE
 import RxSwift
 #endif
+    
+extension UITableView: HasDataSource {
+    public typealias DataSource = UITableViewDataSource
+}
 
 let tableViewDataSourceNotSet = TableViewDataSourceNotSet()
 
@@ -60,18 +64,6 @@ open class RxTableViewDataSourceProxy
     /// Required delegate method implementation.
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         return (_requiredMethodsDataSource ?? tableViewDataSourceNotSet).tableView(tableView, cellForRowAt: indexPath)
-    }
-    
-    // MARK: proxy
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func setCurrentDelegate(_ delegate: UITableViewDataSource?, to object: ParentObject) {
-        object.dataSource = delegate
-    }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func currentDelegate(for object: ParentObject) -> UITableViewDataSource? {
-        return object.dataSource
     }
 
     /// For more information take a look at `DelegateProxyType`.

--- a/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
@@ -12,7 +12,11 @@
         import RxSwift
     #endif
     import UIKit
-    
+
+    extension NSTextStorage: HasDelegate {
+        public typealias Delegate = NSTextStorageDelegate
+    }
+
     open class RxTextStorageDelegateProxy
         : DelegateProxy<NSTextStorage, NSTextStorageDelegate>
         , DelegateProxyType 
@@ -30,16 +34,6 @@
         // Register known implementations
         public static func registerKnownImplementations() {
             self.register { RxTextStorageDelegateProxy(parentObject: $0) }
-        }
-
-        /// For more information take a look at `DelegateProxyType`.
-        open class func setCurrentDelegate(_ delegate: NSTextStorageDelegate?, to object: ParentObject) {
-            object.delegate = delegate
-        }
-        
-        /// For more information take a look at `DelegateProxyType`.
-        open class func currentDelegate(for object: ParentObject) -> NSTextStorageDelegate? {
-            return object.delegate
         }
     }
 #endif

--- a/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
@@ -13,6 +13,10 @@ import UIKit
 import RxSwift
 #endif
 
+extension UIWebView: HasDelegate {
+    public typealias Delegate = UIWebViewDelegate
+}
+
 open class RxWebViewDelegateProxy
     : DelegateProxy<UIWebView, UIWebViewDelegate>
     , DelegateProxyType 
@@ -30,16 +34,6 @@ open class RxWebViewDelegateProxy
     // Register known implementations
     public static func registerKnownImplementations() {
         self.register { RxWebViewDelegateProxy(parentObject: $0) }
-    }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func setCurrentDelegate(_ delegate: UIWebViewDelegate?, to object: UIWebView) {
-        object.delegate = delegate
-    }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open class func currentDelegate(for object: UIWebView) -> UIWebViewDelegate? {
-        return object.delegate
     }
 }
 

--- a/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
+++ b/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
@@ -12,6 +12,10 @@ import CoreLocation
     import RxCocoa
 #endif
 
+extension CLLocationManager: HasDelegate {
+    public typealias Delegate = CLLocationManagerDelegate
+}
+
 public class RxCLLocationManagerDelegateProxy
     : DelegateProxy<CLLocationManager, CLLocationManagerDelegate>
     , DelegateProxyType
@@ -27,14 +31,6 @@ public class RxCLLocationManagerDelegateProxy
 
     internal lazy var didUpdateLocationsSubject = PublishSubject<[CLLocation]>()
     internal lazy var didFailWithErrorSubject = PublishSubject<Error>()
-
-    public class func currentDelegate(for object: ParentObject) -> CLLocationManagerDelegate? {
-        return object.delegate
-    }
-
-    public class func setCurrentDelegate(_ delegate: CLLocationManagerDelegate?, to object: ParentObject) {
-        object.delegate = delegate
-    }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         _forwardToDelegate?.locationManager?(manager, didUpdateLocations: locations)

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -31,13 +31,13 @@ import UIKit
 }
 
 protocol TestDelegateControl: NSObjectProtocol {
-    associatedtype ParentObject: AnyObject
-    associatedtype Delegate: NSObjectProtocol
+    associatedtype TestParentObject: AnyObject
+    associatedtype TestDelegate: NSObjectProtocol
     func doThatTest(_ value: Int)
 
-    var delegateProxy: DelegateProxy<ParentObject, Delegate> { get }
+    var delegateProxy: DelegateProxy<TestParentObject, TestDelegate> { get }
 
-    func setMineForwardDelegate(_ testDelegate: Delegate) -> Disposable
+    func setMineForwardDelegate(_ testDelegate: TestDelegate) -> Disposable
 }
 
 extension TestDelegateControl {
@@ -408,7 +408,7 @@ extension DelegateProxyTest {
 
         autoreleasepool {
             let mine = MockTestDelegateProtocol()
-            let disposable = control.setMineForwardDelegate(mine as! Control.Delegate)
+            let disposable = control.setMineForwardDelegate(mine as! Control.TestDelegate)
 
             XCTAssertEqual(mine.numbers, [])
             control.doThatTest(2)
@@ -452,6 +452,10 @@ final class ThreeDSectionedView: NSObject {
     @objc dynamic var delegate: ThreeDSectionedViewProtocol?
 }
 
+extension ThreeDSectionedView: HasDelegate {
+    typealias Delegate = ThreeDSectionedViewProtocol
+}
+
 // }
 
 // integration {
@@ -481,16 +485,6 @@ final class ThreeDSectionedViewDelegateProxy: DelegateProxy<ThreeDSectionedView,
     
     func threeDView(_ threeDView: ThreeDSectionedView, howTallAmI: IndexPath) -> CGFloat {
         return 1.1
-    }
-    
-    // integration
-    
-    class func currentDelegate(for object: ThreeDSectionedView) -> ThreeDSectionedViewProtocol? {
-        return object.delegate
-    }
-    
-    class func setCurrentDelegate(_ delegate: ThreeDSectionedViewProtocol?, to object: ThreeDSectionedView) {
-        object.delegate = delegate
     }
 }
 


### PR DESCRIPTION
Hi there, this is based on discuss #1415 . CC: @beeth0ven 

I thought workaround when we use abstract method, 
but I'm sorry I didn't check https://github.com/ReactiveX/RxSwift/commit/b34b2ba76827b84a48312a8b4e59427c66a71b27 is avoid using abstract method, and so we can do it simply now. 
It seems work well.

I'm worry that we cannot override `currentDelegate` and `setCurrentDelegate` anymore, but maybe we don't need it.

[Q]
Is it worth to include to the main repo?
