### PR TITLE
Performance improvements in thread lock.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * Lower macOS Deployment Target to 10.9
 * Add `zip<C: Collection>(_ collection: C)` to Single trait
 * Add Smart Key Path subscripting to create a binder for property of object.
+* Performance improvement in thread locking.
 
 #### Anomalies
 

--- a/Platform/RecursiveLock.swift
+++ b/Platform/RecursiveLock.swift
@@ -22,7 +22,7 @@ final class RecursiveLock {
         let attr = UnsafeMutablePointer<pthread_mutexattr_t>.allocate(capacity: 1)
         attr.initialize(to: pthread_mutexattr_t())
         pthread_mutexattr_init(attr)
-        pthread_mutexattr_settype(attr, PTHREAD_MUTEX_RECURSIVE)
+        pthread_mutexattr_settype(attr, Int32(PTHREAD_MUTEX_RECURSIVE))
         
         pthread_mutex_init(mutex, attr)
         

--- a/Platform/RecursiveLock.swift
+++ b/Platform/RecursiveLock.swift
@@ -6,29 +6,55 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSRecursiveLock
+import Foundation
 
-#if TRACE_RESOURCES
-    class RecursiveLock: NSRecursiveLock {
-        override init() {
+final class RecursiveLock {
+    
+    private let mutex = UnsafeMutablePointer<pthread_mutex_t>.allocate(capacity: 1)
+    
+    init() {
+        #if TRACE_RESOURCES
             _ = Resources.incrementTotal()
-            super.init()
-        }
-
-        override func lock() {
-            super.lock()
-            _ = Resources.incrementTotal()
-        }
-
-        override func unlock() {
-            super.unlock()
-            _ = Resources.decrementTotal()
-        }
-
-        deinit {
-            _ = Resources.decrementTotal()
-        }
+        #endif
+        
+        mutex.initialize(to: pthread_mutex_t())
+        
+        let attr = UnsafeMutablePointer<pthread_mutexattr_t>.allocate(capacity: 1)
+        attr.initialize(to: pthread_mutexattr_t())
+        pthread_mutexattr_init(attr)
+        pthread_mutexattr_settype(attr, PTHREAD_MUTEX_RECURSIVE)
+        
+        pthread_mutex_init(mutex, attr)
+        
+        pthread_mutexattr_destroy(attr)
+        attr.deinitialize()
+        attr.deallocate(capacity: 1)
     }
-#else
-    typealias RecursiveLock = NSRecursiveLock
-#endif
+    
+    deinit {
+        pthread_mutex_destroy(mutex)
+        mutex.deinitialize(count: 1)
+        mutex.deallocate(capacity: 1)
+        
+        #if TRACE_RESOURCES
+            _ = Resources.decrementTotal()
+        #endif
+    }
+    
+    func lock() {
+        pthread_mutex_lock(mutex)
+        
+        #if TRACE_RESOURCES
+            _ = Resources.incrementTotal()
+        #endif
+    }
+    
+    func unlock() {
+        pthread_mutex_unlock(mutex)
+        
+        #if TRACE_RESOURCES
+            _ = Resources.decrementTotal()
+        #endif
+    }
+    
+}

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -60,6 +60,10 @@
 		6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA56F202A206B002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA570202A206C002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		6B65F7F2202B6381000D475B /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B65F7F1202B6381000D475B /* RecursiveLock.swift */; };
+		6B65F7F3202B6381000D475B /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B65F7F1202B6381000D475B /* RecursiveLock.swift */; };
+		6B65F7F4202B6381000D475B /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B65F7F1202B6381000D475B /* RecursiveLock.swift */; };
+		6B65F7F5202B6381000D475B /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B65F7F1202B6381000D475B /* RecursiveLock.swift */; };
 		785D5EF420051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
 		785D5EF520051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
 		785D5EF620051B07006BAB40 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
@@ -888,10 +892,6 @@
 		C85217EC1E3374970015DD38 /* GroupedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217E81E3374970015DD38 /* GroupedObservable.swift */; };
 		C85217EE1E33C8E60015DD38 /* PerformanceTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E8BA701E2C18AE00A4AC2C /* PerformanceTools.swift */; };
 		C85217F31E33ECA00015DD38 /* PerformanceTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E8BA701E2C18AE00A4AC2C /* PerformanceTools.swift */; };
-		C85217F71E33FBBE0015DD38 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */; };
-		C85217F81E33FBBE0015DD38 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */; };
-		C85217F91E33FBBE0015DD38 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */; };
-		C85217FA1E33FBBE0015DD38 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */; };
 		C85217FC1E33FBFB0015DD38 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217FB1E33FBFB0015DD38 /* RecursiveLock.swift */; };
 		C85217FD1E33FBFB0015DD38 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217FB1E33FBFB0015DD38 /* RecursiveLock.swift */; };
 		C85217FE1E33FBFB0015DD38 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217FB1E33FBFB0015DD38 /* RecursiveLock.swift */; };
