### PR TITLE
Allow specifying a queue priority on OperationQueueScheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+* Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
+
 #### Anomalies
 
 ## [4.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.2.0)

--- a/RxSwift/Schedulers/OperationQueueScheduler.swift
+++ b/RxSwift/Schedulers/OperationQueueScheduler.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import class Foundation.Operation
 import class Foundation.OperationQueue
 import class Foundation.BlockOperation
 import Dispatch
@@ -15,12 +16,15 @@ import Dispatch
 /// This scheduler is suitable for cases when there is some bigger chunk of work that needs to be performed in background and you want to fine tune concurrent processing using `maxConcurrentOperationCount`.
 public class OperationQueueScheduler: ImmediateSchedulerType {
     public let operationQueue: OperationQueue
+    public let queuePriority: Operation.QueuePriority
     
     /// Constructs new instance of `OperationQueueScheduler` that performs work on `operationQueue`.
     ///
     /// - parameter operationQueue: Operation queue targeted to perform work on.
-    public init(operationQueue: OperationQueue) {
+    /// - parameter queuePriority: Queue priority which will be assigned to new operations.
+    public init(operationQueue: OperationQueue, queuePriority: Operation.QueuePriority = .normal) {
         self.operationQueue = operationQueue
+        self.queuePriority = queuePriority
     }
     
     /**
@@ -41,6 +45,8 @@ public class OperationQueueScheduler: ImmediateSchedulerType {
 
             cancel.setDisposable(action(state))
         }
+
+        operation.queuePriority = self.queuePriority
 
         self.operationQueue.addOperation(operation)
         

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1688,6 +1688,18 @@ final class ObserverTests_ : ObserverTests, RxTestCase {
     ] }
 }
 
+final class OperationQueueSchedulerTests_ : OperationQueueSchedulerTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (OperationQueueSchedulerTests_) -> () -> ())] { return [
+    ("test_scheduleWithPriority", OperationQueueSchedulerTests.test_scheduleWithPriority),
+    ] }
+}
+
 final class PublishSubjectTest_ : PublishSubjectTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -2027,6 +2039,7 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(ObservableWithLatestFromTest_.allTests),
         testCase(ObservableZipTest_.allTests),
         testCase(ObserverTests_.allTests),
+        testCase(OperationQueueSchedulerTests_.allTests),
         testCase(PublishSubjectTest_.allTests),
         testCase(ReactiveTests_.allTests),
         testCase(RecursiveLockTests_.allTests),


### PR DESCRIPTION
This will allow users to activate a OperationQueueScheduler which supports setting a priority for all operations emitted by that scheduler.