### PR TITLE
[Proposal] Create binder with Smart Key Path

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -6,6 +6,7 @@ custom_categories:
   - ControlTarget
   - DelegateProxy
   - DelegateProxyType
+  - KeyPathBinder
   - NSLayoutConstraint+Rx
   - Observable+Bind
   - RxCocoaObjCRuntimeError+Extensions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 * Add `zip<C: Collection>(_ collection: C)` to Single trait
+* Add Smart Key Path subscripting to create a binder for property of object.
 
 #### Anomalies
 

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -53,6 +53,10 @@
 		601AE3DB1EE24E5A00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DC1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DD1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
+		6B9CA569202A1F44002C2D11 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
+		6B9CA56A202A1F44002C2D11 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
+		6B9CA56B202A1F44002C2D11 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
+		6B9CA56C202A1F44002C2D11 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
 		785D5EF420051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
 		785D5EF520051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
 		785D5EF620051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
@@ -1762,6 +1766,7 @@
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
+		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		785D5EF320051B07006BAB40 /* DeprecationWarner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationWarner.swift; sourceTree = "<group>"; };
 		785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationWarner.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
@@ -2632,6 +2637,7 @@
 				C88F76801CE5341700D5A014 /* TextInput.swift */,
 				C89AB1A51DAAC25A0065FBE6 /* RxCocoaObjCRuntimeError+Extensions.swift */,
 				C8E65EFA1F6E91D1004478C3 /* Binder.swift */,
+				6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -4155,6 +4161,7 @@
 				C88254211B8A752B00B02D69 /* RxSearchBarDelegateProxy.swift in Sources */,
 				A520FFF71F0D258E00573734 /* RxPickerViewDataSourceType.swift in Sources */,
 				C8D970CE1F5324D90058F2FE /* Signal+Subscription.swift in Sources */,
+				6B9CA56B202A1F44002C2D11 /* KeyPathBinder.swift in Sources */,
 				7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */,
 				C839365F1C70E02200A9A09E /* UIApplication+Rx.swift in Sources */,
 				844BC8AC1CE4FA6300F5C7CB /* RxPickerViewDelegateProxy.swift in Sources */,
@@ -4234,6 +4241,7 @@
 				C8C8BCD01F8944B800501D4D /* BehaviorRelay.swift in Sources */,
 				C8091C581FAA39C1001DB32A /* ControlEvent+Signal.swift in Sources */,
 				C89AB1DF1DAAC3350065FBE6 /* ObservableConvertibleType+Driver.swift in Sources */,
+				6B9CA56C202A1F44002C2D11 /* KeyPathBinder.swift in Sources */,
 				C89AB1D71DAAC3350065FBE6 /* Driver+Subscription.swift in Sources */,
 				C89AB2511DAAC3A60065FBE6 /* _RXObjCRuntime.m in Sources */,
 				C89AB20B1DAAC3350065FBE6 /* KVORepresentable.swift in Sources */,
@@ -5436,6 +5444,7 @@
 				D9080AD61EA05DEC002B433B /* UINavigationController+Rx.swift in Sources */,
 				C8E65EFE1F6E91D1004478C3 /* Binder.swift in Sources */,
 				C89AB21D1DAAC3350065FBE6 /* NSObject+Rx+RawRepresentable.swift in Sources */,
+				6B9CA56A202A1F44002C2D11 /* KeyPathBinder.swift in Sources */,
 				A5CD038D1F1660F40005A376 /* RxPickerViewAdapter.swift in Sources */,
 				C89AB2191DAAC3350065FBE6 /* NSObject+Rx+KVORepresentable.swift in Sources */,
 				C89AB2531DAAC3A60065FBE6 /* _RXObjCRuntime.m in Sources */,
@@ -5502,6 +5511,7 @@
 				C89AB2201DAAC3350065FBE6 /* NSObject+Rx.swift in Sources */,
 				C8D132461C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */,
 				D203C4F31BB9C4CA00D02D00 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */,