@@ -1771,6 +1771,7 @@
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
+		6B65F7F1202B6381000D475B /* RecursiveLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RecursiveLock.swift; path = Platform/RecursiveLock.swift; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		785D5EF320051B07006BAB40 /* DeprecationWarner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationWarner.swift; sourceTree = "<group>"; };
 		785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeprecationWarner.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
@@ -2054,7 +2055,6 @@
 		C85106871C2D550E0075150C /* String+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Rx.swift"; sourceTree = "<group>"; };
 		C85217E81E3374970015DD38 /* GroupedObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GroupedObservable.swift; sourceTree = "<group>"; };
 		C85217F41E33F9D70015DD38 /* RecursiveLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RecursiveLock.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RecursiveLock.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C85217FB1E33FBFB0015DD38 /* RecursiveLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RecursiveLock.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C85218001E33FC160015DD38 /* RecursiveLock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = RecursiveLock.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C85218041E33FCA50015DD38 /* Resources.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resources.swift; sourceTree = "<group>"; };
@@ -3278,7 +3278,7 @@
 				C8BF34C91C2E426800416CAE /* Platform.Darwin.swift */,
 				C8BF34CA1C2E426800416CAE /* Platform.Linux.swift */,
 				C8F03F491DBBAC0A00AECC4C /* DispatchQueue+Extensions.swift */,
-				C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */,
+				6B65F7F1202B6381000D475B /* RecursiveLock.swift */,
 				785D5EF320051B07006BAB40 /* DeprecationWarner.swift */,
 			);
 			path = Platform;
@@ -4924,7 +4924,6 @@
 				C8093D661B8A72BE0088E94D /* ObservableType.swift in Sources */,
 				C8093D9E1B8A72BE0088E94D /* SerialDispatchQueueScheduler.swift in Sources */,
 				CDDEF16B1D4FB40000CA8546 /* Disposables.swift in Sources */,
-				C85217F81E33FBBE0015DD38 /* RecursiveLock.swift in Sources */,
 				C820A88D1EB4DA5A00D431BC /* DefaultIfEmpty.swift in Sources */,
 				C8093CCA1B8A72BE0088E94D /* Lock.swift in Sources */,
 				C820A8411EB4DA5900D431BC /* Buffer.swift in Sources */,
@@ -4957,6 +4956,7 @@
 				C83D73C51C1DBAEE003DC470 /* ScheduledItem.swift in Sources */,
 				C820A8A91EB4DA5A00D431BC /* WithLatestFrom.swift in Sources */,
 				C867817D1DB8129E00B2029A /* Queue.swift in Sources */,
+				6B65F7F3202B6381000D475B /* RecursiveLock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5172,7 +5172,6 @@
 				C8093D9D1B8A72BE0088E94D /* SerialDispatchQueueScheduler.swift in Sources */,
 				CDDEF16A1D4FB40000CA8546 /* Disposables.swift in Sources */,
 				C8093CC91B8A72BE0088E94D /* Lock.swift in Sources */,
-				C85217F71E33FBBE0015DD38 /* RecursiveLock.swift in Sources */,
 				C820A88C1EB4DA5A00D431BC /* DefaultIfEmpty.swift in Sources */,
 				C820A8401EB4DA5900D431BC /* Buffer.swift in Sources */,
 				C820A82C1EB4DA5900D431BC /* Map.swift in Sources */,
@@ -5205,6 +5204,7 @@
 				C83D73C41C1DBAEE003DC470 /* ScheduledItem.swift in Sources */,
 				C820A8A81EB4DA5A00D431BC /* WithLatestFrom.swift in Sources */,
 				C867817C1DB8129E00B2029A /* Queue.swift in Sources */,
+				6B65F7F2202B6381000D475B /* RecursiveLock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5336,7 +5336,6 @@
 				C8F0BFD81BBBFB8B001B112F /* ObservableType.swift in Sources */,
 				C8F0BFE01BBBFB8B001B112F /* SerialDispatchQueueScheduler.swift in Sources */,
 				CDDEF16D1D4FB40000CA8546 /* Disposables.swift in Sources */,
-				C85217FA1E33FBBE0015DD38 /* RecursiveLock.swift in Sources */,
 				C820A88F1EB4DA5A00D431BC /* DefaultIfEmpty.swift in Sources */,
 				C8F0BFE31BBBFB8B001B112F /* Lock.swift in Sources */,
 				C820A8431EB4DA5900D431BC /* Buffer.swift in Sources */,
@@ -5369,6 +5368,7 @@
 				C83D73C71C1DBAEE003DC470 /* ScheduledItem.swift in Sources */,
 				C820A8AB1EB4DA5A00D431BC /* WithLatestFrom.swift in Sources */,
 				C867817F1DB8129E00B2029A /* Queue.swift in Sources */,
+				6B65F7F5202B6381000D475B /* RecursiveLock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5712,7 +5712,6 @@
 				C820A92A1EB4DA5A00D431BC /* CombineLatest+arity.swift in Sources */,
 				C820A85A1EB4DA5A00D431BC /* Debounce.swift in Sources */,
 				CDDEF16C1D4FB40000CA8546 /* Disposables.swift in Sources */,
