### PR TITLE
Use Signals for tapping events instead of Drivers

### DIFF
--- a/RxExample/RxExample/Examples/GitHubSignup/UsingDriver/GitHubSignupViewController2.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/UsingDriver/GitHubSignupViewController2.swift
@@ -31,7 +31,7 @@ class GitHubSignupViewController2 : ViewController {
                 username: usernameOutlet.rx.text.orEmpty.asDriver(),
                 password: passwordOutlet.rx.text.orEmpty.asDriver(),
                 repeatedPassword: repeatedPasswordOutlet.rx.text.orEmpty.asDriver(),
-                loginTaps: signupOutlet.rx.tap.asDriver()
+                loginTaps: signupOutlet.rx.tap.asSignal()
             ),
             dependency: (
                 API: GitHubDefaultAPI.sharedAPI,

--- a/RxExample/RxExample/Examples/GitHubSignup/UsingDriver/GithubSignupViewModel2.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/UsingDriver/GithubSignupViewModel2.swift
@@ -45,7 +45,7 @@ class GithubSignupViewModel2 {
             username: Driver<String>,
             password: Driver<String>,
             repeatedPassword: Driver<String>,
-            loginTaps: Driver<Void>
+            loginTaps: Signal<Void>
         ),
         dependency: (
             API: GitHubAPI,


### PR DESCRIPTION
Driver does not fit to some UI events such as tapping. Because we do not expect to get past "tap" events.

But Driver is using `share(replay: 1)`. So it may replay accidentally the past event for some conditions. This replay is useful only for observables like Variables such as `rx.text`, but `rx.tap` is not Variable like.

BTW, Signal can fit the usecase. Signal is using `.share()`, so it does not replay past tapping events.