### PR TITLE
Allow specifying a queue priority on OperationQueueScheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+* Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
+
 #### Anomalies
 
 ## [4.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.2.0)

--- a/RxSwift/Schedulers/OperationQueueScheduler.swift
+++ b/RxSwift/Schedulers/OperationQueueScheduler.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import class Foundation.Operation
 import class Foundation.OperationQueue
 import class Foundation.BlockOperation
 import Dispatch
@@ -15,12 +16,15 @@ import Dispatch
 /// This scheduler is suitable for cases when there is some bigger chunk of work that needs to be performed in background and you want to fine tune concurrent processing using `maxConcurrentOperationCount`.
 public class OperationQueueScheduler: ImmediateSchedulerType {
     public let operationQueue: OperationQueue
+    public let queuePriority: Operation.QueuePriority
     
     /// Constructs new instance of `OperationQueueScheduler` that performs work on `operationQueue`.
     ///
     /// - parameter operationQueue: Operation queue targeted to perform work on.
-    public init(operationQueue: OperationQueue) {
+    /// - parameter queuePriority: Queue priority which will be assigned to new operations.
+    public init(operationQueue: OperationQueue, queuePriority: Operation.QueuePriority = .normal) {
         self.operationQueue = operationQueue
+        self.queuePriority = queuePriority
     }
     
     /**
@@ -41,6 +45,8 @@ public class OperationQueueScheduler: ImmediateSchedulerType {
 
             cancel.setDisposable(action(state))
         }
+
+        operation.queuePriority = self.queuePriority
 
         self.operationQueue.addOperation(operation)
         

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -856,6 +856,18 @@ final class ObservableFilterTest_ : ObservableFilterTest, RxTestCase {
     ] }
 }
 
+final class OperationQueueSchedulerTests_ : OperationQueueSchedulerTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (OperationQueueSchedulerTests_) -> () -> ())] { return [
+    ("test_scheduleWithPriority", OperationQueueSchedulerTests.test_scheduleWithPriority),
+    ] }
+}
+
 final class ObservableAmbTest_ : ObservableAmbTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1991,6 +2003,7 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(ObservableSkipUntilTest_.allTests),
         testCase(ObservableDefaultIfEmptyTest_.allTests),
         testCase(ObservableFilterTest_.allTests),
+        testCase(OperationQueueSchedulerTests_.allTests),
         testCase(ObservableAmbTest_.allTests),
         testCase(ObservableConcatTest_.allTests),
         testCase(EventTests_.allTests),

--- a/Tests/RxSwiftTests/SchedulerTests.swift
+++ b/Tests/RxSwiftTests/SchedulerTests.swift
@@ -27,6 +27,18 @@ final class SerialDispatchQueueSchedulerTests: RxTest {
     }
 }
 
+final class OperationQueueSchedulerTests: RxTest {
+    let operationQueue = OperationQueue()
+
+    func createHighPriorityScheduler() -> ImmediateSchedulerType {
+        return OperationQueueScheduler.init(operationQueue: operationQueue, queuePriority: .high)
+    }
+
+    func createLowPriorityScheduler() -> ImmediateSchedulerType {
+        return OperationQueueScheduler.init(operationQueue: operationQueue, queuePriority: .low)
+    }
+}
+
 extension ConcurrentDispatchQueueSchedulerTests {
     func test_scheduleRelative() {
         let expectScheduling = expectation(description: "wait")
@@ -123,5 +135,53 @@ extension ConcurrentDispatchQueueSchedulerTests {
         }
 
         XCTAssertEqual(times.count, 0)
+    }
+}
+
+extension OperationQueueSchedulerTests {
+    func test_scheduleWithPriority() {
+        let expectScheduling = expectation(description: "wait")
+
+        var times = [String]()
+
+        let highPriority = self.createHighPriorityScheduler()
+        let lowPriority = self.createLowPriorityScheduler()
+
+        var disposeBag = DisposeBag()
+
+        highPriority.schedule(Int.self) { (value) -> Disposable in
+            Thread.sleep(forTimeInterval: 0.4)
+            times.append("HIGH")
+
+            return Disposables.create()
+            }
+            .disposed(by: disposeBag)
+
+        lowPriority.schedule(Int.self) { (value) -> Disposable in
+            Thread.sleep(forTimeInterval: 1)
+            times.append("LOW")
+
+            expectScheduling.fulfill()
+
+            return Disposables.create()
+            }
+            .disposed(by: disposeBag)
+
+        highPriority.schedule(Int.self) { (value) -> Disposable in
+            Thread.sleep(forTimeInterval: 0.2)
+            times.append("HIGH")
+
+            return Disposables.create()
+            }
+            .disposed(by: disposeBag)
+
+        waitForExpectations(timeout: 4.0) { error in
+            XCTAssertNil(error)
+        }
+
+        disposeBag = DisposeBag()
+
+        XCTAssertEqual(3, times.count)
+        XCTAssertEqual(["HIGH", "HIGH", "LOW"], times)
     }
 }


### PR DESCRIPTION
This will allow users to activate a OperationQueueScheduler which supports setting a priority for all operations emitted by that scheduler.