### PR TITLE
Introduce `observe` method with Smart keyPath

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -24,6 +24,7 @@ custom_categories:
   - Logging
   - NSObject+Rx+KVORepresentable
   - NSObject+Rx+RawRepresentable
+  - NSObject+Rx+SmartKeyPath
   - NSObject+Rx
   - NotificationCenter+Rx
   - URLSession+Rx

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1517,6 +1517,9 @@
 		D9327EC41FEFF2EC005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */; };
 		D9327EC51FEFF2EC005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */; };
 		D9327EC61FEFF2ED005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */; };
+		D9327ECC1FF29CA7005A429C /* KeyPathKVOObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327ECB1FF29CA6005A429C /* KeyPathKVOObservableTests.swift */; };
+		D9327ECD1FF29CA7005A429C /* KeyPathKVOObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327ECB1FF29CA6005A429C /* KeyPathKVOObservableTests.swift */; };
+		D9327ECE1FF29CA7005A429C /* KeyPathKVOObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327ECB1FF29CA6005A429C /* KeyPathKVOObservableTests.swift */; };
 		ECBBA59B1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */; };
 		ECBBA59C1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */; };
 		ECBBA59E1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */; };
@@ -2239,6 +2242,7 @@
 		D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Rx.swift"; sourceTree = "<group>"; };
 		D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+RxTests.swift"; sourceTree = "<group>"; };
 		D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Rx+SmartKeyPath.swift"; sourceTree = "<group>"; };
+		D9327ECB1FF29CA6005A429C /* KeyPathKVOObservableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyPathKVOObservableTests.swift; sourceTree = "<group>"; };
 		ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Rx.swift"; sourceTree = "<group>"; };
 		ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTabBarControllerDelegateProxy.swift; sourceTree = "<group>"; };
 		ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+RxTests.swift"; sourceTree = "<group>"; };
@@ -2716,6 +2720,7 @@
 				C83508DF1C38706D0027C24C /* DelegateProxyTest+Cocoa.swift */,
 				C83508E01C38706D0027C24C /* DelegateProxyTest+UIKit.swift */,
 				C83508E41C38706D0027C24C /* KVOObservableTests.swift */,
+				D9327ECB1FF29CA6005A429C /* KeyPathKVOObservableTests.swift */,
 				C8C4F1761DE9D84900003FA7 /* NSButton+RxTests.swift */,
 				C834F6C51DB3950600C29244 /* NSControl+RxTests.swift */,
 				C83508E51C38706D0027C24C /* NSLayoutConstraint+RxTests.swift */,
@@ -4461,6 +4466,7 @@
 				C820A9B21EB507D300D431BC /* Observable+TakeWhileTests.swift in Sources */,
 				C820A9FA1EB510D500D431BC /* Observable+MaterializeTests.swift in Sources */,
 				C820A9EA1EB50E3400D431BC /* Observable+RetryWhenTests.swift in Sources */,
+				D9327ECC1FF29CA7005A429C /* KeyPathKVOObservableTests.swift in Sources */,
 				C83509431C38706E0027C24C /* MockDisposable.swift in Sources */,
 				C8323A8E1E33FD5200CC0C7F /* Resources.swift in Sources */,
 				C8C4F16D1DE9D4F400003FA7 /* UIDatePicker+RxTests.swift in Sources */,
@@ -4620,6 +4626,7 @@
 				C8C4F17B1DE9DF0200003FA7 /* UICollectionView+RxTests.swift in Sources */,
 				C820A96F1EB4F7AC00D431BC /* Observable+SequenceTests.swift in Sources */,
 				C820A9A31EB5011700D431BC /* Observable+TakeUntilTests.swift in Sources */,
+				D9327ECD1FF29CA7005A429C /* KeyPathKVOObservableTests.swift in Sources */,
 				C8C4F1841DE9DF0200003FA7 /* UISegmentedControl+RxTests.swift in Sources */,
 				C820A9EB1EB50E3400D431BC /* Observable+RetryWhenTests.swift in Sources */,
 				C83509D01C38752E0027C24C /* RuntimeStateSnapshot.swift in Sources */,
