### PR TITLE
[Feature] - OfType Operator

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -206,6 +206,7 @@ custom_categories:
   - Enumerated
   - Error
   - Filter
+  - OfType
   - First
   - Generate
   - GroupBy

--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -206,7 +206,6 @@ custom_categories:
   - Enumerated
   - Error
   - Filter
-  - OfType
   - First
   - Generate
   - GroupBy
@@ -217,6 +216,7 @@ custom_categories:
   - Multicast
   - Never
   - ObserveOn
+  - OfType
   - Optional
   - Producer
   - Range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
  * Adds Reactive wrapper for `UIStepper.stepValue` property. #1389
 * Adds `materialize()` operator for RxBlocking's `BlockingObservable`. #1383
 * Adds `first` operator to `ObservableType`.
+* Adds `ofType` operator to `ObservableType`. #1529
 
 #### Anomalies
 

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -113,6 +113,13 @@
 		AAE623771C82475700FC7801 /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */; };
 		B44D73EC1EE6D4A300EBFBE8 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
 		B44D73ED1EE6D57600EBFBE8 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
+		C40190B41FE76A3400564939 /* Observable+OfTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40190B31FE76A3400564939 /* Observable+OfTypeTests.swift */; };
+		C40190B51FE76A3400564939 /* Observable+OfTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40190B31FE76A3400564939 /* Observable+OfTypeTests.swift */; };
+		C40190B61FE76A3400564939 /* Observable+OfTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40190B31FE76A3400564939 /* Observable+OfTypeTests.swift */; };
+		C40190BB1FE7980E00564939 /* OfType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40190B71FE7980300564939 /* OfType.swift */; };
+		C40190BC1FE7980F00564939 /* OfType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40190B71FE7980300564939 /* OfType.swift */; };
+		C40190BD1FE7980F00564939 /* OfType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40190B71FE7980300564939 /* OfType.swift */; };
+		C40190BE1FE7981000564939 /* OfType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40190B71FE7980300564939 /* OfType.swift */; };
 		C801DE361F6EAD3C008DB060 /* SingleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE351F6EAD3C008DB060 /* SingleTest.swift */; };
 		C801DE371F6EAD3C008DB060 /* SingleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE351F6EAD3C008DB060 /* SingleTest.swift */; };
 		C801DE381F6EAD3C008DB060 /* SingleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE351F6EAD3C008DB060 /* SingleTest.swift */; };
@@ -1773,6 +1780,8 @@
 		A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewDataSourceProxy.swift; sourceTree = "<group>"; };
 		A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewAdapter.swift; sourceTree = "<group>"; };
 		AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIProgressView+Rx.swift"; sourceTree = "<group>"; };
+		C40190B31FE76A3400564939 /* Observable+OfTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+OfTypeTests.swift"; sourceTree = "<group>"; };
+		C40190B71FE7980300564939 /* OfType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfType.swift; sourceTree = "<group>"; };
 		C801DE351F6EAD3C008DB060 /* SingleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTest.swift; sourceTree = "<group>"; };
 		C801DE391F6EAD48008DB060 /* MaybeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaybeTest.swift; sourceTree = "<group>"; };
 		C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletableTest.swift; sourceTree = "<group>"; };
@@ -2540,6 +2549,7 @@
 				C820A82A1EB4DA5900D431BC /* Zip+arity.swift */,
 				C820A82B1EB4DA5900D431BC /* Zip+arity.tt */,
 				C820A80B1EB4DA5900D431BC /* Zip+Collection.swift */,
+				C40190B71FE7980300564939 /* OfType.swift */,
 			);
 			path = Observables;
 			sourceTree = "<group>";
@@ -2850,6 +2860,7 @@
 				C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */,
 				C801DE491F6EBB84008DB060 /* Observable+PrimitiveSequenceTest.swift */,
 				C82FF0EE1F93DD2E00BDB34D /* ObservableType+SubscriptionTests.swift */,
+				C40190B31FE76A3400564939 /* Observable+OfTypeTests.swift */,
 			);
 			path = RxSwiftTests;
 			sourceTree = "<group>";
@@ -4323,6 +4334,7 @@
 				914FCD671CCDB82E0058B304 /* UIPageControl+RxTest.swift in Sources */,
 				C8C4F1651DE9D3FB00003FA7 /* UIGestureRecognizer+RxTests.swift in Sources */,
 				C83509351C38706E0027C24C /* KVOObservableTests.swift in Sources */,
