### PR TITLE
changed method visibility from public to open

### DIFF
--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -199,7 +199,7 @@
         ///
         /// - parameter forwardToDelegate: Reference of delegate that receives all messages through `self`.
         /// - parameter retainDelegate: Should `self` retain `forwardToDelegate`.
-        open func setForwardToDelegate(_ delegate: Delegate?, retainDelegate: Bool) {
+        public func setForwardToDelegate(_ delegate: Delegate?, retainDelegate: Bool) {
             #if DEBUG // 4.0 all configurations
                 MainScheduler.ensureExecutingOnScheduler()
             #endif

--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -199,7 +199,7 @@
         ///
         /// - parameter forwardToDelegate: Reference of delegate that receives all messages through `self`.
         /// - parameter retainDelegate: Should `self` retain `forwardToDelegate`.
-        public func setForwardToDelegate(_ delegate: Delegate?, retainDelegate: Bool) {
+        open func setForwardToDelegate(_ delegate: Delegate?, retainDelegate: Bool) {
             #if DEBUG // 4.0 all configurations
                 MainScheduler.ensureExecutingOnScheduler()
             #endif

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -163,7 +163,7 @@ extension DelegateProxyType {
     ///             ...
     ///         }
     ///     }
-    public static func proxy(for object: ParentObject) -> Self {
+    public static func proxy(for object: ParentObject, retainDelegate: Bool = false) -> Self {
         MainScheduler.ensureExecutingOnScheduler()
 
         let maybeProxy = self.assignedProxy(for: object)
@@ -182,7 +182,7 @@ extension DelegateProxyType {
         let delegateProxy: Self = castOrFatalError(proxy)
 
         if currentDelegate !== delegateProxy {
-            delegateProxy.setForwardToDelegate(currentDelegate, retainDelegate: false)
+            delegateProxy.setForwardToDelegate(currentDelegate, retainDelegate: retainDelegate)
             assert(delegateProxy.forwardToDelegate() === currentDelegate)
             self.setCurrentDelegate(proxy, to: object)
             assert(self.currentDelegate(for: object) === proxy)


### PR DESCRIPTION
Currently it's not possible to override the `setForwardToDelegate`method.
One use case to do that is described here http://stackoverflow.com/questions/35575305/transform-uiapplicationdelegate-methods-into-rxswift-observables