@@ -4644,6 +4651,7 @@
 				0BA9496E1E224B9C0036DD06 /* AsyncSubjectTests.swift in Sources */,
 				C83509E71C3875580027C24C /* PrimitiveHotObservable.swift in Sources */,
 				C83509CE1C3875230027C24C /* NSObject+RxTests.swift in Sources */,
+				D9327ECE1FF29CA7005A429C /* KeyPathKVOObservableTests.swift in Sources */,
 				C820A9D81EB50C5C00D431BC /* Observable+DistinctUntilChangedTests.swift in Sources */,
 				C820A9B81EB5081400D431BC /* Observable+MapTests.swift in Sources */,
 				C8350A011C38755E0027C24C /* AssumptionsTest.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1513,6 +1513,10 @@
 		D9080AD61EA05DEC002B433B /* UINavigationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */; };
 		D9080AD81EA06189002B433B /* UINavigationController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */; };
 		D9080AD91EA06189002B433B /* UINavigationController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */; };
+		D9327EC31FEFF2EB005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */; };
+		D9327EC41FEFF2EC005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */; };
+		D9327EC51FEFF2EC005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */; };
+		D9327EC61FEFF2ED005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */; };
 		ECBBA59B1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */; };
 		ECBBA59C1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */; };
 		ECBBA59E1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */; };
@@ -2234,6 +2238,7 @@
 		D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxNavigationControllerDelegateProxy.swift; sourceTree = "<group>"; };
 		D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Rx.swift"; sourceTree = "<group>"; };
 		D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+RxTests.swift"; sourceTree = "<group>"; };
+		D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Rx+SmartKeyPath.swift"; sourceTree = "<group>"; };
 		ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Rx.swift"; sourceTree = "<group>"; };
 		ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTabBarControllerDelegateProxy.swift; sourceTree = "<group>"; };
 		ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+RxTests.swift"; sourceTree = "<group>"; };
@@ -3135,6 +3140,7 @@
 				C89AB1BF1DAAC3350065FBE6 /* KVORepresentable.swift */,
 				C89AB1C01DAAC3350065FBE6 /* Logging.swift */,
 				C89AB1C11DAAC3350065FBE6 /* NotificationCenter+Rx.swift */,
+				D9327EC11FEFF1B6005A429C /* NSObject+Rx+SmartKeyPath.swift */,
 				C89AB1C21DAAC3350065FBE6 /* NSObject+Rx+KVORepresentable.swift */,
 				C89AB1C31DAAC3350065FBE6 /* NSObject+Rx+RawRepresentable.swift */,
 				C89AB1C41DAAC3350065FBE6 /* NSObject+Rx.swift */,
@@ -4115,6 +4121,7 @@
 				C89AB2381DAAC3A60065FBE6 /* _RX.m in Sources */,
 				7F600F411C5D0C6E00535B1D /* UIRefreshControl+Rx.swift in Sources */,
 				F31F35B01BB4FED800961002 /* UIStepper+Rx.swift in Sources */,
+				D9327EC31FEFF2EB005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */,
 				C8B0F7221F53135100548EBE /* ObservableConvertibleType+Signal.swift in Sources */,
 				C89AB1C61DAAC3350065FBE6 /* ControlEvent.swift in Sources */,
 				C8091C571FAA39C1001DB32A /* ControlEvent+Signal.swift in Sources */,
@@ -4225,6 +4232,7 @@
 				C89AB1D71DAAC3350065FBE6 /* Driver+Subscription.swift in Sources */,
 				C89AB2511DAAC3A60065FBE6 /* _RXObjCRuntime.m in Sources */,
 				C89AB20B1DAAC3350065FBE6 /* KVORepresentable.swift in Sources */,
