### PR TITLE
behaviorRelay: improve comments

### DIFF
--- a/RxCocoa/Traits/BehaviorRelay.swift
+++ b/RxCocoa/Traits/BehaviorRelay.swift
@@ -16,7 +16,7 @@ public final class BehaviorRelay<Element>: ObservableType {
 
     private let _subject: BehaviorSubject<Element>
 
-    // Accepts `event` and emits it to subscribers
+    /// Accepts `event` and emits it to subscribers
     public func accept(_ event: Element) {
         _subject.onNext(event)
     }
@@ -27,7 +27,7 @@ public final class BehaviorRelay<Element>: ObservableType {
         return try! _subject.value()
     }
 
-    /// Initializes variable with initial value.
+    /// Initializes behavior relay with initial value.
     public init(value: Element) {
         _subject = BehaviorSubject(value: value)
     }


### PR DESCRIPTION
Hello!

Following the very interesting conversation in the issue about BehaviorRelay over Variable, I saw very minor documentation issues.

This commit improves the comments of the class by:
- modifying an existing comment to be rendered in documentation mode
- removing a reference to Variable in the class initializer's comment.

Thanks!