### PR TITLE
Add insert(...) to DisposeBag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
 
 #### Anomalies
 
+## [4.X.X](https://github.com/ReactiveX/RxSwift/releases/tag/4.X.X)
+
+* Adds new `insert` extension to collect and add multiple disposables to `DisposeBag`.
+
 ## [4.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.2.0)
 
 * Adds Smart Key Path subscripting to create a binder for property of object.

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -44,6 +44,9 @@
 		4613457C1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */; };
 		46307D4E1CDE77D800E47A1C /* UIAlertAction+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */; };
 		46307D4F1CDE77D800E47A1C /* UIAlertAction+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */; };
+		4C8DE0E220D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
+		4C8DE0E320D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
+		4C8DE0E420D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		54700CA01CE37E1800EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54700CA11CE37E1900EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54D2138E1CE0824E0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
@@ -1772,6 +1775,7 @@
 		461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+Rx.swift"; sourceTree = "<group>"; };
 		4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxWebViewDelegateProxy.swift; sourceTree = "<group>"; };
 		46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Rx.swift"; sourceTree = "<group>"; };
+		4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBagTest.swift; sourceTree = "<group>"; };
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
@@ -2806,6 +2810,7 @@
 				C8A53AE41F09292A00490535 /* Completable+AndThen.swift */,
 				C83509061C38706D0027C24C /* CurrentThreadSchedulerTest.swift */,
 				C83509071C38706D0027C24C /* DisposableTest.swift */,
+				4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */,
 				C822BAC51DB4048F00F98810 /* Event+Test.swift */,
 				C83509081C38706D0027C24C /* HistoricalSchedulerTest.swift */,
 				C83509091C38706D0027C24C /* MainSchedulerTests.swift */,
@@ -4348,6 +4353,7 @@
 				844BC8BB1CE5024500F5C7CB /* UIPickerView+RxTests.swift in Sources */,
 				C801DE361F6EAD3C008DB060 /* SingleTest.swift in Sources */,
 				C896A68B1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift in Sources */,
+				4C8DE0E220D54545003E2D8A /* DisposeBagTest.swift in Sources */,
 				C820A9AA1EB505A800D431BC /* Observable+WithLatestFromTests.swift in Sources */,
 				C8D970E61F532FD30058F2FE /* SharedSequence+Test.swift in Sources */,
 				C820A94E1EB4EC3C00D431BC /* Observable+ReduceTests.swift in Sources */,
@@ -4614,6 +4620,7 @@
 				C820AA031EB5134000D431BC /* Observable+DelaySubscriptionTests.swift in Sources */,
 				7EDBAEC31C89BCB9006CBE67 /* UITabBarItem+RxTests.swift in Sources */,
 				C8091C541FAA3588001DB32A /* ObservableConvertibleType+SharedSequence.swift in Sources */,
+				4C8DE0E320D54545003E2D8A /* DisposeBagTest.swift in Sources */,
 				914FCD681CCDB82E0058B304 /* UIPageControl+RxTest.swift in Sources */,
 				C8A81CA71E05EAF70008DEF4 /* Binder+Tests.swift in Sources */,
 				C83509DD1C38754C0027C24C /* EquatableArray.swift in Sources */,
@@ -4724,6 +4731,7 @@
 				C8E3906A1F379386004FC993 /* Observable+EnumeratedTests.swift in Sources */,
 				C8353CEB1DA19BC500BE3F5C /* TestErrors.swift in Sources */,
 				C8B2908B1C94D64700E923D0 /* RxTest+Controls.swift in Sources */,
