### PR TITLE
Original Slack URL brought back to life 🧟‍♂️💀

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 
-:warning: If you don't have something to report in the following format, it will probably be easier and faster to ask in the [slack channel](http://rxswift-slack.herokuapp.com/) first. :warning: 
+:warning: If you don't have something to report in the following format, it will probably be easier and faster to ask in the [slack channel](http://slack.rxswift.org/) first. :warning: 
 
 :warning: Please take you time to fill in the fields below. If we aren't provided with this basic information about your issue we probably won't be able to help you and there won't be much we can do except to close the issue :( :warning:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ KVO observing, async operations and streams are all unified under [abstraction o
 
 ###### ... interact
 
-* All of this is great, but it would be nice to talk with other people using RxSwift and exchange experiences. <br />[![Slack channel](http://rxswift-slack.herokuapp.com/badge.svg)](http://bit.ly/rxslack) [Join Slack Channel](http://bit.ly/rxslack)
+* All of this is great, but it would be nice to talk with other people using RxSwift and exchange experiences. <br />[![Slack channel](http://rxswift-slack.herokuapp.com/badge.svg)](http://slack.rxswift.org) [Join Slack Channel](http://slack.rxswift.org)
 * Report a problem using the library. [Open an Issue With Bug Template](.github/ISSUE_TEMPLATE.md)
 * Request a new feature. [Open an Issue With Feature Request Template](Documentation/NewFeatureRequestTemplate.md)
 * Help out [Check out contribution guide](CONTRIBUTING.md)


### PR DESCRIPTION
Happy to say that with immensely kind help from @bontoJR, the RxSwift.org domain is now back, so I’ve set up the `slack` subdomain forwarding back. Woohoo!