### PR TITLE
Add extension to bind Observable to keyPath to Variable's property

### DIFF
--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -65,6 +65,15 @@ extension ObservableType {
         }
     }
 
+    public func bind<T>(to variable: Variable<T>, keyPath: WritableKeyPath<T, E>) -> Disposable {
+        return self.map { element in
+                var value = variable.value
+                value[keyPath: keyPath] = element
+                return value
+            }
+            .bind(to: variable)
+    }
+
     /**
      Creates new subscription and sends elements to variable.
 

--- a/Tests/RxCocoaTests/Observable+BindTests.swift
+++ b/Tests/RxCocoaTests/Observable+BindTests.swift
@@ -92,6 +92,34 @@ extension ObservableBindTest {
 
         XCTAssertEqual(variable.value, 1)
     }
+
+    func testBindToClassTypeVariableKeyPath() {
+        let object = NSURLComponents()
+        let variable = Variable(object)
+
+        var times = 0
+        _ = variable.asObservable().subscribe({ _ in times += 1 })
+
+        _ = Observable.just("apple.com").bind(to: variable, keyPath: \NSURLComponents.host)
+
+        XCTAssertEqual(times, 2)
+        XCTAssertEqual(object.host, "apple.com")
+        XCTAssertEqual(variable.value.host, "apple.com")
+    }
+
+    func testBindToValueTypeVariableKeyPath() {
+        let object = URLComponents()
+        let variable = Variable(object)
+
+        var times = 0
+        _ = variable.asObservable().subscribe({ _ in times += 1 })
+
+        _ = Observable.just("apple.com").bind(to: variable, keyPath: \URLComponents.host)
+
+        XCTAssertEqual(times, 2)
+        XCTAssertNil(object.host)
+        XCTAssertEqual(variable.value.host, "apple.com")
+    }
 }
 
 // MARK: bind(to:) curried


### PR DESCRIPTION
It can be helpful if there is an extension function that takes element from Observable's event sequence and set it to `Variable.E`'s property.