### PR TITLE
Fix memory leak of pthread_key_t pointer

### DIFF
--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -50,7 +50,11 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
 
     private static var isScheduleRequiredKey: pthread_key_t = { () -> pthread_key_t in
         let key = UnsafeMutablePointer<pthread_key_t>.allocate(capacity: 1)
-        if pthread_key_create(key, nil) != 0 {
+        defer {
+            key.deallocate(capacity: 1)
+        }
+                                                               
+        guard pthread_key_create(key, nil) == 0 else {
             rxFatalError("isScheduleRequired key creation failed")
         }
 


### PR DESCRIPTION
The allocated `UnsafeMutablePointer<pthread_key_t>` was never deallocated, therefore causing a memory leak. Calling `deallocate(capacity: 1)` in a deferred block fixes the leak.

The if statement was replaced with a guard statement.

The exit status of `./scripts/all-tests.sh` is 0.