### PR TITLE
Add PublishRelay.asDriver()

### DIFF
--- a/RxCocoa/Traits/PublishRelay.swift
+++ b/RxCocoa/Traits/PublishRelay.swift
@@ -37,4 +37,11 @@ public final class PublishRelay<Element>: ObservableType {
     public func asObservable() -> Observable<Element> {
         return _subject.asObservable()
     }
+
+    /// Warning: It is assumed this is called on the main thread; since Drivers require that.
+    public func asDriver() -> Driver<Element> {
+        return _subject.asDriver(onErrorRecover: { error in
+            rxFatalError("A PublishRelay shouldn't be able to emit an error: \(error)")
+        })
+    }
 }


### PR DESCRIPTION
This seems useful to me, since it's implied that a PublishRelay can't error. So a clean way to convert into a `Driver` was something I implemented for my own convenience 