### PR TITLE
Modify misspellings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 #### Anomalies
 
 * Fixes ambiguity issue with  `Single.do(onNext:onError:onSubscribe:onSubscribed:onDispose:)` and `Single.do(onSuccess:onError:onSubscribe:onSubscribed:onDispose:)`.
+* Fixes various spelling mistakes and missing parameters.
 
 ## [4.1.1](https://github.com/ReactiveX/RxSwift/releases/tag/4.1.1)
 

--- a/Documentation/Traits.md
+++ b/Documentation/Traits.md
@@ -399,7 +399,7 @@ Note however that, theoretically, someone could still define a `drive` method to
 
 Trait for `Observable`/`ObservableType` that represents property of UI element.
  
-Sequence of values only represents initial control value and user initiated value changes. Programatic value changes won't be reported.
+Sequence of values only represents initial control value and user initiated value changes. Programmatic value changes won't be reported.
 
 It's properties are:
 

--- a/RxCocoa/Traits/ControlProperty.swift
+++ b/RxCocoa/Traits/ControlProperty.swift
@@ -19,7 +19,7 @@ public protocol ControlPropertyType : ObservableType, ObserverType {
     Trait for `Observable`/`ObservableType` that represents property of UI element.
  
     Sequence of values only represents initial control value and user initiated value changes.
-    Programatic value changes won't be reported.
+    Programmatic value changes won't be reported.
 
     It's properties are:
 
@@ -69,12 +69,12 @@ public struct ControlProperty<PropertyType> : ControlPropertyType {
     /// `ControlEvent` of user initiated value changes. Every time user updates control value change event
     /// will be emitted from `changed` event.
     ///
-    /// Programatic changes to control value won't be reported.
+    /// Programmatic changes to control value won't be reported.
     ///
     /// It contains all control property values except for first one.
     ///
     /// The name only implies that sequence element will be generated once user changes a value and not that
-    /// adjacent sequence values need to be different (e.g. because of interaction between programatic and user updates,
+    /// adjacent sequence values need to be different (e.g. because of interaction between programmatic and user updates,
     /// or for any other reason).
     public var changed: ControlEvent<PropertyType> {
         get {

--- a/RxExample/RxExample/Feedbacks.swift
+++ b/RxExample/RxExample/Feedbacks.swift
@@ -230,7 +230,7 @@ extension ObservableType {
             .map { _ in completeAsSoonAsPossible }
             // this little piggy will ensure self is being run first
             .startWith(self.asObservable())
-            // this little piggy will ensure that new events are being blocked immediatelly
+            // this little piggy will ensure that new events are being blocked immediately
             .switchLatest()
     }
 }
@@ -270,7 +270,7 @@ extension Observable {
             // observe on is here because results should be cancelable
             .observeOn(scheduler.async)
             // subscribe on is here because side-effects also need to be cancelable
-            // (smooths out any glitches caused by start-cancel immediatelly)
+            // (smooths out any glitches caused by start-cancel immediately)
             .subscribeOn(scheduler.async)
     }
 }

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -26,7 +26,7 @@ extension Observable {
      - seealso: [from operator on reactivex.io](http://reactivex.io/documentation/operators/from.html)
 
      - parameter optional: Optional element in the resulting observable sequence.
-     - parameter: Scheduler to send the optional element on.
+     - parameter scheduler: Scheduler to send the optional element on.
      - returns: An observable sequence containing the wrapped value or not from given optional.
      */
     @available(*, deprecated, message: "Implicit conversions from any type to optional type are allowed and that is causing issues with `from` operator overloading.", renamed: "from(optional:scheduler:)")

--- a/RxSwift/Observables/Delay.swift
+++ b/RxSwift/Observables/Delay.swift
@@ -80,13 +80,13 @@ final fileprivate class DelaySink<O: ObserverType>
             _lock.lock() // {
                 let errorEvent = _errorEvent
 
-                let eventToForwardImmediatelly = ranAtLeastOnce ? nil : _queue.dequeue()?.event
+                let eventToForwardImmediately = ranAtLeastOnce ? nil : _queue.dequeue()?.event
                 let nextEventToScheduleOriginalTime: Date? = ranAtLeastOnce && !_queue.isEmpty ? _queue.peek().eventTime : nil
 
                 if let _ = errorEvent {
                 }
                 else  {
-                    if let _ = eventToForwardImmediatelly {
+                    if let _ = eventToForwardImmediately {
                     }
                     else if let _ = nextEventToScheduleOriginalTime {
                         _running = false
@@ -104,10 +104,10 @@ final fileprivate class DelaySink<O: ObserverType>
                 return
             }
             else {
-                if let eventToForwardImmediatelly = eventToForwardImmediatelly {
+                if let eventToForwardImmediately = eventToForwardImmediately {
                     ranAtLeastOnce = true
-                    self.forwardOn(eventToForwardImmediatelly)
-                    if case .completed = eventToForwardImmediatelly {
+                    self.forwardOn(eventToForwardImmediately)
+                    if case .completed = eventToForwardImmediately {
                         self.dispose()
                         return
                     }
@@ -134,12 +134,12 @@ final fileprivate class DelaySink<O: ObserverType>
         switch event {
         case .error(_):
             _lock.lock()    // {
-                let shouldSendImmediatelly = !_running
+                let shouldSendImmediately = !_running
                 _queue = Queue(capacity: 0)
                 _errorEvent = event
             _lock.unlock()  // }
 
-            if shouldSendImmediatelly {
+            if shouldSendImmediately {
                 forwardOn(event)
                 dispose()
             }

--- a/RxSwift/Observables/Just.swift
+++ b/RxSwift/Observables/Just.swift
@@ -25,7 +25,7 @@ extension ObservableType {
      - seealso: [just operator on reactivex.io](http://reactivex.io/documentation/operators/just.html)
 
      - parameter element: Single element in the resulting observable sequence.
-     - parameter: Scheduler to send the single element on.
+     - parameter scheduler: Scheduler to send the single element on.
      - returns: An observable sequence containing the single specified element.
      */
     public static func just(_ element: E, scheduler: ImmediateSchedulerType) -> Observable<E> {

--- a/RxSwift/Observables/Optional.swift
+++ b/RxSwift/Observables/Optional.swift
@@ -25,7 +25,7 @@ extension ObservableType {
      - seealso: [from operator on reactivex.io](http://reactivex.io/documentation/operators/from.html)
 
      - parameter optional: Optional element in the resulting observable sequence.
-     - parameter: Scheduler to send the optional element on.
+     - parameter scheduler: Scheduler to send the optional element on.
      - returns: An observable sequence containing the wrapped value or not from given optional.
      */
     public static func from(optional: E?, scheduler: ImmediateSchedulerType) -> Observable<E> {

--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -77,7 +77,7 @@ public enum SubjectLifetimeScope {
        continue holding a reference to the same subject.
        If at some later moment a new observer initiates a new connection to source it can potentially receive
        some of the stale events received during previous connection.
-     * After source sequence terminates any new observer will always immediatelly receive replayed elements and terminal event.
+     * After source sequence terminates any new observer will always immediately receive replayed elements and terminal event.
        No new subscriptions to source observable sequence will be attempted.
 
      ```

--- a/RxSwift/Traits/Maybe.swift
+++ b/RxSwift/Traits/Maybe.swift
@@ -130,7 +130,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - seealso: [just operator on reactivex.io](http://reactivex.io/documentation/operators/just.html)
      
      - parameter element: Single element in the resulting observable sequence.
-     - parameter: Scheduler to send the single element on.
+     - parameter scheduler: Scheduler to send the single element on.
      - returns: An observable sequence containing the single specified element.
      */
     public static func just(_ element: ElementType, scheduler: ImmediateSchedulerType) -> Maybe<ElementType> {

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -121,7 +121,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - seealso: [just operator on reactivex.io](http://reactivex.io/documentation/operators/just.html)
      
      - parameter element: Single element in the resulting observable sequence.
-     - parameter: Scheduler to send the single element on.
+     - parameter scheduler: Scheduler to send the single element on.
      - returns: An observable sequence containing the single specified element.
      */
     public static func just(_ element: ElementType, scheduler: ImmediateSchedulerType) -> Single<ElementType> {

--- a/Tests/RxSwiftTests/MainSchedulerTests.swift
+++ b/Tests/RxSwiftTests/MainSchedulerTests.swift
@@ -34,9 +34,9 @@ extension MainSchedulerTest {
     func testMainScheduler_basicScenario() {
 
         var messages = [Int]()
-        var executedImmediatelly = false
+        var executedImmediately = false
         _ = MainScheduler.instance.schedule(()) { s in
-            executedImmediatelly = true
+            executedImmediately = true
             messages.append(1)
             _ = MainScheduler.instance.schedule(()) { s in
                 messages.append(3)
@@ -51,7 +51,7 @@ extension MainSchedulerTest {
             return Disposables.create()
         }
 
-        XCTAssertTrue(executedImmediatelly)
+        XCTAssertTrue(executedImmediately)
 
         runRunLoop()
 

--- a/Tests/RxSwiftTests/Observable+CombineLatestTests.swift
+++ b/Tests/RxSwiftTests/Observable+CombineLatestTests.swift
@@ -842,7 +842,7 @@ extension ObservableCombineLatestTest {
         XCTAssertEqual(nEvents, 1)
     }
     
-    func testCombineLatest_DeadlockErrorImmediatelly() {
+    func testCombineLatest_DeadlockErrorImmediately() {
         var nEvents = 0
         
         let observable = Observable.combineLatest(

--- a/Tests/RxSwiftTests/Observable+MergeTests.swift
+++ b/Tests/RxSwiftTests/Observable+MergeTests.swift
@@ -46,7 +46,7 @@ extension ObservableMergeTest {
         XCTAssertEqual(nEvents, 1)
     }
     
-    func testMerge_DeadlockErrorImmediatelly() {
+    func testMerge_DeadlockErrorImmediately() {
         var nEvents = 0
         
         let observable: Observable<Observable<Int>> = Observable.just(
@@ -114,7 +114,7 @@ extension ObservableMergeTest {
         XCTAssertEqual(nEvents, 1)
     }
     
-    func testMergeConcurrent_DeadlockErrorImmediatelly() {
+    func testMergeConcurrent_DeadlockErrorImmediately() {
         var nEvents = 0
         
         let observable: Observable<Observable<Int>> = Observable.just(
@@ -1016,7 +1016,7 @@ extension ObservableMergeTest {
         }
     }
 
-    func testMergeSync_EmptyData_DoesntCompleteImmediatelly() {
+    func testMergeSync_EmptyData_DoesntCompleteImmediately() {
         let factories: [(Observable<Int>, Observable<Int>) -> Observable<Int>] =
             [
                 { ys1, ys2 in Observable.merge(ys1, ys2) },

--- a/Tests/RxSwiftTests/Observable+MulticastTests.swift
+++ b/Tests/RxSwiftTests/Observable+MulticastTests.swift
@@ -839,7 +839,7 @@ extension ObservableMulticastTest {
         XCTAssertEqual(nEvents, 1)
     }
 
-    func testRefCount_DeadlockErrorImmediatelly() {
+    func testRefCount_DeadlockErrorImmediately() {
         let subject = MySubject<Int>()
 
         var nEvents = 0

--- a/Tests/RxSwiftTests/Observable+ObserveOnTests.swift
+++ b/Tests/RxSwiftTests/Observable+ObserveOnTests.swift
@@ -128,7 +128,7 @@ extension ObservableObserveOnTest {
         }
     #endif
 
-    func testObserveOnDispatchQueue_DeadlockErrorImmediatelly() {
+    func testObserveOnDispatchQueue_DeadlockErrorImmediately() {
         var nEvents = 0
 
         runDispatchQueueSchedulerTests { scheduler in


### PR DESCRIPTION
Modify the misspelling of `immediately` and `Programmatic`