### PR TITLE
reactive wrapper for UIPopoverPresentationController

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -85,6 +85,7 @@ custom_categories:
   - UINavigationItem+Rx
   - UIPageControl+Rx
   - UIPickerView+Rx
+  - UIPopoverPresentationController+Rx
   - UIProgressView+Rx
   - UIRefreshControl+Rx
   - UIScrollView+Rx
@@ -116,6 +117,7 @@ custom_categories:
   - RxNavigationControllerDelegateProxy
   - RxPickerViewDataSourceProxy
   - RxPickerViewDelegateProxy
+  - RxPopoverPresentationControllerProxy
   - RxScrollViewDelegateProxy
   - RxSearchBarDelegateProxy
   - RxSearchControllerDelegateProxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 * Add `Single.catchErrorJustReturn(_:)` and `Maybe.catchErrorJustReturn(_:)`
 * Add `Single.flatMapMaybe(_:)` and `Single.asMaybe()`
 * Add `UICollectionView.rx.prefetchItems`, `UICollectionView.rx.cancelPrefetchingForItems`,  `UITableView.rx.prefetchRows`, and `UITableView.rx.cancelPrefetchingForRows`.
+* Adds `UIPopoverPresentationController` extensions:
+    * `prepareForPresentation`
+    * `willReposition`
+    * `didDismiss`
 
 #### Anomalies
 

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		54D213931CE08DDB0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
 		5626B17520702CF000127015 /* RxPopoverPresentationControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5626B17320702C6200127015 /* RxPopoverPresentationControllerProxy.swift */; };
 		5626B17820702D6C00127015 /* UIPopoverPresentationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5626B17620702D5F00127015 /* UIPopoverPresentationController+Rx.swift */; };
+		56F526B92070E07A00E1150B /* UIPopoverPresentationController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56F526B72070DFBE00E1150B /* UIPopoverPresentationController+RxTests.swift */; };
 		601AE3DA1EE24E4F00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DB1EE24E5A00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DC1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
@@ -1778,6 +1779,7 @@
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		5626B17320702C6200127015 /* RxPopoverPresentationControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxPopoverPresentationControllerProxy.swift; sourceTree = "<group>"; };
 		5626B17620702D5F00127015 /* UIPopoverPresentationController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPopoverPresentationController+Rx.swift"; sourceTree = "<group>"; };
+		56F526B72070DFBE00E1150B /* UIPopoverPresentationController+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPopoverPresentationController+RxTests.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
@@ -2794,6 +2796,7 @@
 				4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */,
 				C8A81CA51E05EAF70008DEF4 /* Binder+Tests.swift */,
 				6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */,
+				56F526B72070DFBE00E1150B /* UIPopoverPresentationController+RxTests.swift */,
 			);
 			path = RxCocoaTests;
 			sourceTree = "<group>";
@@ -4457,6 +4460,7 @@
 				C83509631C38706E0027C24C /* SubjectConcurrencyTest.swift in Sources */,
 				C82FF0EF1F93DD2E00BDB34D /* ObservableType+SubscriptionTests.swift in Sources */,
 				C820A9721EB4F84000D431BC /* Observable+OptionalTests.swift in Sources */,
+				56F526B92070E07A00E1150B /* UIPopoverPresentationController+RxTests.swift in Sources */,
 				84E4D3961C9B011000ADFDC9 /* UISearchController+RxTests.swift in Sources */,
 				C8C4F15F1DE9CC5B00003FA7 /* UISwitch+RxTests.swift in Sources */,
 				ECBBA5A11DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		54D2138E1CE0824E0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
 		54D213921CE08D0C0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
 		54D213931CE08DDB0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
+		5626B17520702CF000127015 /* RxPopoverPresentationControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5626B17320702C6200127015 /* RxPopoverPresentationControllerProxy.swift */; };
 		601AE3DA1EE24E4F00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DB1EE24E5A00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DC1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
@@ -1774,6 +1775,7 @@
 		46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Rx.swift"; sourceTree = "<group>"; };
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
+		5626B17320702C6200127015 /* RxPopoverPresentationControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxPopoverPresentationControllerProxy.swift; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
@@ -3115,6 +3117,7 @@
 				D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */,
 				4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */,
 				A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */,
