### PR TITLE
[MaterializedSequenceResult] Add some useful getters for assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * Lower macOS Deployment Target to 10.9
 * Add `zip<C: Collection>(_ collection: C)` to Single trait
 * Add Smart Key Path subscripting to create a binder for property of object.
+* Add some useful getters to `MaterializedSequenceResult` for assertions
 
 #### Anomalies
 

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -21,6 +21,40 @@ public enum MaterializedSequenceResult<T> {
     case failed(elements: [T], error: Error)
 }
 
+extension MaterializedSequenceResult {
+    /// - returns: true if the result is `.completed`, otherwise false.
+    public var isCompleted: Bool {
+        switch self {
+        case .completed: return true
+        case .failed: return false
+        }
+    }
+
+    /// - returns: true if the result is `.failed`, otherwise false.
+    public var isFailed: Bool {
+        switch self {
+        case .completed: return false
+        case .failed: return true
+        }
+    }
+
+    /// - returns: The array of elements.
+    public var elements: [T] {
+        switch self {
+        case .completed(let elements), .failed(let elements, _):
+            return elements
+        }
+    }
+
+    /// - returns: The terminating error if the result is `failed`, otherwise `nil`.
+    public var error: Error? {
+        switch self {
+        case .completed: return nil
+        case .failed(_, let error): return error
+        }
+    }
+}
+
 extension BlockingObservable {
     /// Blocks current thread until sequence terminates.
     ///

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -151,6 +151,10 @@ final class ObservableBlockingTest_ : ObservableBlockingTest, RxTestCase {
     ("testMaterialize_empty_fail", ObservableBlockingTest.testMaterialize_empty_fail),
     ("testMaterialize_someData", ObservableBlockingTest.testMaterialize_someData),
     ("testMaterialize_someData_fail", ObservableBlockingTest.testMaterialize_someData_fail),
+    ("testMaterializedSequenceResult_isCompleted", ObservableBlockingTest.testMaterializedSequenceResult_isCompleted),
+    ("testMaterializedSequenceResult_isFailed", ObservableBlockingTest.testMaterializedSequenceResult_isFailed),
+    ("testMaterializedSequenceResult_elements", ObservableBlockingTest.testMaterializedSequenceResult_elements),
+    ("testMaterializedSequenceResult_error", ObservableBlockingTest.testMaterializedSequenceResult_error),
     ] }
 }
 

--- a/Tests/RxBlockingTests/Observable+BlockingTest.swift
+++ b/Tests/RxBlockingTests/Observable+BlockingTest.swift
@@ -388,3 +388,25 @@ extension ObservableBlockingTest {
         }
     }
 }
+
+extension ObservableBlockingTest {
+    func testMaterializedSequenceResult_isCompleted() {
+        XCTAssertTrue(MaterializedSequenceResult.completed(elements: [Int]()).isCompleted)
+        XCTAssertFalse(MaterializedSequenceResult.failed(elements: [Int](), error: testError).isCompleted)
+    }
+
+    func testMaterializedSequenceResult_isFailed() {
+        XCTAssertFalse(MaterializedSequenceResult.completed(elements: [Int]()).isFailed)
+        XCTAssertTrue(MaterializedSequenceResult.failed(elements: [Int](), error: testError).isFailed)
+    }
+
+    func testMaterializedSequenceResult_elements() {
+        XCTAssertEqual(MaterializedSequenceResult.completed(elements: [1, 2, 3]).elements, [1, 2, 3])
+        XCTAssertEqual(MaterializedSequenceResult.failed(elements: [1, 2], error: testError).elements, [1, 2])
+    }
+
+    func testMaterializedSequenceResult_error() {
+        XCTAssertNil(MaterializedSequenceResult.completed(elements: [Int]()).error)
+        XCTAssertNotNil(MaterializedSequenceResult.failed(elements: [Int](), error: testError).error)
+    }
+}


### PR DESCRIPTION
Add four computed properties to `MaterializedSequenceResult`:

- `isCompleted`
- `isFailed`
- `elements`
- `error`
