### PR TITLE
Feature/sharing operators polish

### DIFF
--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -112,3 +112,42 @@ extension Disposable {
         disposed(by: bag)
     }
 }
+
+
+extension ObservableType {
+
+    /**
+     Returns an observable sequence that shares a single subscription to the underlying sequence, and immediately upon subscription replays latest element in buffer.
+
+     This operator is a specialization of replay which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+
+     - seealso: [shareReplay operator on reactivex.io](http://reactivex.io/documentation/operators/replay.html)
+
+     - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+     */
+    @available(*, deprecated, message: "use share(replay: 1) instead", renamed: "share(replay:)")
+    public func shareReplayLatestWhileConnected()
+        -> Observable<E> {
+        return share(replay: 1, scope: .whileConnected)
+    }
+}
+
+
+extension ObservableType {
+
+    /**
+     Returns an observable sequence that shares a single subscription to the underlying sequence, and immediately upon subscription replays maximum number of elements in buffer.
+
+     This operator is a specialization of replay which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
+
+     - seealso: [shareReplay operator on reactivex.io](http://reactivex.io/documentation/operators/replay.html)
+
+     - parameter bufferSize: Maximum element count of the replay buffer.
+     - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+     */
+    @available(*, deprecated, message: "Suggested replacement is `share(replay: 1)`. In case old 3.x behavior of `shareReplay` is required please use `share(replay: 1, scope: .forever)` instead.", renamed: "share(replay:)")
+    public func shareReplay(_ bufferSize: Int)
+        -> Observable<E> {
+        return self.share(replay: bufferSize, scope: .forever)
+    }
+}

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -60,7 +60,7 @@ extension ObservableType {
     - returns: A connectable observable sequence that shares a single subscription to the underlying sequence.
     */
     public func publish() -> ConnectableObservable<E> {
-        return self.multicast(PublishSubject())
+        return self.multicast { PublishSubject() }
     }
 }
 
