### PR TITLE
Introduce `Bindable` protocol

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1433,6 +1433,10 @@
 		CDDEF16B1D4FB40000CA8546 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
 		CDDEF16C1D4FB40000CA8546 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
 		CDDEF16D1D4FB40000CA8546 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
+		CEA7688A200D2CCA002D4A96 /* Bindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA76889200D2CCA002D4A96 /* Bindable.swift */; };
+		CEA7688B200D2CCA002D4A96 /* Bindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA76889200D2CCA002D4A96 /* Bindable.swift */; };
+		CEA7688C200D2CCA002D4A96 /* Bindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA76889200D2CCA002D4A96 /* Bindable.swift */; };
+		CEA7688D200D2CCA002D4A96 /* Bindable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA76889200D2CCA002D4A96 /* Bindable.swift */; };
 		D203C4F31BB9C4CA00D02D00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F11B8A752B00B02D69 /* RxCollectionViewReactiveArrayDataSource.swift */; };
 		D203C4F41BB9C52400D02D00 /* RxTableViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F21B8A752B00B02D69 /* RxTableViewReactiveArrayDataSource.swift */; };
 		D203C4F51BB9C52900D02D00 /* ItemEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F41B8A752B00B02D69 /* ItemEvents.swift */; };
@@ -2228,6 +2232,7 @@
 		CB883B3F1BE24C15000AC2EE /* RefCountDisposable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefCountDisposable.swift; sourceTree = "<group>"; };
 		CB883B441BE256D4000AC2EE /* BooleanDisposable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BooleanDisposable.swift; sourceTree = "<group>"; };
 		CDDEF1691D4FB40000CA8546 /* Disposables.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Disposables.swift; sourceTree = "<group>"; };
+		CEA76889200D2CCA002D4A96 /* Bindable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bindable.swift; sourceTree = "<group>"; };
 		D2138C751BB9BE9800339B5C /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2EA280C1BB9B5A200880ED3 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2EBEB811BB9B99D003A27DC /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2408,6 +2413,7 @@
 			children = (
 				C85217E81E3374970015DD38 /* GroupedObservable.swift */,
 				C8093C491B8A72BE0088E94D /* Cancelable.swift */,
+				CEA76889200D2CCA002D4A96 /* Bindable.swift */,
 				C8093C4D1B8A72BE0088E94D /* ConnectableObservableType.swift */,
 				C8093C521B8A72BE0088E94D /* Disposable.swift */,
 				C8093C631B8A72BE0088E94D /* Errors.swift */,
@@ -4834,6 +4840,7 @@
 				C820A9151EB4DA5A00D431BC /* ToArray.swift in Sources */,
 				C820A8751EB4DA5A00D431BC /* SkipWhile.swift in Sources */,
 				25F6ECC21F48C405008552FA /* Completable.swift in Sources */,
+				CEA7688B200D2CCA002D4A96 /* Bindable.swift in Sources */,
 				C820A91D1EB4DA5A00D431BC /* AsSingle.swift in Sources */,
 				C8093D741B8A72BE0088E94D /* ObserverBase.swift in Sources */,
 				C85106891C2D550E0075150C /* String+Rx.swift in Sources */,
@@ -5077,6 +5084,7 @@
 				C820A9141EB4DA5A00D431BC /* ToArray.swift in Sources */,
 				C820A8741EB4DA5A00D431BC /* SkipWhile.swift in Sources */,
 				25F6ECBE1F48C373008552FA /* Completable.swift in Sources */,
+				CEA7688A200D2CCA002D4A96 /* Bindable.swift in Sources */,
 				C820A91C1EB4DA5A00D431BC /* AsSingle.swift in Sources */,
 				C8BF34CF1C2E426800416CAE /* Platform.Linux.swift in Sources */,
 				C8093D791B8A72BE0088E94D /* TailRecursiveSink.swift in Sources */,
@@ -5240,6 +5248,7 @@
 				C820A9171EB4DA5A00D431BC /* ToArray.swift in Sources */,
 				C820A8771EB4DA5A00D431BC /* SkipWhile.swift in Sources */,
 				25F6ECC81F48C407008552FA /* Completable.swift in Sources */,
