### PR TITLE
[Discussion/Idea] Handling "Soft Deprecation" (a-la Variable)

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -262,6 +262,7 @@ custom_categories:
   - Queue
 - name: RxSwift/Platform
   children:
+  - DeprecationWarner
   - DispatchQueue+Extensions
   - Platform.Darwin
   - Platform.Linux

--- a/Platform/DeprecationWarner.swift
+++ b/Platform/DeprecationWarner.swift
@@ -10,14 +10,14 @@ import Foundation
 
 #if DEBUG
     class DeprecationWarner {
-        private static var warned = [Kind]()
+        private static var warned = Set<Kind>()
         private static var _lock = NSRecursiveLock()
         
         static func warnIfNeeded(_ kind: Kind) {
             _lock.lock(); defer { _lock.unlock() }
             guard !warned.contains(kind) else { return }
             
-            warned.append(kind)
+            warned.insert(kind)
             print("ℹ️ [DEPRECATED] \(kind.message)")
         }
     }
@@ -25,23 +25,18 @@ import Foundation
     extension DeprecationWarner {
         enum Kind {
             case variable
-            case globalTestFunction(String)
+            case globalTestFunctionNext
+            case globalTestFunctionError
+            case globalTestFunctionCompleted
             
             var message: String {
                 switch self {
-                case .variable: return "`Variable` is planned for future deprecation. Please consider `RxCocoa.BehaviorRelay` as a replacement. Read more at: https://git.io/vNqvx"
-                case .globalTestFunction(let name): return "The `\(name)()` global function is planned for future deprecation. Please use `Recorded.\(name)()` instead."
+                case .variable: return "`Variable` is planned for future deprecation. Please consider `BehaviorRelay` as a replacement. Read more at: https://git.io/vNqvx"
+                case .globalTestFunctionNext: return "The `next()` global function is planned for future deprecation. Please use `Recorded.next()` instead."
+                case .globalTestFunctionError: return "The `error()` global function is planned for future deprecation. Please use `Recorded.error()` instead."
+                case .globalTestFunctionCompleted: return "The `completed()` global function is planned for future deprecation. Please use `Recorded.completed()` instead."
                 }
             }
-        }
-    }
-    
-    extension DeprecationWarner.Kind: Equatable {}
-    func ==(lhs: DeprecationWarner.Kind, rhs: DeprecationWarner.Kind) -> Bool {
-        switch (lhs, rhs) {
-        case (.variable, .variable): return true
-        case let (.globalTestFunction(name1), .globalTestFunction(name2)): return name1 == name2
-        default: return false
         }
     }
 #endif

--- a/Platform/DeprecationWarner.swift
+++ b/Platform/DeprecationWarner.swift
@@ -1,0 +1,22 @@
+//
+//  DeprecationWarner.swift
+//  Rx
+//
+//  Created by Shai Mishali on 1/9/18.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+#if DEBUG
+    class DeprecationWarner {
+        private static var warned = [String]()
+
+        static func warnIfNeeded(_ message: String) {
+            guard !warned.contains(message) else { return }
+
+            warned.append(message)
+            print("ℹ️ [DEPRECATED] \(message)")
+        }
+    }
+#endif

--- a/Platform/DeprecationWarner.swift
+++ b/Platform/DeprecationWarner.swift
@@ -1,6 +1,6 @@
 //
 //  DeprecationWarner.swift
-//  Rx
+//  Platform
 //
 //  Created by Shai Mishali on 1/9/18.
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.

