### PR TITLE
Replaces global timeless functions next, error, completed with Recorded.next, Recorded.error, Recorded.completed in Tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+* Replaces global timeless functions `next`, `error`, `completed` with `Recorded.next`, `Recorded.error`, `Recorded.completed` in **Tests**. #1537
+
 #### Anomalies
 
 ## [4.1.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.1.0)

--- a/Tests/Recorded+Timeless.swift
+++ b/Tests/Recorded+Timeless.swift
@@ -23,15 +23,3 @@ extension Recorded {
         return Recorded(time: 0, value: .error(error))
     }
 }
-
-func next<T>(_ value: T) -> Recorded<Event<T>> {
-    return Recorded(time: 0, value: .next(value))
-}
-
-func completed<T>() -> Recorded<Event<T>> {
-    return Recorded(time: 0, value: .completed)
-}
-
-func error<T>(_ error: Swift.Error) -> Recorded<Event<T>> {
-    return Recorded(time: 0, value: .error(error))
-}

--- a/Tests/Recorded+Timeless.swift
+++ b/Tests/Recorded+Timeless.swift
@@ -11,15 +11,15 @@ import RxSwift
 
 extension Recorded {
     
-    public static func next<T>(_ element: T) -> Recorded<Event<T>> where Value == Event<T> {
+    static func next<T>(_ element: T) -> Recorded<Event<T>> where Value == Event<T> {
         return Recorded(time: 0, value: .next(element))
     }
     
-    public static func completed<T>(_ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
+    static func completed<T>(_ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
         return Recorded(time: 0, value: .completed)
     }
     
-    public static func error<T>(_ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
+    static func error<T>(_ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
         return Recorded(time: 0, value: .error(error))
     }
 }

--- a/Tests/Recorded+Timeless.swift
+++ b/Tests/Recorded+Timeless.swift
@@ -9,6 +9,21 @@
 import RxTest
 import RxSwift
 
+extension Recorded {
+    
+    public static func next<T>(_ element: T) -> Recorded<Event<T>> where Value == Event<T> {
+        return Recorded(time: 0, value: .next(element))
+    }
+    
+    public static func completed<T>(_ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
+        return Recorded(time: 0, value: .completed)
+    }
+    
+    public static func error<T>(_ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> {
+        return Recorded(time: 0, value: .error(error))
+    }
+}
+
 func next<T>(_ value: T) -> Recorded<Event<T>> {
     return Recorded(time: 0, value: .next(value))
 }

--- a/Tests/RxCocoaTests/ControlPropertyTests.swift
+++ b/Tests/RxCocoaTests/ControlPropertyTests.swift
@@ -82,12 +82,12 @@ extension ControlPropertyTests {
 
         behaviorSubject.on(.next(1))
 
-        XCTAssertEqual(changedObserver.events, [next(1)])
+        XCTAssertEqual(changedObserver.events, [.next(1)])
 
         subscription.dispose()
 
         behaviorSubject.on(.next(2))
 
-        XCTAssertEqual(changedObserver.events, [next(1)])
+        XCTAssertEqual(changedObserver.events, [.next(1)])
     }
 }

--- a/Tests/RxCocoaTests/Observable+BindTests.swift
+++ b/Tests/RxCocoaTests/Observable+BindTests.swift
@@ -28,8 +28,8 @@ extension ObservableBindTest {
         _ = Observable.just(1).bind(to: observer)
 
         XCTAssertEqual(events, [
-            next(1),
-            completed()
+            .next(1),
+            .completed()
             ])
     }
 
@@ -109,7 +109,7 @@ extension ObservableBindTest {
         _ = Observable.just(1).bind(to: relay)
         
         XCTAssertEqual(events, [
-            next(1)
+            .next(1)
             ])
     }
     
@@ -125,7 +125,7 @@ extension ObservableBindTest {
         _ = (Observable.just(1) as Observable<Int>).bind(to: relay)
 
         XCTAssertEqual(events, [
-            next(1)
+            .next(1)
             ])
     }
 
@@ -141,7 +141,7 @@ extension ObservableBindTest {
         _ = Observable.just(1).bind(to: relay)
 
         XCTAssertEqual(events, [
-            next(1)
+            .next(1)
             ])
     }
 }

--- a/Tests/RxSwiftTests/Observable+ObserveOnTests.swift
+++ b/Tests/RxSwiftTests/Observable+ObserveOnTests.swift
@@ -180,7 +180,7 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    next(0)
+                    .next(0)
                     ])
                 xs.on(.next(1))
                 xs.on(.next(2))
@@ -188,9 +188,9 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    next(0),
-                    next(1),
-                    next(2)
+                    .next(0),
+                    .next(1),
+                    .next(2)
                     ])
                 XCTAssert(xs.subscriptions == [SubscribedToHotObservable])
                 xs.on(.completed)
@@ -198,10 +198,10 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    next(0),
-                    next(1),
-                    next(2),
-                    completed()
+                    .next(0),
+                    .next(1),
+                    .next(2),
+                    .completed()
                     ])
                 XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
                 return Disposables.create()
@@ -222,7 +222,7 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    completed()
+                    .completed()
                     ])
                 XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
                 return Disposables.create()
@@ -244,7 +244,7 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    next(0)
+                    .next(0)
                     ])
                 xs.on(.next(1))
                 xs.on(.next(2))
