### PR TITLE
Fix ambiguous compile error Single.do

### DIFF
--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -193,7 +193,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     @available(*, deprecated, message: "Use do(onSuccess:onError:onSubscribe:onSubcribed:onDispose:) instead", renamed: "do(onSuccess:onError:onSubscribe:onSubcribed:onDispose:)")
-    public func `do`(onNext: ((ElementType) throws -> Void)? = nil,
+    public func `do`(onNext: ((ElementType) throws -> Void)?,
                      onError: ((Swift.Error) throws -> Void)? = nil,
                      onSubscribe: (() -> ())? = nil,
                      onSubscribed: (() -> ())? = nil,


### PR DESCRIPTION
<img width="1018" alt="screen shot 2018-01-11 at 12 24 57" src="https://user-images.githubusercontent.com/1830205/34807177-a7c980d6-f6ca-11e7-872e-8fc3c0f11f7a.png">

The latest update contains renaming argument label of `Single.do`, but it make ambiguous compile error now.
In `do(onDispose: xxx)` case, it match both `do(onNext:...` and `do(onSuccess:...`.
I remove default argument `onNext = nil` from `do(onNext:...`, it seems fine now.