### PR TITLE
Added reactive wrapper for UISegmentedControl's setEnabled(_:forSegmentAt:).

### DIFF
--- a/RxCocoa/iOS/UISegmentedControl+Rx.swift
+++ b/RxCocoa/iOS/UISegmentedControl+Rx.swift
@@ -30,6 +30,13 @@ extension Reactive where Base: UISegmentedControl {
             }
         )
     }
+
+    /// Reactive wrapper for `setEnabled(_:forSegmentAt:)`
+    public func enabled(forSegmentAt segmentAt: Int) -> Binder<Bool> {
+        return Binder(self.base) { (segmentedControl, segmentEnabled) -> () in
+            segmentedControl.setEnabled(segmentEnabled, forSegmentAt: segmentAt)
+        }
+    }
     
 }
 

--- a/Tests/RxCocoaTests/UISegmentedControl+RxTests.swift
+++ b/Tests/RxCocoaTests/UISegmentedControl+RxTests.swift
@@ -25,4 +25,12 @@ extension UISegmentedControlTests {
         let createView: () -> UISegmentedControl = { UISegmentedControl(items: ["a", "b", "c"]) }
         ensurePropertyDeallocated(createView, 1) { (view: UISegmentedControl) in view.rx.selectedSegmentIndex }
     }
+
+    func testSegmentedControl_SegmentDisabled() {
+        let segmentedControl = UISegmentedControl(items: ["a", "b", "c"])
+
+        XCTAssertTrue(segmentedControl.isEnabledForSegment(at: 0))
+        _ = Observable.just(false).subscribe(segmentedControl.rx.enabled(forSegmentAt: 0))
+        XCTAssertFalse(segmentedControl.isEnabledForSegment(at: 0))
+    }
 }


### PR DESCRIPTION
Title says it all :) This allows you to bind enabling segments of a `UISegmentedControl`.