### PR TITLE
Modified `completed` condition of `zip`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 #### Anomalies
 
 * Fixes ambiguity issue with  `Single.do(onNext:onError:onSubscribe:onSubscribed:onDispose:)` and `Single.do(onSuccess:onError:onSubscribe:onSubscribed:onDispose:)`.
+* Modified `completed` condition of `zip`.
 
 ## [4.1.1](https://github.com/ReactiveX/RxSwift/releases/tag/4.1.1)
 

--- a/RxSwift/Observables/Zip+Collection.swift
+++ b/RxSwift/Observables/Zip+Collection.swift
@@ -76,7 +76,7 @@ final fileprivate class ZipCollectionTypeSink<C: Collection, O: ObserverType>
                 }
                 
                 if _numberOfValues < _parent.count {
-                    if _numberOfDone == _parent.count - 1 {
+                    if (_numberOfDone + _numberOfValues) == _parent.count {
                         self.forwardOn(.completed)
                         self.dispose()
                     }


### PR DESCRIPTION
If there Three Observables like this:

|  | E1 | E2 | E3 | E4 | E5 | E6 |
| -- | -- | -- | -- | -- | -- | -- |
| O1 | 🍎| 🍎| 🍎| 🍎| 🍎| completed |
| O2 | 🍎| 🍎| 🍎| completed | | |
| O3 | 🍎| completed | | | | |

Should it end at E2 or should it end at E4 ?



