### PR TITLE
Remove unnecessary check in Bag

### DIFF
--- a/Platform/DataStructures/Bag.swift
+++ b/Platform/DataStructures/Bag.swift
@@ -83,12 +83,8 @@ struct Bag<T> : CustomDebugStringConvertible {
             _pairs.append(key: key, value: element)
             return key
         }
-
-        if _dictionary == nil {
-            _dictionary = [:]
-        }
-
-        _dictionary![key] = element
+        
+        _dictionary = [key: element]
         
         return key
     }


### PR DESCRIPTION
Hi all~~

There seems to be an unnecessary check in Bag. 

So I change:

```swift
mutating func insert(_ element: T) -> BagKey {

    ...

    if _dictionary != nil {
        _dictionary![key] = element
        return key
    }

    ...
    
    if _dictionary == nil {
        _dictionary = [:]
     }

     _dictionary![key] = element
    
    ...
}
```

to this:

```swift
mutating func insert(_ element: T) -> BagKey {

    ...

    if _dictionary != nil {
        _dictionary![key] = element
        return key
    }

    ...
    
    _dictionary = [key: element]
    
    ...
}
```
