### PR TITLE
Set CFBundleShortVersionString from 4.0.0-beta.0 to 4.0.0

### DIFF
--- a/RxBlocking/Info.plist
+++ b/RxBlocking/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0-beta.0</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RxCocoa/Info.plist
+++ b/RxCocoa/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0-beta.0</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RxSwift/Info.plist
+++ b/RxSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0-beta.0</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RxTest/Info.plist
+++ b/RxTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0-beta.0</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
The current frameworks can't be used to do a AppStore/Testflight release because of the following error:

> **ERROR ITMS-90060**: "This bundle is invalid. The value for key CFBundleShortVersionString '4.0.0-beta.0' in the Info.plist file must be a period-separated list of at most three non-negative integers."