### PR TITLE
Change `share(replay:scope:)`'s default scope to `.forever`

### DIFF
--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -138,7 +138,7 @@ extension ObservableType {
 
      - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
      */
-    public func share(replay: Int = 0, scope: SubjectLifetimeScope = .whileConnected)
+    public func share(replay: Int = 0, scope: SubjectLifetimeScope = .forever)
         -> Observable<E> {
         switch scope {
         case .forever:


### PR DESCRIPTION
Hi @kzaher ,

There is an issue in `share(replay:scope:)` that uses `.whileConnected` as a default value.

When calling `.share()` without any arguments, this will no longer behave as previous `.publish().refCount()` in v3.6.1, but will work _quite_ differently as follows, especially when upstream is finite cold observable:

```swift
let o = Observable.of(1, 2) // finite cold
    .map { x -> Int in
        print("[map]", x)
        return x
    }
    .share()

print("--- 1 ---")
o.subscribe(onNext: { print("[sink1]", $0) })
print("--- 2 ---")
o.subscribe(onNext: { print("[sink2]", $0) })
```

```
--- 1 ---
[map] 1
[sink1] 1
[map] 2
[sink1] 2
--- 2 ---
[map] 1
[sink2] 1
[map] 2
[sink2] 2
```

Replacing above with `.share(scope: .forever)` will work as expected (same as `.share()` in v3.6.1):

```
--- 1 ---
[map] 1
[sink1] 1
[map] 2
[sink1] 2
--- 2 ---
(no output for 2nd subscription because 2nd connection to cold observable will not be produced)
```

Since `.share()` as `.publish().refCount()` is the right implementation for ReactiveX, I think it is better to have `.forever` as a default scope instead.