### PR TITLE
Rename deprecated UIBindingObserver in documentation

### DIFF
--- a/Documentation/Traits.md
+++ b/Documentation/Traits.md
@@ -430,7 +430,7 @@ extension Reactive where Base: UISearchBar {
                     .startWith(text)
         }
 
-        let bindingObserver = UIBindingObserver(UIElement: self.base) { (searchBar, text: String?) in
+        let bindingObserver = Binder(self.base) { (searchBar, text: String?) in
             searchBar.text = text
         }
         


### PR DESCRIPTION
Traits documentation still uses a deprecated UIBindingObserver as an example of using ControlProperty / ControlEvent. This pull request fixes this issue by updating deprecated code to use the new Binder class.