-				C85217F91E33FBBE0015DD38 /* RecursiveLock.swift in Sources */,
 				D2EBEB3B1BB9B6D8003A27DC /* OperationQueueScheduler.swift in Sources */,
 				C820A88E1EB4DA5A00D431BC /* DefaultIfEmpty.swift in Sources */,
 				D2EBEAE51BB9B697003A27DC /* AnyObserver.swift in Sources */,
@@ -5747,6 +5746,7 @@
 				C83D73C61C1DBAEE003DC470 /* ScheduledItem.swift in Sources */,
 				C820A8AA1EB4DA5A00D431BC /* WithLatestFrom.swift in Sources */,
 				C867817E1DB8129E00B2029A /* Queue.swift in Sources */,
+				6B65F7F4202B6381000D475B /* RecursiveLock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxSwift/Concurrency/AsyncLock.swift
+++ b/RxSwift/Concurrency/AsyncLock.swift
@@ -22,7 +22,7 @@ final class AsyncLock<I: InvocableType>
     , SynchronizedDisposeType {
     typealias Action = () -> Void
     
-    var _lock = SpinLock()
+    var _lock = RecursiveLock()
     
     private var _queue: Queue<I> = Queue(capacity: 0)
 

--- a/RxSwift/Concurrency/Lock.swift
+++ b/RxSwift/Concurrency/Lock.swift
@@ -11,9 +11,6 @@ protocol Lock {
     func unlock()
 }
 
-// https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151214/000321.html
-typealias SpinLock = RecursiveLock
-
 extension RecursiveLock : Lock {
     @inline(__always)
     final func performLocked(_ action: () -> Void) {

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -173,7 +173,7 @@ public final class Variable<Element> {
 
     private let _subject: BehaviorSubject<Element>
 
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
 
     // state
     private var _value: E

--- a/RxSwift/Disposables/CompositeDisposable.swift
+++ b/RxSwift/Disposables/CompositeDisposable.swift
@@ -16,7 +16,7 @@ public final class CompositeDisposable : DisposeBase, Cancelable {
         }
     }
 
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     
     // state
     private var _disposables: Bag<Disposable>? = Bag()

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -29,7 +29,7 @@ In case explicit disposal is necessary, there is also `CompositeDisposable`.
 */
 public final class DisposeBag: DisposeBase {
     
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     
     // state
     private var _disposables = [Disposable]()

--- a/RxSwift/Disposables/RefCountDisposable.swift
+++ b/RxSwift/Disposables/RefCountDisposable.swift
@@ -8,7 +8,7 @@
 
 /// Represents a disposable resource that only disposes its underlying disposable resource when all dependent disposable objects have been disposed.
 public final class RefCountDisposable : DisposeBase, Cancelable {
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     private var _disposable = nil as Disposable?
     private var _primaryDisposed = false
     private var _count = 0

--- a/RxSwift/Disposables/SerialDisposable.swift
+++ b/RxSwift/Disposables/SerialDisposable.swift
@@ -8,7 +8,7 @@
 
 /// Represents a disposable resource whose underlying disposable resource can be replaced by another disposable resource, causing automatic disposal of the previous underlying disposable resource.
 public final class SerialDisposable : DisposeBase, Cancelable {
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     
     // state
     private var _current = nil as Disposable?

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -113,8 +113,6 @@ extension ObservableType {
     }
 }
 
-import class Foundation.NSRecursiveLock
-
 extension Hooks {
     public typealias DefaultErrorHandler = (_ subscriptionCallStack: [String], _ error: Error) -> ()
 

--- a/RxSwift/Observables/ObserveOn.swift
+++ b/RxSwift/Observables/ObserveOn.swift
@@ -68,7 +68,7 @@ final fileprivate class ObserveOnSink<O: ObserverType> : ObserverBase<O.E> {
     
     let _scheduler: ImmediateSchedulerType
 
-    var _lock = SpinLock()
+    var _lock = RecursiveLock()
     let _observer: O
 
     // state

--- a/RxSwift/Schedulers/RecursiveScheduler.swift
+++ b/RxSwift/Schedulers/RecursiveScheduler.swift
@@ -151,7 +151,7 @@ final class AnyRecursiveScheduler<State> {
 final class RecursiveImmediateScheduler<State> {
     typealias Action =  (_ state: State, _ recurse: (State) -> Void) -> Void
     
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     private let _group = CompositeDisposable()
     
     private var _action: Action?


### PR DESCRIPTION
RxSwift uses Foundation `NSRecursiveLock`, but it includes an implementation that is no needed.
See [here](https://github.com/apple/swift-corelibs-foundation/blob/master/Foundation/NSLock.swift) about it.

In FRP, thread lock is very frequently used.
So, can be expect drastic performance improvements by implementing that minimal using pthread mutex.

This is before and after of my benchmark results.
In the tests with the most impact, it has improved by more than **1 sec**.
Have little effects in creation tests that don't involving much thread lock.

<img src=https://user-images.githubusercontent.com/7347118/35934933-456a0d02-0c82-11e8-9e23-779f20ae7c9d.png width=500>

Incidentally, I've removed the typealias of SpinLick that no longer needed.