@@ -78,7 +78,7 @@ extension ObservableType {
      */
     public func replay(_ bufferSize: Int)
         -> ConnectableObservable<E> {
-        return self.multicast(ReplaySubject.create(bufferSize: bufferSize))
+        return self.multicast { ReplaySubject.create(bufferSize: bufferSize) }
     }
 
     /**
@@ -92,7 +92,7 @@ extension ObservableType {
      */
     public func replayAll()
         -> ConnectableObservable<E> {
-        return self.multicast(ReplaySubject.createUnbounded())
+        return self.multicast { ReplaySubject.createUnbounded() }
     }
 }
 

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -113,22 +113,6 @@ extension ConnectableObservableType {
 extension ObservableType {
 
     /**
-     Returns an observable sequence that shares a single subscription to the underlying sequence.
-
-     This operator is a specialization of publish which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
-
-     - seealso: [share operator on reactivex.io](http://reactivex.io/documentation/operators/refcount.html)
-
-     - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
-     */
-    public func share() -> Observable<E> {
-        return self.publish().refCount()
-    }
-}
-
-extension ObservableType {
-
-    /**
      Multicasts the source sequence notifications through the specified subject to the resulting connectable observable.
 
      Upon connection of the connectable observable, the subject is subscribed to the source exactly one, and messages are forwarded to the observers registered with the connectable observable.

--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -144,7 +144,7 @@ extension ObservableType {
         case .forever:
             switch replay {
             case 0: return self.multicast(PublishSubject()).refCount()
-            default: return shareReplay(replay)
+            default: return self.multicast(ReplaySubject.create(bufferSize: replay)).refCount()
             }
         case .whileConnected:
             switch replay {
@@ -153,44 +153,6 @@ extension ObservableType {
             default: return self.multicast(makeSubject: { ReplaySubject.create(bufferSize: replay) }).refCount()
             }
         }
-    }
-}
-
-extension ObservableType {
-
-    /**
-     Returns an observable sequence that shares a single subscription to the underlying sequence, and immediately upon subscription replays latest element in buffer.
-
-     This operator is a specialization of replay which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
-
-     Unlike `shareReplay(bufferSize: Int)`, this operator will clear latest element from replay buffer in case number of subscribers drops from one to zero. In case sequence
-     completes or errors out replay buffer is also cleared.
-
-     - seealso: [shareReplay operator on reactivex.io](http://reactivex.io/documentation/operators/replay.html)
-
-     - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
-     */
-    public func shareReplayLatestWhileConnected()
-        -> Observable<E> {
-        return ShareReplay1WhileConnected(source: self.asObservable())
-    }
-}
-
-extension ObservableType {
-
-    /**
-     Returns an observable sequence that shares a single subscription to the underlying sequence, and immediately upon subscription replays maximum number of elements in buffer.
-
-     This operator is a specialization of replay which creates a subscription when the number of observers goes from zero to one, then shares that subscription with all subsequent observers until the number of observers returns to zero, at which point the subscription is disposed.
-
-     - seealso: [shareReplay operator on reactivex.io](http://reactivex.io/documentation/operators/replay.html)
-
-     - parameter bufferSize: Maximum element count of the replay buffer.
-     - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
-     */
-    public func shareReplay(_ bufferSize: Int)
-        -> Observable<E> {
-        return self.replay(bufferSize).refCount()
     }
 }
 

--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -138,7 +138,7 @@ extension ObservableType {
 
      - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
      */
-    public func share(replay: Int = 0, scope: SubjectLifetimeScope)
+    public func share(replay: Int = 0, scope: SubjectLifetimeScope = .whileConnected)
         -> Observable<E> {
         switch scope {
         case .forever:

--- a/RxTest/ColdObservable.swift
+++ b/RxTest/ColdObservable.swift
@@ -26,14 +26,19 @@ final class ColdObservable<Element>
         
         let i = self.subscriptions.count - 1
 
+        var disposed = false
+
         for recordedEvent in recordedEvents {
             _ = testScheduler.scheduleRelativeVirtual((), dueTime: recordedEvent.time, action: { _ in
-                observer.on(recordedEvent.value)
+                if !disposed {
+                    observer.on(recordedEvent.value)
+                }
                 return Disposables.create()
             })
         }
         
         return Disposables.create {
+            disposed = true
             let existing = self.subscriptions[i]
             self.subscriptions[i] = Subscription(existing.subscribe, self.testScheduler.clock)
         }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1217,12 +1217,13 @@ final class ObservableShareReplayScopeTests_ : ObservableShareReplayScopeTests, 
     #endif
 
     static var allTests: [(String, (ObservableShareReplayScopeTests_) -> () -> ())] { return [
-    ("testReplay_forever_receivesCorrectElements", ObservableShareReplayScopeTests.testReplay_forever_receivesCorrectElements),
-    ("testReplay_whileConnected_receivesCorrectElements", ObservableShareReplayScopeTests.testReplay_whileConnected_receivesCorrectElements),
-    ("testReplay_forever_error", ObservableShareReplayScopeTests.testReplay_forever_error),
-    ("testReplay_whileConnected_error", ObservableShareReplayScopeTests.testReplay_whileConnected_error),
-    ("testReplay_forever_completed", ObservableShareReplayScopeTests.testReplay_forever_completed),
-    ("testReplay_whileConnected_completed", ObservableShareReplayScopeTests.testReplay_whileConnected_completed),
+    ("test_testDefaultArguments", ObservableShareReplayScopeTests.test_testDefaultArguments),
+    ("test_forever_receivesCorrectElements", ObservableShareReplayScopeTests.test_forever_receivesCorrectElements),
+    ("test_whileConnected_receivesCorrectElements", ObservableShareReplayScopeTests.test_whileConnected_receivesCorrectElements),
+    ("test_forever_error", ObservableShareReplayScopeTests.test_forever_error),
+    ("test_whileConnected_error", ObservableShareReplayScopeTests.test_whileConnected_error),
+    ("test_forever_completed", ObservableShareReplayScopeTests.test_forever_completed),
+    ("test_whileConnected_completed", ObservableShareReplayScopeTests.test_whileConnected_completed),
     ] }
 }
 

--- a/Tests/RxSwiftTests/Observable+MulticastTests.swift
+++ b/Tests/RxSwiftTests/Observable+MulticastTests.swift
@@ -1284,21 +1284,16 @@ extension ObservableMulticastTest {
     func testReplayCount_Basic() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            error(130, testError)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1306,53 +1301,47 @@ extension ObservableMulticastTest {
         var connection: Disposable! = nil
         let res = scheduler.createObserver(Int.self)
 
-        scheduler.scheduleAt(Defaults.created) { ys = xs.replay(3) }
-        scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
+        scheduler.scheduleAt(Defaults.created) { ys = xs.debug("1").replay(3) }
+        scheduler.scheduleAt(450, action: { subscription = ys.debug("2").subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
-
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(550) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
         scheduler.scheduleAt(650) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 5),
-            next(450, 6),
-            next(450, 7),
-            next(520, 11),
+            next(450, 9),
+            next(450, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 550),
-            Subscription(650, 800)
+            Subscription(400, 520),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayCount_Error() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            error(90, testError)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1364,47 +1353,44 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(650) { connection = ys.connect() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 5),
-            next(450, 6),
-            next(450, 7),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError),
+            next(450, 9),
+            next(450, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
+            error(490, testError),
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 600),
+            Subscription(400, 490),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayCount_Complete() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            completed(90)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1416,47 +1402,44 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(650) { connection = ys.connect() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 5),
-            next(450, 6),
-            next(450, 7),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+            next(450, 9),
+            next(450, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
+            completed(490),
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 600),
+            Subscription(400, 490),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayCount_Dispose() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            completed(130)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1468,48 +1451,42 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(475) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
-
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(550) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
         scheduler.scheduleAt(650) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 5),
-            next(450, 6),
-            next(450, 7),
+            next(450, 9),
+            next(450, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 550),
-            Subscription(650, 800),
+            Subscription(400, 520),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayOneCount_Basic() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            completed(130)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1521,47 +1498,41 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
-
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(550) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
         scheduler.scheduleAt(650) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 7),
-            next(520, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 550),
-            Subscription(650, 800)
+            Subscription(400, 520),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayOneCount_Error() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            error(90, testError)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1573,45 +1544,42 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(650) { connection = ys.connect() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 7),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
+            error(490, testError)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 600),
+            Subscription(400, 490),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayOneCount_Complete() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            completed(90)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1623,45 +1591,42 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(650) { connection = ys.connect() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 7),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
+            completed(490)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 600),
+            Subscription(400, 490),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayOneCount_Dispose() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            completed(90)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1673,46 +1638,40 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(475) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
-
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(550) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
         scheduler.scheduleAt(650) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 7),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 550),
