### PR TITLE
Update old references to RxTests as RxTest #trivial

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -14,7 +14,7 @@ warn("No CHANGELOG changes made") if git.lines_of_code > 50 && !git.modified_fil
 # Warn pod spec changes
 warn("RxCocoa.podspec changed") if git.modified_files.include?("RxCocoa.podspec")
 warn("RxSwift.podspec changed") if git.modified_files.include?("RxSwift.podspec")
-warn("RxTests.podspec changed") if git.modified_files.include?("RxTests.podspec")
+warn("RxTest.podspec changed") if git.modified_files.include?("RxTest.podspec")
 warn("RxBlocking.podspec changed") if git.modified_files.include?("RxBlocking.podspec")
 
 # Warn summary on pull request

--- a/Documentation/UnitTests.md
+++ b/Documentation/UnitTests.md
@@ -3,7 +3,7 @@ Unit Tests
 
 ## Testing custom operators
 
-RxSwift uses `RxTests` for all operator tests, located in the AllTests-* target inside the project `Rx.xcworkspace`.
+RxSwift uses `RxTest` for all operator tests, located in the AllTests-* target inside the project `Rx.xcworkspace`.
 
 This is an example of a typical `RxSwift` operator unit test:
 
@@ -59,7 +59,7 @@ func testMap_Range() {
 
 Examples of how to test operator compositions are contained inside `Rx.xcworkspace` > `RxExample-iOSTests` target.
 
-It's easy to define `RxTests` extensions so you can write your tests in a readable way. Provided examples inside `RxExample-iOSTests` are just suggestions on how you can write those extensions, but there are a lot of possibilities on how to write those tests.
+It's easy to define `RxTest` extensions so you can write your tests in a readable way. Provided examples inside `RxExample-iOSTests` are just suggestions on how you can write those extensions, but there are a lot of possibilities on how to write those tests.
 
 ```swift
     // expected events and test data

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ target 'YOUR_TARGET_NAME' do
     pod 'RxCocoa',    '~> 4.0'
 end
 
-# RxTests and RxBlocking make the most sense in the context of unit/integration tests
+# RxTest and RxBlocking make the most sense in the context of unit/integration tests
 target 'YOUR_TESTING_TARGET' do
     pod 'RxBlocking', '~> 4.0'
     pod 'RxTest',     '~> 4.0'

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1162,10 +1162,10 @@
 		C89CFA331DAABBE20079D23B /* Recorded.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA151DAABBE20079D23B /* Recorded.swift */; };
 		C89CFA341DAABBE20079D23B /* Recorded.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA151DAABBE20079D23B /* Recorded.swift */; };
 		C89CFA351DAABBE20079D23B /* Recorded.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA151DAABBE20079D23B /* Recorded.swift */; };
-		C89CFA361DAABBE20079D23B /* RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTests.swift */; };
-		C89CFA371DAABBE20079D23B /* RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTests.swift */; };
-		C89CFA381DAABBE20079D23B /* RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTests.swift */; };
-		C89CFA391DAABBE20079D23B /* RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTests.swift */; };
+		C89CFA361DAABBE20079D23B /* RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTest.swift */; };
+		C89CFA371DAABBE20079D23B /* RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTest.swift */; };
+		C89CFA381DAABBE20079D23B /* RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTest.swift */; };
+		C89CFA391DAABBE20079D23B /* RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTest.swift */; };
 		C89CFA3A1DAABBE20079D23B /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA181DAABBE20079D23B /* TestScheduler.swift */; };
 		C89CFA3B1DAABBE20079D23B /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA181DAABBE20079D23B /* TestScheduler.swift */; };
 		C89CFA3C1DAABBE20079D23B /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA181DAABBE20079D23B /* TestScheduler.swift */; };
@@ -2160,7 +2160,7 @@
 		C89CFA131DAABBE20079D23B /* HotObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HotObservable.swift; sourceTree = "<group>"; };
 		C89CFA141DAABBE20079D23B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C89CFA151DAABBE20079D23B /* Recorded.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recorded.swift; sourceTree = "<group>"; };
-		C89CFA161DAABBE20079D23B /* RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTests.swift; sourceTree = "<group>"; };
+		C89CFA161DAABBE20079D23B /* RxTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTest.swift; sourceTree = "<group>"; };
 		C89CFA181DAABBE20079D23B /* TestScheduler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestScheduler.swift; sourceTree = "<group>"; };
 		C89CFA191DAABBE20079D23B /* TestSchedulerVirtualTimeConverter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSchedulerVirtualTimeConverter.swift; sourceTree = "<group>"; };
 		C89CFA1A1DAABBE20079D23B /* Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Subscription.swift; sourceTree = "<group>"; };
@@ -3189,7 +3189,7 @@
 				C89CFA131DAABBE20079D23B /* HotObservable.swift */,
 				C89CFA151DAABBE20079D23B /* Recorded.swift */,
 				4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */,
-				C89CFA161DAABBE20079D23B /* RxTests.swift */,
+				C89CFA161DAABBE20079D23B /* RxTest.swift */,
 				C89CFA1A1DAABBE20079D23B /* Subscription.swift */,
 				C89CFA1B1DAABBE20079D23B /* TestableObservable.swift */,
 				C89CFA1C1DAABBE20079D23B /* TestableObserver.swift */,
@@ -4953,7 +4953,7 @@
 				C89CFA321DAABBE20079D23B /* Recorded.swift in Sources */,
 				C89CFA4A1DAABBE20079D23B /* TestableObserver.swift in Sources */,
 				C89CFA4E1DAABBE20079D23B /* XCTest+Rx.swift in Sources */,
-				C89CFA361DAABBE20079D23B /* RxTests.swift in Sources */,
+				C89CFA361DAABBE20079D23B /* RxTest.swift in Sources */,
 				C89CFA261DAABBE20079D23B /* Event+Equatable.swift in Sources */,
 				C89CFA221DAABBE20079D23B /* ColdObservable.swift in Sources */,
 				C89CFA461DAABBE20079D23B /* TestableObservable.swift in Sources */,
@@ -4976,7 +4976,7 @@
 				C89CFA331DAABBE20079D23B /* Recorded.swift in Sources */,
 				C89CFA4B1DAABBE20079D23B /* TestableObserver.swift in Sources */,
 				C89CFA4F1DAABBE20079D23B /* XCTest+Rx.swift in Sources */,
-				C89CFA371DAABBE20079D23B /* RxTests.swift in Sources */,
+				C89CFA371DAABBE20079D23B /* RxTest.swift in Sources */,
 				C89CFA271DAABBE20079D23B /* Event+Equatable.swift in Sources */,
 				C89CFA231DAABBE20079D23B /* ColdObservable.swift in Sources */,
 				C89CFA471DAABBE20079D23B /* TestableObservable.swift in Sources */,
@@ -4999,7 +4999,7 @@
 				C89CFA341DAABBE20079D23B /* Recorded.swift in Sources */,
 				C89CFA4C1DAABBE20079D23B /* TestableObserver.swift in Sources */,
 				C89CFA501DAABBE20079D23B /* XCTest+Rx.swift in Sources */,
-				C89CFA381DAABBE20079D23B /* RxTests.swift in Sources */,
+				C89CFA381DAABBE20079D23B /* RxTest.swift in Sources */,
 				C89CFA281DAABBE20079D23B /* Event+Equatable.swift in Sources */,
 				C89CFA241DAABBE20079D23B /* ColdObservable.swift in Sources */,
 				C89CFA481DAABBE20079D23B /* TestableObservable.swift in Sources */,
@@ -5022,7 +5022,7 @@
 				C89CFA351DAABBE20079D23B /* Recorded.swift in Sources */,
 				C89CFA4D1DAABBE20079D23B /* TestableObserver.swift in Sources */,
 				C89CFA511DAABBE20079D23B /* XCTest+Rx.swift in Sources */,
-				C89CFA391DAABBE20079D23B /* RxTests.swift in Sources */,
+				C89CFA391DAABBE20079D23B /* RxTest.swift in Sources */,
 				C89CFA291DAABBE20079D23B /* Event+Equatable.swift in Sources */,
 				C89CFA251DAABBE20079D23B /* ColdObservable.swift in Sources */,
 				C89CFA491DAABBE20079D23B /* TestableObservable.swift in Sources */,

--- a/RxTest/RxTest.swift
+++ b/RxTest/RxTest.swift
@@ -1,5 +1,5 @@
 //
-//  RxTests.swift
+//  RxTest.swift
 //  RxTest
 //
 //  Created by Krunoslav Zaher on 12/19/15.

--- a/Sources/RxTest/RxTest.swift
+++ b/Sources/RxTest/RxTest.swift
@@ -1,0 +1,1 @@
+../../RxTest/RxTest.swift

--- a/Sources/RxTest/RxTests.swift
+++ b/Sources/RxTest/RxTests.swift
@@ -1,1 +1,0 @@
-../../RxTest/RxTests.swift


### PR DESCRIPTION
This PR:
- Fixes Dangerfile to look for the correct podspec
- Fix some incorrect README occurrences
- Rename the RxTests.swift file to RxTest.swift

I’ve marked this as trivial since I don’t think this needs a CHANGELOG entry, up to you.

Noticed this issue when doing #1567 since it didn't trigger for RxTest.