### PR TITLE
Implement error Hook for Traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
  * Adds Reactive wrapper for `UIStepper.stepValue` property. #1389
 * Adds `materialize()` operator for RxBlocking's `BlockingObservable`. #1383
 * Adds `first` operator to `ObservableType`.
+* Adds error handling Hook to Single, Maybe and Completable #1532
 
 #### Anomalies
 

--- a/RxSwift/Traits/Completable.swift
+++ b/RxSwift/Traits/Completable.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
+#if DEBUG
+import Foundation
+#endif
+
 /// Sequence containing 0 elements
 public enum CompletableTrait { }
 /// Represents a push style sequence containing 0 elements.
@@ -75,10 +79,20 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
     public func subscribe(onCompleted: (() -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil) -> Disposable {
+        #if DEBUG
+                let callStack = Hooks.recordCallStackOnError ? Thread.callStackSymbols : []
+        #else
+                let callStack = [String]()
+        #endif
+
         return self.primitiveSequence.subscribe { event in
             switch event {
             case .error(let error):
-                onError?(error)
+                if let onError = onError {
+                    onError(error)
+                } else {
+                    Hooks.defaultErrorHandler(callStack, error)
+                }
             case .completed:
                 onCompleted?()
             }

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
+#if DEBUG
+import Foundation
+#endif
+
 /// Sequence containing exactly 1 element
 public enum SingleTrait { }
 /// Represents a push style sequence containing 1 element.
@@ -77,12 +81,22 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
     public func subscribe(onSuccess: ((ElementType) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil) -> Disposable {
+        #if DEBUG
+             let callStack = Hooks.recordCallStackOnError ? Thread.callStackSymbols : []
+        #else
+            let callStack = [String]()
+        #endif
+    
         return self.primitiveSequence.subscribe { event in
             switch event {
             case .success(let element):
                 onSuccess?(element)
             case .error(let error):
-                onError?(error)
+                if let onError = onError {
+                    onError(error)
+                } else {
+                    Hooks.defaultErrorHandler(callStack, error)
+                }
             }
         }
     }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -388,6 +388,7 @@ final class CompletableTest_ : CompletableTest, RxTestCase {
     ("test_merge_collection", CompletableTest.test_merge_collection),
     ("test_merge_array", CompletableTest.test_merge_array),
     ("test_merge_variadic", CompletableTest.test_merge_variadic),
+    ("testDefaultErrorHandler", CompletableTest.testDefaultErrorHandler),
     ] }
 }
 
@@ -707,6 +708,7 @@ final class SingleTest_ : SingleTest, RxTestCase {
     ("test_flatMap", SingleTest.test_flatMap),
     ("test_zip_tuple", SingleTest.test_zip_tuple),
     ("test_zip_resultSelector", SingleTest.test_zip_resultSelector),
+    ("testDefaultErrorHandler", SingleTest.testDefaultErrorHandler),
     ] }
 }
 
@@ -1276,6 +1278,7 @@ final class MaybeTest_ : MaybeTest, RxTestCase {
     ("test_flatMap", MaybeTest.test_flatMap),
     ("test_zip_tuple", MaybeTest.test_zip_tuple),
     ("test_zip_resultSelector", MaybeTest.test_zip_resultSelector),
+    ("testDefaultErrorHandler", MaybeTest.testDefaultErrorHandler),
     ("testZip2_selector", MaybeTest.testZip2_selector),
     ("testZip2_tuple", MaybeTest.testZip2_tuple),
     ("testZip3_selector", MaybeTest.testZip3_selector),

--- a/Tests/RxSwiftTests/CompletableTest.swift
+++ b/Tests/RxSwiftTests/CompletableTest.swift
@@ -535,6 +535,29 @@ extension CompletableTest {
     }
 }
 
+extension CompletableTest {
+    func testDefaultErrorHandler() {
+        var loggedErrors = [TestError]()
+
+        _ = Completable.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [])
+
+        let originalErrorHandler = Hooks.defaultErrorHandler
+
+        Hooks.defaultErrorHandler = { _, error in
+            loggedErrors.append(error as! TestError)
+        }
+
+        _ = Completable.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [testError])
+
+        Hooks.defaultErrorHandler = originalErrorHandler
+
+        _ = Completable.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [testError])
+    }
+}
+
 extension Never: Equatable {
 
 }

--- a/Tests/RxSwiftTests/MaybeTest.swift
+++ b/Tests/RxSwiftTests/MaybeTest.swift
@@ -615,4 +615,28 @@ extension MaybeTest {
     }
 }
 
+extension MaybeTest {
+    func testDefaultErrorHandler() {
+        var loggedErrors = [TestError]()
+
+        _ = Maybe<Int>.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [])
+
+        let originalErrorHandler = Hooks.defaultErrorHandler
+
+        Hooks.defaultErrorHandler = { _, error in
+            loggedErrors.append(error as! TestError)
+        }
+
+        _ = Maybe<Int>.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [testError])
+
+        Hooks.defaultErrorHandler = originalErrorHandler
+
+        _ = Maybe<Int>.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [testError])
+    }
+}
+
+
 

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -563,3 +563,26 @@ extension SingleTest {
             ])
     }
 }
+
+extension SingleTest {
+    func testDefaultErrorHandler() {
+        var loggedErrors = [TestError]()
+
+        _ = Single<Int>.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [])
+
+        let originalErrorHandler = Hooks.defaultErrorHandler
+
+        Hooks.defaultErrorHandler = { _, error in
+            loggedErrors.append(error as! TestError)
+        }
+
+        _ = Single<Int>.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [testError])
+
+        Hooks.defaultErrorHandler = originalErrorHandler
+
+        _ = Single<Int>.error(testError).subscribe()
+        XCTAssertEqual(loggedErrors, [testError])
+    }
+}


### PR DESCRIPTION
Link to issue #1532

Hi,

I tried to implement error Hook for Rx.Traits: Single, Maybe and Completable.
It's inspired by the implementation of error Hook for Observable. However, I'm not sure about the usage of SynchronizationTracker and if I should also add it. If it's not required I'll remove it.

Need to add
- [x] Changelog
- [x] Tests
