### PR TITLE
Add static libs support

### DIFF
--- a/RxBlocking.podspec
+++ b/RxBlocking.podspec
@@ -16,6 +16,7 @@ Waiting for observable sequence to complete before exiting command line applicat
   s.source           = { :git => "https://github.com/ReactiveX/RxSwift.git", :tag => s.version.to_s }
 
   s.requires_arc          = true
+  s.static_framework = true
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'

--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -26,6 +26,7 @@ gitDiff().grep("bug").less          // sequences of swift objects
   s.source           = { :git => "https://github.com/ReactiveX/RxSwift.git", :tag => s.version.to_s }
 
   s.requires_arc          = true
+  s.static_framework = true
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'

--- a/RxTest.podspec
+++ b/RxTest.podspec
@@ -46,6 +46,7 @@ func testMap() {
   s.source           = { :git => "https://github.com/ReactiveX/RxSwift.git", :tag => s.version.to_s }
 
   s.requires_arc          = true
+  s.static_framework = true
 
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'


### PR DESCRIPTION
Addresses #1485 

### Description of change

- Added `s.static_framework = true` flag to `RxSwift`, `RxBlocking`, `RxTest` podspecs
- Everything seems to work fine for `RxSwift`, `RxBlocking`, `RxTest`, I was able to build them in the test project.

<img width="176" alt="screen shot 2018-03-18 at 11 54 00" src="https://user-images.githubusercontent.com/4622322/37565909-b62dd7e0-2aa9-11e8-822f-b3135bd7fa2a.png">


### Issues

- It seems like adding `s.static_framework = true` is not enough for `RxCocoa`  as it is mixed `Objc` and `Swift` library.  [Example](https://drive.google.com/open?id=1rmT7ORe6W_tXrgHXZUIwWpIi6J8WDTU7)
- Also, It seems that we can not leave `RxCocoa` to be dynamic at the moment as well, as it can't link statically compiled `RxSwift` ¯\_(ツ)_/¯. The error I'm getting:

<img width="720" alt="screen shot 2018-03-18 at 13 02 23" src="https://user-images.githubusercontent.com/4622322/37566132-a30f0352-2aac-11e8-88b7-d66324cd7fa4.png">