### PR TITLE
Add `Recorded<Event<T>>` array factory method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Master
 
+* Add `Recorded<Event<T>>` arry factory method in **RxText**. #1530
 * Replaces global functions `next`, `error`, `completed` with `Recorded.next`, `Recorded.error`, `Recorded.completed` in **RxText**. #1510
  * Add documentation for the `ControlProperty/ControlEvent` traits. #1513
 * Adds Reactive wrapper for `UIStepper.stepValue` property. #1389

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Master
 
-* Add `Recorded<Event<T>>` arry factory method in **RxText**. #1530
+* Add `Recorded<Event<T>>` arry factory method in **RxText**. #1531
 * Replaces global functions `next`, `error`, `completed` with `Recorded.next`, `Recorded.error`, `Recorded.completed` in **RxText**. #1510
  * Add documentation for the `ControlProperty/ControlEvent` traits. #1513
 * Adds Reactive wrapper for `UIStepper.stepValue` property. #1389

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Master
 
-* Add `Recorded<Event<T>>` arry factory method in **RxText**. #1531
+* Adds `Recorded<Event<T>>` array factory method in **RxText**. #1531
 * Replaces global functions `next`, `error`, `completed` with `Recorded.next`, `Recorded.error`, `Recorded.completed` in **RxText**. #1510
  * Add documentation for the `ControlProperty/ControlEvent` traits. #1513
 * Adds Reactive wrapper for `UIStepper.stepValue` property. #1389

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -35,6 +35,10 @@
 		25F6ECC91F48C407008552FA /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F6ECBF1F48C37C008552FA /* Single.swift */; };
 		271A97411CFC996B00D64125 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
 		271A97441CFC9F7B00D64125 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
+		4583D8231FE94BBA00AA1BB1 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
+		4583D8241FE94BBB00AA1BB1 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
+		4583D8251FE94BBC00AA1BB1 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
+		4583D8261FE94BBD00AA1BB1 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
 		4613456F1D9A4467001ABAF2 /* UIWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */; };
 		461345711D9A4543001ABAF2 /* UIWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */; };
 		4613457C1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */; };
@@ -1742,6 +1746,7 @@
 		25F6ECBF1F48C37C008552FA /* Single.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Single.swift; sourceTree = "<group>"; };
 		271A97401CFC996B00D64125 /* UIViewController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
 		271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+RxTests.swift"; sourceTree = "<group>"; };
+		4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Recorded+Event.swift"; sourceTree = "<group>"; };
 		4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+RxTests.swift"; sourceTree = "<group>"; };
 		461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+Rx.swift"; sourceTree = "<group>"; };
 		4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxWebViewDelegateProxy.swift; sourceTree = "<group>"; };
@@ -3172,6 +3177,7 @@
 				C89CFA121DAABBE20079D23B /* Event+Equatable.swift */,
 				C89CFA131DAABBE20079D23B /* HotObservable.swift */,
 				C89CFA151DAABBE20079D23B /* Recorded.swift */,
+				4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */,
 				C89CFA161DAABBE20079D23B /* RxTests.swift */,
 				C89CFA1A1DAABBE20079D23B /* Subscription.swift */,
 				C89CFA1B1DAABBE20079D23B /* TestableObservable.swift */,
@@ -4940,6 +4946,7 @@
 				C89CFA3A1DAABBE20079D23B /* TestScheduler.swift in Sources */,
 				C86781831DB8143A00B2029A /* Bag.swift in Sources */,
 				C89CFA2A1DAABBE20079D23B /* HotObservable.swift in Sources */,
+				4583D8231FE94BBA00AA1BB1 /* Recorded+Event.swift in Sources */,
 				C89CFA421DAABBE20079D23B /* Subscription.swift in Sources */,
 				C89CFA1E1DAABBE20079D23B /* Any+Equatable.swift in Sources */,
 				C89CFA3E1DAABBE20079D23B /* TestSchedulerVirtualTimeConverter.swift in Sources */,
@@ -4961,6 +4968,7 @@
 				C89CFA3B1DAABBE20079D23B /* TestScheduler.swift in Sources */,
 				C86781841DB8143A00B2029A /* Bag.swift in Sources */,
 				C89CFA2B1DAABBE20079D23B /* HotObservable.swift in Sources */,
+				4583D8241FE94BBB00AA1BB1 /* Recorded+Event.swift in Sources */,
 				C89CFA431DAABBE20079D23B /* Subscription.swift in Sources */,
 				C89CFA1F1DAABBE20079D23B /* Any+Equatable.swift in Sources */,
 				C89CFA3F1DAABBE20079D23B /* TestSchedulerVirtualTimeConverter.swift in Sources */,
@@ -4982,6 +4990,7 @@
 				C89CFA3C1DAABBE20079D23B /* TestScheduler.swift in Sources */,
 				C86781851DB8143B00B2029A /* Bag.swift in Sources */,
 				C89CFA2C1DAABBE20079D23B /* HotObservable.swift in Sources */,
+				4583D8251FE94BBC00AA1BB1 /* Recorded+Event.swift in Sources */,
 				C89CFA441DAABBE20079D23B /* Subscription.swift in Sources */,
 				C89CFA201DAABBE20079D23B /* Any+Equatable.swift in Sources */,
 				C89CFA401DAABBE20079D23B /* TestSchedulerVirtualTimeConverter.swift in Sources */,
@@ -5003,6 +5012,7 @@
 				C89CFA3D1DAABBE20079D23B /* TestScheduler.swift in Sources */,
 				C86781861DB8143B00B2029A /* Bag.swift in Sources */,
 				C89CFA2D1DAABBE20079D23B /* HotObservable.swift in Sources */,
