### PR TITLE
Change `onNext` to `onSuccess` in `do` method in Single

### DIFF
--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -152,6 +152,34 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
 }
 
 extension PrimitiveSequenceType where TraitType == SingleTrait {
+
+    /**
+     Invokes an action for each event in the observable sequence, and propagates all observer messages through the result sequence.
+
+     - seealso: [do operator on reactivex.io](http://reactivex.io/documentation/operators/do.html)
+
+     - parameter onSuccess: Action to invoke for each element in the observable sequence.
+     - parameter onError: Action to invoke upon errored termination of the observable sequence.
+     - parameter onSubscribe: Action to invoke before subscribing to source observable sequence.
+     - parameter onSubscribed: Action to invoke after subscribing to source observable sequence.
+     - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
+     - returns: The source sequence with the side-effecting behavior applied.
+     */
+    public func `do`(onSuccess: ((ElementType) throws -> Void)? = nil,
+                     onError: ((Swift.Error) throws -> Void)? = nil,
+                     onSubscribe: (() -> ())? = nil,
+                     onSubscribed: (() -> ())? = nil,
+                     onDispose: (() -> ())? = nil)
+        -> Single<ElementType> {
+            return Single(raw: primitiveSequence.source.do(
+                onNext: onSuccess,
+                onError: onError,
+                onSubscribe: onSubscribe,
+                onSubscribed: onSubscribed,
+                onDispose: onDispose)
+            )
+    }
+
     /**
      Invokes an action for each event in the observable sequence, and propagates all observer messages through the result sequence.
      
@@ -164,18 +192,19 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
+    @available(*, deprecated, message: "Use do(onSuccess:onError:onSubscribe:onSubcribed:onDispose:) instead", renamed: "do(onSuccess:onError:onSubscribe:onSubcribed:onDispose:)")
     public func `do`(onNext: ((ElementType) throws -> Void)? = nil,
                      onError: ((Swift.Error) throws -> Void)? = nil,
                      onSubscribe: (() -> ())? = nil,
                      onSubscribed: (() -> ())? = nil,
                      onDispose: (() -> ())? = nil)
         -> Single<ElementType> {
-            return Single(raw: primitiveSequence.source.do(
-                onNext: onNext,
+            return `do`(
+                onSuccess: onNext,
                 onError: onError,
                 onSubscribe: onSubscribe,
                 onSubscribed: onSubscribed,
-                onDispose: onDispose)
+                onDispose: onDispose
             )
     }
     

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -488,7 +488,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(1).do(onNext: { _ in () }, onError: { _ in () }, onSubscribe: { () in () }, onSubscribed: { () in () }, onDispose: { () in () }) as Single<Int>).asObservable()
+            (Single<Int>.just(1).do(onSuccess: { _ in () }, onError: { _ in () }, onSubscribe: { () in () }, onSubscribed: { () in () }, onDispose: { () in () }) as Single<Int>).asObservable()
         }
 
         XCTAssertEqual(res.events, [


### PR DESCRIPTION
This PR changes name of first parameter in `do` method in Single. Previously this parameter was named `onNext` which didn't match Single semantics and also was inconsistent with naming in `subscribe` method. I renamed this parameter to `onSuccess`. To provide backwards compatibility, previous version is still available but marked as deprecated. 