### PR TITLE
Fix bad performance caused by stacktrace

### DIFF
--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -50,7 +50,7 @@ extension ObservableType {
                 
                 let synchronizationTracker = SynchronizationTracker()
 
-                let callStack = Thread.callStackSymbols
+                let callStack = Hooks.recordCallStackOnError ? Thread.callStackSymbols : []
 
                 let observer = AnonymousObserver<E> { event in
                     

--- a/RxSwift/Rx.swift
+++ b/RxSwift/Rx.swift
@@ -135,5 +135,8 @@ func decrementChecked(_ i: inout Int) throws -> Int {
 
 /// RxSwift global hooks
 public enum Hooks {
+    
+    // Should capture call stack
+    public static var recordCallStackOnError: Bool = false
 
 }


### PR DESCRIPTION
`Thread.callStackSymbols` takes too much time.
So, I want to call the method only when unhandled error is thrown.