### PR TITLE
Add `asDriver` and `asSharedSequence` methods to PublishRelay

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -115,6 +115,10 @@
 		AEBE14181F8B52F3001FAE4C /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */; };
 		AEBE14191F8B52F4001FAE4C /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */; };
 		AEBE141A1F8B52F5001FAE4C /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */; };
+		AEBE141D1F8B5FA9001FAE4C /* SharedSequence+PublishRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE141B1F8B5F07001FAE4C /* SharedSequence+PublishRelay.swift */; };
+		AEBE141E1F8B5FAA001FAE4C /* SharedSequence+PublishRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE141B1F8B5F07001FAE4C /* SharedSequence+PublishRelay.swift */; };
+		AEBE141F1F8B5FAA001FAE4C /* SharedSequence+PublishRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE141B1F8B5F07001FAE4C /* SharedSequence+PublishRelay.swift */; };
+		AEBE14201F8B5FAB001FAE4C /* SharedSequence+PublishRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE141B1F8B5F07001FAE4C /* SharedSequence+PublishRelay.swift */; };
 		B44D73EC1EE6D4A300EBFBE8 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
 		B44D73ED1EE6D57600EBFBE8 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
 		C801DE361F6EAD3C008DB060 /* SingleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE351F6EAD3C008DB060 /* SingleTest.swift */; };
@@ -1773,6 +1777,7 @@
 		A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewAdapter.swift; sourceTree = "<group>"; };
 		AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIProgressView+Rx.swift"; sourceTree = "<group>"; };
 		AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublishRelay+Driver.swift"; sourceTree = "<group>"; };
+		AEBE141B1F8B5F07001FAE4C /* SharedSequence+PublishRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharedSequence+PublishRelay.swift"; sourceTree = "<group>"; };
 		C801DE351F6EAD3C008DB060 /* SingleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTest.swift; sourceTree = "<group>"; };
 		C801DE391F6EAD48008DB060 /* MaybeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaybeTest.swift; sourceTree = "<group>"; };
 		C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletableTest.swift; sourceTree = "<group>"; };
@@ -3112,6 +3117,7 @@
 			isa = PBXGroup;
 			children = (
 				C89AB1B51DAAC3350065FBE6 /* ObservableConvertibleType+SharedSequence.swift */,
+				AEBE141B1F8B5F07001FAE4C /* SharedSequence+PublishRelay.swift */,
 				C89AB1B61DAAC3350065FBE6 /* SharedSequence+Operators+arity.swift */,
 				C89AB1B71DAAC3350065FBE6 /* SharedSequence+Operators+arity.tt */,
 				C89AB1B81DAAC3350065FBE6 /* SharedSequence+Operators.swift */,
@@ -4096,6 +4102,7 @@
 				461345711D9A4543001ABAF2 /* UIWebView+Rx.swift in Sources */,
 				C8093EE31B8A732E0088E94D /* DelegateProxyType.swift in Sources */,
 				C8093EFD1B8A732E0088E94D /* RxTarget.swift in Sources */,
+				AEBE141D1F8B5FA9001FAE4C /* SharedSequence+PublishRelay.swift in Sources */,
 				C8C8BCCF1F8944B800501D4D /* BehaviorRelay.swift in Sources */,
 				C88254361B8A752B00B02D69 /* UITextView+Rx.swift in Sources */,
 				C88254171B8A752B00B02D69 /* RxTableViewReactiveArrayDataSource.swift in Sources */,
@@ -4245,6 +4252,7 @@
 				C89AB1F31DAAC3350065FBE6 /* SharedSequence+Operators.swift in Sources */,
 				C8B0F71A1F530FE400548EBE /* PublishRelay.swift in Sources */,
 				C86781A61DB823B500B2029A /* NSSlider+Rx.swift in Sources */,
+				AEBE141E1F8B5FAA001FAE4C /* SharedSequence+PublishRelay.swift in Sources */,
 				C89AB2231DAAC3350065FBE6 /* URLSession+Rx.swift in Sources */,
 				C86781A11DB823B500B2029A /* NSImageView+Rx.swift in Sources */,
 				C89AB2281DAAC33F0065FBE6 /* RxCocoa.swift in Sources */,