+				D9327EC41FEFF2EC005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */,
 				C89AB1A71DAAC25A0065FBE6 /* RxCocoaObjCRuntimeError+Extensions.swift in Sources */,
 				A520FFFD1F0D291500573734 /* RxPickerViewDataSourceProxy.swift in Sources */,
 				C89AB2411DAAC3A60065FBE6 /* _RXDelegateProxy.m in Sources */,
@@ -5391,6 +5399,7 @@
 				C89AB1A91DAAC25A0065FBE6 /* RxCocoaObjCRuntimeError+Extensions.swift in Sources */,
 				842A5A2E1C357F94003568D5 /* NSTextStorage+Rx.swift in Sources */,
 				C8F0C0281BBBFBB9001B112F /* RxTextViewDelegateProxy.swift in Sources */,
+				D9327EC61FEFF2ED005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */,
 				C8F0C0291BBBFBB9001B112F /* UIBarButtonItem+Rx.swift in Sources */,
 				C8F0C02C1BBBFBB9001B112F /* UIDatePicker+Rx.swift in Sources */,
 				C8F0C02D1BBBFBB9001B112F /* RxTableViewDataSourceProxy.swift in Sources */,
@@ -5541,6 +5550,7 @@
 				91BE429D1CBF7EC000F6B062 /* UIPageControl+Rx.swift in Sources */,
 				C89AB2521DAAC3A60065FBE6 /* _RXObjCRuntime.m in Sources */,
 				D203C4FE1BB9C53700D02D00 /* RxTableViewDataSourceProxy.swift in Sources */,
+				D9327EC51FEFF2EC005A429C /* NSObject+Rx+SmartKeyPath.swift in Sources */,
 				D203C5001BB9C53700D02D00 /* RxTextViewDelegateProxy.swift in Sources */,
 				844BC8AD1CE4FA6400F5C7CB /* RxPickerViewDelegateProxy.swift in Sources */,
 				C89AB2181DAAC3350065FBE6 /* NSObject+Rx+KVORepresentable.swift in Sources */,

--- a/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
@@ -26,6 +26,20 @@ public struct KeyValueObservingOptions: OptionSet {
     public static let new = KeyValueObservingOptions(rawValue: 1 << 1)
 }
 