+				C40190B41FE76A3400564939 /* Observable+OfTypeTests.swift in Sources */,
 				C89046581DC5F6F70041C7D8 /* UISearchBar+RxTests.swift in Sources */,
 				C85218011E33FC160015DD38 /* RecursiveLock.swift in Sources */,
 				C822BACA1DB4058000F98810 /* Event+Test.swift in Sources */,
@@ -4554,6 +4566,7 @@
 				C8F27DC31CE68DAC00D5FB4F /* UITextField+RxTests.swift in Sources */,
 				C83509FF1C38755D0027C24C /* Observable+CombineLatestTests+arity.swift in Sources */,
 				C8C4F1831DE9DF0200003FA7 /* UISearchController+RxTests.swift in Sources */,
+				C40190B51FE76A3400564939 /* Observable+OfTypeTests.swift in Sources */,
 				C83509D81C3875420027C24C /* SentMessageTest.swift in Sources */,
 				C8C4F1851DE9DF0200003FA7 /* UISlider+RxTests.swift in Sources */,
 				0BA9496D1E224B9C0036DD06 /* AsyncSubjectTests.swift in Sources */,
@@ -4728,6 +4741,7 @@
 				C834F6C41DB394E100C29244 /* Observable+BlockingTest.swift in Sources */,
 				C820AA141EB5145200D431BC /* Observable+DelayTests.swift in Sources */,
 				C8350A1D1C38756B0027C24C /* Observable+SubscriptionTest.swift in Sources */,
+				C40190B61FE76A3400564939 /* Observable+OfTypeTests.swift in Sources */,
 				C8A81CA81E05EAF70008DEF4 /* Binder+Tests.swift in Sources */,
 				C820A9C01EB509B500D431BC /* Observable+TakeLastTests.swift in Sources */,
 				C820A9B41EB507D300D431BC /* Observable+TakeWhileTests.swift in Sources */,
@@ -4907,6 +4921,7 @@
 				C8BF34CC1C2E426800416CAE /* Platform.Darwin.swift in Sources */,
 				C8093CC61B8A72BE0088E94D /* Cancelable.swift in Sources */,
 				C8093CE81B8A72BE0088E94D /* ScheduledDisposable.swift in Sources */,
+				C40190BC1FE7980F00564939 /* OfType.swift in Sources */,
 				C8093CDC1B8A72BE0088E94D /* CompositeDisposable.swift in Sources */,
 				C8093D7E1B8A72BE0088E94D /* ObserverType.swift in Sources */,
 				C820A8F11EB4DA5A00D431BC /* Empty.swift in Sources */,
@@ -5146,6 +5161,7 @@
 				C8093CC51B8A72BE0088E94D /* Cancelable.swift in Sources */,
 				C8093CE71B8A72BE0088E94D /* ScheduledDisposable.swift in Sources */,
 				C8FA891C1C30412A00CD3A17 /* HistoricalSchedulerTimeConverter.swift in Sources */,
+				C40190BB1FE7980E00564939 /* OfType.swift in Sources */,
 				C8093CDB1B8A72BE0088E94D /* CompositeDisposable.swift in Sources */,
 				C8093D7D1B8A72BE0088E94D /* ObserverType.swift in Sources */,
 				C820A8F01EB4DA5A00D431BC /* Empty.swift in Sources */,
@@ -5309,6 +5325,7 @@
 				C8BF34CE1C2E426800416CAE /* Platform.Darwin.swift in Sources */,
 				C8F0BFED1BBBFB8B001B112F /* Cancelable.swift in Sources */,
 				C8F0BFEE1BBBFB8B001B112F /* ScheduledDisposable.swift in Sources */,
+				C40190BE1FE7981000564939 /* OfType.swift in Sources */,
 				C8F0BFF11BBBFB8B001B112F /* CompositeDisposable.swift in Sources */,
 				C8F0BFF21BBBFB8B001B112F /* ObserverType.swift in Sources */,
 				C820A8F31EB4DA5A00D431BC /* Empty.swift in Sources */,
@@ -5684,6 +5701,7 @@
 				C8BF34CD1C2E426800416CAE /* Platform.Darwin.swift in Sources */,
 				D2EBEAE01BB9B697003A27DC /* Event.swift in Sources */,
 				D2EBEB411BB9B6DE003A27DC /* PublishSubject.swift in Sources */,
