### PR TITLE
Use Shortened URL for RxSwift Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ KVO observing, async operations and streams are all unified under [abstraction o
 
 ###### ... interact
 
-* All of this is great, but it would be nice to talk with other people using RxSwift and exchange experiences. <br />[![Slack channel](http://rxswift-slack.herokuapp.com/badge.svg)](http://rxswift-slack.herokuapp.com/) [Join Slack Channel](http://rxswift-slack.herokuapp.com)
+* All of this is great, but it would be nice to talk with other people using RxSwift and exchange experiences. <br />[![Slack channel](http://rxswift-slack.herokuapp.com/badge.svg)](http://bit.ly/rxslack) [Join Slack Channel](http://bit.ly/rxslack)
 * Report a problem using the library. [Open an Issue With Bug Template](.github/ISSUE_TEMPLATE.md)
 * Request a new feature. [Open an Issue With Feature Request Template](Documentation/NewFeatureRequestTemplate.md)
 * Help out [Check out contribution guide](CONTRIBUTING.md)


### PR DESCRIPTION
Since http://swift.rxslack.org is down, the README has been using the long version of the URL.
I've made a shortened link to share in presentations etc that's easier to send so I've added it here as well: http://bit.ly/rxslack 

Feel free to close this if you prefer leaving the long URL or wait for the old subdomain to be fixed :) 