### PR TITLE
Disabled code coverage

### DIFF
--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-iOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-iOS.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-macOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-macOS.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-tvOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-tvOS.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-watchOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-watchOS.xcscheme
@@ -27,8 +27,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <AdditionalOptions>


### PR DESCRIPTION
When submitting a build to Testflight, we get the following error:

> **Invalid Bundle** - Disallowed LLVM instrumentation. Do not submit apps with LLVM profiling instrumentation or coverage collection enabled. Turn off LLVM profiling or code coverage, rebuild your app and resubmit the app.

For more information: https://github.com/Carthage/Carthage/issues/2056