+extension KeyValueObservingOptions {
+    var nsOptions: NSKeyValueObservingOptions {
+        var result: UInt = 0
+        if self.contains(.new) {
+            result |= NSKeyValueObservingOptions.new.rawValue
+        }
+        if self.contains(.initial) {
+            result |= NSKeyValueObservingOptions.initial.rawValue
+        }
+
+        return NSKeyValueObservingOptions(rawValue: result)
+    }
+}
+
 extension Reactive where Base: NSObject {
 
     /**

--- a/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
@@ -10,11 +10,45 @@ import Foundation.NSObject
 import RxSwift
 
 extension Reactive where Base: NSObject {
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and retains `self` if `retainSelf` is set.
+
+     `observe` is just a simple and performant wrapper around KVO mechanism.
+
+     * it can be used to observe paths starting from `self` or from ancestors in ownership graph (`retainSelf = false`)
+     * it can be used to observe paths starting from descendants in ownership graph (`retainSelf = true`)
+     * the paths have to consist only of `strong` properties, otherwise you are risking crashing the system by not unregistering KVO observer before dealloc.
+
+     If support for weak properties is needed or observing arbitrary or unknown relationships in the
+     ownership tree, `observeWeakly` is the preferred option.
+
+     - parameter keyPath: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - parameter retainSelf: Retains self during observation if set `true`.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
     public func observe<Value>(_ keyPath: KeyPath<Base, Value>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Value> {
         return KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: retainSelf)
             .asObservable()
     }
+}
 
+#if !DISABLE_SWIZZLING && !os(Linux)
+extension Reactive where Base: NSObject {
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     - parameter keyPath: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
     public func observeWeakly<Value>(_ keyPath: KeyPath<Base, Value>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
         let observable = KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: false)
             .map { value -> Value? in value }
@@ -25,6 +59,20 @@ extension Reactive where Base: NSObject {
             .switchLatest()
     }
 
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     - parameter keyPath: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
     public func observeWeakly<Value>(_ keyPath: KeyPath<Base, Value?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
         let observable = KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: false)
             .asObservable()
@@ -36,78 +84,415 @@ extension Reactive where Base: NSObject {
 }
 
 extension Reactive where Base: NSObject {
-    public func observeWeakly<Value, A: NSObject>(_ keyPath: KeyPath<Base, A?>, _ keyPath1: KeyPath<A, Value?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
-        return observeWeakly(keyPath, options: options.union(.initial))
-            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options) ?? .just(nil) }
-    }
-    public func observeWeakly<Value, A: NSObject>(_ keyPath: KeyPath<Base, A?>, _ keyPath1: KeyPath<A, Value>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
-        return observeWeakly(keyPath, options: options.union(.initial))
-            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options) ?? .just(nil) }
-    }
-    public func observeWeakly<Value, A: NSObject>(_ keyPath: KeyPath<Base, A>, _ keyPath1: KeyPath<A, Value?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
-        return observeWeakly(keyPath, options: options.union(.initial))
-            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options) ?? .just(nil) }
-    }
-    public func observeWeakly<Value, A: NSObject>(_ keyPath: KeyPath<Base, A>, _ keyPath1: KeyPath<A, Value>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
-        return observeWeakly(keyPath, options: options.union(.initial))
-            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options) ?? .just(nil) }
-    }
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
 
-    public func observeWeakly<Value, A: NSObject, B: NSObject>(
-        _ keyPath: KeyPath<Base, A?>,
-        _ keyPath1: KeyPath<A, B?>,
-        _ keyPath2: KeyPath<B, Value?>,
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject>(
+        _ keyPath0: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, Value?>,
         options: KeyValueObservingOptions = [.new, .initial]
     ) -> Observable<Value?> {
-        return observeWeakly(keyPath, keyPath1, options: options)
-            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+        let observable = observeWeakly(keyPath0, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
     }
-    public func observeWeakly<Value, A: NSObject, B: NSObject>(
-        _ keyPath: KeyPath<Base, A?>,
-        _ keyPath1: KeyPath<A, B?>,
-        _ keyPath2: KeyPath<B, Value>,
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject>(
+        _ keyPath0: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, Value>,
         options: KeyValueObservingOptions = [.new, .initial]
     ) -> Observable<Value?> {
-        return observeWeakly(keyPath, keyPath1, options: options)
-            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+        let observable = observeWeakly(keyPath0, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
     }
-    public func observeWeakly<Value, A: NSObject, B: NSObject>(
-        _ keyPath: KeyPath<Base, A?>,
-        _ keyPath1: KeyPath<A, B>,
-        _ keyPath2: KeyPath<B, Value>,
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject>(
+        _ keyPath0: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, Value?>,
         options: KeyValueObservingOptions = [.new, .initial]
     ) -> Observable<Value?> {
-        return observeWeakly(keyPath, keyPath1, options: options)
-            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+        let observable = observeWeakly(keyPath0, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
     }
-    public func observeWeakly<Value, A: NSObject, B: NSObject>(
-        _ keyPath: KeyPath<Base, A>,
-        _ keyPath1: KeyPath<A, B>,
-        _ keyPath2: KeyPath<B, Value>,
-        options: KeyValueObservingOptions = [.new, .initial]
-        ) -> Observable<Value?> {
-        return observeWeakly(keyPath, keyPath1, options: options)
-            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
-    }
-    public func observeWeakly<Value, A: NSObject, B: NSObject>(
-        _ keyPath: KeyPath<Base, A>,
-        _ keyPath1: KeyPath<A, B?>,
-        _ keyPath2: KeyPath<B, Value?>,
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject>(
+        _ keyPath0: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, Value>,
         options: KeyValueObservingOptions = [.new, .initial]
     ) -> Observable<Value?> {
-        return observeWeakly(keyPath, keyPath1, options: options)
-            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
-    }
-    public func observeWeakly<Value, A: NSObject, B: NSObject>(
-        _ keyPath: KeyPath<Base, A>,
-        _ keyPath1: KeyPath<A, B>,
-        _ keyPath2: KeyPath<B, Value?>,
-        options: KeyValueObservingOptions = [.new, .initial]
-    ) -> Observable<Value?> {
-        return observeWeakly(keyPath, keyPath1, options: options)
-            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+        let observable = observeWeakly(keyPath0, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
     }
 }
+
+extension Reactive where Base: NSObject {
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath0: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, B?>,
+        _ keyPath2: KeyPath<B, Value?>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        let observable = observeWeakly(keyPath0, keyPath1, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
+    }
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath0: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, B?>,
+        _ keyPath2: KeyPath<B, Value>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        let observable = observeWeakly(keyPath0, keyPath1, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
+    }
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath0: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, B>,
+        _ keyPath2: KeyPath<B, Value?>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        let observable = observeWeakly(keyPath0, keyPath1, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
+    }
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath0: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, B>,
+        _ keyPath2: KeyPath<B, Value>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        let observable = observeWeakly(keyPath0, keyPath1, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
+    }
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath0: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, B?>,
+        _ keyPath2: KeyPath<B, Value?>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        let observable = observeWeakly(keyPath0, keyPath1, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
+    }
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath0: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, B?>,
+        _ keyPath2: KeyPath<B, Value>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        let observable = observeWeakly(keyPath0, keyPath1, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
+    }
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath0: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, B>,
+        _ keyPath2: KeyPath<B, Value?>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        let observable = observeWeakly(keyPath0, keyPath1, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
+    }
+    /**
+     Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
+
+     It can be used in all cases where `observe` can be used and additionally
+
+     * because it won't retain observed target, it can be used to observe arbitrary object graph whose ownership relation is unknown
+     * it can be used to observe `weak` properties
+
+     **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
+
+     `NSObject.observe` cannot detect ARC zeroing weak reference.
+     If you want to observe chaining keyPath with weakly, use this method.
+
+     ```
+     object.rx.observeWeakly(\.weakValue?.value)
+     ↓
+     object.rx.observeWeakly(\.weakValue, \.value)
+     ```
+
+     - parameter keyPath0: Key path of property to observe.
+     - parameter keyPath1: Key path of property to observe.
+     - parameter options: KVO mechanism notification options.
+     - returns: Observable sequence of objects on `keyPath`.
+     */
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath0: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, B>,
+        _ keyPath2: KeyPath<B, Value>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        let observable = observeWeakly(keyPath0, keyPath1, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options.union(.initial)) ?? .just(nil) }
+        return !options.contains(.initial) ? observable.skip(1) : observable
+    }
+}
+#endif
 
 private final class KVOObservable<Object: NSObject, Element>: ObservableType {
     typealias E = Element

--- a/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
@@ -1,9 +1,9 @@
 //
 //  NSObject+Rx+SmartKeyPath.swift
-//  RxSwift-iOS
+//  RxCocoa
 //
 //  Created by Hayashi Tatsuya on 12/24/17.
-//  Copyright © 2017年 Krunoslav Zaher. All rights reserved.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
 import Foundation.NSObject

--- a/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
@@ -5,7 +5,7 @@
 //  Created by Hayashi Tatsuya on 12/24/17.
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
-
+#if !os(Linux)
 import Foundation.NSObject
 import RxSwift
 
@@ -33,7 +33,7 @@ extension Reactive where Base: NSObject {
     }
 }
 