--- a/Platform/DeprecationWarner.swift
+++ b/Platform/DeprecationWarner.swift
@@ -10,13 +10,39 @@ import Foundation
 
 #if DEBUG
     class DeprecationWarner {
-        private static var warned = [String]()
-
-        static func warnIfNeeded(_ message: String) {
-            guard !warned.contains(message) else { return }
-
-            warned.append(message)
-            print("ℹ️ [DEPRECATED] \(message)")
+        private static var warned = [Kind]()
+        private static var _lock = NSRecursiveLock()
+        
+        static func warnIfNeeded(_ kind: Kind) {
+            _lock.lock(); defer { _lock.unlock() }
+            guard !warned.contains(kind) else { return }
+            
+            warned.append(kind)
+            print("ℹ️ [DEPRECATED] \(kind.message)")
+        }
+    }
+    
+    extension DeprecationWarner {
+        enum Kind {
+            case variable
+            case globalTestFunction(String)
+            
+            var message: String {
+                switch self {
+                case .variable: return "`Variable` is planned for future deprecation. Please consider `RxCocoa.BehaviorRelay` as a replacement. Read more at: https://git.io/vNqvx"
+                case .globalTestFunction(let name): return "The `\(name)()` global function is planned for future deprecation. Please use `Recorded.\(name)()` instead."
+                }
+            }
+        }
+    }
+    
+    extension DeprecationWarner.Kind: Equatable {}
+    func ==(lhs: DeprecationWarner.Kind, rhs: DeprecationWarner.Kind) -> Bool {
+        switch (lhs, rhs) {
+        case (.variable, .variable): return true
+        case let (.globalTestFunction(name1), .globalTestFunction(name2)): return name1 == name2
+        default: return false
         }
     }
 #endif
+

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -53,6 +53,14 @@
 		601AE3DB1EE24E5A00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DC1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DD1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
+		785D5EF420051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
+		785D5EF520051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
+		785D5EF620051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
+		785D5EF720051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
+		785D5F0120051B1F006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */; };
+		785D5F0220051B1F006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */; };
+		785D5F0320051B1F006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */; };
+		785D5F0420051B1F006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEBE1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
@@ -1754,6 +1762,8 @@
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
+		785D5EF320051B07006BAB40 /* DeprecationWarner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationWarner.swift; sourceTree = "<group>"; };
+		785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationWarner.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -2966,6 +2976,7 @@
 		C86781801DB8143A00B2029A /* Platform */ = {
 			isa = PBXGroup;
 			children = (
+				785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */,
 				C86781811DB8143A00B2029A /* DataStructures */,
 			);
 			path = Platform;
@@ -3257,6 +3268,7 @@
 				C8BF34CA1C2E426800416CAE /* Platform.Linux.swift */,
 				C8F03F491DBBAC0A00AECC4C /* DispatchQueue+Extensions.swift */,
 				C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */,
+				785D5EF320051B07006BAB40 /* DeprecationWarner.swift */,
 			);
 			path = Platform;
 			sourceTree = "<group>";
@@ -4858,6 +4870,7 @@
 				C820A9391EB4DA5A00D431BC /* Zip.swift in Sources */,
 				C8C3DA101B939767004D233E /* CurrentThreadScheduler.swift in Sources */,
 				C820A9351EB4DA5A00D431BC /* Sink.swift in Sources */,
+				785D5EF520051B07006BAB40 /* DeprecationWarner.swift in Sources */,
 				C8093D861B8A72BE0088E94D /* Rx.swift in Sources */,
 				C820A87D1EB4DA5A00D431BC /* TakeWhile.swift in Sources */,
 				C8093DA61B8A72BE0088E94D /* SubjectType.swift in Sources */,
@@ -4936,6 +4949,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C820A9451EB4E06800D431BC /* Deprecated.swift in Sources */,
+				785D5F0120051B1F006BAB40 /* DeprecationWarner.swift in Sources */,
 				C89CFA321DAABBE20079D23B /* Recorded.swift in Sources */,
 				C89CFA4A1DAABBE20079D23B /* TestableObserver.swift in Sources */,
 				C89CFA4E1DAABBE20079D23B /* XCTest+Rx.swift in Sources */,
@@ -4958,6 +4972,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C820A9461EB4E06800D431BC /* Deprecated.swift in Sources */,
+				785D5F0220051B1F006BAB40 /* DeprecationWarner.swift in Sources */,
 				C89CFA331DAABBE20079D23B /* Recorded.swift in Sources */,
 				C89CFA4B1DAABBE20079D23B /* TestableObserver.swift in Sources */,
 				C89CFA4F1DAABBE20079D23B /* XCTest+Rx.swift in Sources */,
