### PR TITLE
Add wrappers for `observe` methods to use Swift 4 KeyPath

### DIFF
--- a/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
@@ -45,7 +45,15 @@ extension Reactive where Base: NSObject {
         return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
     }
 
+    /**
+     Specialization of generic `observe` method.
 
+     This specialization first observes `KVORepresentable` value and then converts it to `RawRepresentable` value.
+
+     It is useful for observing bridged ObjC enum values.
+
+     For more information take a look at `observe` method.
+     */
     @available(swift 4.0)
     public func observe<E: RawRepresentable>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> where E.RawValue: KVORepresentable {
         guard let keyPathString = keyPath._kvcKeyPathString else {

--- a/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
@@ -27,6 +27,32 @@ extension Reactive where Base: NSObject {
         return observe(E.RawValue.KVOType.self, keyPath, options: options, retainSelf: retainSelf)
             .map(E.init)
     }
+
+    /**
+     Specialization of generic `observe` method.
+
+     This specialization first observes `KVORepresentable` value and then converts it to `RawRepresentable` value.
+
+     It is useful for observing bridged ObjC enum values.
+
+     For more information take a look at `observe` method.
+     */
+    @available(swift 4.0)
+    public func observe<E: RawRepresentable>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> where E.RawValue: KVORepresentable {
+        guard let keyPathString = keyPath._kvcKeyPathString else {
+            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+        }
+        return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
+    }
+
+
+    @available(swift 4.0)
+    public func observe<E: RawRepresentable>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> where E.RawValue: KVORepresentable {
+        guard let keyPathString = keyPath._kvcKeyPathString else {
+            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+        }
+        return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
+    }
 }
 
 #if !DISABLE_SWIZZLING
@@ -46,6 +72,40 @@ extension Reactive where Base: NSObject {
         public func observeWeakly<E: RawRepresentable>(_ type: E.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> where E.RawValue: KVORepresentable {
             return observeWeakly(E.RawValue.KVOType.self, keyPath, options: options)
                 .map(E.init)
+        }
+
+        /**
+         Specialization of generic `observeWeakly` method.
+
+         This specialization first observes `KVORepresentable` value and then converts it to `RawRepresentable` value.
+
+         It is useful for observing bridged ObjC enum values.
+
+         For more information take a look at `observeWeakly` method.
+         */
+        @available(swift 4.0)
+        public func observeWeakly<E: RawRepresentable>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> where E.RawValue: KVORepresentable {
+            guard let keyPathString = keyPath._kvcKeyPathString else {
+                rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+            }
+            return observeWeakly(E.self, keyPathString, options: options)
+        }
+
+        /**
+         Specialization of generic `observeWeakly` method.
+
+         This specialization first observes `KVORepresentable` value and then converts it to `RawRepresentable` value.
+
+         It is useful for observing bridged ObjC enum values.
+
+         For more information take a look at `observeWeakly` method.
+         */
+        @available(swift 4.0)
+        public func observeWeakly<E: RawRepresentable>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> where E.RawValue: KVORepresentable {
+            guard let keyPathString = keyPath._kvcKeyPathString else {
+                rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+            }
+            return observeWeakly(E.self, keyPathString, options: options)
         }
     }
 #endif

--- a/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
@@ -38,8 +38,17 @@ extension Reactive where Base: NSObject {
      For more information take a look at `observe` method.
      */
     @available(swift 4.0)
-    public func observe<E: RawRepresentable>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> where E.RawValue: KVORepresentable {
-        return observe(E.self, keyPath.kvcKeyPathString, options: options, retainSelf: retainSelf)
+    public func observe<E: RawRepresentable>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E> where E.RawValue: KVORepresentable {
+        return observe(E.self, keyPath.kvcKeyPathString, options: options, retainSelf: retainSelf).flatMap { value -> Observable<E> in
+            guard let value  = value else {
+                #if DEBUG
+                    rxFatalError("Something went wrong with KVO observing mechanism")
+                #else
+                    return Observable.empty()
+                #endif
+            }
+            return Observable.just(value)
+        }
     }
 
     /**

--- a/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
@@ -39,10 +39,7 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observe<E: RawRepresentable>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> where E.RawValue: KVORepresentable {
-        guard let keyPathString = keyPath._kvcKeyPathString else {
-            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
-        }
-        return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
+        return observe(E.self, keyPath.kvcKeyPathString, options: options, retainSelf: retainSelf)
     }
 
     /**
@@ -56,10 +53,7 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observe<E: RawRepresentable>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> where E.RawValue: KVORepresentable {
-        guard let keyPathString = keyPath._kvcKeyPathString else {
-            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
-        }
-        return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
+        return observe(E.self, keyPath.kvcKeyPathString, options: options, retainSelf: retainSelf)
     }
 }
 
@@ -93,10 +87,7 @@ extension Reactive where Base: NSObject {
          */
         @available(swift 4.0)
         public func observeWeakly<E: RawRepresentable>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> where E.RawValue: KVORepresentable {
-            guard let keyPathString = keyPath._kvcKeyPathString else {
-                rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
-            }
-            return observeWeakly(E.self, keyPathString, options: options)
+            return observeWeakly(E.self, keyPath.kvcKeyPathString, options: options)
         }
 
         /**
@@ -110,10 +101,7 @@ extension Reactive where Base: NSObject {
          */
         @available(swift 4.0)
         public func observeWeakly<E: RawRepresentable>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> where E.RawValue: KVORepresentable {
-            guard let keyPathString = keyPath._kvcKeyPathString else {
-                rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
-            }
-            return observeWeakly(E.self, keyPathString, options: options)
+            return observeWeakly(E.self, keyPath.kvcKeyPathString, options: options)
         }
     }
 #endif

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -88,10 +88,7 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> {
-        guard let keyPathString = keyPath._kvcKeyPathString else {
-            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
-        }
-        return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
+        return observe(E.self, keyPath.kvcKeyPathString, options: options, retainSelf: retainSelf)
     }
 
     /**
@@ -113,10 +110,7 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observe<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> {
-        guard let keyPathString = keyPath._kvcKeyPathString else {
-            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
-        }
-        return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
+        return observe(E.self, keyPath.kvcKeyPathString, options: options, retainSelf: retainSelf)
     }
 }
 
@@ -162,10 +156,7 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observeWeakly<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> {
-        guard let keyPathString = keyPath._kvcKeyPathString else {
-            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
-        }
-        return observeWeakly(E.self, keyPathString, options: options)
+        return observeWeakly(E.self, keyPath.kvcKeyPathString, options: options)
     }
 
     /**
@@ -184,10 +175,7 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observeWeakly<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> {
-        guard let keyPathString = keyPath._kvcKeyPathString else {
-            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
-        }
-        return observeWeakly(E.self, keyPathString, options: options)
+        return observeWeakly(E.self, keyPath.kvcKeyPathString, options: options)
     }
 }
 #endif
@@ -638,3 +626,18 @@ extension Reactive where Base: AnyObject {
 }
 
 #endif
+
+// MARK: KeyPath + kvcKeyPathString
+
+extension KeyPath {
+    /**
+     Helper method to return string representation of the current key path.
+     Raise fatal error if key path string cannot be resolved.
+     */
+    var kvcKeyPathString: String {
+        guard let keyPathString = _kvcKeyPathString else {
+            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+        }
+        return keyPathString
+    }
+}

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -87,7 +87,7 @@ extension Reactive where Base: NSObject {
      - returns: Observable sequence of objects on `keyPath`.
      */
     @available(swift 4.0)
-    public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
+    public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> {
         guard let keyPathString = keyPath._kvcKeyPathString else {
             rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
         }
@@ -112,7 +112,7 @@ extension Reactive where Base: NSObject {
      - returns: Observable sequence of objects on `keyPath`.
      */
     @available(swift 4.0)
-    public func observe<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
+    public func observe<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> {
         guard let keyPathString = keyPath._kvcKeyPathString else {
             rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
         }
@@ -161,7 +161,7 @@ extension Reactive where Base: NSObject {
      - returns: Observable sequence of objects on `keyPath`.
      */
     @available(swift 4.0)
-    public func observeWeakly<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
+    public func observeWeakly<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> {
         guard let keyPathString = keyPath._kvcKeyPathString else {
             rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
         }
@@ -183,7 +183,7 @@ extension Reactive where Base: NSObject {
      - returns: Observable sequence of objects on `keyPath`.
      */
     @available(swift 4.0)
-    public func observeWeakly<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
+    public func observeWeakly<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> {
         guard let keyPathString = keyPath._kvcKeyPathString else {
             rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
         }

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -86,6 +86,7 @@ extension Reactive where Base: NSObject {
      - parameter retainSelf: Retains self during observation if set `true`.
      - returns: Observable sequence of objects on `keyPath`.
      */
+    @available(swift 4.0)
     public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
         return observe(E.self, keyPath._kvcKeyPathString!, options: options, retainSelf: retainSelf)
     }
@@ -107,6 +108,7 @@ extension Reactive where Base: NSObject {
      - parameter retainSelf: Retains self during observation if set `true`.
      - returns: Observable sequence of objects on `keyPath`.
      */
+    @available(swift 4.0)
     public func observe<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
         return observe(E.self, keyPath._kvcKeyPathString!, options: options, retainSelf: retainSelf)
     }
@@ -152,6 +154,7 @@ extension Reactive where Base: NSObject {
      - parameter options: KVO mechanism notification options.
      - returns: Observable sequence of objects on `keyPath`.
      */
+    @available(swift 4.0)
     public func observeWeakly<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
         return observeWeakly(E.self, keyPath._kvcKeyPathString!, options: options)
     }
@@ -170,6 +173,7 @@ extension Reactive where Base: NSObject {
      - parameter options: KVO mechanism notification options.
      - returns: Observable sequence of objects on `keyPath`.
      */
+    @available(swift 4.0)
     public func observeWeakly<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
         return observeWeakly(E.self, keyPath._kvcKeyPathString!, options: options)
     }

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -87,8 +87,17 @@ extension Reactive where Base: NSObject {
      - returns: Observable sequence of objects on `keyPath`.
      */
     @available(swift 4.0)
-    public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> {
-        return observe(E.self, keyPath.kvcKeyPathString, options: options, retainSelf: retainSelf)
+    public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E> {
+        return observe(E.self, keyPath.kvcKeyPathString, options: options, retainSelf: retainSelf).flatMap { value -> Observable<E> in
+            guard let value  = value else {
+                #if DEBUG
+                    rxFatalError("Something went wrong with KVO observing mechanism")
+                #else
+                    return Observable.empty()
+                #endif
+            }
+            return Observable.just(value)
+        }
     }
 
     /**

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -88,7 +88,10 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
-        return observe(E.self, keyPath._kvcKeyPathString!, options: options, retainSelf: retainSelf)
+        guard let keyPathString = keyPath._kvcKeyPathString else {
+            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+        }
+        return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
     }
 
     /**
@@ -110,7 +113,10 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observe<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
-        return observe(E.self, keyPath._kvcKeyPathString!, options: options, retainSelf: retainSelf)
+        guard let keyPathString = keyPath._kvcKeyPathString else {
+            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+        }
+        return observe(E.self, keyPathString, options: options, retainSelf: retainSelf)
     }
 }
 
@@ -156,7 +162,10 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observeWeakly<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
-        return observeWeakly(E.self, keyPath._kvcKeyPathString!, options: options)
+        guard let keyPathString = keyPath._kvcKeyPathString else {
+            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+        }
+        return observeWeakly(E.self, keyPathString, options: options)
     }
 
     /**
@@ -175,7 +184,10 @@ extension Reactive where Base: NSObject {
      */
     @available(swift 4.0)
     public func observeWeakly<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
-        return observeWeakly(E.self, keyPath._kvcKeyPathString!, options: options)
+        guard let keyPathString = keyPath._kvcKeyPathString else {
+            rxFatalError("Key path cannot be observed. You may need to prefix it with @objc.")
+        }
+        return observeWeakly(E.self, keyPathString, options: options)
     }
 }
 #endif

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -89,6 +89,27 @@ extension Reactive where Base: NSObject {
     public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
         return observe(E.self, keyPath._kvcKeyPathString!, options: options, retainSelf: retainSelf)
     }
+
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and retains `self` if `retainSelf` is set.
+
+     `observe` is just a simple and performant wrapper around KVO mechanism.
+
+     * it can be used to observe paths starting from `self` or from ancestors in ownership graph (`retainSelf = false`)
+     * it can be used to observe paths starting from descendants in ownership graph (`retainSelf = true`)
+     * the paths have to consist only of `strong` properties, otherwise you are risking crashing the system by not unregistering KVO observer before dealloc.
+
+     If support for weak properties is needed or observing arbitrary or unknown relationships in the
+     ownership tree, `observeWeakly` is the preferred option.
+
+     - parameter keyPath: Key path of property names to observe.
+     - parameter options: KVO mechanism notification options.
+     - parameter retainSelf: Retains self during observation if set `true`.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observe<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
+        return observe(E.self, keyPath._kvcKeyPathString!, options: options, retainSelf: retainSelf)
+    }
 }
 
 #endif
@@ -132,6 +153,24 @@ extension Reactive where Base: NSObject {
      - returns: Observable sequence of objects on `keyPath`.
      */
     public func observeWeakly<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
+        return observeWeakly(E.self, keyPath._kvcKeyPathString!, options: options)
+    }
+
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     - parameter keyPath: Key path of property names to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<E>(_ keyPath: KeyPath<Base, E?>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
         return observeWeakly(E.self, keyPath._kvcKeyPathString!, options: options)
     }
 }

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -68,6 +68,27 @@ extension Reactive where Base: NSObject {
     public func observe<E>(_ type: E.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> {
         return KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: retainSelf).asObservable()
     }
+
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and retains `self` if `retainSelf` is set.
+
+     `observe` is just a simple and performant wrapper around KVO mechanism.
+
+     * it can be used to observe paths starting from `self` or from ancestors in ownership graph (`retainSelf = false`)
+     * it can be used to observe paths starting from descendants in ownership graph (`retainSelf = true`)
+     * the paths have to consist only of `strong` properties, otherwise you are risking crashing the system by not unregistering KVO observer before dealloc.
+
+     If support for weak properties is needed or observing arbitrary or unknown relationships in the
+     ownership tree, `observeWeakly` is the preferred option.
+
+     - parameter keyPath: Key path of property names to observe.
+     - parameter options: KVO mechanism notification options.
+     - parameter retainSelf: Retains self during observation if set `true`.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observe<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true)-> Observable<E?> {
+        return observe(E.self, keyPath._kvcKeyPathString!, options: options, retainSelf: retainSelf)
+    }
 }
 
 #endif
@@ -94,6 +115,24 @@ extension Reactive where Base: NSObject {
             .map { n in
                 return n as? E
             }
+    }
+
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     - parameter keyPath: Key path of property names to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<E>(_ keyPath: KeyPath<Base, E>, options: KeyValueObservingOptions = [.new, .initial])-> Observable<E?> {
+        return observeWeakly(E.self, keyPath._kvcKeyPathString!, options: options)
     }
 }
 #endif

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -2201,6 +2201,76 @@ extension KVOObservableSmartKVOTests {
     }
 #endif
 
+// MARK: KVORepresentable
+
+extension KVOObservableSmartKVOTests {
+    func testObserve_ObserveIntegerRepresentable() {
+        var root: HasStrongProperty! = HasStrongProperty()
+
+        var latest: Int?
+
+        XCTAssertTrue(latest == nil)
+
+        let disposable = root.rx.observe(\.integer)
+            .subscribe(onNext: { n in
+                latest = n
+            })
+        XCTAssertTrue(latest == 1)
+
+        root.integer = 2
+
+        XCTAssertTrue(latest == 2)
+
+        var rootDeallocated = false
+
+        _ = root
+            .rx.deallocated
+            .subscribe(onCompleted: {
+                rootDeallocated = true
+            })
+
+        root = nil
+
+        XCTAssertTrue(latest == 2)
+        XCTAssertTrue(!rootDeallocated)
+
+        disposable.dispose()
+    }
+
+    func testObserve_ObserveUIntegerRepresentable() {
+        var root: HasStrongProperty! = HasStrongProperty()
+
+        var latest: UInt?
+
+        XCTAssertTrue(latest == nil)
+
+        let disposable = root.rx.observe(\.uinteger)
+            .subscribe(onNext: { n in
+                latest = n
+            })
+        XCTAssertTrue(latest == 1)
+
+        root.uinteger = 2
+
+        XCTAssertTrue(latest == 2)
+
+        var rootDeallocated = false
+
+        _ = root
+            .rx.deallocated
+            .subscribe(onCompleted: {
+                rootDeallocated = true
+            })
+
+        root = nil
+
+        XCTAssertTrue(latest == 2)
+        XCTAssertTrue(!rootDeallocated)
+
+        disposable.dispose()
+    }
+}
+
 // MARK: - Utilities
 
 extension NSString {

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -23,7 +23,7 @@ final class TestClass : NSObject {
     @objc dynamic var pr: String? = "0"
 }
 
-final class Parent : NSObject {
+final class ParentStringBasedKVO : NSObject {
     var disposeBag: DisposeBag! = DisposeBag()
 
     @objc dynamic var val: String = ""
@@ -41,10 +41,10 @@ final class Parent : NSObject {
     }
 }
 
-final class Child : NSObject {
+final class ChildStringBasedKVO : NSObject {
     let disposeBag = DisposeBag()
     
-    init(parent: ParentWithChild, callback: @escaping (String?) -> Void) {
+    init(parent: ParentWithChildStringBasedKVO, callback: @escaping (String?) -> Void) {
         super.init()
         parent.rx.observe(String.self, "val", options: [.initial, .new], retainSelf: false)
             .subscribe(onNext: callback)
@@ -56,14 +56,14 @@ final class Child : NSObject {
     }
 }
 
-final class ParentWithChild : NSObject {
+final class ParentWithChildStringBasedKVO : NSObject {
     @objc dynamic var val: String = ""
     
-    var child: Child? = nil
+    var child: ChildStringBasedKVO? = nil
     
     init(callback: @escaping (String?) -> Void) {
         super.init()
-        child = Child(parent: self, callback: callback)
+        child = ChildStringBasedKVO(parent: self, callback: callback)
     }
 }
 
@@ -242,7 +242,7 @@ extension KVOObservableTests {
         var latest: String?
         var isDisposed = false
         
-        var parent: Parent! = Parent { n in
+        var parent: ParentStringBasedKVO! = ParentStringBasedKVO { n in
             latest = n
         }
         
@@ -269,7 +269,7 @@ extension KVOObservableTests {
         var latest: String?
         var isDisposed = false
         
-        var parent: ParentWithChild! = ParentWithChild { n in
+        var parent: ParentWithChildStringBasedKVO! = ParentWithChildStringBasedKVO { n in
             latest = n
         }
         

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -2271,6 +2271,406 @@ extension KVOObservableSmartKVOTests {
     }
 }
 
+// MARK: RawRepresentable
+
+extension KVOObservableSmartKVOTests {
+    func testObserve_ObserveIntEnum() {
+        var root: HasStrongProperty! = HasStrongProperty()
+
+        var latest: IntEnum?
+
+        XCTAssertTrue(latest == nil)
+
+        let disposable = root.rx.observe(\.intEnum)
+            .subscribe(onNext: { n in
+                latest = n
+            })
+        XCTAssertEqual(latest, .one)
+
+        root.intEnum = .two
+
+        XCTAssertEqual(latest, .two)
+
+        var rootDeallocated = false
+
+        _ = root
+            .rx.deallocated
+            .subscribe(onCompleted: {
+                rootDeallocated = true
+            })
+
+        root = nil
+
+        XCTAssertTrue(latest == .two)
+        XCTAssertTrue(!rootDeallocated)
+
+        disposable.dispose()
+    }
+
+    func testObserve_ObserveInt32Enum() {
+        var root: HasStrongProperty! = HasStrongProperty()
+
+        var latest: Int32Enum?
+
+        XCTAssertTrue(latest == nil)
+
+        let disposable = root.rx.observe(\.int32Enum)
+            .subscribe(onNext: { n in
+                latest = n
+            })
+        XCTAssertTrue(latest == .one)
+
+        root.int32Enum = .two
+
+        XCTAssertTrue(latest == .two)
+
+        var rootDeallocated = false
+
+        _ = root
+            .rx.deallocated
+            .subscribe(onCompleted: {
+                rootDeallocated = true
+            })
+
+        root = nil
+
+        XCTAssertTrue(latest == .two)
+        XCTAssertTrue(!rootDeallocated)
+
+        disposable.dispose()
+    }
+
+    func testObserve_ObserveInt64Enum() {
+        var root: HasStrongProperty! = HasStrongProperty()
+
+        var latest: Int64Enum?
+
+        XCTAssertTrue(latest == nil)
+
+        let disposable = root.rx.observe(\.int64Enum)
+            .subscribe(onNext: { n in
+                latest = n
+            })
+        XCTAssertTrue(latest == .one)
+
+        root.int64Enum = .two
+
+        XCTAssertTrue(latest == .two)
+
+        var rootDeallocated = false
+
+        _ = root
+            .rx.deallocated
+            .subscribe(onCompleted: {
+                rootDeallocated = true
+            })
+
+        root = nil
+
+        XCTAssertTrue(latest == .two)
+        XCTAssertTrue(!rootDeallocated)
+
+        disposable.dispose()
+    }
+
+
+    func testObserve_ObserveUIntEnum() {
+        var root: HasStrongProperty! = HasStrongProperty()
+
+        var latest: UIntEnum?
+
+        XCTAssertTrue(latest == nil)
+
+        let disposable = root.rx.observe(\.uintEnum)
+            .subscribe(onNext: { n in
+                latest = n
+            })
+        XCTAssertTrue(latest == .one)
+
+        root.uintEnum = .two
+
+        XCTAssertTrue(latest == .two)
+
+        var rootDeallocated = false
+
+        _ = root
+            .rx.deallocated
+            .subscribe(onCompleted: {
+                rootDeallocated = true
+            })
+
+        root = nil
+
+        XCTAssertTrue(latest == .two)
+        XCTAssertTrue(!rootDeallocated)
+
+        disposable.dispose()
+    }
+
+    func testObserve_ObserveUInt32Enum() {
+        var root: HasStrongProperty! = HasStrongProperty()
+
+        var latest: UInt32Enum?
+
+        XCTAssertTrue(latest == nil)
+
+        let disposable = root.rx.observe(\.uint32Enum)
+            .subscribe(onNext: { n in
+                latest = n
+            })
+        XCTAssertTrue(latest == .one)
+
+        root.uint32Enum = .two
+
+        XCTAssertTrue(latest == .two)
+
+        var rootDeallocated = false
+
+        _ = root
+            .rx.deallocated
+            .subscribe(onCompleted: {
+                rootDeallocated = true
+            })
+
+        root = nil
+
+        XCTAssertTrue(latest == .two)
+        XCTAssertTrue(!rootDeallocated)
+
+        disposable.dispose()
+    }
+
+    func testObserve_ObserveUInt64Enum() {
+        var root: HasStrongProperty! = HasStrongProperty()
+
+        var latest: UInt64Enum?
+
+        XCTAssertTrue(latest == nil)
+
+        let disposable = root.rx.observe(\.uint64Enum)
+            .subscribe(onNext: { n in
+                latest = n
+            })
+        XCTAssertTrue(latest == .one)
+
+        root.uint64Enum = .two
+
+        XCTAssertTrue(latest == .two)
+
+        var rootDeallocated = false
+
+        _ = root
+            .rx.deallocated
+            .subscribe(onCompleted: {
+                rootDeallocated = true
+            })
+
+        root = nil
+
+        XCTAssertTrue(latest == .two)
+        XCTAssertTrue(!rootDeallocated)
+
+        disposable.dispose()
+    }
+}
+
+#if !DISABLE_SWIZZLING
+    extension KVOObservableSmartKVOTests {
+        func testObserveWeak_ObserveIntEnum() {
+            var root: HasStrongProperty! = HasStrongProperty()
+
+            var latest: IntEnum?
+
+            XCTAssertEqual(latest, nil)
+
+            _ = root
+                .rx.observeWeakly(\.intEnum)
+                .subscribe(onNext: { n in
+                    latest = n
+                })
+            
+            XCTAssertEqual(latest, .one)
+
+            root.intEnum = .two
+
+            XCTAssertEqual(latest, .two)
+
+            var rootDeallocated = false
+
+            _ = root
+                .rx.deallocated
+                .subscribe(onCompleted: {
+                    rootDeallocated = true
+                })
+
+            root = nil
+
+            XCTAssertEqual(latest, nil)
+            XCTAssertTrue(rootDeallocated)
+        }
+
+        func testObserveWeak_ObserveInt32Enum() {
+            var root: HasStrongProperty! = HasStrongProperty()
+
+            var latest: Int32Enum?
+
+            XCTAssertTrue(latest == nil)
+
+            _ = root
+                .rx.observeWeakly(\.int32Enum)
+                .subscribe(onNext: { n in
+                    latest = n
+                })
+            XCTAssertTrue(latest == .one)
+
+            root.int32Enum = .two
+
+            XCTAssertTrue(latest == .two)
+
+            var rootDeallocated = false
+
+            _ = root
+                .rx.deallocated
+                .subscribe(onCompleted: {
+                    rootDeallocated = true
+                })
+
+            root = nil
+
+            XCTAssertTrue(latest == nil)
+            XCTAssertTrue(rootDeallocated)
+        }
+
+        func testObserveWeak_ObserveInt64Enum() {
+            var root: HasStrongProperty! = HasStrongProperty()
+
+            var latest: Int64Enum?
+
+            XCTAssertTrue(latest == nil)
+
+            _ = root
+                .rx.observeWeakly(\.int64Enum)
+                .subscribe(onNext: { n in
+                    latest = n
+                })
+            XCTAssertTrue(latest == .one)
+
+            root.int64Enum = .two
+
+            XCTAssertTrue(latest == .two)
+
+            var rootDeallocated = false
+
+            _ = root
+                .rx.deallocated
+                .subscribe(onCompleted: {
+                    rootDeallocated = true
+                })
+
+            root = nil
+
+            XCTAssertTrue(latest == nil)
+            XCTAssertTrue(rootDeallocated)
+        }
+
+        func testObserveWeak_ObserveUIntEnum() {
+            var root: HasStrongProperty! = HasStrongProperty()
+
+            var latest: UIntEnum?
+
+            XCTAssertTrue(latest == nil)
+
+            _ = root
+                .rx.observeWeakly(\.uintEnum)
+                .subscribe(onNext: { n in
+                    latest = n
+                })
+            XCTAssertTrue(latest == .one)
+
+            root.uintEnum = .two
+
+            XCTAssertTrue(latest == .two)
+
+            var rootDeallocated = false
+
+            _ = root
+                .rx.deallocated
+                .subscribe(onCompleted: {
+                    rootDeallocated = true
+                })
+
+            root = nil
+
+            XCTAssertTrue(latest == nil)
+            XCTAssertTrue(rootDeallocated)
+        }
+
+        func testObserveWeak_ObserveUInt32Enum() {
+            var root: HasStrongProperty! = HasStrongProperty()
+
+            var latest: UInt32Enum?
+
+            XCTAssertTrue(latest == nil)
+
+            _ = root
+                .rx.observeWeakly(\.uint32Enum)
+                .subscribe(onNext: { n in
+                    latest = n
+                })
+            XCTAssertTrue(latest == .one)
+
+            root.uint32Enum = .two
+
+            XCTAssertTrue(latest == .two)
+
+            var rootDeallocated = false
+
+            _ = root
+                .rx.deallocated
+                .subscribe(onCompleted: {
+                    rootDeallocated = true
+                })
+
+            root = nil
+
+            XCTAssertTrue(latest == nil)
+            XCTAssertTrue(rootDeallocated)
+        }
+
+        func testObserveWeak_ObserveUInt64Enum() {
+            var root: HasStrongProperty! = HasStrongProperty()
+
+            var latest: UInt64Enum?
+
+            XCTAssertTrue(latest == nil)
+
+            _ = root
+                .rx.observeWeakly(\.uint64Enum)
+                .subscribe(onNext: { n in
+                    latest = n
+                })
+            XCTAssertTrue(latest == .one)
+
+            root.uint64Enum = .two
+
+            XCTAssertTrue(latest == .two)
+
+            var rootDeallocated = false
+
+            _ = root
+                .rx.deallocated
+                .subscribe(onCompleted: {
+                    rootDeallocated = true
+                })
+
+            root = nil
+
+            XCTAssertTrue(latest == nil)
+            XCTAssertTrue(rootDeallocated)
+        }
+    }
+#endif
+
 // MARK: - Utilities
 
 extension NSString {

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -1600,12 +1600,12 @@ extension KVOObservableStringBasedKVOTests {
     func testObserveWeak_ObserveUInt64Enum() {
         var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: UInt32Enum?
+        var latest: UInt64Enum?
 
         XCTAssertTrue(latest == nil)
 
         _ = root
-            .rx.observeWeakly(UInt32Enum.self, "uint64Enum")
+            .rx.observeWeakly(UInt64.self, "uint64Enum")
             .subscribe(onNext: { n in
                 latest = n
         })

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -41,6 +41,24 @@ final class ParentStringBasedKVO : NSObject {
     }
 }
 
+final class ParentSmartKVO : NSObject {
+    var disposeBag: DisposeBag! = DisposeBag()
+
+    @objc dynamic var val: String = ""
+
+    init(callback: @escaping (String?) -> Void) {
+        super.init()
+
+        self.rx.observe(\.val, options: [.initial, .new], retainSelf: false)
+            .subscribe(onNext: callback)
+            .disposed(by: disposeBag)
+    }
+
+    deinit {
+        disposeBag = nil
+    }
+}
+
 final class ChildStringBasedKVO : NSObject {
     let disposeBag = DisposeBag()
     
@@ -56,6 +74,21 @@ final class ChildStringBasedKVO : NSObject {
     }
 }
 
+final class ChildSmartKVO : NSObject {
+    let disposeBag = DisposeBag()
+
+    init(parent: ParentWithChildSmartKVO, callback: @escaping (String?) -> Void) {
+        super.init()
+        parent.rx.observe(\.val, options: [.initial, .new], retainSelf: false)
+            .subscribe(onNext: callback)
+            .disposed(by: disposeBag)
+    }
+
+    deinit {
+
+    }
+}
+
 final class ParentWithChildStringBasedKVO : NSObject {
     @objc dynamic var val: String = ""
     
@@ -64,6 +97,17 @@ final class ParentWithChildStringBasedKVO : NSObject {
     init(callback: @escaping (String?) -> Void) {
         super.init()
         child = ChildStringBasedKVO(parent: self, callback: callback)
+    }
+}
+
+final class ParentWithChildSmartKVO : NSObject {
+    @objc dynamic var val: String = ""
+
+    var child: ChildSmartKVO? = nil
+
+    init(callback: @escaping (String?) -> Void) {
+        super.init()
+        child = ChildSmartKVO(parent: self, callback: callback)
     }
 }
 

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -1605,7 +1605,7 @@ extension KVOObservableStringBasedKVOTests {
         XCTAssertTrue(latest == nil)
 
         _ = root
-            .rx.observeWeakly(UInt64.self, "uint64Enum")
+            .rx.observeWeakly(UInt64Enum.self, "uint64Enum")
             .subscribe(onNext: { n in
                 latest = n
         })


### PR DESCRIPTION
This PR adds wrapper `observe` methods that accept new Swift 4 [Smart KeyPaths](https://github.com/apple/swift-evolution/blob/master/proposals/0161-key-paths.md) which includes both key path and type information.

So the below code:
```swift
self.rx.observe(CGRect.self, #keyPath(UIViewController.view.frame))
```
can be rewritten to:
```swift
self.rx.observe(\view.frame)
```

Mostly the tests are copied from the old tests except for `property.property...` key paths and non-exists key paths which cannot be composed with the new style key path.

This is a revised PR for #1407 