-            Subscription(650, 800),
+            Subscription(400, 490),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayAll_Basic() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            completed(130)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1724,32 +1683,28 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(200) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
-
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(550) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
         scheduler.scheduleAt(650) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 3),
-            next(450, 4),
-            next(450, 1),
-            next(450, 8),
             next(450, 5),
-            next(450, 6),
-            next(450, 7),
-            next(520, 11),
+            next(450, 9),
+            next(450, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(200, 400),
-            Subscription(500, 550),
-            Subscription(650, 800)
+            Subscription(400, 520),
+            Subscription(650, 700)
             ])
     }
 
@@ -1757,21 +1712,16 @@ extension ObservableMulticastTest {
     func testReplayAll_Error() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            error(90, testError)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1783,48 +1733,45 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(650) { connection = ys.connect() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 8),
             next(450, 5),
-            next(450, 6),
-            next(450, 7),
-            next(520, 11),
-            next(560, 20),
-            error(600, testError),
+            next(450, 9),
+            next(450, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
+            error(490, testError)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 600),
+            Subscription(400, 490),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayAll_Complete() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            completed(90)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1836,48 +1783,45 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(Defaults.disposed) { subscription.dispose() }
 
-        scheduler.scheduleAt(300) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(650) { connection = ys.connect() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 8),
             next(450, 5),
-            next(450, 6),
-            next(450, 7),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+            next(450, 9),
+            next(450, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
+            next(480, 25),
+            completed(490)
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(300, 400),
-            Subscription(500, 600),
+            Subscription(400, 490),
+            Subscription(650, 700)
             ])
     }
 
     func testReplayAll_Dispose() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
-            next(110, 7),
-            next(220, 3),
-            next(280, 4),
-            next(290, 1),
-            next(340, 8),
-            next(360, 5),
-            next(370, 6),
-            next(390, 7),
-            next(410, 13),
-            next(430, 2),
-            next(450, 9),
-            next(520, 11),
-            next(560, 20),
-            completed(600)
+        let xs = scheduler.createColdObservable([
+            next(10, 5),
+            next(20, 9),
+            next(30, 11),
+            next(40, 20),
+            next(50, 22),
+            next(60, 23),
+            next(70, 24),
+            next(80, 25),
+            completed(130)
             ])
 
         var ys: ConnectableObservable<Int>! = nil
@@ -1889,30 +1833,27 @@ extension ObservableMulticastTest {
         scheduler.scheduleAt(450, action: { subscription = ys.subscribe(res) })
         scheduler.scheduleAt(475) { subscription.dispose() }
 
-        scheduler.scheduleAt(250) { connection = ys.connect() }
-        scheduler.scheduleAt(400) { connection.dispose() }
-
-        scheduler.scheduleAt(500) { connection = ys.connect() }
-        scheduler.scheduleAt(550) { connection.dispose() }
+        scheduler.scheduleAt(400) { connection = ys.connect() }
+        scheduler.scheduleAt(520) { connection.dispose() }
 
         scheduler.scheduleAt(650) { connection = ys.connect() }
-        scheduler.scheduleAt(800) { connection.dispose() }
+        scheduler.scheduleAt(700) { connection.dispose() }
 
         scheduler.start()
 
         XCTAssertEqual(res.events, [
-            next(450, 4),
-            next(450, 1),
-            next(450, 8),
             next(450, 5),
-            next(450, 6),
-            next(450, 7),
+            next(450, 9),
+            next(450, 11),
+            next(450, 20),
+            next(450, 22),
+            next(460, 23),
+            next(470, 24),
             ])
 
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(250, 400),
-            Subscription(500, 550),
-            Subscription(650, 800),
+            Subscription(400, 520),
+            Subscription(650, 700)
             ])
     }
 


### PR DESCRIPTION
This PR polishes our sharing operators.

* Deprecates `shareReplayLatestWhileConnected` and `shareReplay` in favor of `share(replay:scope:)`
* Changes `publish`, `replay`, `replay` all to clear state in case of sequence termination to be more consistent with other Rx implementations and enable retries.
* Replaces `share` with default implementation of `share(replay:scope:)` so majority of operators can be derived from a single operator.