### PR TITLE
Add zip operator to Single

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 * Replaces global timeless functions `next`, `error`, `completed` with `Recorded.next`, `Recorded.error`, `Recorded.completed` in **Tests**. #1537
+* Add `zip<C: Collection>(_ collection: C)` to Single trait
 
 #### Anomalies
 

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -258,7 +258,9 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     public static func zip<C: Collection, R>(_ collection: C, _ resultSelector: @escaping ([ElementType]) throws -> R) -> PrimitiveSequence<TraitType, R> where C.Iterator.Element == PrimitiveSequence<TraitType, ElementType> {
         
         if collection.isEmpty {
-            return PrimitiveSequence<TraitType, R>(raw: .just(try! resultSelector([])))
+            return PrimitiveSequence<TraitType, R>.deferred {
+                return PrimitiveSequence<TraitType, R>(raw: .just(try resultSelector([])))
+            }
         }
         
         let raw = Observable.zip(collection.map { $0.asObservable() }, resultSelector)

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -248,4 +248,35 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
         -> Single<R> {
             return Single<R>(raw: primitiveSequence.source.flatMap(selector))
     }
+    
+    /**
+     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
+     
+     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
+     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+     */
+    public static func zip<C: Collection, R>(_ collection: C, _ resultSelector: @escaping ([ElementType]) throws -> R) -> PrimitiveSequence<TraitType, R> where C.Iterator.Element == PrimitiveSequence<TraitType, ElementType> {
+        
+        if collection.isEmpty {
+            return PrimitiveSequence<TraitType, R>(raw: .just(try! resultSelector([])))
+        }
+        
+        let raw = Observable.zip(collection.map { $0.asObservable() }, resultSelector)
+        return PrimitiveSequence<TraitType, R>(raw: raw)
+    }
+    
+    /**
+     Merges the specified observable sequences into one observable sequence all of the observable sequences have produced an element at a corresponding index.
+     
+     - returns: An observable sequence containing the result of combining elements of the sources.
+     */
+    public static func zip<C: Collection>(_ collection: C) -> PrimitiveSequence<TraitType, [ElementType]> where C.Iterator.Element == PrimitiveSequence<TraitType, ElementType> {
+        
+        if collection.isEmpty {
+            return PrimitiveSequence<TraitType, [ElementType]>(raw: .just([]))
+        }
+        
+        let raw = Observable.zip(collection.map { $0.asObservable() })
+        return PrimitiveSequence(raw: raw)
+    }
 }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -708,6 +708,10 @@ final class SingleTest_ : SingleTest, RxTestCase {
     ("test_flatMap", SingleTest.test_flatMap),
     ("test_zip_tuple", SingleTest.test_zip_tuple),
     ("test_zip_resultSelector", SingleTest.test_zip_resultSelector),
+    ("testZipCollection_selector", SingleTest.testZipCollection_selector),
+    ("testZipCollection_selector_when_empty", SingleTest.testZipCollection_selector_when_empty),
+    ("testZipCollection_tuple", SingleTest.testZipCollection_tuple),
+    ("testZipCollection_tuple_when_empty", SingleTest.testZipCollection_tuple_when_empty),
     ("testDefaultErrorHandler", SingleTest.testDefaultErrorHandler),
     ] }
 }

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -565,22 +565,46 @@ extension SingleTest {
     
     func testZipCollection_selector() {
         let collection = [Single<Int>.just(1), Single<Int>.just(1), Single<Int>.just(1)]
-        let singleResult: Single<Int> = Single.zip(collection) { $0.reduce(0, combine: +) }
+        let singleResult: Single<Int> = Single.zip(collection) { $0.reduce(0, +) }
         
         let result = try! singleResult
-            .toBlocking().first()!
+            .toBlocking()
+            .first()!
         
         XCTAssertEqual(result, 3)
     }
     
-    func testZipCollection_tuple() {
-        let collection = [Single<Int>.just(1), Single<Int>.just(1), Single<Int>.just(1)]
-        let singleResult: Single<Int> = Single.zip(collection).map { $0.reduce(0, combine: +) }
+    func testZipCollection_selector_when_empty() {
+        let collection: [Single<Int>] = []
+        let singleResult = Single.zip(collection) { $0.reduce(0, +) }
         
         let result = try! singleResult
-            .toBlocking().first()!
+            .toBlocking()
+            .first()!
+        
+        XCTAssertEqual(result, 0)
+    }
+    
+    func testZipCollection_tuple() {
+        let collection = [Single<Int>.just(1), Single<Int>.just(1), Single<Int>.just(1)]
+        let singleResult: Single<Int> = Single.zip(collection).map { $0.reduce(0, +) }
+        
+        let result = try! singleResult
+            .toBlocking()
+            .first()!
         
         XCTAssertEqual(result, 3)
+    }
+    
+    func testZipCollection_tuple_when_empty() {
+        let collection: [Single<Int>] = []
+        let singleResult = Single.zip(collection)
+        
+        let result = try! singleResult
+            .toBlocking()
+            .first()!
+        
+        XCTAssertEqual(result, [])
     }
 }
 

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -562,6 +562,26 @@ extension SingleTest {
             .completed(200)
             ])
     }
+    
+    func testZipCollection_selector() {
+        let collection = [Single<Int>.just(1), Single<Int>.just(1), Single<Int>.just(1)]
+        let singleResult: Single<Int> = Single.zip(collection) { $0.reduce(0, combine: +) }
+        
+        let result = try! singleResult
+            .toBlocking().first()!
+        
+        XCTAssertEqual(result, 3)
+    }
+    
+    func testZipCollection_tuple() {
+        let collection = [Single<Int>.just(1), Single<Int>.just(1), Single<Int>.just(1)]
+        let singleResult: Single<Int> = Single.zip(collection).map { $0.reduce(0, combine: +) }
+        
+        let result = try! singleResult
+            .toBlocking().first()!
+        
+        XCTAssertEqual(result, 3)
+    }
 }
 
 extension SingleTest {


### PR DESCRIPTION
Resubmit #1554(because commits will be messy)
Added `zip<C: Collection>` operator to Single trait and fixed changes @kzaher mentioned in #1554