+				C40190BD1FE7980F00564939 /* OfType.swift in Sources */,
 				D2EBEB431BB9B6DE003A27DC /* SubjectType.swift in Sources */,
 				D2EBEAF41BB9B6AE003A27DC /* DisposeBase.swift in Sources */,
 				C820A8F21EB4DA5A00D431BC /* Empty.swift in Sources */,

--- a/RxSwift/Observables/OfType.swift
+++ b/RxSwift/Observables/OfType.swift
@@ -1,0 +1,58 @@
+//
+//  OfType.swift
+//  Rx
+//
+//  Created by Nate Kim on 18/12/2017.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+extension ObservableType {
+    
+    /**
+     Filters the elements of an observable sequence, if that is an instance of the supplied type.
+     
+     - seealso: [filter operator on reactivex.io](http://reactivex.io/documentation/operators/filter.html)
+     
+     - parameter type: The Type to filter each source element.
+     - returns: An observable sequence that contains elements which is an instance of the suppplied type.
+     */
+    public func ofType<T>(_ type:T.Type) -> Observable<T> {
+        return OfType(source: asObservable(), type: type)
+    }
+}
+
+final fileprivate class OfTypeSink<SourceType, ResultType, O : ObserverType>: Sink<O>, ObserverType where O.E == ResultType {
+
+    typealias Element = SourceType
+    
+    func on(_ event: Event<Element>) {
+        switch event {
+        case .next(let value):
+            if let satisfies = value as? ResultType {
+                forwardOn(.next(satisfies))
+            }
+        case .error(let error):
+            forwardOn(.error(error))
+            dispose()
+        case .completed:
+            forwardOn(.completed)
+            dispose()
+        }
+    }
+}
+
+final fileprivate class OfType<SourceType, ResultType> : Producer<ResultType> {
+    
+    private let _source: Observable<SourceType>
+    
+    init(source: Observable<SourceType>, type: ResultType.Type) {
+        _source = source
+    }
+    
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == ResultType {
+        let sink = OfTypeSink<SourceType, ResultType, O>(observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+}
+

--- a/RxSwift/Observables/OfType.swift
+++ b/RxSwift/Observables/OfType.swift
@@ -1,6 +1,6 @@
 //
 //  OfType.swift
-//  Rx
+//  RxSwift
 //
 //  Created by Nate Kim on 18/12/2017.
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.

--- a/Sources/AllTestz/Observable+OfTypeTests.swift
+++ b/Sources/AllTestz/Observable+OfTypeTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Observable+OfTypeTests.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -851,11 +851,11 @@ final class ObservableOfTypeTest_ : ObservableOfTypeTest, RxTestCase {
     }
     #endif
     
-    static var allTests: [(String, (ObservableFilterTest_) -> () -> ())] { return [
-    ("test_ofTypeComplete", ObservableFilterTest.test_ofTypeComplete),
-    ("test_ofTypeDowncastComplete", ObservableFilterTest.test_ofTypeDowncastComplete),
-    ("test_ofTypeNoInstanceComplete", ObservableFilterTest.test_ofTypeNoInstanceComplete),
-    ("test_ofTypeDisposed", ObservableFilterTest.test_ofTypeDisposed)
+    static var allTests: [(String, (ObservableOfTypeTest_) -> () -> ())] { return [
+    ("test_ofTypeComplete", ObservableOfTypeTest.test_ofTypeComplete),
+    ("test_ofTypeDowncastComplete", ObservableOfTypeTest.test_ofTypeDowncastComplete),
+    ("test_ofTypeNoInstanceComplete", ObservableOfTypeTest.test_ofTypeNoInstanceComplete),
+    ("test_ofTypeDisposed", ObservableOfTypeTest.test_ofTypeDisposed)
     ] }
 }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -844,6 +844,21 @@ final class ObservableFilterTest_ : ObservableFilterTest, RxTestCase {
     ] }
 }
 
+final class ObservableOfTypeTest_ : ObservableOfTypeTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+    
+    static var allTests: [(String, (ObservableFilterTest_) -> () -> ())] { return [
+    ("test_ofTypeComplete", ObservableFilterTest.test_ofTypeComplete),
+    ("test_ofTypeDowncastComplete", ObservableFilterTest.test_ofTypeDowncastComplete),
+    ("test_ofTypeNoInstanceComplete", ObservableFilterTest.test_ofTypeNoInstanceComplete),
+    ("test_ofTypeDisposed", ObservableFilterTest.test_ofTypeDisposed)
+    ] }
+}
+
 final class ObservableAmbTest_ : ObservableAmbTest, RxTestCase {
     #if os(macOS)
     required override init() {

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -12,6 +12,21 @@ protocol RxTestCase {
 }
 
 
+final class ObservableOfTypeTest_ : ObservableOfTypeTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableOfTypeTest_) -> () -> ())] { return [
+    ("test_ofTypeComplete", ObservableOfTypeTest.test_ofTypeComplete),
+    ("test_ofTypeDowncastComplete", ObservableOfTypeTest.test_ofTypeDowncastComplete),
+    ("test_ofTypeNoInstanceComplete", ObservableOfTypeTest.test_ofTypeNoInstanceComplete),
+    ("test_ofTypeDisposed", ObservableOfTypeTest.test_ofTypeDisposed),
+    ] }
+}
+
 final class ObservableWithLatestFromTest_ : ObservableWithLatestFromTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -841,21 +856,6 @@ final class ObservableFilterTest_ : ObservableFilterTest, RxTestCase {
     ("test_filterFalse", ObservableFilterTest.test_filterFalse),
     ("test_filterDisposed", ObservableFilterTest.test_filterDisposed),
     ("testIgnoreElements_DoesNotSendValues", ObservableFilterTest.testIgnoreElements_DoesNotSendValues),
-    ] }
-}
-
-final class ObservableOfTypeTest_ : ObservableOfTypeTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-    
-    static var allTests: [(String, (ObservableOfTypeTest_) -> () -> ())] { return [
-    ("test_ofTypeComplete", ObservableOfTypeTest.test_ofTypeComplete),
-    ("test_ofTypeDowncastComplete", ObservableOfTypeTest.test_ofTypeDowncastComplete),
-    ("test_ofTypeNoInstanceComplete", ObservableOfTypeTest.test_ofTypeNoInstanceComplete),
-    ("test_ofTypeDisposed", ObservableOfTypeTest.test_ofTypeDisposed)
     ] }
 }
 
