### PR TITLE
Set Content-Type header to application/json

### DIFF
--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -210,6 +210,8 @@ extension Reactive where Base: URLSession {
     - returns: Observable sequence of response JSON.
     */
     public func json(request: URLRequest, options: JSONSerialization.ReadingOptions = []) -> Observable<Any> {
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        
         return data(request: request).map { (data) -> Any in
             do {
                 return try JSONSerialization.jsonObject(with: data, options: options)


### PR DESCRIPTION
So that the server recognizes the request body as JSON

Noticed this when sending a PUT request to a Rails backend. The server ignores the body when this header is not set.