+				6B9CA569202A1F44002C2D11 /* KeyPathBinder.swift in Sources */,
 				A5CD038C1F1660F40005A376 /* RxPickerViewAdapter.swift in Sources */,
 				D203C50B1BB9C53E00D02D00 /* UIScrollView+Rx.swift in Sources */,
 				C89AB1A81DAAC25A0065FBE6 /* RxCocoaObjCRuntimeError+Extensions.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		6B9CA56A202A1F44002C2D11 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
 		6B9CA56B202A1F44002C2D11 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
 		6B9CA56C202A1F44002C2D11 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
+		6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		6B9CA56F202A206B002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		6B9CA570202A206C002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		785D5EF420051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
 		785D5EF520051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
 		785D5EF620051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
@@ -1767,6 +1770,7 @@
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
+		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
 		785D5EF320051B07006BAB40 /* DeprecationWarner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationWarner.swift; sourceTree = "<group>"; };
 		785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationWarner.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
@@ -2777,6 +2781,7 @@
 				271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */,
 				4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */,
 				C8A81CA51E05EAF70008DEF4 /* Binder+Tests.swift */,
+				6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */,
 			);
 			path = RxCocoaTests;
 			sourceTree = "<group>";
@@ -4417,6 +4422,7 @@
 				4613456F1D9A4467001ABAF2 /* UIWebView+RxTests.swift in Sources */,
 				C820A9BA1EB5097700D431BC /* Observable+TakeTests.swift in Sources */,
 				C835094C1C38706E0027C24C /* AssumptionsTest.swift in Sources */,
+				6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */,
 				C8D970F21F532FD30058F2FE /* SharedSequence+OperatorTest.swift in Sources */,
 				C834F6C21DB394E100C29244 /* Observable+BlockingTest.swift in Sources */,
 				C8BAA78D1E34F8D400EEC727 /* RecursiveLockTest.swift in Sources */,
@@ -4569,6 +4575,7 @@
 				C8350A161C38756A0027C24C /* QueueTests.swift in Sources */,
 				C820A9DB1EB50CAA00D431BC /* Observable+DoOnTests.swift in Sources */,
 				C820A9971EB4FF7000D431BC /* Observable+ConcatTests.swift in Sources */,
+				6B9CA56F202A206B002C2D11 /* KeyPathBinder+RxTests.swift in Sources */,
 				C801DE3F1F6EAD57008DB060 /* CompletableTest.swift in Sources */,
 				C898147F1E75AD380035949C /* PrimitiveSequenceTest+zip+arity.swift in Sources */,
 				C89CFA0D1DAAB4670079D23B /* RxTest.swift in Sources */,
@@ -4722,6 +4729,7 @@
 				C820A98C1EB4FBD600D431BC /* Observable+CatchTests.swift in Sources */,
 				C820A9AC1EB505A800D431BC /* Observable+WithLatestFromTests.swift in Sources */,
 				C8350A061C38755E0027C24C /* HistoricalSchedulerTest.swift in Sources */,
+				6B9CA570202A206C002C2D11 /* KeyPathBinder+RxTests.swift in Sources */,
 				C820A9E81EB50DB900D431BC /* Observable+TimerTests.swift in Sources */,
 				C820A9CC1EB50A7100D431BC /* Observable+ElementAtTests.swift in Sources */,
 				C83509D11C38752E0027C24C /* RuntimeStateSnapshot.swift in Sources */,

--- a/RxCocoa/Common/KeyPathBinder.swift
+++ b/RxCocoa/Common/KeyPathBinder.swift
@@ -3,7 +3,7 @@
 //  RxCocoa
 //
 //  Created by Ryo Aoyama on 2/7/18.
-//  Copyright © 2018 Ryo Aoyama. All rights reserved.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
 //
 
 #if swift(>=3.2)

