### PR TITLE
UITableViewCell+Rx added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+* Add `UITableViewCell.rx`
 * Lower macOS Deployment Target to 10.9
 * Add `zip<C: Collection>(_ collection: C)` to Single trait
 * Add Smart Key Path subscripting to create a binder for property of object.

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		A5CD038D1F1660F40005A376 /* RxPickerViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */; };
 		AAE623761C82475700FC7801 /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */; };
 		AAE623771C82475700FC7801 /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */; };
+		B2DC843920BF91A1009C5357 /* UITableViewCell+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DC843820BF91A1009C5357 /* UITableViewCell+Rx.swift */; };
 		B44D73EC1EE6D4A300EBFBE8 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
 		B44D73ED1EE6D57600EBFBE8 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
 		B562478F203515DD00D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B562478D2035154900D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift */; };
@@ -1803,6 +1804,7 @@
 		A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewDataSourceProxy.swift; sourceTree = "<group>"; };
 		A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewAdapter.swift; sourceTree = "<group>"; };
 		AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIProgressView+Rx.swift"; sourceTree = "<group>"; };
+		B2DC843820BF91A1009C5357 /* UITableViewCell+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Rx.swift"; sourceTree = "<group>"; };
 		B562478D2035154900D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxCollectionViewDataSourcePrefetchingProxy.swift; sourceTree = "<group>"; };
 		B5624793203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTableViewDataSourcePrefetchingProxy.swift; sourceTree = "<group>"; };
 		C801DE351F6EAD3C008DB060 /* SingleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTest.swift; sourceTree = "<group>"; };
@@ -3050,6 +3052,7 @@
 				F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */,
 				C88254111B8A752B00B02D69 /* UISwitch+Rx.swift */,
 				C88254121B8A752B00B02D69 /* UITableView+Rx.swift */,
+				B2DC843820BF91A1009C5357 /* UITableViewCell+Rx.swift */,
 				C88254131B8A752B00B02D69 /* UITextField+Rx.swift */,
 				C88254141B8A752B00B02D69 /* UITextView+Rx.swift */,
 				842A5A281C357F7D003568D5 /* NSTextStorage+Rx.swift */,
@@ -4229,6 +4232,7 @@
 				4613457C1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift in Sources */,
 				C88254301B8A752B00B02D69 /* UISearchBar+Rx.swift in Sources */,
 				C89AB2121DAAC3350065FBE6 /* NotificationCenter+Rx.swift in Sources */,
+				B2DC843920BF91A1009C5357 /* UITableViewCell+Rx.swift in Sources */,
 				C88254181B8A752B00B02D69 /* ItemEvents.swift in Sources */,
 				C89AB1731DAAC1680065FBE6 /* ControlTarget.swift in Sources */,
 				C882541B1B8A752B00B02D69 /* RxTableViewDataSourceType.swift in Sources */,

--- a/Rx.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Rx.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/RxCocoa/iOS/UITableViewCell+Rx.swift
+++ b/RxCocoa/iOS/UITableViewCell+Rx.swift
@@ -9,7 +9,8 @@
 import UIKit
 import ObjectiveC
 import RxSwift
-import RxCocoa
+
+#if os(iOS)
 
 private var disposeBagKey: UInt8 = 0
 
@@ -38,3 +39,5 @@ extension Reactive where Base : UITableViewCell {
     }
     
 }
+
+#endif

--- a/RxCocoa/iOS/UITableViewCell+Rx.swift
+++ b/RxCocoa/iOS/UITableViewCell+Rx.swift
@@ -1,0 +1,40 @@
+//
+//  UITableViewCell+Rx.swift
+//  RxCocoa
+//
+//  Created by Mohammadreza Hemmati on 5/31/2018 AP.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+import UIKit
+import ObjectiveC
+import RxSwift
+import RxCocoa
+
+private var disposeBagKey: UInt8 = 0
+
+fileprivate extension UITableViewCell{
+    
+    func diposeOnReuse(){
+        objc_setAssociatedObject(self, &disposeBagKey, nil, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+    }
+    
+}
+
+extension Reactive where Base : UITableViewCell {
+
+    var diposeOnReuseDisposeBag : DisposeBag {
+        
+        guard let disposeBag =  objc_getAssociatedObject(base, &disposeBagKey) as? DisposeBag else{
+            let disposeBag = DisposeBag()
+            objc_setAssociatedObject(base, &disposeBagKey, disposeBag, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
+            methodInvoked(#selector(Base.prepareForReuse)).subscribe(onNext: { [weak base] (_) in
+                base?.diposeOnReuse()
+            }).disposed(by: disposeBag)
+            return disposeBag
+        }
+        
+        return disposeBag
+    }
+    
+}

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -1200,7 +1200,7 @@
 					};
 					C83366DC1AD0293800C668A7 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = 783T66X79Y;
+						DevelopmentTeam = 6U23444BFT;
 						LastSwiftMigration = 0800;
 					};
 					C849EF601C3190360048AC4A = {
@@ -1867,7 +1867,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 783T66X79Y;
+				DEVELOPMENT_TEAM = 6U23444BFT;
 				INFOPLIST_FILE = "RxExample/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1882,7 +1882,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 783T66X79Y;
+				DEVELOPMENT_TEAM = 6U23444BFT;
 				INFOPLIST_FILE = "RxExample/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -2089,7 +2089,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 783T66X79Y;
+				DEVELOPMENT_TEAM = 6U23444BFT;
 				INFOPLIST_FILE = "RxExample/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/scripts/.jazzy.yml
+++ b/scripts/.jazzy.yml
@@ -1,0 +1,2 @@
+---
+custom_categories: []


### PR DESCRIPTION
Hi
I have added an extension for UITableViewCell. It provides a dispose bag that disposes its subscriptions on reuse. It can be used like this:

 
    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
        guard let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as? SomeTableViewCellWithControl else {
            fatalError("")
        }
        let model =  models[indexPath.row]
        cell.label.text = model.name
        cell.button
            .rx
            .controlEvent(.touchUpInside).subscribe(onNext: { (_) in
                // Add what ever subscription that you want and it will be disposed on reuse and it will not add to create duplicate calls
            })
            .disposed(by: cell.rx.diposeOnReuseDisposeBag)
        return cell
    }