@@ -1953,6 +1953,7 @@ func XCTMain(_ tests: [() -> ()]) {
 #endif
 
     XCTMain([
+        testCase(ObservableOfTypeTest_.allTests),
         testCase(ObservableWithLatestFromTest_.allTests),
         testCase(ObservableOptionalTest_.allTests),
         testCase(AnomaliesTest_.allTests),

--- a/Sources/RxSwift/OfType.swift
+++ b/Sources/RxSwift/OfType.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/OfType.swift

--- a/Tests/RxSwiftTests/Observable+OfTypeTests.swift
+++ b/Tests/RxSwiftTests/Observable+OfTypeTests.swift
@@ -84,7 +84,7 @@ extension ObservableOfTypeTest {
         ])
     }
     
-    func test_filterNoInstanceComplete() {
+    func test_ofTypeNoInstanceComplete() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let xs: TestableObservable<NSNumber> = scheduler.createHotObservable([
@@ -112,7 +112,7 @@ extension ObservableOfTypeTest {
         ])
     }
     
-    func test_filterDisposed() {
+    func test_ofTypeDisposed() {
         let scheduler = TestScheduler(initialClock: 0)
 
         let xs = scheduler.createHotObservable([
@@ -146,11 +146,11 @@ extension ObservableOfTypeTest {
     }
     
     #if TRACE_RESOURCES
-    func testFilterReleasesResourcesOnComplete() {
+    func testOfTypeReleasesResourcesOnComplete() {
         _ = Observable<Int>.just(1).ofType(Int.self).subscribe()
     }
     
-    func testFilter1ReleasesResourcesOnError() {
+    func testOfTypeReleasesResourcesOnError() {
         _ = Observable<Int>.error(testError).ofType(Int.self).subscribe()
     }
     #endif

--- a/Tests/RxSwiftTests/Observable+OfTypeTests.swift
+++ b/Tests/RxSwiftTests/Observable+OfTypeTests.swift
@@ -1,0 +1,157 @@
+//
+//  Observable+OfTypeTests.swift
+//  Rx
+//
+//  Created by Nate Kim on 18/12/2017.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+#if os(Linux)
+    import Glibc
+#endif
+
+class ObservableOfTypeTest : RxTest {
+}
+
+extension ObservableOfTypeTest {
+    func test_ofTypeComplete() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            next(110, NSNumber(value: 1)),
+            next(180, NSDecimalNumber(string: "2") as NSNumber),
+            next(230, NSNumber(value: 3)),
+            next(270, NSNumber(value: 4)),
+            next(340, NSDecimalNumber(string: "5") as NSNumber),
+            next(380, NSDecimalNumber(string: "6") as NSNumber),
+            completed(400),
+            next(410, NSDecimalNumber(string: "7") as NSNumber),
+            next(420, NSNumber(value: 8)),
+            error(430, testError),
+            completed(440)
+        ])
+        
+        let res = scheduler.start { () -> Observable<NSDecimalNumber> in
+            return xs.ofType(NSDecimalNumber.self)
+        }
+        
+        XCTAssertEqual(res.events, [
+            next(340, NSDecimalNumber(string: "5")),
+            next(380, NSDecimalNumber(string: "6")),
+            completed(400)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(TestScheduler.Defaults.subscribed, 400)
+        ])
+    }
+    
+    func test_ofTypeDowncastComplete() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs: TestableObservable<NSNumber> = scheduler.createHotObservable([
+            next(110, NSNumber(value: 1)),
+            next(180, NSDecimalNumber(string: "2") as NSNumber),
+            next(230, NSNumber(value: 3)),
+            next(270, NSNumber(value: 4)),
+            next(340, NSDecimalNumber(string: "5") as NSNumber),
+            next(380, NSDecimalNumber(string: "6") as NSNumber),
+            completed(400),
+            next(410, NSDecimalNumber(string: "7") as NSNumber),
+            next(420, NSNumber(value: 8)),
+            error(430, testError),
+            completed(440)
+        ])
+        
+        let res = scheduler.start { () -> Observable<NSNumber> in
+            return xs.ofType(NSNumber.self)
+        }
+        
+        XCTAssertEqual(res.events, [
+            next(230, NSNumber(value: 3)),
+            next(270, NSNumber(value: 4)),
+            next(340, NSDecimalNumber(string: "5")),
+            next(380, NSDecimalNumber(string: "6")),
+            completed(400)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(TestScheduler.Defaults.subscribed, 400)
+        ])
+    }
+    
+    func test_filterNoInstanceComplete() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs: TestableObservable<NSNumber> = scheduler.createHotObservable([
+            next(110, NSNumber(value: 1)),
+            next(180, NSDecimalNumber(string: "2") as NSNumber),
+            next(230, NSNumber(value: 3)),
+            next(270, NSNumber(value: 4)),
+            next(340, NSDecimalNumber(string: "5") as NSNumber),
+            next(380, NSDecimalNumber(string: "6") as NSNumber),
+            completed(400),
+            next(410, NSDecimalNumber(string: "7") as NSNumber),
+            next(420, NSNumber(value: 8)),
+            error(430, testError),
+            completed(440)
+        ])
+        
+        let res = scheduler.start { () -> Observable<String> in
+            return xs.ofType(String.self)
+        }
+        
+        XCTAssertEqual(res.events, [completed(400)])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(TestScheduler.Defaults.subscribed, 400)
+        ])
+    }
+    
+    func test_filterDisposed() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            next(110, 1),
+            next(180, 2),
+            next(230, 3),
+            next(270, 4),
+            next(340, 5),
+            next(380, 6),
+            next(390, 7),
+            next(450, 8),
+            next(470, 9),
+            completed(500)
+        ])
+
+        let res = scheduler.start(disposed: 400) { () -> Observable<Int> in
+            return xs.ofType(Int.self)
+        }
+
+        XCTAssertEqual(res.events, [
+            next(230, 3),
+            next(270, 4),
+            next(340, 5),
+            next(380, 6),
+            next(390, 7)
+        ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(TestScheduler.Defaults.subscribed, 400)
+        ])
+    }
+    
+    #if TRACE_RESOURCES
+    func testFilterReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).ofType(Int.self).subscribe()
+    }
+    
+    func testFilter1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).ofType(Int.self).subscribe()
+    }
+    #endif
+}

--- a/Tests/RxSwiftTests/Observable+OfTypeTests.swift
+++ b/Tests/RxSwiftTests/Observable+OfTypeTests.swift
@@ -1,6 +1,6 @@
 //
 //  Observable+OfTypeTests.swift
-//  Rx
+//  Tests
 //
 //  Created by Nate Kim on 18/12/2017.
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.


### PR DESCRIPTION
- Implement `ofType` operator using type casting operator (`as`) in Swift
- Add `ofType` extension methods on `ObservableType`
- Create `OfType`, `OfTypeSink`class