+				5626B17320702C6200127015 /* RxPopoverPresentationControllerProxy.swift */,
 			);
 			path = Proxies;
 			sourceTree = "<group>";
@@ -4156,6 +4159,7 @@
 				C882542A1B8A752B00B02D69 /* UIControl+Rx.swift in Sources */,
 				C8E65EFB1F6E91D1004478C3 /* Binder.swift in Sources */,
 				C8D132441C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */,
+				5626B17520702CF000127015 /* RxPopoverPresentationControllerProxy.swift in Sources */,
 				B562478F203515DD00D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift in Sources */,
 				84E4D3921C9AFD3400ADFDC9 /* UISearchController+Rx.swift in Sources */,
 				C88254341B8A752B00B02D69 /* UITableView+Rx.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		54D213921CE08D0C0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
 		54D213931CE08DDB0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
 		5626B17520702CF000127015 /* RxPopoverPresentationControllerProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5626B17320702C6200127015 /* RxPopoverPresentationControllerProxy.swift */; };
+		5626B17820702D6C00127015 /* UIPopoverPresentationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5626B17620702D5F00127015 /* UIPopoverPresentationController+Rx.swift */; };
 		601AE3DA1EE24E4F00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DB1EE24E5A00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
 		601AE3DC1EE24E5B00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
@@ -1776,6 +1777,7 @@
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		5626B17320702C6200127015 /* RxPopoverPresentationControllerProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxPopoverPresentationControllerProxy.swift; sourceTree = "<group>"; };
+		5626B17620702D5F00127015 /* UIPopoverPresentationController+Rx.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIPopoverPresentationController+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
@@ -3065,6 +3067,7 @@
 				844BC8B31CE4FD7500F5C7CB /* UIPickerView+Rx.swift */,
 				46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */,
 				461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */,
+				5626B17620702D5F00127015 /* UIPopoverPresentationController+Rx.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -4237,6 +4240,7 @@
 				C89AB1731DAAC1680065FBE6 /* ControlTarget.swift in Sources */,
 				C882541B1B8A752B00B02D69 /* RxTableViewDataSourceType.swift in Sources */,
 				B5624794203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift in Sources */,
