### PR TITLE
make function for control properties accessible

### DIFF
--- a/RxCocoa/iOS/UIControl+Rx.swift
+++ b/RxCocoa/iOS/UIControl+Rx.swift
@@ -76,7 +76,7 @@ extension Reactive where Base: UIControl {
     ///    }
     ///}
     ///```
-    static func value<C: UIControl, T>(_ control: C, getter: @escaping (C) -> T, setter: @escaping (C, T) -> Void) -> ControlProperty<T> {
+    public static func value<C: UIControl, T>(_ control: C, getter: @escaping (C) -> T, setter: @escaping (C, T) -> Void) -> ControlProperty<T> {
         let source: Observable<T> = Observable.create { [weak weakControl = control] observer in
                 guard let control = weakControl else {
                     observer.on(.completed)


### PR DESCRIPTION
When i have custom UI component, like `MaterialButton`, i want to add control properties to bind its state to ViewModel, lets say i have this control: 

```
final public class MaterialButton: UIButton {
public var loaderActive: Bool = false {
        didSet {
            if loaderActive {
                startAnimating()
            } else {
                stopAnimating()
            }
        }
    }
}
```
i want to bind property isLoaderActive, to viewModel like here: 
```
@IBOutlet weak var exampleButton: MaterialButton!
func setupObservers() {
viewModel.buttonLoader.asObservable().bind(to: exampleButton.rx.loader) >>> bag
}
```
so i have to only add extension: 
```
public extension Reactive where Base: MaterialButton {
    
    public var loader: ControlProperty<Bool> {
        return UIControl.rx.value(base, getter: { button in
            button.loaderActive
        }, setter: { button, value in
            button.loaderActive = value
        })
    }
}
```

since this method: 
```
statuc func value<C: UIControl, T>(_ control: C, getter: @escaping (C) -> T, setter: @escaping (C, T) -> Void) -> ControlProperty<T>
``` 
was internal, i coun't add control propety to custom control. 