@@ -5364,6 +5372,7 @@
 				C817729B1E7F408100EA679B /* Deprecated.swift in Sources */,
 				C89AB1E11DAAC3350065FBE6 /* ObservableConvertibleType+Driver.swift in Sources */,
 				C8F0C01B1BBBFBB9001B112F /* RxScrollViewDelegateProxy.swift in Sources */,
+				AEBE14201F8B5FAB001FAE4C /* SharedSequence+PublishRelay.swift in Sources */,
 				C8F0C01C1BBBFBB9001B112F /* UILabel+Rx.swift in Sources */,
 				C8F0C01D1BBBFBB9001B112F /* RxSearchBarDelegateProxy.swift in Sources */,
 				C8BCD3F01C14B5FB005F1280 /* UIView+Rx.swift in Sources */,
@@ -5496,6 +5505,7 @@
 				C88F76831CE5341700D5A014 /* TextInput.swift in Sources */,
 				C89AB20C1DAAC3350065FBE6 /* KVORepresentable.swift in Sources */,
 				54D213921CE08D0C0028D5B4 /* UINavigationItem+Rx.swift in Sources */,
+				AEBE141F1F8B5FAA001FAE4C /* SharedSequence+PublishRelay.swift in Sources */,
 				C89AB1F41DAAC3350065FBE6 /* SharedSequence+Operators.swift in Sources */,
 				C817729A1E7F408100EA679B /* Deprecated.swift in Sources */,
 				C8BCD3EF1C14B5FB005F1280 /* UIView+Rx.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -111,6 +111,10 @@
 		A5CD038D1F1660F40005A376 /* RxPickerViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */; };
 		AAE623761C82475700FC7801 /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */; };
 		AAE623771C82475700FC7801 /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */; };
+		AEBE14171F8B52ED001FAE4C /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */; };
+		AEBE14181F8B52F3001FAE4C /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */; };
+		AEBE14191F8B52F4001FAE4C /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */; };
+		AEBE141A1F8B52F5001FAE4C /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */; };
 		B44D73EC1EE6D4A300EBFBE8 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
 		B44D73ED1EE6D57600EBFBE8 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
 		C801DE361F6EAD3C008DB060 /* SingleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE351F6EAD3C008DB060 /* SingleTest.swift */; };
@@ -1768,6 +1772,7 @@
 		A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewDataSourceProxy.swift; sourceTree = "<group>"; };
 		A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewAdapter.swift; sourceTree = "<group>"; };
 		AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIProgressView+Rx.swift"; sourceTree = "<group>"; };
+		AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublishRelay+Driver.swift"; sourceTree = "<group>"; };
 		C801DE351F6EAD3C008DB060 /* SingleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTest.swift; sourceTree = "<group>"; };
 		C801DE391F6EAD48008DB060 /* MaybeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaybeTest.swift; sourceTree = "<group>"; };
 		C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletableTest.swift; sourceTree = "<group>"; };
@@ -3098,6 +3103,7 @@
 				C89AB1B01DAAC3350065FBE6 /* Driver+Subscription.swift */,
 				C89AB1B11DAAC3350065FBE6 /* Driver.swift */,
 				C89AB1B21DAAC3350065FBE6 /* ObservableConvertibleType+Driver.swift */,
+				AEBE14151F8B52C7001FAE4C /* PublishRelay+Driver.swift */,
 			);
 			path = Driver;
 			sourceTree = "<group>";
@@ -4085,6 +4091,7 @@
 				C88254321B8A752B00B02D69 /* UISlider+Rx.swift in Sources */,
 				C882542F1B8A752B00B02D69 /* UIScrollView+Rx.swift in Sources */,
 				844BC8B41CE4FD7500F5C7CB /* UIPickerView+Rx.swift in Sources */,
+				AEBE14171F8B52ED001FAE4C /* PublishRelay+Driver.swift in Sources */,
 				C89AB20E1DAAC3350065FBE6 /* Logging.swift in Sources */,
 				461345711D9A4543001ABAF2 /* UIWebView+Rx.swift in Sources */,
 				C8093EE31B8A732E0088E94D /* DelegateProxyType.swift in Sources */,
@@ -4205,6 +4212,7 @@
 				C85E6FBF1F53025700C5681E /* SchedulerType+SharedSequence.swift in Sources */,
 				C8A81CA11E05E82C0008DEF4 /* DispatchQueue+Extensions.swift in Sources */,
 				C88F76821CE5341700D5A014 /* TextInput.swift in Sources */,
