### PR TITLE
Fix remove method signature inconsistence

### DIFF
--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -32,11 +32,10 @@ extension ObservableType {
      gracefully completed, errored, or if the generation is canceled by disposing subscription).
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(file: String = #file, line: UInt = #line, function: String = #function, onNext: ((E) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
+    public func subscribe(onNext: ((E) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
         -> Disposable {
             
             #if DEBUG
-                
                 
                 let disposable: Disposable
                 
@@ -63,7 +62,7 @@ extension ObservableType {
                             onError(e)
                         }
                         else {
-                            print("Received unhandled error: \(file):\(line):\(function) -> \(e)")
+                            print("Received unhandled error: \(e)")
                         }
                         disposable.dispose()
                     case .completed:


### PR DESCRIPTION
Fix for the issue #1416 

The case is following:
1. You have a framework that uses RxSwift. Framework built as a static library in debug mode.
2. You use this framework in an app, and you want to build it in Release (or any non-debug) mode.

The problem is that there are two different methods declared in RxSwift: one for debug and one for release. So at compile-time, it's ok to call any method (because of default argument values they can be called the same way), but at runtime, there's no valid method signature can be found.

So the fix is to declare ONE method for both debug and non-debug schemes, but break method implementation into debug and non-debug parts.

This fix should not affect any working projects but give an opportunity to avoid a crash while debugging apps with release-build static libs which calls debug-built RxSwift methods.
