### PR TITLE
Add subscribe(...,onDisposed:) to Single

### DIFF
--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -40,6 +40,16 @@ extension SingleTest {
         XCTAssertEqual(events, [.error(testError)])
     }
 
+    func testSingle_Subscription_onDispose() {
+        let xs = Single.just(1)
+
+        var disposed = false
+
+        _ = xs.subscribe(onDisposed: { disposed = true })
+
+        XCTAssertEqual(disposed, true)
+    }
+
     func testSingle_create_success() {
         let scheduler = TestScheduler(initialClock: 0)
 


### PR DESCRIPTION
I was surprised that this parameter from `Observable.subscribe` was not available on `Single.subscribe`.

I'm not sure whether this qualifies as a [new operator](https://github.com/ReactiveX/RxSwift/blob/master/CONTRIBUTING.md#new-operators). It sounds like there was some resistance to #501 and #398 recommending to do `using` instead. Just let me know if you feel this PR belongs in the same bucket.

---

In my specific instance the `Single` is a promise/future, so I'm looking for a *finally*-like solution. This could be very concise like this:

```
single
  .subscribe(
    onSuccess: { ... }
    onError: { ... }
    onDisposed: alwaysDoThis
  )
```

Currently, I would have to use `do`:

```
single
  .do(
    onSuccess: { ... }
    onError: { ... }
    onDispose: alwaysDoThis
  )
  .subscribe()
```

or switch to Observable:

```
single
  .asObservable()
  .subscribe(
    onNext: { ... }
    onError: { ... }
    onDisposed: alwaysDoThis
  )
```

or repeat code (at the risk that one forgets calling it in one branch):

```
let alwaysDoThis = { ... }

single
  .subscribe(
    onSuccess: { ...; alwaysDoThis() }
    onError: { ...; alwaysDoThis() }
  )
```

or rely that `onDispose` will be called after onSuccess/onError (which feels odd and breaks the second someone inserts `observeOn` between the two instead of in front of them):

```
single
  .do(onDispose: { ... })
  .subscribe(
    onSuccess: { ... }
    onError: { ... }
  )
```