+				CEA7688D200D2CCA002D4A96 /* Bindable.swift in Sources */,
 				C820A91F1EB4DA5A00D431BC /* AsSingle.swift in Sources */,
 				C8F0BFAF1BBBFB8B001B112F /* ObserverBase.swift in Sources */,
 				C851068B1C2D550E0075150C /* String+Rx.swift in Sources */,
@@ -5615,6 +5624,7 @@
 				D2EBEB421BB9B6DE003A27DC /* ReplaySubject.swift in Sources */,
 				C820A9161EB4DA5A00D431BC /* ToArray.swift in Sources */,
 				25F6ECC51F48C406008552FA /* Completable.swift in Sources */,
+				CEA7688C200D2CCA002D4A96 /* Bindable.swift in Sources */,
 				C820A8761EB4DA5A00D431BC /* SkipWhile.swift in Sources */,
 				C820A91E1EB4DA5A00D431BC /* AsSingle.swift in Sources */,
 				D2EBEB381BB9B6D8003A27DC /* ConcurrentDispatchQueueScheduler.swift in Sources */,

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -10,6 +10,25 @@
 import RxSwift
 
 extension ObservableType {
+    /**
+     Creates new subscription and sends elements to bindable.
+
+     - parameter to: Bindable that receives events.
+     - returns: Disposable object that can be used to unsubscribe the observer.
+     */
+    public func bind<B: Bindable>(to bindable: B) -> Disposable where B.T == E {
+        return self.subscribe { bindable.handle($0) }
+    }
+
+    /**
+     Creates new subscription and sends elements to bindable.
+
+     - parameter to: Bindable that receives events.
+     - returns: Disposable object that can be used to unsubscribe the observer.
+     */
+    public func bind<B: Bindable>(to bindable: B) -> Disposable where B.T == E? {
+        return self.map { $0 }.subscribe { bindable.handle($0) }
+    }
     
     /**
     Creates new subscription and sends elements to observer.

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -31,41 +31,6 @@ extension ObservableType {
     }
     
     /**
-     Creates new subscription and sends elements to behavior relay.
-     
-     In case error occurs in debug mode, `fatalError` will be raised.
-     In case error occurs in release mode, `error` will be logged.
-     
-     - parameter to: Target behavior relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    public func bind(to relay: BehaviorRelay<E>) -> Disposable {
-        return subscribe { e in
-            switch e {
-            case let .next(element):
-                relay.accept(element)
-            case let .error(error):
-                rxFatalErrorInDebug("Binding error to behavior relay: \(error)")
-            case .completed:
-                break
-            }
-        }
-    }
-    
-    /**
-     Creates new subscription and sends elements to behavior relay.
-     
-     In case error occurs in debug mode, `fatalError` will be raised.
-     In case error occurs in release mode, `error` will be logged.
-     
-     - parameter to: Target behavior relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    public func bind(to relay: BehaviorRelay<E?>) -> Disposable {
-        return self.map { $0 as E? }.bind(to: relay)
-    }
-    
-    /**
     Subscribes to observable sequence using custom binder function.
     
     - parameter to: Function used to bind elements from `self`.
@@ -120,6 +85,24 @@ extension PublishRelay: Bindable {
             self.accept(element)
         case let .error(error):
             rxFatalErrorInDebug("Binding error to publish relay: \(error)")
+        case .completed:
+            break
+        }
+    }
+}
+
+extension BehaviorRelay: Bindable {
+    public typealias T = Element
+    /**
+     In case error occurs in debug mode, `fatalError` will be raised.
+     In case error occurs in release mode, `error` will be logged.
+     */
+    public func handle(_ event: Event<T>) {
+        switch event {
+        case let .next(element):
+            self.accept(element)
+        case let .error(error):
+            rxFatalErrorInDebug("Binding error to behavior relay: \(error)")
         case .completed:
             break
         }

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -29,32 +29,6 @@ extension ObservableType {
     public func bind<B: Bindable>(to bindable: B) -> Disposable where B.T == E? {
         return self.map { $0 }.subscribe { bindable.handle($0) }
     }
-    
-    /**
-    Creates new subscription and sends elements to observer.
-    
-    In this form it's equivalent to `subscribe` method, but it communicates intent better, and enables
-    writing more consistent binding code.
-    
-    - parameter to: Observer that receives events.
-    - returns: Disposable object that can be used to unsubscribe the observer.
-    */
-    public func bind<O: ObserverType>(to observer: O) -> Disposable where O.E == E {
-        return self.subscribe(observer)
-    }
-
-    /**
-     Creates new subscription and sends elements to observer.
-
-     In this form it's equivalent to `subscribe` method, but it communicates intent better, and enables
-     writing more consistent binding code.
-
-     - parameter to: Observer that receives events.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    public func bind<O: ObserverType>(to observer: O) -> Disposable where O.E == E? {
-        return self.map { $0 }.subscribe(observer)
-    }
 
     /**
      Creates new subscription and sends elements to publish relay.

--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -444,46 +444,20 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     }
 }
 
-extension ObservableType {
+extension Variable: Bindable {
+    public typealias T = Element
     /**
-     Creates new subscription and sends elements to variable.
-
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-
-     - parameter to: Target variable for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to variable: Variable<E>) -> Disposable {
-        return subscribe { e in
-            switch e {
-            case let .next(element):
-                variable.value = element
-            case let .error(error):
-                let error = "Binding error to variable: \(error)"
-                #if DEBUG
-                    rxFatalError(error)
-                #else
-                    print(error)
-                #endif
-            case .completed:
-                break
-            }
+    public func handle(_ event: Event<T>) {
+        switch event {
+        case let .next(element):
+            self.value = element
+        case let .error(error):
+            rxFatalErrorInDebug("Binding error to behavior relay: \(error)")
+        case .completed:
+            break
         }
     }
-
-    /**
-     Creates new subscription and sends elements to variable.
-
-     In case error occurs in debug mode, `fatalError` will be raised.
-     In case error occurs in release mode, `error` will be logged.
-
-     - parameter to: Target variable for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    public func bind(to variable: Variable<E?>) -> Disposable {
-        return self.map { $0 as E? }.bind(to: variable)
-    }
 }
-
-

--- a/RxSwift/Bindable.swift
+++ b/RxSwift/Bindable.swift
@@ -16,3 +16,13 @@ public protocol Bindable {
     func handle(_ event: Event<T>)
 }
 
+extension ObserverType {
+    public typealias T = E
+    /**
+     In this form it's equivalent to `on` method, but it helps communicating intent better, and allows
+     writing more consistent binding code.
+     */
+    public func handle(_ event: Event<T>) {
+        self.on(event)
+    }
+}

--- a/RxSwift/Bindable.swift
+++ b/RxSwift/Bindable.swift
@@ -1,0 +1,18 @@
+//
+//  Bindable.swift
+//  Rx
+//
+//  Created by Mostafa Amer on 15.01.18.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+/// Represents a type that can be used with `func bind(to:) -> Disposable`.
+public protocol Bindable {
+    /// The type of elements in sequence that observer can observe.
+    associatedtype T
+    /// Handle a given sequence event.
+    ///
+    /// - parameter event: Event that occurred.
+    func handle(_ event: Event<T>)
+}
+

--- a/RxSwift/ObserverType.swift
+++ b/RxSwift/ObserverType.swift
@@ -7,7 +7,7 @@
 //
 
 /// Supports push-style iteration over an observable sequence.
-public protocol ObserverType {
+public protocol ObserverType: Bindable {
     /// The type of elements in sequence that observer can observe.
     associatedtype E
 


### PR DESCRIPTION
This is a proof-of-concept implementation for `Bindable` protocol discussed in #1550 . 

It adds the following protocol
```swift
public protocol Bindable {
    associatedtype T
    func handle(_ event: Event<T>)
}
```
This moves responsibility of implementing `func bind(to:)` behavior  from `ObservableType` to `ObserverType`-like types.