+				4C8DE0E420D54545003E2D8A /* DisposeBagTest.swift in Sources */,
 				C8C4F1751DE9D80A00003FA7 /* NSSlider+RxTests.swift in Sources */,
 				C820A9E41EB50D6C00D431BC /* Observable+SampleTests.swift in Sources */,
 				C8F03F511DBBAE9400AECC4C /* DispatchQueue+Extensions.swift in Sources */,

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -86,12 +86,7 @@ public final class DisposeBag: DisposeBase {
 extension DisposeBag {
     /// Convenience function allows a list of disposables to be gathered for disposal.
     public func insert(_ disposables: Disposable...) {
-        _lock.lock(); defer { _lock.unlock() }
-        if _isDisposed {
-            disposables.forEach { $0.dispose() }
-        } else {
-            _disposables += disposables
-        }
+        insert(disposables)
     }
 
     /// Convenience function allows an array of disposables to be gathered for disposal.

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -32,14 +32,14 @@ public final class DisposeBag: DisposeBase {
     private var _lock = SpinLock()
     
     // state
-    private var _disposables = [Disposable]()
-    private var _isDisposed = false
+    fileprivate var _disposables = [Disposable]()
+    fileprivate var _isDisposed = false
     
     /// Constructs new empty dispose bag.
     public override init() {
         super.init()
     }
-    
+
     /// Adds `disposable` to be disposed when dispose bag is being deinited.
     ///
     /// - parameter disposable: Disposable to add.
@@ -80,5 +80,17 @@ public final class DisposeBag: DisposeBase {
     
     deinit {
         dispose()
+    }
+}
+
+extension DisposeBag {
+    /// Convenience function allows a list of disposables to be gathered for disposal.
+    public func insert(_ disposables: Disposable...) {
+        _lock.lock(); defer { _lock.unlock() }
+        if _isDisposed {
+            disposables.forEach { $0.dispose() }
+        } else {
+            _disposables += disposables
+        }
     }
 }

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -93,4 +93,14 @@ extension DisposeBag {
             _disposables += disposables
         }
     }
+
+    /// Convenience function allows an array of disposables to be gathered for disposal.
+    public func insert(_ disposables: [Disposable]) {
+        _lock.lock(); defer { _lock.unlock() }
+        if _isDisposed {
+            disposables.forEach { $0.dispose() }
+        } else {
+            _disposables += disposables
+        }
+    }
 }

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -84,6 +84,19 @@ public final class DisposeBag: DisposeBase {
 }
 
 extension DisposeBag {
+
+    /// Convenience init allows a list of disposables to be gathered for disposal.
+    public convenience init(disposing disposables: Disposable...) {
+        self.init()
+        _disposables += disposables
+    }
+
+    /// Convenience init allows an array of disposables to be gathered for disposal.
+    public convenience init(disposing disposables: [Disposable]) {
+        self.init()
+        _disposables += disposables
+    }
+
     /// Convenience function allows a list of disposables to be gathered for disposal.
     public func insert(_ disposables: Disposable...) {
         insert(disposables)

--- a/Sources/AllTestz/DisposeBagTest.swift
+++ b/Sources/AllTestz/DisposeBagTest.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/DisposeBagTest.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -198,6 +198,7 @@ final class DisposeBagTest_ : DisposeBagTest, RxTestCase {
     static var allTests: [(String, (DisposeBagTest_) -> () -> ())] { return [
     ("testDisposeBagInsert", DisposeBagTest.testDisposeBagInsert),
     ("testDisposeBagVaradicInsert", DisposeBagTest.testDisposeBagVaradicInsert),
+    ("testDisposeBagVaradicInsertArray", DisposeBagTest.testDisposeBagVaradicInsertArray),
     ] }
 }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -188,6 +188,19 @@ final class DisposableTest_ : DisposableTest, RxTestCase {
     ] }
 }
 
+final class DisposeBagTest_ : DisposeBagTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (DisposeBagTest_) -> () -> ())] { return [
+    ("testDisposeBagInsert", DisposeBagTest.testDisposeBagInsert),
+    ("testDisposeBagVaradicInsert", DisposeBagTest.testDisposeBagVaradicInsert),
+    ] }
+}
+
 final class DriverTest_ : DriverTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1975,6 +1988,7 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(ConcurrentDispatchQueueSchedulerTests_.allTests),
         testCase(CurrentThreadSchedulerTest_.allTests),
         testCase(DisposableTest_.allTests),
+        testCase(DisposeBagTest_.allTests),
         testCase(DriverTest_.allTests),
         testCase(EventTests_.allTests),
         testCase(HistoricalSchedulerTest_.allTests),

