### PR TITLE
Use pthread_mutex_t in future optimization

### DIFF
--- a/RxSwift/Concurrency/AsyncLock.swift
+++ b/RxSwift/Concurrency/AsyncLock.swift
@@ -22,7 +22,7 @@ final class AsyncLock<I: InvocableType>
     , SynchronizedDisposeType {
     typealias Action = () -> Void
     
-    var _lock = SpinLock()
+    var _lock = RecursiveLock()
     
     private var _queue: Queue<I> = Queue(capacity: 0)
 

--- a/RxSwift/Concurrency/Lock.swift
+++ b/RxSwift/Concurrency/Lock.swift
@@ -11,9 +11,6 @@ protocol Lock {
     func unlock()
 }
 
-// https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151214/000321.html
-typealias SpinLock = RecursiveLock
-
 extension RecursiveLock : Lock {
     @inline(__always)
     final func performLocked(_ action: () -> Void) {

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -173,7 +173,7 @@ public final class Variable<Element> {
 
     private let _subject: BehaviorSubject<Element>
 
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
 
     // state
     private var _value: E

--- a/RxSwift/Disposables/CompositeDisposable.swift
+++ b/RxSwift/Disposables/CompositeDisposable.swift
@@ -16,7 +16,7 @@ public final class CompositeDisposable : DisposeBase, Cancelable {
         }
     }
 
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     
     // state
     private var _disposables: Bag<Disposable>? = Bag()

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -29,7 +29,7 @@ In case explicit disposal is necessary, there is also `CompositeDisposable`.
 */
 public final class DisposeBag: DisposeBase {
     
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     
     // state
     private var _disposables = [Disposable]()

--- a/RxSwift/Disposables/RefCountDisposable.swift
+++ b/RxSwift/Disposables/RefCountDisposable.swift
@@ -8,7 +8,7 @@
 
 /// Represents a disposable resource that only disposes its underlying disposable resource when all dependent disposable objects have been disposed.
 public final class RefCountDisposable : DisposeBase, Cancelable {
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     private var _disposable = nil as Disposable?
     private var _primaryDisposed = false
     private var _count = 0

--- a/RxSwift/Disposables/SerialDisposable.swift
+++ b/RxSwift/Disposables/SerialDisposable.swift
@@ -8,7 +8,7 @@
 
 /// Represents a disposable resource whose underlying disposable resource can be replaced by another disposable resource, causing automatic disposal of the previous underlying disposable resource.
 public final class SerialDisposable : DisposeBase, Cancelable {
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     
     // state
     private var _current = nil as Disposable?

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -99,8 +99,6 @@ extension ObservableType {
     }
 }
 
-import class Foundation.NSRecursiveLock
-
 extension Hooks {
     public typealias DefaultErrorHandler = (_ subscriptionCallStack: [String], _ error: Error) -> ()
 

--- a/RxSwift/Observables/ObserveOn.swift
+++ b/RxSwift/Observables/ObserveOn.swift
@@ -46,7 +46,7 @@ final fileprivate class ObserveOn<E> : Producer<E> {
     override func run(_ observer: @escaping (Event<E>) -> (), cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) {
         let scheduler = self.scheduler
 
-        var lock = SpinLock()
+        var lock = RecursiveLock()
 
         // state
         var _state = ObserveOnState.stopped

--- a/RxSwift/Schedulers/RecursiveScheduler.swift
+++ b/RxSwift/Schedulers/RecursiveScheduler.swift
@@ -151,7 +151,7 @@ final class AnyRecursiveScheduler<State> {
 final class RecursiveImmediateScheduler<State> {
     typealias Action =  (_ state: State, _ recurse: (State) -> Void) -> Void
     
-    private var _lock = SpinLock()
+    private var _lock = RecursiveLock()
     private let _group = CompositeDisposable()
     
     private var _action: Action?


### PR DESCRIPTION
Base branch is `optimizations2`.
Refer https://github.com/ReactiveX/RxSwift/pull/1565

@kzaher 
I've failed to compile in test.
<img width="400" alt="screen shot 2018-02-14 at 19 12 20" src="https://user-images.githubusercontent.com/7347118/36198817-07e71efa-11bb-11e8-8e65-da6da16cc07d.png">
<img width="450" alt="screen shot 2018-02-14 at 19 13 07" src="https://user-images.githubusercontent.com/7347118/36198848-1ce3c60a-11bb-11e8-8a7a-683e142db98b.png">
https://github.com/ReactiveX/RxSwift/blob/optimizations2/RxBlocking/BlockingObservable%2BOperators.swift#L117
https://github.com/ReactiveX/RxSwift/blob/optimizations2/RxBlocking/Resources.swift#L22