@@ -252,9 +252,9 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    next(0),
-                    next(1),
-                    next(2)
+                    .next(0),
+                    .next(1),
+                    .next(2)
                     ])
                 XCTAssert(xs.subscriptions == [SubscribedToHotObservable])
                 xs.on(.error(testError))
@@ -262,10 +262,10 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    next(0),
-                    next(1),
-                    next(2),
-                    error(testError)
+                    .next(0),
+                    .next(1),
+                    .next(2),
+                    .error(testError)
                     ])
                 XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
                 return Disposables.create()
@@ -288,7 +288,7 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    next(0)
+                    .next(0)
                     ])
 
                 XCTAssert(xs.subscriptions == [SubscribedToHotObservable])
@@ -301,7 +301,7 @@ extension ObservableObserveOnTest {
             },
             { scheduler in
                 XCTAssertEqual(observer.events, [
-                    next(0),
+                    .next(0),
                     ])
                 XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
                 return Disposables.create()
@@ -419,7 +419,7 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            next(0)
+            .next(0)
             ])
         xs.on(.next(1))
         xs.on(.next(2))
@@ -427,9 +427,9 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            next(0),
-            next(1),
-            next(2)
+            .next(0),
+            .next(1),
+            .next(2)
             ])
         XCTAssert(xs.subscriptions == [SubscribedToHotObservable])
         xs.on(.completed)
@@ -437,10 +437,10 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            next(0),
-            next(1),
-            next(2),
-            completed()
+            .next(0),
+            .next(1),
+            .next(2),
+            .completed()
             ])
         XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
 
@@ -463,7 +463,7 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            completed()
+            .completed()
             ])
         XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
     }
@@ -495,9 +495,9 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.3)
 
         XCTAssertEqual(observer.events, [
-            next(0),
-            next(1),
-            completed()
+            .next(0),
+            .next(1),
+            .completed()
             ])
         XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
 
@@ -520,7 +520,7 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            next(0)
+            .next(0)
             ])
         xs.on(.next(1))
         xs.on(.next(2))
@@ -528,9 +528,9 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            next(0),
-            next(1),
-            next(2)
+            .next(0),
+            .next(1),
+            .next(2)
             ])
         XCTAssert(xs.subscriptions == [SubscribedToHotObservable])
         xs.on(.error(testError))
@@ -538,10 +538,10 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            next(0),
-            next(1),
-            next(2),
-            error(testError)
+            .next(0),
+            .next(1),
+            .next(2),
+            .error(testError)
             ])
         XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
 
@@ -559,7 +559,7 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            next(0)
+            .next(0)
             ])
 
         XCTAssert(xs.subscriptions == [SubscribedToHotObservable])
@@ -571,7 +571,7 @@ class ObservableObserveOnTestConcurrentSchedulerTest: ObservableObserveOnTestBas
         sleep(0.1)
 
         XCTAssertEqual(observer.events, [
-            next(0),
+            .next(0),
             ])
         XCTAssert(xs.subscriptions == [UnsunscribedFromHotObservable])
     }

--- a/Tests/RxSwiftTests/ObserverTests.swift
+++ b/Tests/RxSwiftTests/ObserverTests.swift
@@ -98,7 +98,7 @@ extension ObserverTests {
             return x / 2
         }.on(.next(2))
 
-        XCTAssertEqual(observer.events, [next(1)])
+        XCTAssertEqual(observer.events, [.next(1)])
     }
 
     func testMapElementCompleted() {
@@ -108,7 +108,7 @@ extension ObserverTests {
             return x / 2
         }.on(.completed)
 
-        XCTAssertEqual(observer.events, [completed()])
+        XCTAssertEqual(observer.events, [.completed()])
     }
 
     func testMapElementError() {
@@ -118,7 +118,7 @@ extension ObserverTests {
             return x / 2
         }.on(.error(testError))
 
-        XCTAssertEqual(observer.events, [error(testError)])
+        XCTAssertEqual(observer.events, [.error(testError)])
     }
 
     func testMapElementThrow() {
@@ -128,6 +128,6 @@ extension ObserverTests {
             throw testError
         }.on(.next(2))
 
-        XCTAssertEqual(observer.events, [error(testError)])
+        XCTAssertEqual(observer.events, [.error(testError)])
     }
 }


### PR DESCRIPTION
Hi there~~

This PR is an extension to #1510 . I make these PRs separately, since the previous one is too big. 

## Changes:

```diff
XCTAssertEqual(observer.events, [
-    next(0),
-    next(1),
-    next(2),
-    completed(),
+    .next(0),
+    .next(1),
+    .next(2),
+    .completed()
    ])
```
Replaces global **timeless** functions `next`, `error`, `completed` in **Tests**:

```swift

func next<T>(_ value: T) -> Recorded<Event<T>> { ... }

func completed<T>() -> Recorded<Event<T>> { ... }

func error<T>(_ error: Swift.Error) -> Recorded<Event<T>> { ... }

```

with Recorded static functions:

```swift
extension Recorded {
    
    public static func next<T>(_ element: T) -> Recorded<Event<T>> where Value == Event<T> { ... }
    
    public static func completed<T>(_ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> { ... }
    
    public static func error<T>(_ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> where Value == Event<T> { ... }
}
```

Much more swifty.