### PR TITLE
Fix UITableView.rx.didUpdateFocusInContextWithAnimationCoordinator parameter type

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -911,6 +911,8 @@ _ = variable.asObservable()
         print("Completed 2")
     })
 
+print("Before send 2")
+
 variable.value = 2
 
 print("End ---")
@@ -925,6 +927,7 @@ Before send 1
 First 1
 Before second subscription ---
 Second 1
+Before send 2
 First 2
 Second 2
 End ---

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -443,7 +443,7 @@ extension SharedSequenceConvertibleType {
     }
 
     /**
-    Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emitts an element.
+    Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emits an element.
 
     - parameter second: Second observable source.
     - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -405,11 +405,11 @@ extension Reactive where Base: UITableView {
         /**
          Reactive wrapper for `delegate` message `tableView:didUpdateFocusInContext:withAnimationCoordinator:`.
          */
-        public var didUpdateFocusInContextWithAnimationCoordinator: ControlEvent<(context: UIFocusUpdateContext, animationCoordinator: UIFocusAnimationCoordinator)> {
+        public var didUpdateFocusInContextWithAnimationCoordinator: ControlEvent<(context: UITableViewFocusUpdateContext, animationCoordinator: UIFocusAnimationCoordinator)> {
             
             let source = delegate.methodInvoked(#selector(UITableViewDelegate.tableView(_:didUpdateFocusIn:with:)))
-                .map { a -> (context: UIFocusUpdateContext, animationCoordinator: UIFocusAnimationCoordinator) in
-                    let context = a[1] as! UIFocusUpdateContext
+                .map { a -> (context: UITableViewFocusUpdateContext, animationCoordinator: UIFocusAnimationCoordinator) in
+                    let context = a[1] as! UITableViewFocusUpdateContext
                     let animationCoordinator = try castOrThrow(UIFocusAnimationCoordinator.self, a[2])
                     return (context: context, animationCoordinator: animationCoordinator)
             }

--- a/RxSwift/Observables/WithLatestFrom.swift
+++ b/RxSwift/Observables/WithLatestFrom.swift
@@ -22,7 +22,7 @@ extension ObservableType {
     }
 
     /**
-     Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emitts an element.
+     Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emits an element.
 
      - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
 


### PR DESCRIPTION
Looks like `UITableView.rx.didUpdateFocusInContextWithAnimationCoordinator` parameter type is wrong.

🙅 UIFocusUpdateContext
🙆 UITableViewFocusUpdateContext

UICollectionView+Rx is correctly handling this.