### PR TITLE
Corrected spelling of `emits`

### DIFF
--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -443,7 +443,7 @@ extension SharedSequenceConvertibleType {
     }
 
     /**
-    Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emitts an element.
+    Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emits an element.
 
     - parameter second: Second observable source.
     - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.

--- a/RxSwift/Observables/WithLatestFrom.swift
+++ b/RxSwift/Observables/WithLatestFrom.swift
@@ -22,7 +22,7 @@ extension ObservableType {
     }
 
     /**
-     Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emitts an element.
+     Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emits an element.
 
      - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
 


### PR DESCRIPTION
Just a small spelling correction `emitts` -> `emits`.