-#if !DISABLE_SWIZZLING && !os(Linux)
+#if !DISABLE_SWIZZLING
 extension Reactive where Base: NSObject {
     /**
      Observes values on `keyPath` starting from `self` with `options` and doesn't retain `self`.
@@ -530,3 +530,4 @@ private final class KVOObservable<Object: NSObject, Element>: ObservableType {
         }
     }
 }
+#endif

--- a/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
@@ -10,12 +10,14 @@ import Foundation.NSObject
 import RxSwift
 
 extension Reactive where Base: NSObject {
-    public func observe<Value>(_ keyPath: KeyPath<Base, Value>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Value?> {
-        return KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: retainSelf).asObservable()
+    public func observe<Value>(_ keyPath: KeyPath<Base, Value>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Value> {
+        return KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: retainSelf)
+            .asObservable()
     }
 
     public func observeWeakly<Value>(_ keyPath: KeyPath<Base, Value>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
         let observable = KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: false)
+            .map { value -> Value? in value }
             .asObservable()
         return deallocating
             .map { _ in .just(nil) }
@@ -26,7 +28,6 @@ extension Reactive where Base: NSObject {
     public func observeWeakly<Value>(_ keyPath: KeyPath<Base, Value?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
         let observable = KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: false)
             .asObservable()
-            .map { $0 ?? nil }
         return deallocating
             .map { _ in .just(nil) }
             .startWith(observable)
@@ -34,9 +35,82 @@ extension Reactive where Base: NSObject {
     }
 }
 
+extension Reactive where Base: NSObject {
+    public func observeWeakly<Value, A: NSObject>(_ keyPath: KeyPath<Base, A?>, _ keyPath1: KeyPath<A, Value?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
+        return observeWeakly(keyPath, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options) ?? .just(nil) }
+    }
+    public func observeWeakly<Value, A: NSObject>(_ keyPath: KeyPath<Base, A?>, _ keyPath1: KeyPath<A, Value>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
+        return observeWeakly(keyPath, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options) ?? .just(nil) }
+    }
+    public func observeWeakly<Value, A: NSObject>(_ keyPath: KeyPath<Base, A>, _ keyPath1: KeyPath<A, Value?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
+        return observeWeakly(keyPath, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options) ?? .just(nil) }
+    }
+    public func observeWeakly<Value, A: NSObject>(_ keyPath: KeyPath<Base, A>, _ keyPath1: KeyPath<A, Value>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
+        return observeWeakly(keyPath, options: options.union(.initial))
+            .flatMap { $0?.rx.observeWeakly(keyPath1, options: options) ?? .just(nil) }
+    }
+
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, B?>,
+        _ keyPath2: KeyPath<B, Value?>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        return observeWeakly(keyPath, keyPath1, options: options)
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+    }
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, B?>,
+        _ keyPath2: KeyPath<B, Value>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        return observeWeakly(keyPath, keyPath1, options: options)
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+    }
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath: KeyPath<Base, A?>,
+        _ keyPath1: KeyPath<A, B>,
+        _ keyPath2: KeyPath<B, Value>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        return observeWeakly(keyPath, keyPath1, options: options)
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+    }
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, B>,
+        _ keyPath2: KeyPath<B, Value>,
+        options: KeyValueObservingOptions = [.new, .initial]
+        ) -> Observable<Value?> {
+        return observeWeakly(keyPath, keyPath1, options: options)
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+    }
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, B?>,
+        _ keyPath2: KeyPath<B, Value?>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        return observeWeakly(keyPath, keyPath1, options: options)
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+    }
+    public func observeWeakly<Value, A: NSObject, B: NSObject>(
+        _ keyPath: KeyPath<Base, A>,
+        _ keyPath1: KeyPath<A, B>,
+        _ keyPath2: KeyPath<B, Value?>,
+        options: KeyValueObservingOptions = [.new, .initial]
+    ) -> Observable<Value?> {
+        return observeWeakly(keyPath, keyPath1, options: options)
+            .flatMap { $0?.rx.observeWeakly(keyPath2, options: options) ?? .just(nil) }
+    }
+}
 
 private final class KVOObservable<Object: NSObject, Element>: ObservableType {
-    typealias E = Element?
+    typealias E = Element
 
     unowned var target: Object
     var strongTarget: Object?
@@ -54,12 +128,20 @@ private final class KVOObservable<Object: NSObject, Element>: ObservableType {
         }
     }
 
-    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element? {
+    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+        let keyPath = self.keyPath
+        var options = self.options
         let token = target.observe(keyPath, options: options.nsOptions) { (object, change) in
-            observer.on(.next(change.newValue))
+            if options.contains(.initial) {
+                options.remove(.initial)
+                observer.on(.next(object[keyPath: keyPath]))
+            } else if options.contains(.new) {
+                observer.on(.next(object[keyPath: keyPath]))
+            }
         }
         return Disposables.create {
             token.invalidate()
+            self.strongTarget = nil
         }
     }
 }

--- a/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift
@@ -1,0 +1,65 @@
+//
+//  NSObject+Rx+SmartKeyPath.swift
+//  RxSwift-iOS
+//
+//  Created by Hayashi Tatsuya on 12/24/17.
+//  Copyright © 2017年 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation.NSObject
+import RxSwift
+
+extension Reactive where Base: NSObject {
+    public func observe<Value>(_ keyPath: KeyPath<Base, Value>, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Value?> {
+        return KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: retainSelf).asObservable()
+    }
+
+    public func observeWeakly<Value>(_ keyPath: KeyPath<Base, Value>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
+        let observable = KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: false)
+            .asObservable()
+        return deallocating
+            .map { _ in .just(nil) }
+            .startWith(observable)
+            .switchLatest()
+    }
+
+    public func observeWeakly<Value>(_ keyPath: KeyPath<Base, Value?>, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Value?> {
+        let observable = KVOObservable(object: base, keyPath: keyPath, options: options, retainTarget: false)
+            .asObservable()
+            .map { $0 ?? nil }
+        return deallocating
+            .map { _ in .just(nil) }
+            .startWith(observable)
+            .switchLatest()
+    }
+}
+
+
+private final class KVOObservable<Object: NSObject, Element>: ObservableType {
+    typealias E = Element?
+
+    unowned var target: Object
+    var strongTarget: Object?
+    var keyPath: KeyPath<Object, Element>
+    var options: KeyValueObservingOptions
+    var retainTarget: Bool
+
+    init(object: Object, keyPath: KeyPath<Object, Element>, options: KeyValueObservingOptions, retainTarget: Bool) {
+        self.target = object
+        self.keyPath = keyPath
+        self.options = options
+        self.retainTarget = retainTarget
+        if retainTarget {
+            self.strongTarget = object
+        }
+    }
+
+    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element? {
+        let token = target.observe(keyPath, options: options.nsOptions) { (object, change) in
+            observer.on(.next(change.newValue))
+        }
+        return Disposables.create {
+            token.invalidate()
+        }
+    }
+}

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -437,20 +437,6 @@ fileprivate final class KVOObservable<Element>
                     .switchLatest()
         }
     }
-
-    fileprivate extension KeyValueObservingOptions {
-        fileprivate var nsOptions: NSKeyValueObservingOptions {
-            var result: UInt = 0
-            if self.contains(.new) {
-                result |= NSKeyValueObservingOptions.new.rawValue
-            }
-            if self.contains(.initial) {
-                result |= NSKeyValueObservingOptions.initial.rawValue
-            }
-
-            return NSKeyValueObservingOptions(rawValue: result)
-        }
-    }
     
     fileprivate func observeWeaklyKeyPathFor(
         _ target: NSObject,

--- a/Sources/RxCocoa/NSObject+Rx+SmartKeyPath.swift
+++ b/Sources/RxCocoa/NSObject+Rx+SmartKeyPath.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/Foundation/NSObject+Rx+SmartKeyPath.swift


### PR DESCRIPTION
This PR introduce `NSObject.observe` wrapper for RX.

can be written to:

```swift
self.rx.observe(\.frame)
```