### PR TITLE
Add operator asCompletable on Single trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 * Add `Single.flatMapMaybe(_:)` and `Single.asMaybe()`
 * Add `UICollectionView.rx.prefetchItems`, `UICollectionView.rx.cancelPrefetchingForItems`,  `UITableView.rx.prefetchRows`, and `UITableView.rx.cancelPrefetchingForRows`.
 * Add `Single.flatMapCompletable()`
+* ADD `Single.asCompletable()`
 
 #### Anomalies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 * Add `Single.flatMapMaybe(_:)` and `Single.asMaybe()`
 * Add `UICollectionView.rx.prefetchItems`, `UICollectionView.rx.cancelPrefetchingForItems`,  `UITableView.rx.prefetchRows`, and `UITableView.rx.cancelPrefetchingForRows`.
 * Add `Single.flatMapCompletable()`
-* ADD `Single.asCompletable()`
+* Add `Single.asCompletable()`
 
 #### Anomalies
 

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -332,12 +332,6 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     ///
     /// - returns: Completable trait that represents `self`.
     public func asCompletable() -> Completable {
-        return Completable.create { completable -> Disposable in
-            return self.subscribe(onSuccess: { _ in
-                completable(.completed)
-            }, onError: { error in
-                completable(.error(error))
-            })
-        }
+        return primitiveSequence.source.ignoreElements()
     }
 }

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -327,4 +327,17 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     public func asMaybe() -> Maybe<ElementType> {
         return Maybe(raw: primitiveSequence.source)
     }
+
+    /// Converts `self` to `Completable` trait.
+    ///
+    /// - returns: Completable trait that represents `self`.
+    public func asCompletable() -> Completable {
+        return Completable.create { completable -> Disposable in
+            return self.subscribe(onSuccess: { _ in
+                completable(.completed)
+            }, onError: { error in
+                completable(.error(error))
+            })
+        }
+    }
 }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -710,6 +710,7 @@ final class SingleTest_ : SingleTest, RxTestCase {
     ("test_flatMapMaybe", SingleTest.test_flatMapMaybe),
     ("test_flatMapCompletable", SingleTest.test_flatMapCompletable),
     ("test_asMaybe", SingleTest.test_asMaybe),
+    ("test_asCompletable", SingleTest.test_asCompletable),
     ("test_zip_tuple", SingleTest.test_zip_tuple),
     ("test_zip_resultSelector", SingleTest.test_zip_resultSelector),
     ("testZipCollection_selector", SingleTest.testZipCollection_selector),

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -711,6 +711,7 @@ final class SingleTest_ : SingleTest, RxTestCase {
     ("test_flatMapCompletable", SingleTest.test_flatMapCompletable),
     ("test_asMaybe", SingleTest.test_asMaybe),
     ("test_asCompletable", SingleTest.test_asCompletable),
+    ("test_asCompletableError", SingleTest.test_asCompletableError),
     ("test_zip_tuple", SingleTest.test_zip_tuple),
     ("test_zip_resultSelector", SingleTest.test_zip_resultSelector),
     ("testZipCollection_selector", SingleTest.testZipCollection_selector),

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -597,6 +597,18 @@ extension SingleTest {
             .completed(200)
             ])
     }
+
+    func test_asCompletableError() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let res = scheduler.start {
+            (Single<Int>.error(testError).asCompletable() as Completable).asObservable()
+        }
+
+        XCTAssertEqual(res.events, [
+            .error(200, testError)
+            ])
+    }
 }
 
 extension SingleTest {

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -585,6 +585,18 @@ extension SingleTest {
             .completed(200)
             ])
     }
+
+    func test_asCompletable() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let res = scheduler.start {
+            (Single<Int>.just(5).asCompletable() as Completable).asObservable()
+        }
+
+        XCTAssertEqual(res.events, [
+            .completed(200)
+            ])
+    }
 }
 
 extension SingleTest {


### PR DESCRIPTION
This PR adds the operator `asCompletable` on Single, related to what we discussed on #1580