### PR TITLE
Removing wrong type checking line in DelegateProxy

### DIFF
--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -388,7 +388,6 @@ extension DelegateProxyType where ParentObject: HasDataSource, Self.Delegate == 
         fileprivate func extend<DelegateProxy: DelegateProxyType, ParentObject>(make: @escaping (ParentObject) -> DelegateProxy) {
                 MainScheduler.ensureExecutingOnScheduler()
                 precondition(_identifier == DelegateProxy.identifier, "Delegate proxy has inconsistent identifier")
-                precondition((DelegateProxy.self as? DelegateProxy.Delegate) != nil, "DelegateProxy subclass should be as a Delegate")
                 guard _factories[ObjectIdentifier(ParentObject.self)] == nil else {
                     rxFatalError("The factory of \(ParentObject.self) is duplicated. DelegateProxy is not allowed of duplicated base object type.")
                 }


### PR DESCRIPTION
I'm sorry it was my mistaken, 
This line comes from Swift's bug 🐛 
`DelegateProxy.self` is not instance of `Delegate`.

I reported this behavior, https://bugs.swift.org/browse/SR-6304
And we'd remove this line from master branch.
Could you please review it? @kzaher 
