### PR TITLE
Fix for issue #1494 "Infinite recursion in `SerialDisposable.disposable` getter."

### DIFF
--- a/RxSwift/Disposables/SerialDisposable.swift
+++ b/RxSwift/Disposables/SerialDisposable.swift
@@ -34,7 +34,7 @@ public final class SerialDisposable : DisposeBase, Cancelable {
     public var disposable: Disposable {
         get {
             return _lock.calculateLocked {
-                return self.disposable
+                return _current ?? Disposables.create()
             }
         }
         set (newDisposable) {


### PR DESCRIPTION
Now the getter don't cause recursion. When SerialDisposable itself becomes disposed then the getter will just return dummy NOP disposable as result.