@@ -4980,6 +4995,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C820A9471EB4E06800D431BC /* Deprecated.swift in Sources */,
+				785D5F0320051B1F006BAB40 /* DeprecationWarner.swift in Sources */,
 				C89CFA341DAABBE20079D23B /* Recorded.swift in Sources */,
 				C89CFA4C1DAABBE20079D23B /* TestableObserver.swift in Sources */,
 				C89CFA501DAABBE20079D23B /* XCTest+Rx.swift in Sources */,
@@ -5002,6 +5018,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C820A9481EB4E06800D431BC /* Deprecated.swift in Sources */,
+				785D5F0420051B1F006BAB40 /* DeprecationWarner.swift in Sources */,
 				C89CFA351DAABBE20079D23B /* Recorded.swift in Sources */,
 				C89CFA4D1DAABBE20079D23B /* TestableObserver.swift in Sources */,
 				C89CFA511DAABBE20079D23B /* XCTest+Rx.swift in Sources */,
@@ -5101,6 +5118,7 @@
 				C820A9381EB4DA5A00D431BC /* Zip.swift in Sources */,
 				C8093DA51B8A72BE0088E94D /* SubjectType.swift in Sources */,
 				C820A9341EB4DA5A00D431BC /* Sink.swift in Sources */,
+				785D5EF420051B07006BAB40 /* DeprecationWarner.swift in Sources */,
 				C8FA89171C30409900CD3A17 /* HistoricalScheduler.swift in Sources */,
 				C820A87C1EB4DA5A00D431BC /* TakeWhile.swift in Sources */,
 				C8093D6B1B8A72BE0088E94D /* AnonymousObserver.swift in Sources */,
@@ -5264,6 +5282,7 @@
 				C820A93B1EB4DA5A00D431BC /* Zip.swift in Sources */,
 				C8F0BFBB1BBBFB8B001B112F /* CurrentThreadScheduler.swift in Sources */,
 				C820A9371EB4DA5A00D431BC /* Sink.swift in Sources */,
+				785D5EF720051B07006BAB40 /* DeprecationWarner.swift in Sources */,
 				C8F0BFBC1BBBFB8B001B112F /* Rx.swift in Sources */,
 				C820A87F1EB4DA5A00D431BC /* TakeWhile.swift in Sources */,
 				C8F0BFBE1BBBFB8B001B112F /* SubjectType.swift in Sources */,
@@ -5639,6 +5658,7 @@
 				C820A93A1EB4DA5A00D431BC /* Zip.swift in Sources */,
 				C84CC5501BDCF48200E06A64 /* LockOwnerType.swift in Sources */,
 				C820A9361EB4DA5A00D431BC /* Sink.swift in Sources */,
+				785D5EF620051B07006BAB40 /* DeprecationWarner.swift in Sources */,
 				C84CC5551BDCF49300E06A64 /* SynchronizedOnType.swift in Sources */,
 				C820A87E1EB4DA5A00D431BC /* TakeWhile.swift in Sources */,
 				D2EBEB351BB9B6D2003A27DC /* ObserverBase.swift in Sources */,

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -209,6 +209,10 @@ public final class Variable<Element> {
     ///
     /// - parameter value: Initial variable value.
     public init(_ value: Element) {
+        #if DEBUG
+            Deprecated.warnIfNeeded("Variable is planned for future deprecation. Please consider `RxCocoa.BehaviorRelay` as a replacement. Read more at: https://git.io/vNqvx")
+        #endif
+
         _value = value
         _subject = BehaviorSubject(value: value)
     }
@@ -222,3 +226,16 @@ public final class Variable<Element> {
         _subject.on(.completed)
     }
 }