+				AEBE14181F8B52F3001FAE4C /* PublishRelay+Driver.swift in Sources */,
 				C8C8BCD01F8944B800501D4D /* BehaviorRelay.swift in Sources */,
 				C89AB1DF1DAAC3350065FBE6 /* ObservableConvertibleType+Driver.swift in Sources */,
 				C89AB1D71DAAC3350065FBE6 /* Driver+Subscription.swift in Sources */,
@@ -5360,6 +5368,7 @@
 				C8F0C01D1BBBFBB9001B112F /* RxSearchBarDelegateProxy.swift in Sources */,
 				C8BCD3F01C14B5FB005F1280 /* UIView+Rx.swift in Sources */,
 				C89AB2051DAAC3350065FBE6 /* KVORepresentable+CoreGraphics.swift in Sources */,
+				AEBE141A1F8B52F5001FAE4C /* PublishRelay+Driver.swift in Sources */,
 				C8F0C01F1BBBFBB9001B112F /* Observable+Bind.swift in Sources */,
 				C8F0C0201BBBFBB9001B112F /* UISegmentedControl+Rx.swift in Sources */,
 				C89AB1ED1DAAC3350065FBE6 /* SharedSequence+Operators+arity.swift in Sources */,
@@ -5440,6 +5449,7 @@
 				D203C5081BB9C53E00D02D00 /* UIGestureRecognizer+Rx.swift in Sources */,
 				88D98F2F1CE7549A00D50457 /* RxTabBarDelegateProxy.swift in Sources */,
 				844BC8B51CE4FD7500F5C7CB /* UIPickerView+Rx.swift in Sources */,
+				AEBE14191F8B52F4001FAE4C /* PublishRelay+Driver.swift in Sources */,
 				B44D73ED1EE6D57600EBFBE8 /* UIViewController+Rx.swift in Sources */,
 				D203C4F61BB9C52E00D02D00 /* RxCollectionViewDataSourceType.swift in Sources */,
 				C89AB2101DAAC3350065FBE6 /* Logging.swift in Sources */,

--- a/RxCocoa/Traits/Driver/PublishRelay+Driver.swift
+++ b/RxCocoa/Traits/Driver/PublishRelay+Driver.swift
@@ -1,0 +1,28 @@
+//
+//  PublishRelay+Driver.swift
+//  RxSwift-iOS
+//
+//  Created by yuzushioh on 2017/10/09.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+#if !RX_NO_MODULE
+    import RxSwift
+#endif
+
+extension PublishRelay {
+    /// Converts `PublishReplay` to `Driver`.
+    ///
+    /// `PublishReplay` can't fail, so no special case needs to be handled.
+    ///
+    /// - returns: Observable sequence.
+    public func asDriver() -> Driver<Element> {
+        return self.asDriver { error -> Driver<Element> in
+            #if DEBUG
+                rxFatalError("Somehow driver received error from a source that shouldn't fail.")
+            #else
+                return Driver.empty()
+            #endif
+        }
+    }
+}

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+PublishRelay.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+PublishRelay.swift
@@ -1,0 +1,25 @@
+//
+//  SharedSequence+PublishRelay.swift
+//  RxSwift-iOS
+//
+//  Created by yuzushioh on 2017/10/09.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+#if !RX_NO_MODULE
+    import RxSwift
+#endif
+
+extension PublishRelay {
+    /// Converts `PublishReplay` to `SharedSequence`.
+    ///
+    /// `PublishReplay` can't fail, so no special case needs to be handled.
+    ///
+    /// - returns: Observable sequence.
+    public func asSharedSequence<SharingStrategy: SharingStrategyProtocol>(strategy: SharingStrategy.Type = SharingStrategy.self) -> SharedSequence<SharingStrategy, Element> {
+        let source = self.asObservable()
+            .observeOn(SharingStrategy.scheduler)
+        return SharedSequence(source)
+    }
+}
+


### PR DESCRIPTION
PublishReplay can't fail with error or completed so it would not be strange if `PublishRelay` trait could be converted to `Driver` without any error handling. So I added `asDriver()` method to it! And I also added `asSharedSequence`