### PR TITLE
Search controller delegate

### DIFF
--- a/RxCocoa/iOS/UISearchBar+Rx.swift
+++ b/RxCocoa/iOS/UISearchBar+Rx.swift
@@ -67,27 +67,21 @@ extension Reactive where Base: UISearchBar {
     /// Reactive wrapper for delegate method `searchBarCancelButtonClicked`.
     public var cancelButtonClicked: ControlEvent<Void> {
         let source: Observable<Void> = self.delegate.methodInvoked(#selector(UISearchBarDelegate.searchBarCancelButtonClicked(_:)))
-            .map { _ in
-                return ()
-            }
+            .map { _ in }
         return ControlEvent(events: source)
     }
 
 	/// Reactive wrapper for delegate method `searchBarBookmarkButtonClicked`.
 	public var bookmarkButtonClicked: ControlEvent<Void> {
 		let source: Observable<Void> = self.delegate.methodInvoked(#selector(UISearchBarDelegate.searchBarBookmarkButtonClicked(_:)))
-			.map { _ in
-				return ()
-			}
+			.map { _ in }
 		return ControlEvent(events: source)
 	}
 
 	/// Reactive wrapper for delegate method `searchBarResultsListButtonClicked`.
 	public var resultsListButtonClicked: ControlEvent<Void> {
 		let source: Observable<Void> = self.delegate.methodInvoked(#selector(UISearchBarDelegate.searchBarResultsListButtonClicked(_:)))
-			.map { _ in
-				return ()
-		}
+			.map { _ in }
 		return ControlEvent(events: source)
 	}
 #endif
@@ -95,30 +89,23 @@ extension Reactive where Base: UISearchBar {
     /// Reactive wrapper for delegate method `searchBarSearchButtonClicked`.
     public var searchButtonClicked: ControlEvent<Void> {
         let source: Observable<Void> = self.delegate.methodInvoked(#selector(UISearchBarDelegate.searchBarSearchButtonClicked(_:)))
-            .map { _ in
-                return ()
-        }
+            .map { _ in }
         return ControlEvent(events: source)
     }
 	
 	/// Reactive wrapper for delegate method `searchBarTextDidBeginEditing`.
 	public var textDidBeginEditing: ControlEvent<Void> {
 		let source: Observable<Void> = self.delegate.methodInvoked(#selector(UISearchBarDelegate.searchBarTextDidBeginEditing(_:)))
-			.map { _ in
-				return ()
-		}
+			.map { _ in }
 		return ControlEvent(events: source)
 	}
 	
 	/// Reactive wrapper for delegate method `searchBarTextDidEndEditing`.
 	public var textDidEndEditing: ControlEvent<Void> {
 		let source: Observable<Void> = self.delegate.methodInvoked(#selector(UISearchBarDelegate.searchBarTextDidEndEditing(_:)))
-			.map { _ in
-				return ()
-		}
+			.map { _ in }
 		return ControlEvent(events: source)
 	}
-	
 }
 
 #endif

--- a/RxCocoa/iOS/UISearchController+Rx.swift
+++ b/RxCocoa/iOS/UISearchController+Rx.swift
@@ -20,38 +20,38 @@
         }
 
         /// Reactive wrapper for `delegate` message.
-        public var didDismiss: Observable<Void> {
+        public var didDismiss: Observable<UISearchController> {
             return delegate
                 .methodInvoked( #selector(UISearchControllerDelegate.didDismissSearchController(_:)))
-                .map {_ in}
+                .map {args in try castOrThrow(UISearchController.self, args[0])}
         }
 
         /// Reactive wrapper for `delegate` message.
-        public var didPresent: Observable<Void> {
+        public var didPresent: Observable<UISearchController> {
             return delegate
                 .methodInvoked(#selector(UISearchControllerDelegate.didPresentSearchController(_:)))
-                .map {_ in}
+                .map {args in try castOrThrow(UISearchController.self, args[0])}
         }
 
         /// Reactive wrapper for `delegate` message.
-        public var present: Observable<Void> {
+        public var present: Observable<UISearchController> {
             return delegate
                 .methodInvoked( #selector(UISearchControllerDelegate.presentSearchController(_:)))
-                .map {_ in}
+                .map {args in try castOrThrow(UISearchController.self, args[0])}
         }
 
         /// Reactive wrapper for `delegate` message.
-        public var willDismiss: Observable<Void> {
+        public var willDismiss: Observable<UISearchController> {
             return delegate
                 .methodInvoked(#selector(UISearchControllerDelegate.willDismissSearchController(_:)))
-                .map {_ in}
+                .map {args in try castOrThrow(UISearchController.self, args[0])}
         }
         
         /// Reactive wrapper for `delegate` message.
-        public var willPresent: Observable<Void> {
+        public var willPresent: Observable<UISearchController> {
             return delegate
                 .methodInvoked( #selector(UISearchControllerDelegate.willPresentSearchController(_:)))
-                .map {_ in}
+                .map {args in try castOrThrow(UISearchController.self, args[0])}
         }
         
     }


### PR DESCRIPTION
### Review UISearchControllerDelegate
This #PR is related to a problem that I had while working with `UISearchController` all it's delegate methods where returning a `Void` type and this I couldn't do something like this: 
```swift 
viewController.searchController.rx.didPresent.bind(to: didPresentSearch).disposed(by: bag)
```
But when you actually look at the `UISearchControllerDelegate` it does return the `UISearchController` with all it's invocation. 
So I have decided to return it based on the `UIKit` implementation.  If someone still wants only the `Void` type from the events they can always use a map to `Void`. Let me know what you think. Thanks