--- a/RxCocoa/Common/KeyPathBinder.swift
+++ b/RxCocoa/Common/KeyPathBinder.swift
@@ -1,0 +1,36 @@
+//
+//  KeyPathBinder.swift
+//  RxCocoa
+//
+//  Created by Ryo Aoyama on 2/7/18.
+//  Copyright © 2018 Ryo Aoyama. All rights reserved.
+//
+
+#if swift(>=3.2)
+    import RxSwift
+    
+    extension Reactive where Base: AnyObject {
+        
+        /// Bindable sink for arbitrary property using the given key path.
+        /// Binding runs on the MainScheduler.
+        ///
+        /// - parameter keyPath: Key path to write to the property.
+        public subscript<Value>(keyPath: ReferenceWritableKeyPath<Base, Value>) -> Binder<Value> {
+            return Binder(self.base) { base, value in
+                base[keyPath: keyPath] = value
+            }
+        }
+        
+        /// Bindable sink for arbitrary property using the given key path.
+        /// Binding runs on the specified scheduler.
+        ///
+        /// - parameter keyPath: Key path to write to the property.
+        /// - parameter scheduler: Scheduler to run bindings on.
+        public subscript<Value>(keyPath: ReferenceWritableKeyPath<Base, Value>, on scheduler: ImmediateSchedulerType) -> Binder<Value> {
+            return Binder(self.base, scheduler: scheduler) { base, value in
+                base[keyPath: keyPath] = value
+            }
+        }
+        
+    }
+#endif

--- a/Sources/RxCocoa/KeyPathBinder.swift
+++ b/Sources/RxCocoa/KeyPathBinder.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/Common/KeyPathBinder.swift

--- a/Tests/RxCocoaTests/KeyPathBinder+RxTests.swift
+++ b/Tests/RxCocoaTests/KeyPathBinder+RxTests.swift
@@ -1,0 +1,71 @@
+//
+//  KeyPathBinder.swift
+//  RxCocoa
+//
+//  Created by Ryo Aoyama on 2/7/18.
+//  Copyright © 2018 Ryo Aoyama. All rights reserved.
+//
+
+#if swift(>=3.2)
+    
+    import RxCocoa
+    import RxSwift
+    import XCTest
+    
+    final class KeyPathBinderTests: RxTest {}
+    
+    private final class Object: ReactiveCompatible {
+        var value: Int = 0 {
+            didSet { valueDidSet() }
+        }
+        
+        private let valueDidSet: () -> Void
+        
+        init(valueDidSet: @escaping () -> Void) {
+            self.valueDidSet = valueDidSet
+        }
+    }
+    
+    extension KeyPathBinderTests {
+        
+        func testBindingOnNonMainQueueDispatchesToMainQueue() {
+            let waitForElement = self.expectation(description: "wait until element arrives")
+            
+            let object = Object {
+                MainScheduler.ensureExecutingOnScheduler()
+                waitForElement.fulfill()
+            }
+            
+            let bindingObserver = object.rx[\.value]
+            
+            DispatchQueue.global(qos: .default).async {
+                bindingObserver.on(.next(1))
+            }
+            
+            self.waitForExpectations(timeout: 1.0) { (e) in
+                XCTAssertNil(e)
+            }
+        }
+        
+        func testBindingOnMainQueueDispatchesToNonMainQueue() {
+            let waitForElement = self.expectation(description: "wait until element arrives")
+            
+            let object = Object {
+                XCTAssert(!DispatchQueue.isMain)
+                waitForElement.fulfill()
+            }
+            
+            let scheduler = ConcurrentDispatchQueueScheduler(qos: .default)
+            let bindingObserver = object.rx[\.value, on: scheduler]
+            
+            bindingObserver.on(.next(1))
+            
+            self.waitForExpectations(timeout: 1.0) { (e) in
+                XCTAssertNil(e)
+            }
+        }
+        
+    }
+    
+#endif
+

--- a/Tests/RxCocoaTests/KeyPathBinder+RxTests.swift
+++ b/Tests/RxCocoaTests/KeyPathBinder+RxTests.swift
@@ -1,9 +1,9 @@
 //
-//  KeyPathBinder.swift
-//  RxCocoa
+//  KeyPathBinder+RxTests.swift
+//  Tests
 //
 //  Created by Ryo Aoyama on 2/7/18.
-//  Copyright © 2018 Ryo Aoyama. All rights reserved.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
 //
 
 #if swift(>=3.2)


### PR DESCRIPTION
Hi✋ 

`Binder` is a good parts for binding` Observable` to object.
In current RxSwift, it's need to implement for every one of  property of object.
So, I propose to create `Binder` with Swift 4' smart key path.
Extensions that create Binder of properties is no longer needed after this.

It maybe not match ReactiveX rule, because smar key path is the Swift's unique feature.
However, the Binder is a part of RxCocoa, so I think this is acceptable extension.

Example:
```swift
textObservable
    .bind(to: label.rx[\.text])
    .disposed(by: bag)
```