+				5626B17820702D6C00127015 /* UIPopoverPresentationController+Rx.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RxCocoa/RxCocoa.swift
+++ b/RxCocoa/RxCocoa.swift
@@ -138,6 +138,12 @@ func castOrFatalError<T>(_ value: Any!) -> T {
     return result
 }
 
+func castToPointerOrThrow<T>(_ pointeeType: T.Type, _ object: Any) throws -> UnsafeMutablePointer<T> {
+    let value = try castOrThrow(NSValue.self, object)
+    guard let rawPointer = value.pointerValue else { throw RxCocoaError.unknown }
+    return rawPointer.bindMemory(to: T.self, capacity: MemoryLayout<T>.size)
+}
+
 // MARK: Error messages
 
 let dataSourceNotSet = "DataSource not set"

--- a/RxCocoa/RxCocoa.swift
+++ b/RxCocoa/RxCocoa.swift
@@ -138,11 +138,13 @@ func castOrFatalError<T>(_ value: Any!) -> T {
     return result
 }
 
+#if os(iOS) || os(tvOS)
 func castToPointerOrThrow<T>(_ pointeeType: T.Type, _ object: Any) throws -> UnsafeMutablePointer<T> {
     let value = try castOrThrow(NSValue.self, object)
     guard let rawPointer = value.pointerValue else { throw RxCocoaError.unknown }
     return rawPointer.bindMemory(to: T.self, capacity: MemoryLayout<T>.size)
 }
+#endif
 
 // MARK: Error messages
 

--- a/RxCocoa/iOS/Proxies/RxPopoverPresentationControllerProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPopoverPresentationControllerProxy.swift
@@ -1,0 +1,38 @@
+//
+//  RxPopoverPresentationControllerProxy.swift
+//  RxSwift-iOS
+//
+//  Created by Vladimir Kushelkov on 31/03/2018.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS)
+
+import UIKit
+import RxSwift
+
+@available(iOS 8.0, *)
+extension UIPopoverPresentationController: HasDelegate {
+    public typealias Delegate = UIPopoverPresentationControllerDelegate
+}
+
+@available(iOS 8.0, *)
+open class RxPopoverPresentationControllerProxy
+    : DelegateProxy<UIPopoverPresentationController, UIPopoverPresentationControllerDelegate>
+    , UIPopoverPresentationControllerDelegate
+    , DelegateProxyType {
+    
+    public weak private(set) var popoverPresentationController: UIPopoverPresentationController?
+    
+    public init(popoverPresentationController: UIPopoverPresentationController) {
+        self.popoverPresentationController = popoverPresentationController
+        super.init(parentObject: popoverPresentationController,
+                   delegateProxy: RxPopoverPresentationControllerProxy.self)
+    }
+    
+    public static func registerKnownImplementations() {
+        self.register { RxPopoverPresentationControllerProxy(popoverPresentationController: $0) }
+    }
+}
+
+#endif

--- a/RxCocoa/iOS/Proxies/RxPopoverPresentationControllerProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPopoverPresentationControllerProxy.swift
@@ -1,6 +1,6 @@
 //
 //  RxPopoverPresentationControllerProxy.swift
-//  RxSwift-iOS
+//  RxCocoa
 //
 //  Created by Vladimir Kushelkov on 31/03/2018.
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.

--- a/RxCocoa/iOS/Proxies/RxPopoverPresentationControllerProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPopoverPresentationControllerProxy.swift
@@ -22,14 +22,17 @@ open class RxPopoverPresentationControllerProxy
     , UIPopoverPresentationControllerDelegate
     , DelegateProxyType {
     
+    /// Typed parent object.
     public weak private(set) var popoverPresentationController: UIPopoverPresentationController?
     
+    /// - parameter popoverPresentationController: Parent object for delegate proxy.
     public init(popoverPresentationController: UIPopoverPresentationController) {
         self.popoverPresentationController = popoverPresentationController
         super.init(parentObject: popoverPresentationController,
                    delegateProxy: RxPopoverPresentationControllerProxy.self)
     }
     
+    // Register known implementations
     public static func registerKnownImplementations() {
         self.register { RxPopoverPresentationControllerProxy(popoverPresentationController: $0) }
     }

--- a/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
+++ b/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
@@ -17,19 +17,21 @@ extension Reactive where Base: UIPopoverPresentationController {
         (toRect: UnsafeMutablePointer<CGRect>, inView: AutoreleasingUnsafeMutablePointer<UIView>)
     
     public var delegate: DelegateProxy<UIPopoverPresentationController, UIPopoverPresentationControllerDelegate> {
-        return RxPopoverPresentationControllerProxy.proxy(for: base)
+        return RxPopoverPresentationControllerProxy.proxy(for: self.base)
     }
     
-    public var didDismiss: Observable<Void> {
-        return delegate
+    public var didDismiss: ControlEvent<Void> {
+        let source = delegate
             .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.popoverPresentationControllerDidDismissPopover(_:)))
-            .map {_ in}
+            .map { _ in }
+        return ControlEvent(events: source)
     }
     
-    public var prepareForPresentation: Observable<Void> {
-        return delegate
+    public var prepareForPresentation: ControlEvent<Void> {
+        let source = delegate
             .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.prepareForPopoverPresentation(_:)))
-            .map {_ in}
+            .map { _ in }
+        return ControlEvent(events: source)
     }
     
     public var willReposition: ControlEvent<WillRepositionPopoverEvent> {

--- a/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
+++ b/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
@@ -43,16 +43,9 @@ extension Reactive where Base: UIPopoverPresentationController {
         let source = delegate
             .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.popoverPresentationController(_:willRepositionPopoverTo:in:)))
             .map { args -> WillRepositionPopoverEvent in
-                let rect = try castOrThrow(NSValue.self, args[1])
-                let view = try castOrThrow(NSValue.self, args[2])
-                
-                guard let rawRectPointer = rect.pointerValue else { throw RxCocoaError.unknown }
-                let typedRectPointer = rawRectPointer.bindMemory(to: CGRect.self, capacity: MemoryLayout<CGRect>.size)
-                
-                guard let rawViewPointer = view.pointerValue else { throw RxCocoaError.unknown }
-                let typedViewPointer = rawViewPointer.bindMemory(to: UIView.self, capacity: MemoryLayout<UIView>.size)
-                
-                return (typedRectPointer, .init(typedViewPointer))
+                let rectPointer = try castToPointerOrThrow(CGRect.self, args[1])
+                let viewPointer = try castToPointerOrThrow(UIView.self, args[2])
+                return (rectPointer, .init(viewPointer))
             }
         
         return ControlEvent(events: source)

--- a/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
+++ b/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
@@ -1,0 +1,38 @@
+//
+//  UIPopoverPresentationController+Rx.swift
+//  RxSwift-iOS
+//
+//  Created by Vladimir Kushelkov on 31/03/2018.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS)
+
+import UIKit
+import RxSwift
+
+@available(iOS 8.0, *)
+extension Reactive where Base: UIPopoverPresentationController {
+    public var delegate: DelegateProxy<UIPopoverPresentationController, UIPopoverPresentationControllerDelegate> {
+        return RxPopoverPresentationControllerProxy.proxy(for: base)
+    }
+    
+    public var didDismiss: Observable<Void> {
+        return delegate
+            .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.popoverPresentationControllerDidDismissPopover(_:)))
+            .map {_ in}
+    }
+    
+    public var prepareForPresentation: Observable<Void> {
+        return delegate
+            .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.prepareForPopoverPresentation(_:)))
+            .map {_ in}
+    }
+    
+    public func setDelegate(_ delegate: UIPopoverPresentationControllerDelegate) -> Disposable {
+        return RxPopoverPresentationControllerProxy
+            .installForwardDelegate(delegate, retainDelegate: false, onProxyForObject: self.base)
+    }
+}
+
+#endif

--- a/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
+++ b/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
@@ -13,6 +13,9 @@ import RxSwift
 
 @available(iOS 8.0, *)
 extension Reactive where Base: UIPopoverPresentationController {
+    public typealias WillRepositionPopoverEvent =
+        (toRect: UnsafeMutablePointer<CGRect>, inView: AutoreleasingUnsafeMutablePointer<UIView>)
+    
     public var delegate: DelegateProxy<UIPopoverPresentationController, UIPopoverPresentationControllerDelegate> {
         return RxPopoverPresentationControllerProxy.proxy(for: base)
     }
@@ -27,6 +30,25 @@ extension Reactive where Base: UIPopoverPresentationController {
         return delegate
             .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.prepareForPopoverPresentation(_:)))
             .map {_ in}
+    }
+    
+    public var willReposition: ControlEvent<WillRepositionPopoverEvent> {
+        let source = delegate
+            .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.popoverPresentationController(_:willRepositionPopoverTo:in:)))
+            .map { args -> WillRepositionPopoverEvent in
+                let rect = try castOrThrow(NSValue.self, args[1])
+                let view = try castOrThrow(NSValue.self, args[2])
+                
+                guard let rawRectPointer = rect.pointerValue else { throw RxCocoaError.unknown }
+                let typedRectPointer = rawRectPointer.bindMemory(to: CGRect.self, capacity: MemoryLayout<CGRect>.size)
+                
+                guard let rawViewPointer = view.pointerValue else { throw RxCocoaError.unknown }
+                let typedViewPointer = rawViewPointer.bindMemory(to: UIView.self, capacity: MemoryLayout<UIView>.size)
+                
+                return (typedRectPointer, .init(typedViewPointer))
+            }
+        
+        return ControlEvent(events: source)
     }
     
     public func setDelegate(_ delegate: UIPopoverPresentationControllerDelegate) -> Disposable {

--- a/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
+++ b/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
@@ -16,10 +16,13 @@ extension Reactive where Base: UIPopoverPresentationController {
     public typealias WillRepositionPopoverEvent =
         (toRect: UnsafeMutablePointer<CGRect>, inView: AutoreleasingUnsafeMutablePointer<UIView>)
     
+    /// Reactive wrapper for `delegate`.
+    /// For more information take a look at `DelegateProxyType` protocol documentation.
     public var delegate: DelegateProxy<UIPopoverPresentationController, UIPopoverPresentationControllerDelegate> {
         return RxPopoverPresentationControllerProxy.proxy(for: self.base)
     }
     
+    /// Reactive wrapper for delegate method `popoverPresentationControllerDidDismissPopover(_:)`
     public var didDismiss: ControlEvent<Void> {
         let source = delegate
             .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.popoverPresentationControllerDidDismissPopover(_:)))
@@ -27,6 +30,7 @@ extension Reactive where Base: UIPopoverPresentationController {
         return ControlEvent(events: source)
     }
     
+    /// Reactive wrapper for delegate method `prepareForPopoverPresentation(_:)`
     public var prepareForPresentation: ControlEvent<Void> {
         let source = delegate
             .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.prepareForPopoverPresentation(_:)))
@@ -34,6 +38,7 @@ extension Reactive where Base: UIPopoverPresentationController {
         return ControlEvent(events: source)
     }
     
+    /// Reactive wrapper for delegate method `popoverPresentationController(_:willRepositionPopoverTo:in:)`
     public var willReposition: ControlEvent<WillRepositionPopoverEvent> {
         let source = delegate
             .methodInvoked(#selector(UIPopoverPresentationControllerDelegate.popoverPresentationController(_:willRepositionPopoverTo:in:)))
@@ -53,6 +58,13 @@ extension Reactive where Base: UIPopoverPresentationController {
         return ControlEvent(events: source)
     }
     
+    /// Installs delegate as forwarding delegate on `delegate`.
+    /// Delegate won't be retained.
+    ///
+    /// It enables using normal delegate mechanism with reactive delegate mechanism.
+    ///
+    /// - parameter delegate: Delegate object.
+    /// - returns: Disposable object that can be used to unbind the delegate.
     public func setDelegate(_ delegate: UIPopoverPresentationControllerDelegate) -> Disposable {
         return RxPopoverPresentationControllerProxy
             .installForwardDelegate(delegate, retainDelegate: false, onProxyForObject: self.base)

--- a/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
+++ b/RxCocoa/iOS/UIPopoverPresentationController+Rx.swift
@@ -1,6 +1,6 @@
 //
 //  UIPopoverPresentationController+Rx.swift
-//  RxSwift-iOS
+//  RxCocoa
 //
 //  Created by Vladimir Kushelkov on 31/03/2018.
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.

--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -69,12 +69,8 @@
             let source = delegate.methodInvoked(#selector(UIScrollViewDelegate.scrollViewWillEndDragging(_:withVelocity:targetContentOffset:)))
                 .map { value -> WillEndDraggingEvent in
                     let velocity = try castOrThrow(CGPoint.self, value[1])
-                    let targetContentOffsetValue = try castOrThrow(NSValue.self, value[2])
-
-                    guard let rawPointer = targetContentOffsetValue.pointerValue else { throw RxCocoaError.unknown }
-                    let typedPointer = rawPointer.bindMemory(to: CGPoint.self, capacity: MemoryLayout<CGPoint>.size)
-
-                    return (velocity, typedPointer)
+                    let targetContentOffsetPointer = try castToPointerOrThrow(CGPoint.self, value[2])
+                    return (velocity, targetContentOffsetPointer)
             }
             return ControlEvent(events: source)
         }

--- a/Sources/RxCocoa/RxPopoverPresentationControllerProxy.swift
+++ b/Sources/RxCocoa/RxPopoverPresentationControllerProxy.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/iOS/Proxies/RxPopoverPresentationControllerProxy.swift

--- a/Sources/RxCocoa/UIPopoverPresentationController+Rx.swift
+++ b/Sources/RxCocoa/UIPopoverPresentationController+Rx.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/iOS/UIPopoverPresentationController+Rx.swift

--- a/Tests/RxCocoaTests/UIPopoverPresentationController+RxTests.swift
+++ b/Tests/RxCocoaTests/UIPopoverPresentationController+RxTests.swift
@@ -1,0 +1,117 @@
+//
+//  UIPopoverPresentationController+RxTests.swift
+//  RxSwift-iOS
+//
+//  Created by Vladimir Kushelkov on 01/04/2018.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS)
+
+import RxCocoa
+import UIKit
+import XCTest
+import RxSwift
+
+final class UIPopoverPresentationControllerTests : RxTest {
+    
+}
+
+@available(iOS 8.0, *)
+extension UIPopoverPresentationControllerTests {
+    func testDidDismissPopoverPresentationController() {
+        var didDismissed = false
+        var completed = false
+        
+        autoreleasepool {
+            let popoverController = UIPopoverPresentationController(presentedViewController: UIViewController(),
+                                                                    presenting: UIViewController())
+            
+            XCTAssertNotEqual(popoverController.presentedViewController, popoverController.presentingViewController)
+
+            _ = popoverController.rx.didDismiss
+                .subscribe(onNext: { _ in
+                    didDismissed = true
+                }, onCompleted: {
+                    completed = true
+                })
+
+            popoverController.delegate!.popoverPresentationControllerDidDismissPopover!(popoverController)
+        }
+        
+        XCTAssertTrue(didDismissed)
+        XCTAssertTrue(completed)
+    }
+    
+    func testPrepareForPresentationPopoverPresentationController() {
+        var preparedForPresentation = false
+        var completed = false
+        
+        autoreleasepool {
+            let popoverController = UIPopoverPresentationController(presentedViewController: UIViewController(),
+                                                                    presenting: UIViewController())
+            
+            XCTAssertNotEqual(popoverController.presentedViewController, popoverController.presentingViewController)
+            
+            _ = popoverController.rx.prepareForPresentation
+                .subscribe(onNext: { _ in
+                    preparedForPresentation = true
+                }, onCompleted: {
+                    completed = true
+                })
+            
+            popoverController.delegate!.prepareForPopoverPresentation!(popoverController)
+        }
+        
+        XCTAssertTrue(preparedForPresentation)
+        XCTAssertTrue(completed)
+    }
+    
+    func testWillRepositionPopoverPresentationController() {
+        var completed = false
+        
+        autoreleasepool {
+            let firstView = UIView(frame: CGRect(x: 1, y: 2, width: 3, height: 4))
+            let secondView = UIView(frame: CGRect(x: 5, y: 6, width: 7, height: 8))
+            let popoverController = UIPopoverPresentationController(presentedViewController: UIViewController(),
+                                                                    presenting: UIViewController())
+            
+            var argView = firstView
+            var argRect = firstView.frame
+            
+            var rect: CGRect? = nil
+            var view: UIView? = nil
+
+            _ = popoverController.rx.willReposition
+                .subscribe(onNext: { args in
+                    rect = args.toRect.pointee
+                    view = args.inView.pointee
+
+                    args.toRect.pointee = secondView.frame
+                    args.inView.pointee = secondView
+                }, onCompleted: {
+                    completed = true
+                })
+            
+            XCTAssertNil(rect)
+            XCTAssertNil(view)
+            
+            XCTAssertEqual(argRect, firstView.frame)
+            XCTAssertEqual(argView, firstView)
+
+            popoverController.delegate!.popoverPresentationController!(popoverController,
+                                                                       willRepositionPopoverTo: &argRect,
+                                                                       in: &argView)
+            
+            XCTAssertEqual(rect, firstView.frame)
+            XCTAssertEqual(view, firstView)
+            
+            XCTAssertEqual(argRect, secondView.frame)
+            XCTAssertEqual(argView, secondView)
+        }
+        
+        XCTAssertTrue(completed)
+    }
+}
+
+#endif

--- a/Tests/RxCocoaTests/UIPopoverPresentationController+RxTests.swift
+++ b/Tests/RxCocoaTests/UIPopoverPresentationController+RxTests.swift
@@ -1,6 +1,6 @@
 //
 //  UIPopoverPresentationController+RxTests.swift
-//  RxSwift-iOS
+//  Tests
 //
 //  Created by Vladimir Kushelkov on 01/04/2018.
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.

--- a/Tests/RxCocoaTests/UIPopoverPresentationController+RxTests.swift
+++ b/Tests/RxCocoaTests/UIPopoverPresentationController+RxTests.swift
@@ -103,6 +103,9 @@ extension UIPopoverPresentationControllerTests {
                                                                        willRepositionPopoverTo: &argRect,
                                                                        in: &argView)
             
+            XCTAssertNotEqual(firstView.frame, secondView.frame)
+            XCTAssertNotEqual(firstView, secondView)
+            
             XCTAssertEqual(rect, firstView.frame)
             XCTAssertEqual(view, firstView)
             


### PR DESCRIPTION
The pull request adds a reactive wrapper for UIPopoverPresentationController.
Extensions:
- `prepareForPresentation`
- `willReposition`
- `didDismiss`