### PR TITLE
Add operator to convert Single to Maybe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * Add `zip<C: Collection>(_ collection: C)` to Single trait
 * Add Smart Key Path subscripting to create a binder for property of object.
 * Add `Single.catchErrorJustReturn(_:)` and `Maybe.catchErrorJustReturn(_:)`
+* Add `Single.flatMapMaybe(_:)` and `Single.asMaybe()`
 
 #### Anomalies
 

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -248,6 +248,19 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
         -> Single<R> {
             return Single<R>(raw: primitiveSequence.source.flatMap(selector))
     }
+
+	/**
+	Projects each element of an observable sequence to an observable sequence and merges the resulting observable sequences into one observable sequence.
+
+	- seealso: [flatMap operator on reactivex.io](http://reactivex.io/documentation/operators/flatmap.html)
+
+	- parameter selector: A transform function to apply to each element.
+	- returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
+	*/
+	public func flatMapMaybe<R>(_ selector: @escaping (ElementType) throws -> Maybe<R>)
+		-> Maybe<R> {
+			return Maybe<R>(raw: primitiveSequence.source.flatMap(selector))
+	}
     
     /**
      Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -307,4 +307,11 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
         -> PrimitiveSequence<TraitType, ElementType> {
         return PrimitiveSequence(raw: primitiveSequence.source.catchErrorJustReturn(element))
     }
+
+	/// Converts `self` to `Maybe` trait.
+	///
+	/// - returns: Maybe trait that represents `self`.
+	public func asMaybe() -> Maybe<ElementType> {
+		return Maybe(raw: primitiveSequence.source)
+	}
 }

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -249,18 +249,18 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
             return Single<R>(raw: primitiveSequence.source.flatMap(selector))
     }
 
-	/**
-	Projects each element of an observable sequence to an observable sequence and merges the resulting observable sequences into one observable sequence.
+    /**
+     Projects each element of an observable sequence to an observable sequence and merges the resulting observable sequences into one observable sequence.
 
-	- seealso: [flatMap operator on reactivex.io](http://reactivex.io/documentation/operators/flatmap.html)
+     - seealso: [flatMap operator on reactivex.io](http://reactivex.io/documentation/operators/flatmap.html)
 
-	- parameter selector: A transform function to apply to each element.
-	- returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
-	*/
-	public func flatMapMaybe<R>(_ selector: @escaping (ElementType) throws -> Maybe<R>)
-		-> Maybe<R> {
-			return Maybe<R>(raw: primitiveSequence.source.flatMap(selector))
-	}
+     - parameter selector: A transform function to apply to each element.
+     - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
+     */
+    public func flatMapMaybe<R>(_ selector: @escaping (ElementType) throws -> Maybe<R>)
+        -> Maybe<R> {
+            return Maybe<R>(raw: primitiveSequence.source.flatMap(selector))
+    }
     
     /**
      Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
@@ -308,10 +308,10 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
         return PrimitiveSequence(raw: primitiveSequence.source.catchErrorJustReturn(element))
     }
 
-	/// Converts `self` to `Maybe` trait.
-	///
-	/// - returns: Maybe trait that represents `self`.
-	public func asMaybe() -> Maybe<ElementType> {
-		return Maybe(raw: primitiveSequence.source)
-	}
+    /// Converts `self` to `Maybe` trait.
+    ///
+    /// - returns: Maybe trait that represents `self`.
+    public func asMaybe() -> Maybe<ElementType> {
+        return Maybe(raw: primitiveSequence.source)
+    }
 }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -707,6 +707,8 @@ final class SingleTest_ : SingleTest, RxTestCase {
     ("test_filter", SingleTest.test_filter),
     ("test_map", SingleTest.test_map),
     ("test_flatMap", SingleTest.test_flatMap),
+    ("test_flatMapMaybe", SingleTest.test_flatMapMaybe),
+    ("test_asMaybe", SingleTest.test_asMaybe),
     ("test_zip_tuple", SingleTest.test_zip_tuple),
     ("test_zip_resultSelector", SingleTest.test_zip_resultSelector),
     ("testZipCollection_selector", SingleTest.testZipCollection_selector),

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -548,31 +548,31 @@ extension SingleTest {
             ])
     }
 
-	func test_flatMapMaybe() {
-		let scheduler = TestScheduler(initialClock: 0)
+    func test_flatMapMaybe() {
+        let scheduler = TestScheduler(initialClock: 0)
 
-		let res = scheduler.start {
-			(Single<Int>.just(1).flatMapMaybe { Maybe.just($0 * 2) } as Maybe<Int>).asObservable()
-		}
+        let res = scheduler.start {
+            (Single<Int>.just(1).flatMapMaybe { Maybe.just($0 * 2) } as Maybe<Int>).asObservable()
+        }
 
-		XCTAssertEqual(res.events, [
-			.next(200, 2),
-			.completed(200)
-			])
-	}
+        XCTAssertEqual(res.events, [
+            .next(200, 2),
+            .completed(200)
+            ])
+    }
 
-	func test_asMaybe() {
-		let scheduler = TestScheduler(initialClock: 0)
+    func test_asMaybe() {
+        let scheduler = TestScheduler(initialClock: 0)
 
-		let res = scheduler.start {
-			(Single<Int>.just(1).asMaybe() as Maybe<Int>).asObservable()
-		}
+        let res = scheduler.start {
+            (Single<Int>.just(1).asMaybe() as Maybe<Int>).asObservable()
+        }
 
-		XCTAssertEqual(res.events, [
-			.next(200, 1),
-			.completed(200)
-			])
-	}
+        XCTAssertEqual(res.events, [
+            .next(200, 1),
+            .completed(200)
+            ])
+    }
 }
 
 extension SingleTest {

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -560,6 +560,19 @@ extension SingleTest {
 			.completed(200)
 			])
 	}
+
+	func test_asMaybe() {
+		let scheduler = TestScheduler(initialClock: 0)
+
+		let res = scheduler.start {
+			(Single<Int>.just(1).asMaybe() as Maybe<Int>).asObservable()
+		}
+
+		XCTAssertEqual(res.events, [
+			.next(200, 1),
+			.completed(200)
+			])
+	}
 }
 
 extension SingleTest {

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -547,6 +547,19 @@ extension SingleTest {
             .completed(200)
             ])
     }
+
+	func test_flatMapMaybe() {
+		let scheduler = TestScheduler(initialClock: 0)
+
+		let res = scheduler.start {
+			(Single<Int>.just(1).flatMapMaybe { Maybe.just($0 * 2) } as Maybe<Int>).asObservable()
+		}
+
+		XCTAssertEqual(res.events, [
+			.next(200, 2),
+			.completed(200)
+			])
+	}
 }
 
 extension SingleTest {


### PR DESCRIPTION
This pull request add two operators on Single trait
* `Single.flatMapMaybe`: Same as `Single.flatMap` but returns a Maybe trait;
* `Single.asMaybe`: Converts the Single trait to Maybe trait.

Closes #1580 