+				4583D8261FE94BBD00AA1BB1 /* Recorded+Event.swift in Sources */,
 				C89CFA451DAABBE20079D23B /* Subscription.swift in Sources */,
 				C89CFA211DAABBE20079D23B /* Any+Equatable.swift in Sources */,
 				C89CFA411DAABBE20079D23B /* TestSchedulerVirtualTimeConverter.swift in Sources */,

--- a/RxTest/Recorded+Event.swift
+++ b/RxTest/Recorded+Event.swift
@@ -42,3 +42,69 @@ extension Recorded {
     }
 }
 
+extension Recorded {
+    
+    /**
+     Factory method for an array of recorded events, this may help if you don't want to declare the type of array:
+     
+     ```
+     let correctMessages = Recorded.events(
+         .next(210, 2),
+         .next(220, 3),
+         .next(230, 4),
+         .next(240, 5),
+         .completed(250),
+     )
+     ```
+     
+     is equivalent to:
+     
+     ```
+     let correctMessages: [Recorded<Event<Int>>] = [
+         .next(210, 2),
+         .next(220, 3),
+         .next(230, 4),
+         .next(240, 5),
+         .completed(250),
+     ]
+     ```
+     
+     - parameter recordedEvents: the Recorded events which will return
+     */
+    public static func events<T>(_ recordedEvents: Recorded<Event<T>>...) -> [Recorded<Event<T>>] where Value == Event<T> {
+        return self.events(recordedEvents)
+    }
+    
+    
+    /**
+     Factory method for an array of recorded events, this may help if you don't want to declare the type of array:
+     
+     ```
+     let correctMessages = Recorded.events([
+         .next(210, 2),
+         .next(220, 3),
+         .next(230, 4),
+         .next(240, 5),
+         .completed(250),
+     ])
+     ```
+     
+     is equivalent to:
+     
+     ```
+     let correctMessages: [Recorded<Event<Int>>] = [
+         .next(210, 2),
+         .next(220, 3),
+         .next(230, 4),
+         .next(240, 5),
+         .completed(250),
+     ]
+     ```
+     
+     - parameter recordedEvents: the Recorded events which will return
+     */
+    public static func events<T>(_ recordedEvents: [Recorded<Event<T>>]) -> [Recorded<Event<T>>] where Value == Event<T> {
+        return recordedEvents
+    }
+}
+

