### PR TITLE
Removing only the specified image transition animation

### DIFF
--- a/RxCocoa/iOS/UIImageView+Rx.swift
+++ b/RxCocoa/iOS/UIImageView+Rx.swift
@@ -35,7 +35,7 @@ extension Reactive where Base: UIImageView {
                 }
             }
             else {
-                imageView.layer.removeAllAnimations()
+                imageView.layer.removeAnimation(forKey: kCATransition)
             }
             imageView.image = image
         }


### PR DESCRIPTION
This can fix animation bugs if you are doing multiple animations on the UIImageView