+
+#if DEBUG
+    private class Deprecated {
+        private static var warned = [String]()
+
+        static func warnIfNeeded(_ message: String) {
+            guard !warned.contains(message) else { return }
+
+            warned.append(message)
+            print("ℹ️ [DEPRECATED] \(message)")
+        }
+    }
+#endif

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -210,7 +210,7 @@ public final class Variable<Element> {
     /// - parameter value: Initial variable value.
     public init(_ value: Element) {
         #if DEBUG
-            DeprecationWarner.warnIfNeeded("`Variable` is planned for future deprecation. Please consider `RxCocoa.BehaviorRelay` as a replacement. Read more at: https://git.io/vNqvx")
+            DeprecationWarner.warnIfNeeded(.variable)
         #endif
 
         _value = value

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -210,7 +210,7 @@ public final class Variable<Element> {
     /// - parameter value: Initial variable value.
     public init(_ value: Element) {
         #if DEBUG
-            Deprecated.warnIfNeeded("Variable is planned for future deprecation. Please consider `RxCocoa.BehaviorRelay` as a replacement. Read more at: https://git.io/vNqvx")
+            DeprecationWarner.warnIfNeeded("`Variable` is planned for future deprecation. Please consider `RxCocoa.BehaviorRelay` as a replacement. Read more at: https://git.io/vNqvx")
         #endif
 
         _value = value
@@ -226,16 +226,3 @@ public final class Variable<Element> {
         _subject.on(.completed)
     }
 }
-
-#if DEBUG
-    private class Deprecated {
-        private static var warned = [String]()
-
-        static func warnIfNeeded(_ message: String) {
-            guard !warned.contains(message) else { return }
-
-            warned.append(message)
-            print("ℹ️ [DEPRECATED] \(message)")
-        }
-    }
-#endif

--- a/RxSwift/Platform/DeprecationWarner.swift
+++ b/RxSwift/Platform/DeprecationWarner.swift
@@ -1,0 +1,1 @@
+../../Platform/DeprecationWarner.swift

--- a/RxTest/Deprecated.swift
+++ b/RxTest/Deprecated.swift
@@ -34,7 +34,7 @@ extension TestScheduler {
      */
     public func next<T>(_ time: TestTime, _ element: T) -> Recorded<Event<T>> {
         #if DEBUG
-            DeprecationWarner.warnIfNeeded(.globalTestFunction("next"))
+            DeprecationWarner.warnIfNeeded(.globalTestFunctionNext)
         #endif
         return Recorded.next(time, element)
     }
@@ -48,7 +48,7 @@ extension TestScheduler {
      */
     public func completed<T>(_ time: TestTime, _ type: T.Type = T.self) -> Recorded<Event<T>> {
         #if DEBUG
-            DeprecationWarner.warnIfNeeded(.globalTestFunction("completed"))
+            DeprecationWarner.warnIfNeeded(.globalTestFunctionCompleted)
         #endif
         return Recorded.completed(time, type)
     }
@@ -60,7 +60,7 @@ extension TestScheduler {
      */
     public func error<T>(_ time: TestTime, _ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> {
         #if DEBUG
-            DeprecationWarner.warnIfNeeded(.globalTestFunction("error"))
+            DeprecationWarner.warnIfNeeded(.globalTestFunctionError)
         #endif
         return Recorded.error(time, error, type)
     }

--- a/RxTest/Deprecated.swift
+++ b/RxTest/Deprecated.swift
@@ -33,6 +33,9 @@ extension TestScheduler {
      - returns: Recorded event in time.
      */
     public func next<T>(_ time: TestTime, _ element: T) -> Recorded<Event<T>> {
+        #if DEBUG
+            DeprecationWarner.warnIfNeeded("The `next()` global function is planned for future deprecation. Please use `Recorded.next()` instead.")
+        #endif
         return Recorded.next(time, element)
     }
 
@@ -44,6 +47,9 @@ extension TestScheduler {
      - returns: Recorded event in time.
      */
     public func completed<T>(_ time: TestTime, _ type: T.Type = T.self) -> Recorded<Event<T>> {
+        #if DEBUG
+            DeprecationWarner.warnIfNeeded("The `completed()` global function is planned for future deprecation. Please use `Recorded.completed()` instead.")
+        #endif
         return Recorded.completed(time, type)
     }
 
@@ -53,6 +59,9 @@ extension TestScheduler {
      - parameter time: Recorded virtual time the `.completed` event occurs.
      */
     public func error<T>(_ time: TestTime, _ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> {
+        #if DEBUG
+            DeprecationWarner.warnIfNeeded("The `error()` global function is planned for future deprecation. Please use `Recorded.error()` instead.")
+        #endif
         return Recorded.error(time, error, type)
     }
 //}

--- a/RxTest/Deprecated.swift
+++ b/RxTest/Deprecated.swift
@@ -34,7 +34,7 @@ extension TestScheduler {
      */
     public func next<T>(_ time: TestTime, _ element: T) -> Recorded<Event<T>> {
         #if DEBUG
-            DeprecationWarner.warnIfNeeded("The `next()` global function is planned for future deprecation. Please use `Recorded.next()` instead.")
+            DeprecationWarner.warnIfNeeded(.globalTestFunction("next"))
         #endif
         return Recorded.next(time, element)
     }
@@ -48,7 +48,7 @@ extension TestScheduler {
      */
     public func completed<T>(_ time: TestTime, _ type: T.Type = T.self) -> Recorded<Event<T>> {
         #if DEBUG
-            DeprecationWarner.warnIfNeeded("The `completed()` global function is planned for future deprecation. Please use `Recorded.completed()` instead.")
+            DeprecationWarner.warnIfNeeded(.globalTestFunction("completed"))
         #endif
         return Recorded.completed(time, type)
     }
@@ -60,7 +60,7 @@ extension TestScheduler {
      */
     public func error<T>(_ time: TestTime, _ error: Swift.Error, _ type: T.Type = T.self) -> Recorded<Event<T>> {
         #if DEBUG
-            DeprecationWarner.warnIfNeeded("The `error()` global function is planned for future deprecation. Please use `Recorded.error()` instead.")
+            DeprecationWarner.warnIfNeeded(.globalTestFunction("error"))
         #endif
         return Recorded.error(time, error, type)
     }

--- a/RxTest/Platform/DeprecationWarner.swift
+++ b/RxTest/Platform/DeprecationWarner.swift
@@ -1,0 +1,1 @@
+../../Platform/DeprecationWarner.swift

--- a/Sources/AllTestz/DeprecationWarner.swift
+++ b/Sources/AllTestz/DeprecationWarner.swift
@@ -1,0 +1,1 @@
+../../Platform/DeprecationWarner.swift

--- a/Sources/RxSwift/DeprecationWarner.swift
+++ b/Sources/RxSwift/DeprecationWarner.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Platform/DeprecationWarner.swift

--- a/Sources/RxTest/DeprecationWarner.swift
+++ b/Sources/RxTest/DeprecationWarner.swift
@@ -1,0 +1,1 @@
+../../RxTest/Platform/DeprecationWarner.swift

--- a/scripts/validate-headers.swift
+++ b/scripts/validate-headers.swift
@@ -53,6 +53,7 @@ let excludePaths = [
     "Platform/DataStructures/PriorityQueue.swift",
     "Platform/DataStructures/Queue.swift",
     "Platform/DispatchQueue+Extensions.swift",
+    "Platform/DeprecationWarner.swift",
     "RxExample/Services/Reachability.swift",
     "RxDataSources"
 ]


### PR DESCRIPTION
## Motivation

Sometimes there are classes that we want to deprecate in RxSwift in the long term, but we can’t mark them with a `@available` clause, since that would contaminate the user’s project with a massive amount of warnings. 

The problem with this approach is that many users aren’t aware `Variable`, free test functions, etc are planned for deprecation. 

So, we need a way to notify a developer this is going to happen without spamming their build phase with warnings. 

## Implementation

This implementation is extremely naive and is only here to serve a purpose for the base of a discussion.

It provides a runtime warning when a softly-Deprecated class (such as Variable) has been initialized, but only provides this warning once, and only when the `DEBUG` flag is set.

Example:

![c1454a23-0a3f-4c82-bf42-4f722a1b1597](https://user-images.githubusercontent.com/605076/34723316-cf60e9b4-f552-11e7-84ea-01a22e2a465f.png)

There are probably many nicer ways to implement this but I just wanted to do the hacky, “get it to work” kind of way and gather some feedback from @kzaher and others. 

Opinions are very welcomed.

Thanks! 

P.S. This would probably have to either be implemented in every target, or be in a file that is a member of all targets
  
  