--- a/RxTest/Recorded+Event.swift
+++ b/RxTest/Recorded+Event.swift
@@ -45,7 +45,7 @@ extension Recorded {
 extension Recorded {
     
     /**
-     Factory method for an array of recorded events, this may help if you don't want to declare the type of array:
+     Convenience method for recording a sequence of events. Its primary use case is improving readability in cases where type inference is unable to deduce the type of recorded events.
      
      ```
      let correctMessages = Recorded.events(
@@ -69,7 +69,7 @@ extension Recorded {
      ]
      ```
      
-     - parameter recordedEvents: The recorded events which will return
+     - parameter recordedEvents: Method return value.
      */
     public static func events<T>(_ recordedEvents: Recorded<Event<T>>...) -> [Recorded<Event<T>>] where Value == Event<T> {
         return self.events(recordedEvents)
@@ -77,7 +77,7 @@ extension Recorded {
     
     
     /**
-     Factory method for an array of recorded events, this may help if you don't want to declare the type of array:
+     Convenience method for recording a sequence of events. Its primary use case is improving readability in cases where type inference is unable to deduce the type of recorded events.
      
      ```
      let correctMessages = Recorded.events([
@@ -101,7 +101,7 @@ extension Recorded {
      ]
      ```
      
-     - parameter recordedEvents: The recorded events which will return
+     - parameter recordedEvents: Method return value.
      */
     public static func events<T>(_ recordedEvents: [Recorded<Event<T>>]) -> [Recorded<Event<T>>] where Value == Event<T> {
         return recordedEvents

--- a/RxTest/Recorded+Event.swift
+++ b/RxTest/Recorded+Event.swift
@@ -1,0 +1,44 @@
+//
+//  Recorded+Event.swift
+//  RxTest
+//
+//  Created by luojie on 2017/12/19.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import RxSwift
+
+extension Recorded {
+    
+    /**
+     Factory method for an `.next` event recorded at a given time with a given value.
+     
+     - parameter time: Recorded virtual time the `.next` event occurs.
+     - parameter element: Next sequence element.
+     - returns: Recorded event in time.
+     */
+    public static func next<T>(_ time: TestTime, _ element: T) -> Recorded<Event<T>> where Value == Event<T> {
+        return Recorded(time: time, value: .next(element))
+    }
+    
+    /**
+     Factory method for an `.completed` event recorded at a given time.
+     
+     - parameter time: Recorded virtual time the `.completed` event occurs.
+     - parameter type: Sequence elements type.
+     - returns: Recorded event in time.
+     */
+    public static func completed<T>(_ time: TestTime, _ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
+        return Recorded(time: time, value: .completed)
+    }
+    
+    /**
+     Factory method for an `.error` event recorded at a given time with a given error.
+     
+     - parameter time: Recorded virtual time the `.completed` event occurs.
+     */
+    public static func error<T>(_ time: TestTime, _ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
+        return Recorded(time: time, value: .error(error))
+    }
+}
+

--- a/RxTest/Recorded+Event.swift
+++ b/RxTest/Recorded+Event.swift
@@ -53,7 +53,7 @@ extension Recorded {
          .next(220, 3),
          .next(230, 4),
          .next(240, 5),
-         .completed(250),
+         .completed(250)
      )
      ```
      
@@ -65,11 +65,11 @@ extension Recorded {
          .next(220, 3),
          .next(230, 4),
          .next(240, 5),
-         .completed(250),
+         .completed(250)
      ]
      ```
      
-     - parameter recordedEvents: the Recorded events which will return
+     - parameter recordedEvents: The recorded events which will return
      */
     public static func events<T>(_ recordedEvents: Recorded<Event<T>>...) -> [Recorded<Event<T>>] where Value == Event<T> {
         return self.events(recordedEvents)
@@ -85,7 +85,7 @@ extension Recorded {
          .next(220, 3),
          .next(230, 4),
          .next(240, 5),
-         .completed(250),
+         .completed(250)
      ])
      ```
      
@@ -97,11 +97,11 @@ extension Recorded {
          .next(220, 3),
          .next(230, 4),
          .next(240, 5),
-         .completed(250),
+         .completed(250)
      ]
      ```
      
-     - parameter recordedEvents: the Recorded events which will return
+     - parameter recordedEvents: The recorded events which will return
      */
     public static func events<T>(_ recordedEvents: [Recorded<Event<T>>]) -> [Recorded<Event<T>>] where Value == Event<T> {
         return recordedEvents

--- a/RxTest/Recorded.swift
+++ b/RxTest/Recorded.swift
@@ -32,40 +32,6 @@ extension Recorded {
     }
 }
 
-extension Recorded {
-    
-    /**
-     Factory method for an `.next` event recorded at a given time with a given value.
-     
-     - parameter time: Recorded virtual time the `.next` event occurs.
-     - parameter element: Next sequence element.
-     - returns: Recorded event in time.
-     */
-    public static func next<T>(_ time: TestTime, _ element: T) -> Recorded<Event<T>> where Value == Event<T> {
-        return Recorded(time: time, value: .next(element))
-    }
-    
-    /**
-     Factory method for an `.completed` event recorded at a given time.
-     
-     - parameter time: Recorded virtual time the `.completed` event occurs.
-     - parameter type: Sequence elements type.
-     - returns: Recorded event in time.
-     */
-    public static func completed<T>(_ time: TestTime, _ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
-        return Recorded(time: time, value: .completed)
-    }
-    
-    /**
-     Factory method for an `.error` event recorded at a given time with a given error.
-     
-     - parameter time: Recorded virtual time the `.completed` event occurs.
-     */
-    public static func error<T>(_ time: TestTime, _ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
-        return Recorded(time: time, value: .error(error))
-    }
-}
-
 public func == <T: Equatable>(lhs: Recorded<T>, rhs: Recorded<T>) -> Bool {
     return lhs.time == rhs.time && lhs.value == rhs.value
 }

--- a/Sources/RxTest/Recorded+Event.swift
+++ b/Sources/RxTest/Recorded+Event.swift
@@ -1,0 +1,1 @@
+../../RxTest/Recorded+Event.swift

--- a/Tests/RxSwiftTests/Observable+CombineLatestTests.swift
+++ b/Tests/RxSwiftTests/Observable+CombineLatestTests.swift
@@ -675,14 +675,14 @@ extension ObservableCombineLatestTest {
                 factory(e0, e1)
             }
 
-            let messages: [Recorded<Event<Int>>] = [
+            let messages = Recorded.events(
                 .next(220, 2 + 3),
                 .next(225, 3 + 4),
                 .next(230, 4 + 5),
                 .next(235, 4 + 6),
                 .next(240, 4 + 7),
                 .completed(250)
-            ]
+            )
             
             XCTAssertEqual(res.events, messages)
             
@@ -719,11 +719,11 @@ extension ObservableCombineLatestTest {
                 factory(e0, e1)
             }
             
-            let messages: [Recorded<Event<Int>>] = [
+            let messages = Recorded.events(
                 .next(235, 4 + 6),
                 .next(240, 4 + 7),
                 .completed(250)
-            ]
+            )
             
             XCTAssertEqual(res.events, messages)
             

--- a/Tests/RxSwiftTests/Observable+ConcatTests.swift
+++ b/Tests/RxSwiftTests/Observable+ConcatTests.swift
@@ -72,7 +72,7 @@ extension ObservableConcatTest {
             Observable.concat([xs1, xs2, xs3].map { $0.asObservable() })
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(210, 1),
             .next(220, 2),
             .next(230, 3),
@@ -83,7 +83,7 @@ extension ObservableConcatTest {
             .next(300, 8),
             .next(310, 9),
             .completed(320)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -302,10 +302,10 @@ extension ObservableConcatTest {
             Observable.concat([xs1, xs2].map { $0.asObservable() })
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(210, 2),
             .completed(250)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -336,10 +336,10 @@ extension ObservableConcatTest {
             Observable.concat([xs1, xs2].map { $0.asObservable() })
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(240, 2),
             .completed(250)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -433,11 +433,11 @@ extension ObservableConcatTest {
             Observable.concat([xs1, xs2].map { $0.asObservable() })
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(220, 2),
             .next(240, 3),
             .completed(250)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -500,10 +500,10 @@ extension ObservableConcatTest {
             Observable.concat([xs1, xs2].map { $0.asObservable() })
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(220, 2),
             .error(250, testError2)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -537,13 +537,13 @@ extension ObservableConcatTest {
             Observable.concat([xs1, xs2].map { $0.asObservable() })
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -589,7 +589,7 @@ extension ObservableConcatTest {
             Observable.concat([xs1, xs2, xs3, xs2].map { $0.asObservable() })
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(280, 4),
@@ -601,7 +601,7 @@ extension ObservableConcatTest {
             .next(400, 5),
             .next(410, 6),
             .completed(420)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         

--- a/Tests/RxSwiftTests/Observable+DelayTests.swift
+++ b/Tests/RxSwiftTests/Observable+DelayTests.swift
@@ -338,13 +338,13 @@ extension ObservableDelayTest {
     func testDelay_TimeSpan_Positive() {
         let scheduler = TestScheduler(initialClock: 0)
     
-        let msgs: [Recorded<Event<Int>>] = [
+        let msgs = Recorded.events(
             .next(150, 1),
             .next(250, 2),
             .next(350, 3),
             .next(450, 4),
             .completed(550)
-        ]
+        )
     
         let xs = scheduler.createHotObservable(msgs)
     

--- a/Tests/RxSwiftTests/Observable+DistinctUntilChangedTests.swift
+++ b/Tests/RxSwiftTests/Observable+DistinctUntilChangedTests.swift
@@ -28,13 +28,13 @@ extension ObservableDistinctUntilChangedTest {
 
         let res = scheduler.start { xs.distinctUntilChanged { $0 } }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -62,14 +62,14 @@ extension ObservableDistinctUntilChangedTest {
 
         let res = scheduler.start { xs.distinctUntilChanged { $0 } }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(215, 3),
             .next(225, 2),
             .next(230, 1),
             .next(240, 2),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -93,10 +93,10 @@ extension ObservableDistinctUntilChangedTest {
 
         let res = scheduler.start { xs.distinctUntilChanged { l, r in true } }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -120,13 +120,13 @@ extension ObservableDistinctUntilChangedTest {
 
         let res = scheduler.start { xs.distinctUntilChanged({ l, r in false }) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 2),
             .next(230, 2),
             .next(240, 2),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -150,11 +150,11 @@ extension ObservableDistinctUntilChangedTest {
 
         let res = scheduler.start { xs.distinctUntilChanged({ $0 % 2 }) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(230, 3),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -176,10 +176,10 @@ extension ObservableDistinctUntilChangedTest {
 
         let res = scheduler.start { xs.distinctUntilChanged({ (_, _) -> Bool in throw testError }) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .error(220, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 220)
@@ -201,10 +201,10 @@ extension ObservableDistinctUntilChangedTest {
 
         let res = scheduler.start { xs.distinctUntilChanged({ $0 }, comparer: { _, _ in throw testError }) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .error(220, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 220)

--- a/Tests/RxSwiftTests/Observable+DoOnTests.swift
+++ b/Tests/RxSwiftTests/Observable+DoOnTests.swift
@@ -37,13 +37,13 @@ extension ObservableDoOnTest {
         XCTAssertEqual(i, 4)
         XCTAssertEqual(sum, 0)
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -73,13 +73,13 @@ extension ObservableDoOnTest {
 
         XCTAssertEqual(i, 4)
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -116,13 +116,13 @@ extension ObservableDoOnTest {
         XCTAssertEqual(sum, 0)
         XCTAssertEqual(completedEvaluation, true)
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -190,13 +190,13 @@ extension ObservableDoOnTest {
         XCTAssertEqual(sum, 0)
         XCTAssertEqual(sawError, true)
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .error(250, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -233,13 +233,13 @@ extension ObservableDoOnTest {
         XCTAssertEqual(sum, 0)
         XCTAssertEqual(sawError, false)
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -268,13 +268,13 @@ extension ObservableDoOnTest {
             })
         }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -308,12 +308,12 @@ extension ObservableDoOnTest {
             })
         }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .error(240, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 240)
@@ -343,10 +343,10 @@ extension ObservableDoOnTest {
             })
         }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .error(250, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -373,10 +373,10 @@ extension ObservableDoOnTest {
             })
         }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .error(250, testError1)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -405,13 +405,13 @@ extension ObservableDoOnTest {
             })
         }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -440,13 +440,13 @@ extension ObservableDoOnTest {
             })
         }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .error(250, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)

--- a/Tests/RxSwiftTests/Observable+MapTests.swift
+++ b/Tests/RxSwiftTests/Observable+MapTests.swift
@@ -276,13 +276,13 @@ extension ObservableMapTest {
 
         let res = scheduler.start { xs.map { $0 * 10 }.map { $0 + 1 } }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
             .next(230, 2 * 10 + 1),
             .next(240, 4 * 10 + 1),
             .error(300, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 300)

--- a/Tests/RxSwiftTests/Observable+MapTests.swift
+++ b/Tests/RxSwiftTests/Observable+MapTests.swift
@@ -70,13 +70,13 @@ extension ObservableMapTest {
         
         let res = scheduler.start { xs.map { $0 * 2 } }
         
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 2),
             .next(220, 1 * 2),
             .next(230, 2 * 2),
             .next(240, 4 * 2),
             .completed(300)
-        ]
+        )
         
         let correctSubscriptions = [
             Subscription(200, 300)
@@ -100,13 +100,13 @@ extension ObservableMapTest {
         
         let res = scheduler.start { xs.map { $0 * 2 } }
         
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 2),
             .next(220, 1 * 2),
             .next(230, 2 * 2),
             .next(240, 4 * 2),
             .error(300, testError)
-        ]
+        )
         
         let correctSubscriptions = [
             Subscription(200, 300)
@@ -130,12 +130,12 @@ extension ObservableMapTest {
         
         let res = scheduler.start(disposed: 290) { xs.map { $0 * 2 } }
         
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 2),
             .next(220, 1 * 2),
             .next(230, 2 * 2),
-            .next(240, 4 * 2),
-        ]
+            .next(240, 4 * 2)
+        )
         
         let correctSubscriptions = [
             Subscription(200, 290)
@@ -159,11 +159,11 @@ extension ObservableMapTest {
         
         let res = scheduler.start { xs.map { x throws -> Int in if x < 2 { return x * 2 } else { throw testError } } }
         
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 2),
             .next(220, 1 * 2),
             .error(230, testError)
-        ]
+        )
         
         let correctSubscriptions = [
             Subscription(200, 230)
@@ -246,13 +246,13 @@ extension ObservableMapTest {
 
         let res = scheduler.start { xs.map { $0 * 10 }.map { $0 + 1 } }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
             .next(230, 2 * 10 + 1),
             .next(240, 4 * 10 + 1),
             .completed(300)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 300)
@@ -306,12 +306,12 @@ extension ObservableMapTest {
 
         let res = scheduler.start(disposed: 290) { xs.map { $0 * 10 }.map { $0 + 1 } }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
             .next(230, 2 * 10 + 1),
-            .next(240, 4 * 10 + 1),
-        ]
+            .next(240, 4 * 10 + 1)
+        )
 
         let correctSubscriptions = [
             Subscription(200, 290)
@@ -339,11 +339,11 @@ extension ObservableMapTest {
             .map { $0 + 1 }
         }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
             .error(230, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 230)
@@ -371,11 +371,11 @@ extension ObservableMapTest {
                 .map { x throws -> Int in if x < 20 { return x + 1 } else { throw testError } }
         }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
             .error(230, testError)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 230)

--- a/Tests/RxSwiftTests/Observable+MaterializeTests.swift
+++ b/Tests/RxSwiftTests/Observable+MaterializeTests.swift
@@ -51,11 +51,11 @@ extension ObservableMaterializeTest {
         let res = scheduler.start {
             return xs.materialize()
         }
-        let expectedEvents: [Recorded<Event<Event<Int>>>] = [
+        let expectedEvents = Recorded.events(
             .next(210, Event.next(2)),
             .next(250, Event.completed),
             .completed(250)
-        ]
+        )
         
         XCTAssertEqual(xs.subscriptions, [Subscription(200, 250)])
         XCTAssertEqual(res.events, expectedEvents, materializedRecoredEventsComparison)
@@ -71,10 +71,10 @@ extension ObservableMaterializeTest {
         let res = scheduler.start {
             return xs.materialize()
         }
-        let expectedEvents: [Recorded<Event<Event<Int>>>] = [
+        let expectedEvents = Recorded.events(
             .next(250, Event<Int>.error(testError)),
             .completed(250)
-        ]
+        )
         
         XCTAssertEqual(xs.subscriptions, [Subscription(200, 250)])
         XCTAssertEqual(res.events, expectedEvents, materializedRecoredEventsComparison)

--- a/Tests/RxSwiftTests/Observable+MaterializeTests.swift
+++ b/Tests/RxSwiftTests/Observable+MaterializeTests.swift
@@ -31,10 +31,10 @@ extension ObservableMaterializeTest {
         let res = scheduler.start {
             return xs.materialize()
         }
-        let expectedEvents: [Recorded<Event<Event<Int>>>] = [
+        let expectedEvents = Recorded.events(
             .next(201, Event<Int>.completed),
             .completed(201)
-        ]
+        )
         
         XCTAssertEqual(xs.subscriptions, [Subscription(200, 201)])
         XCTAssertEqual(res.events, expectedEvents, materializedRecoredEventsComparison)

--- a/Tests/RxSwiftTests/Observable+MergeTests.swift
+++ b/Tests/RxSwiftTests/Observable+MergeTests.swift
@@ -193,7 +193,7 @@ extension ObservableMergeTest {
             xs.merge()
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 103),
@@ -210,7 +210,7 @@ extension ObservableMergeTest {
             .next(540, 304),
             .next(620, 305),
             .completed(650)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
 
@@ -263,7 +263,7 @@ extension ObservableMergeTest {
             xs.merge()
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 201),
@@ -275,7 +275,7 @@ extension ObservableMergeTest {
             .next(530, 303),
             .next(540, 304),
             .completed(600)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
 
@@ -336,7 +336,7 @@ extension ObservableMergeTest {
             xs.merge()
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 103),
@@ -346,7 +346,7 @@ extension ObservableMergeTest {
             .next(430, 203),
             .next(440, 204),
             .error(450, testError1)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -397,7 +397,7 @@ extension ObservableMergeTest {
             xs.merge()
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 103),
@@ -407,7 +407,7 @@ extension ObservableMergeTest {
             .next(430, 203),
             .next(440, 204),
             .error(500, testError1)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
 
@@ -465,7 +465,7 @@ extension ObservableMergeTest {
             xs.merge(maxConcurrent: 2)
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(260, 1),
             .next(280, 4),
             .next(310, 2),
@@ -477,7 +477,7 @@ extension ObservableMergeTest {
             .next(670, 9),
             .next(700, 10),
             .completed(760)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -543,7 +543,7 @@ extension ObservableMergeTest {
             xs.merge(maxConcurrent: 2)
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(260, 1),
             .next(280, 4),
             .next(310, 2),
@@ -555,7 +555,7 @@ extension ObservableMergeTest {
             .next(690, 9),
             .next(720, 10),
             .completed(780)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -621,7 +621,7 @@ extension ObservableMergeTest {
             xs.merge(maxConcurrent: 3)
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(260, 1),
             .next(280, 4),
             .next(280, 6),
@@ -633,7 +633,7 @@ extension ObservableMergeTest {
             .next(630, 9),
             .next(660, 10),
             .completed(720)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -699,7 +699,7 @@ extension ObservableMergeTest {
             xs.merge(maxConcurrent: 3)
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(260, 1),
             .next(280, 4),
             .next(280, 6),
@@ -711,7 +711,7 @@ extension ObservableMergeTest {
             .next(630, 9),
             .next(660, 10),
             .completed(750)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -777,7 +777,7 @@ extension ObservableMergeTest {
             xs.merge(maxConcurrent: 2)
         }
 
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(260, 1),
             .next(280, 4),
             .next(310, 2),
@@ -785,7 +785,7 @@ extension ObservableMergeTest {
             .next(330, 5),
             .next(360, 6),
             .next(440, 7)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -850,7 +850,7 @@ extension ObservableMergeTest {
             xs.merge(maxConcurrent: 2)
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(260, 1),
             .next(280, 4),
             .next(310, 2),
@@ -858,7 +858,7 @@ extension ObservableMergeTest {
             .next(330, 5),
             .next(360, 6),
             .error(400, testError1)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -923,7 +923,7 @@ extension ObservableMergeTest {
             xs.merge(maxConcurrent: 2)
         }
         
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(260, 1),
             .next(280, 4),
             .next(310, 2),
@@ -933,7 +933,7 @@ extension ObservableMergeTest {
             .next(440, 7),
             .next(460, 8),
             .error(490, testError1)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
         
@@ -1038,11 +1038,11 @@ extension ObservableMergeTest {
                 factory(ys1.asObservable(), ys2.asObservable())
             }
 
-            let messages: [Recorded<Event<Int>>] = [
+            let messages = Recorded.events(
                 .next(210, 201),
                 .next(220, 202),
                 .completed(250)
-            ]
+            )
 
             XCTAssertEqual(res.events, messages)
 
@@ -1110,7 +1110,7 @@ extension ObservableMergeTest {
                 factory(ys1.asObservable(), ys2.asObservable(), ys3.asObservable())
             }
 
-            let messages: [Recorded<Event<Int>>] = [
+            let messages = Recorded.events(
                 .next(210, 101),
                 .next(210, 201),
                 .next(210, 301),
@@ -1118,7 +1118,7 @@ extension ObservableMergeTest {
                 .next(220, 202),
                 .next(220, 302),
                 .completed(430)
-            ]
+            )
 
             XCTAssertEqual(res.events, messages)
 
@@ -1167,12 +1167,12 @@ extension ObservableMergeTest {
                 factory(ys1.asObservable(), ys2.asObservable(), ys3.asObservable())
             }
 
-            let messages: [Recorded<Event<Int>>] = [
+            let messages = Recorded.events(
                 .next(210, 101),
                 .next(210, 201),
                 .next(210, 301),
                 .error(215, testError)
-            ]
+            )
 
             XCTAssertEqual(res.events, messages)
 

--- a/Tests/RxSwiftTests/Observable+ReduceTests.swift
+++ b/Tests/RxSwiftTests/Observable+ReduceTests.swift
@@ -25,10 +25,10 @@ extension ObservableReduceTest {
 
         let res = scheduler.start { xs.reduce(42, accumulator: +) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(250, 42),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -49,10 +49,10 @@ extension ObservableReduceTest {
 
         let res = scheduler.start { xs.reduce(42, accumulator: +) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(250, 42 + 24),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -119,10 +119,10 @@ extension ObservableReduceTest {
 
         let res = scheduler.start { xs.reduce(42, accumulator: +) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(260, 42 + 0 + 1 + 2 + 3 + 4),
             .completed(260)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 260)
@@ -178,10 +178,10 @@ extension ObservableReduceTest {
 
         let res = scheduler.start { xs.reduce(42, accumulator: +) { $0 * 5 } }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(250, 42 * 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -202,10 +202,10 @@ extension ObservableReduceTest {
 
         let res = scheduler.start { xs.reduce(42, accumulator: +, mapResult: { $0 * 5 }) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(250, (42 + 24) * 5),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -272,10 +272,10 @@ extension ObservableReduceTest {
 
         let res = scheduler.start { xs.reduce(42, accumulator: +, mapResult: { $0 * 5 }) }
 
-        let correctMessages: [Recorded<Event<Int>>] = [
+        let correctMessages = Recorded.events(
             .next(260, (42 + 0 + 1 + 2 + 3 + 4) * 5),
             .completed(260)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 260)

--- a/Tests/RxSwiftTests/Observable+RetryWhenTests.swift
+++ b/Tests/RxSwiftTests/Observable+RetryWhenTests.swift
@@ -84,12 +84,12 @@ extension ObservableRetryWhenTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -121,13 +121,13 @@ extension ObservableRetryWhenTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .next(220, 3),
             .next(230, 4),
             .next(240, 5),
             .completed(250)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -158,12 +158,12 @@ extension ObservableRetryWhenTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(300, 1),
             .next(350, 2),
             .next(400, 3),
             .completed(450)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -197,13 +197,13 @@ extension ObservableRetryWhenTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 1),
             .next(220, 2),
             .next(240, 1),
             .next(250, 2),
             .error(260, testError1)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -236,11 +236,11 @@ extension ObservableRetryWhenTest {
             })
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 1),
             .next(220, 2),
             .completed(230)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -270,13 +270,13 @@ extension ObservableRetryWhenTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 1),
             .next(220, 2),
             .next(240, 1),
             .next(250, 2),
             .completed(260)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -307,10 +307,10 @@ extension ObservableRetryWhenTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 1),
             .next(220, 2)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -344,13 +344,13 @@ extension ObservableRetryWhenTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(205, 1),
             .next(265, 1),
             .next(375, 1),
             .next(535, 1),
             .error(540, retryError)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -378,10 +378,10 @@ extension ObservableRetryWhenTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(205, 1),
             .error(210, retryError)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 

--- a/Tests/RxSwiftTests/Observable+SampleTests.swift
+++ b/Tests/RxSwiftTests/Observable+SampleTests.swift
@@ -39,10 +39,10 @@ extension ObservableSampleTest {
             xs.sample(ys)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(250, 3),
             .error(320, testError)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -81,11 +81,11 @@ extension ObservableSampleTest {
             xs.sample(ys)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(250, 3),
             .next(320, 6),
             .completed(500)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -125,12 +125,12 @@ extension ObservableSampleTest {
             xs.sample(ys)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(250, 3),
             .next(320, 6),
             .next(500, 7),
             .completed(500)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -167,11 +167,11 @@ extension ObservableSampleTest {
             xs.sample(ys)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(250, 3),
             .next(320, 4),
             .completed(320)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -210,11 +210,11 @@ extension ObservableSampleTest {
             xs.sample(ys)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(250, 3),
             .next(300, 5),
             .error(320, testError)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 

--- a/Tests/RxSwiftTests/Observable+ScanTests.swift
+++ b/Tests/RxSwiftTests/Observable+ScanTests.swift
@@ -124,13 +124,13 @@ extension ObservableScanTest {
             xs.scan(seed) { $0 + $1 }
         }
 
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(210, seed + 2),
             .next(220, seed + 2 + 3),
             .next(230, seed + 2 + 3 + 4),
             .next(240, seed + 2 + 3 + 4 + 5),
             .completed(250)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
 

--- a/Tests/RxSwiftTests/Observable+SwitchTests.swift
+++ b/Tests/RxSwiftTests/Observable+SwitchTests.swift
@@ -44,12 +44,12 @@ extension ObservableSwitchTest {
             .completed(150)
         ])
         
-        let xSequence: [Recorded<Event<TestableObservable<Int>>>] = [
+        let xSequence = Recorded.events(
             .next(300, ys1),
             .next(400, ys2),
             .next(500, ys3),
             .completed(600)
-        ]
+        )
         
         let xs = scheduler.createHotObservable(xSequence)
         
@@ -57,7 +57,7 @@ extension ObservableSwitchTest {
             xs.switchLatest()
         }
         
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 201),
@@ -69,7 +69,7 @@ extension ObservableSwitchTest {
             .next(530, 303),
             .next(540, 304),
             .completed(650)
-        ]
+        )
         
         XCTAssertEqual(res.events, correct)
         
@@ -127,12 +127,12 @@ extension ObservableSwitchTest {
             .completed(150)
             ])
         
-        let xSequence: [Recorded<Event<TestableObservable<Int>>>] = [
+        let xSequence = Recorded.events(
             .next(300, ys1),
             .next(400, ys2),
             .next(500, ys3),
             .completed(600)
-        ]
+        )
         
         let xs = scheduler.createHotObservable(xSequence)
         
@@ -140,15 +140,15 @@ extension ObservableSwitchTest {
             xs.switchLatest()
         }
         
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 201),
             .next(420, 202),
             .next(430, 203),
             .next(440, 204),
-            .error(450, testError),
-        ]
+            .error(450, testError)
+        )
         
         XCTAssertEqual(res.events, correct)
         
@@ -197,11 +197,11 @@ extension ObservableSwitchTest {
             .completed(50)
             ])
         
-        let xSequence: [Recorded<Event<TestableObservable<Int>>>] = [
+        let xSequence = Recorded.events(
             .next(300, ys1),
             .next(400, ys2),
             .error(500, testError)
-        ]
+        )
         
         let xs = scheduler.createHotObservable(xSequence)
         
@@ -209,15 +209,15 @@ extension ObservableSwitchTest {
             xs.switchLatest()
         }
         
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 201),
             .next(420, 202),
             .next(430, 203),
             .next(440, 204),
-            .error(500, testError),
-        ]
+            .error(500, testError)
+        )
         
         XCTAssertEqual(res.events, correct)
         
@@ -288,12 +288,12 @@ extension ObservableSwitchTest {
 
         let observables = [ys1, ys2, ys3]
         
-        let xSequence: [Recorded<Event<Int>>] = [
+        let xSequence = Recorded.events(
             .next(300, 0),
             .next(400, 1),
             .next(500, 2),
             .completed(600)
-        ]
+        )
         
         let xs = scheduler.createHotObservable(xSequence)
         
@@ -301,7 +301,7 @@ extension ObservableSwitchTest {
             xs.flatMapLatest { observables[$0] }
         }
         
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 201),
@@ -313,7 +313,7 @@ extension ObservableSwitchTest {
             .next(530, 303),
             .next(540, 304),
             .completed(650)
-        ]
+        )
         
         XCTAssertEqual(res.events, correct)
         
@@ -373,12 +373,12 @@ extension ObservableSwitchTest {
 
         let observables = [ys1, ys2, ys3]
         
-        let xSequence: [Recorded<Event<Int>>] = [
+        let xSequence = Recorded.events(
             .next(300, 0),
             .next(400, 1),
             .next(500, 2),
             .completed(600)
-        ]
+        )
         
         let xs = scheduler.createHotObservable(xSequence)
         
@@ -386,15 +386,15 @@ extension ObservableSwitchTest {
             xs.flatMapLatest { observables[$0] }
         }
         
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 201),
             .next(420, 202),
             .next(430, 203),
             .next(440, 204),
-            .error(450, testError),
-        ]
+            .error(450, testError)
+        )
         
         XCTAssertEqual(res.events, correct)
         
@@ -445,11 +445,11 @@ extension ObservableSwitchTest {
 
         let observables = [ys1, ys2]
         
-        let xSequence: [Recorded<Event<Int>>] = [
+        let xSequence = Recorded.events(
             .next(300, 0),
             .next(400, 1),
             .error(500, testError)
-        ]
+        )
         
         let xs = scheduler.createHotObservable(xSequence)
         
@@ -457,15 +457,15 @@ extension ObservableSwitchTest {
             xs.flatMapLatest { observables[$0] }
         }
         
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(310, 101),
             .next(320, 102),
             .next(410, 201),
             .next(420, 202),
             .next(430, 203),
             .next(440, 204),
-            .error(500, testError),
-        ]
+            .error(500, testError)
+        )
         
         XCTAssertEqual(res.events, correct)
         
@@ -511,10 +511,10 @@ extension ObservableSwitchTest {
 
         let observables = [ys1, ys2]
 
-        let xSequence: [Recorded<Event<Int>>] = [
+        let xSequence = Recorded.events(
             .next(300, 0),
             .next(400, 1)
-        ]
+        )
 
         let xs = scheduler.createHotObservable(xSequence)
 
@@ -529,11 +529,11 @@ extension ObservableSwitchTest {
             }
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(310, 101),
             .next(320, 102),
-            .error(400, testError),
-        ]
+            .error(400, testError)
+        )
 
         XCTAssertEqual(res.events, correct)
 

--- a/Tests/RxSwiftTests/Observable+Tests.swift
+++ b/Tests/RxSwiftTests/Observable+Tests.swift
@@ -147,10 +147,10 @@ extension ObservableTest {
 
         let res = scheduler.start { ys }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(220, 2),
             .completed(250)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
     }

--- a/Tests/RxSwiftTests/Observable+ThrottleTests.swift
+++ b/Tests/RxSwiftTests/Observable+ThrottleTests.swift
@@ -34,11 +34,11 @@ extension ObservableThrottleTest {
             xs.throttle(200, latest: false, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .next(410, 6),
             .completed(500)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -116,10 +116,10 @@ extension ObservableThrottleTest {
             xs.throttle(200, latest: false, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .error(410, testError)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -147,10 +147,10 @@ extension ObservableThrottleTest {
             xs.throttle(200, latest: false, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .next(410, 6)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -215,12 +215,12 @@ extension ObservableThrottleTest {
             xs.throttle(200, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .next(410, 6),
             .next(610, 7),
             .completed(610)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -249,12 +249,12 @@ extension ObservableThrottleTest {
             xs.throttle(200, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .next(410, 6),
             .next(610, 7),
             .completed(900)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -332,10 +332,10 @@ extension ObservableThrottleTest {
             xs.throttle(200, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .error(410, testError)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
 
@@ -363,11 +363,11 @@ extension ObservableThrottleTest {
             xs.throttle(200, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(210, 2),
             .next(410, 6),
-            .next(610, 7),
-        ]
+            .next(610, 7)
+        )
         
         XCTAssertEqual(res.events, correct)
         

--- a/Tests/RxSwiftTests/Observable+TimerTests.swift
+++ b/Tests/RxSwiftTests/Observable+TimerTests.swift
@@ -23,10 +23,10 @@ extension ObservableTimerTest {
             Observable<Int>.timer(100, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int>>] = [
+        let correct = Recorded.events(
             .next(300, 0),
             .completed(300)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
     }
@@ -52,15 +52,15 @@ extension ObservableTimerTest {
             Observable<Int64>.interval(100, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int64>>] = [
-            .next(300, 0),
+        let correct = Recorded.events(
+            .next(300, 0 as Int64),
             .next(400, 1),
             .next(500, 2),
             .next(600, 3),
             .next(700, 4),
             .next(800, 5),
             .next(900, 6)
-        ]
+        )
 
         XCTAssertEqual(res.events, correct)
     }
@@ -72,8 +72,8 @@ extension ObservableTimerTest {
             Observable<Int64>.interval(0, scheduler: scheduler)
         }
 
-        let correct: [Recorded<Event<Int64>>] = [
-            .next(201, 0),
+        let correct = Recorded.events(
+            .next(201, 0 as Int64),
             .next(202, 1),
             .next(203, 2),
             .next(204, 3),
@@ -81,8 +81,8 @@ extension ObservableTimerTest {
             .next(206, 5),
             .next(207, 6),
             .next(208, 7),
-            .next(209, 8),
-        ]
+            .next(209, 8)
+        )
 
         XCTAssertEqual(res.events, correct)
     }

--- a/Tests/RxSwiftTests/Observable+ToArrayTests.swift
+++ b/Tests/RxSwiftTests/Observable+ToArrayTests.swift
@@ -28,10 +28,10 @@ extension ObservableToArrayTest {
             return xs.toArray().map { EquatableArray($0) }
         }
 
-        let correctMessages: [Recorded<Event<EquatableArray<Int>>>] = [
+        let correctMessages = Recorded.events(
             .next(220, EquatableArray([1])),
             .completed(220)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 220)
@@ -56,10 +56,10 @@ extension ObservableToArrayTest {
             return xs.toArray().map { EquatableArray($0) }
         }
 
-        let correctMessages: [Recorded<Event<EquatableArray<Int>>>] = [
+        let correctMessages = Recorded.events(
             .next(250, EquatableArray([1,2,3,4])),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)
@@ -80,10 +80,10 @@ extension ObservableToArrayTest {
             return xs.toArray().map { EquatableArray($0) }
         }
 
-        let correctMessages: [Recorded<Event<EquatableArray<Int>>>] = [
+        let correctMessages = Recorded.events(
             .next(250, EquatableArray([Int]())),
             .completed(250)
-        ]
+        )
 
         let correctSubscriptions = [
             Subscription(200, 250)

--- a/Tests/RxSwiftTests/Observable+ZipTests.swift
+++ b/Tests/RxSwiftTests/Observable+ZipTests.swift
@@ -209,10 +209,10 @@ extension ObservableZipTest {
             Observable.zip(o1, o2) { $0 + $1 }
         }
    
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(220, 2 + 3),
             .completed(240)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
 
@@ -468,10 +468,10 @@ extension ObservableZipTest {
             Observable.zip(o1, o2) { $0 + $1 }
         }
    
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(215, 2 + 4),
             .completed(225)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
 
@@ -503,10 +503,10 @@ extension ObservableZipTest {
             Observable.zip(o2, o1) { $0 + $1 }
         }
    
-        let messages: [Recorded<Event<Int>>] = [
+        let messages = Recorded.events(
             .next(215, 2 + 4),
             .completed(225)
-        ]
+        )
 
         XCTAssertEqual(res.events, messages)
 


### PR DESCRIPTION
Hi there~~

This PR is an extension to #1510.

 Introducing `Recorded<Event<T>>` array factory method:

```swift
extension Recorded {
    
    public static func events<T>(_ recordedEvents: Recorded<Event<T>>...) -> [Recorded<Event<T>>] 
        where Value == Event<T> { ... }
    
    public static func events<T>(_ recordedEvents: [Recorded<Event<T>>]) -> [Recorded<Event<T>>] 
        where Value == Event<T> { ...  }
}
```

 This may help if you don't want to declare the type  when create recorded events:


```diff

- let correctMessages: [Recorded<Event<Int>>] = [
-     .next(210, 2),
-     .next(220, 3),
-     .next(230, 4),
-     .next(240, 5),
-     .completed(250)
- ]

+ let correctMessages = Recorded.events(
+     .next(210, 2),
+     .next(220, 3),
+     .next(230, 4),
+     .next(240, 5),
+     .completed(250)
+ )
```