### PR TITLE
Escape wayward * in Getting Started regex example

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -69,7 +69,7 @@ These are called marble diagrams. There are more marble diagrams at [rxmarbles.c
 
 If we were to specify sequence grammar as a regular expression it would look like:
 
-**next* (error | completed)?**
+**next\* (error | completed)?**
 
 This describes the following:
 


### PR DESCRIPTION
I believe the intended regex here is

`next* (error | completed)?`

However, GitHub is rendering it as

`next (error | completed)?*`

Backslash-escaping the * after "next" seems to fix the problem.