### PR TITLE
Fix documentation for drive function

### DIFF
--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -44,8 +44,8 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     Creates new subscription and sends elements to `BehaviorRelay`.
     This method can be only called from `MainThread`.
 
-    - parameter variable: Target variable for sequence elements.
-    - returns: Disposable object that can be used to unsubscribe the observer from the variable.
+    - parameter relay: Target relay for sequence elements.
+    - returns: Disposable object that can be used to unsubscribe the observer from the relay.
     */
     public func drive(_ relay: BehaviorRelay<E>) -> Disposable {
         MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
@@ -55,11 +55,11 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     }
 
     /**
-     Creates new subscription and sends elements to variable.
+     Creates new subscription and sends elements to `BehaviorRelay`.
      This method can be only called from `MainThread`.
 
-     - parameter variable: Target variable for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer from the variable.
+     - parameter relay: Target relay for sequence elements.
+     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func drive(_ relay: BehaviorRelay<E?>) -> Disposable {
         MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)


### PR DESCRIPTION
This commit replaces the 'variable' references for 2 'drive' functions
by 'relay' references.