--- a/Tests/RxSwiftTests/DisposeBagTest.swift
+++ b/Tests/RxSwiftTests/DisposeBagTest.swift
@@ -1,0 +1,69 @@
+//
+//  DisposeBagTest.swift
+//  Tests
+//
+//  Created by Michael Long on 6/16/18.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+class DisposeBagTest : RxTest {
+    override func setUp() {
+        super.setUp()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+}
+
+// DisposeBag insert test
+extension DisposeBagTest {
+
+    func testDisposeBagInsert() {
+        let disposable1 = TestDisposable()
+        let disposable2 = TestDisposable()
+
+        var disposeBag: DisposeBag? = DisposeBag()
+
+        disposeBag?.insert(disposable1)
+        disposeBag?.insert(disposable2)
+
+        XCTAssert(disposable1.count == 0)
+        XCTAssert(disposable2.count == 0)
+        disposeBag = nil
+        XCTAssert(disposable1.count == 1)
+        XCTAssert(disposable2.count == 1)
+    }
+
+}
+
+// DisposeBag bag test
+extension DisposeBagTest {
+
+    func testDisposeBagVaradicInsert() {
+        let disposable1 = TestDisposable()
+        let disposable2 = TestDisposable()
+
+        var disposeBag: DisposeBag? = DisposeBag()
+
+        disposeBag?.insert(disposable1, disposable2)
+
+        XCTAssert(disposable1.count == 0)
+        XCTAssert(disposable2.count == 0)
+        disposeBag = nil
+        XCTAssert(disposable1.count == 1)
+        XCTAssert(disposable2.count == 1)
+    }
+
+}
+
+fileprivate class TestDisposable: Disposable {
+    var count = 0
+    func dispose() {
+        count += 1
+    }
+}

--- a/Tests/RxSwiftTests/DisposeBagTest.swift
+++ b/Tests/RxSwiftTests/DisposeBagTest.swift
@@ -59,6 +59,21 @@ extension DisposeBagTest {
         XCTAssert(disposable2.count == 1)
     }
 
+    func testDisposeBagVaradicInsertArray() {
+        let disposable1 = TestDisposable()
+        let disposable2 = TestDisposable()
+
+        var disposeBag: DisposeBag? = DisposeBag()
+
+        disposeBag?.insert([disposable1, disposable2])
+
+        XCTAssert(disposable1.count == 0)
+        XCTAssert(disposable2.count == 0)
+        disposeBag = nil
+        XCTAssert(disposable1.count == 1)
+        XCTAssert(disposable2.count == 1)
+    }
+
 }
 
 fileprivate class TestDisposable: Disposable {


### PR DESCRIPTION
DisposeBags are a necessary evil in Swift's ARC-based environment. Who hasn't written the following code?

```
    viewModel.name.bind(to: nameLabel).disposed(by: disposeBag)
    viewModel.address.bind(to: addressLabel).disposed(by: disposeBag)
    viewModel.city.bind(to: cityLabel).disposed(by: disposeBag)
    viewModel.state.bind(to: stateLabel).disposed(by: disposeBag)
    viewModel.zip.bind(to: zipLabel).disposed(by: disposeBag)
```

Every element is properly disposed of with its own `.disposed(by: disposeBag)`, but we're writing a lot of boilerplate code in the process.

Worse, almost 40% of our code is devoted to housekeeping and memory management, obscuring our actual intent.

This [PR](https://github.com/ReactiveX/RxSwift/pull/1676) adds a simple addition to RxSwift's DisposeBag: Bag. 

With it, the above code can be written as follows:

```
    disposeBag.bag(
        viewModel.name.bind(to: nameLabel),
        viewModel.address.bind(to: addressLabel),
        viewModel.city.bind(to: cityLabel),
        viewModel.state.bind(to: stateLabel),
        viewModel.zip.bind(to: zipLabel)
    )
```

The disposeBag.bag() function simply gathers up (bags) all of the disposables into a Swift variadic function and inserts all of them into the DisposeBag as a single group.

Even better, our code is a lot cleaner and our actual intent is much more obvious.

DisposeBag.bag can be written as a simple extension...

```
extension DisposeBag {
    public func bag(_ disposables: Disposable...) {
        disposables.forEach { self.insert($0) }
    }
}
```

But baking it directly into DisposeBag makes the functionality much more performant, requiring only a single lock/unlock pair and a single memory reallocation to the _disposables array. 

```
extension DisposeBag {
    public func bag(_ disposables: Disposable...) {
        _lock.lock(); defer { _lock.unlock() }
        if _isDisposed {
            disposables.forEach { $0.dispose() }
        } else {
            _disposables += disposables
        }
    }
}
```

One should note that in our first code sample each individual `.bind(to:).disposed(by: disposeBag)` is going to require its own individual lock/insert/unlock as well. DisposeBag.bag() avoids this.

So. Less code. Clearer code. Faster code. What's not to like?