### PR TITLE
Add custom subscription callstack generation handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
 * Performance enhancement reduces Bag dispatch inline code size by 12%.
+* Adds `subscriptionCallstackGenerationHandler` hook to allow custom subscription callstacks to be generated.
 
 #### Anomalies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
 * Performance enhancement reduces Bag dispatch inline code size by 12%.
-* Adds `subscriptionCallstackHandler` hook to allow custom subscription callstacks to be generated.
+* Adds `customCaptureSubscriptionCallstack` hook to allow custom subscription callstacks to be generated.
 
 #### Anomalies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 * Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
 * Performance enhancement reduces Bag dispatch inline code size by 12%.
-* Adds `subscriptionCallstackGenerationHandler` hook to allow custom subscription callstacks to be generated.
+* Adds `subscriptionCallstackHandler` hook to allow custom subscription callstacks to be generated.
 
 #### Anomalies
 

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -51,7 +51,7 @@ extension ObservableType {
                 let synchronizationTracker = SynchronizationTracker()
             #endif
             
-            let callStack = Hooks.recordCallStackOnError ? Hooks.subscriptionCallstackHandler() : []
+            let callStack = Hooks.recordCallStackOnError ? Hooks.customCaptureSubscriptionCallstack() : []
             
             let observer = AnonymousObserver<E> { event in
                 
@@ -87,7 +87,7 @@ import class Foundation.NSRecursiveLock
 
 extension Hooks {
     public typealias DefaultErrorHandler = (_ subscriptionCallStack: [String], _ error: Error) -> ()
-    public typealias SubscriptionCallstackHandler = () -> [String]
+    public typealias CustomCaptureSubscriptionCallstack = () -> [String]
 
     fileprivate static let _lock = RecursiveLock()
     fileprivate static var _defaultErrorHandler: DefaultErrorHandler = { subscriptionCallStack, error in
@@ -96,7 +96,7 @@ extension Hooks {
             print("Unhandled error happened: \(error)\n subscription called from:\n\(serializedCallStack)")
         #endif
     }
-    fileprivate static var _subscriptionCallstackHandler: SubscriptionCallstackHandler = {
+    fileprivate static var _customCaptureSubscriptionCallstack: CustomCaptureSubscriptionCallstack = {
         #if DEBUG
             return Thread.callStackSymbols
         #else
@@ -116,15 +116,15 @@ extension Hooks {
         }
     }
     
-    /// Subscription callstack handler to fetch custom callstack information.
-    public static var subscriptionCallstackHandler: SubscriptionCallstackHandler {
+    /// Subscription callstack block to fetch custom callstack information.
+    public static var customCaptureSubscriptionCallstack: CustomCaptureSubscriptionCallstack {
         get {
             _lock.lock(); defer { _lock.unlock() }
-            return _subscriptionCallstackHandler
+            return _customCaptureSubscriptionCallstack
         }
         set {
             _lock.lock(); defer { _lock.unlock() }
-            _subscriptionCallstackHandler = newValue
+            _customCaptureSubscriptionCallstack = newValue
         }
     }
 }

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -38,78 +38,48 @@ extension ObservableType {
      */
     public func subscribe(onNext: ((E) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
         -> Disposable {
+            let disposable: Disposable
+            
+            if let disposed = onDisposed {
+                disposable = Disposables.create(with: disposed)
+            }
+            else {
+                disposable = Disposables.create()
+            }
+            
             #if DEBUG
-                let disposable: Disposable
-                
-                if let disposed = onDisposed {
-                    disposable = Disposables.create(with: disposed)
-                }
-                else {
-                    disposable = Disposables.create()
-                }
-                
                 let synchronizationTracker = SynchronizationTracker()
-
-                let callStack = Hooks.recordCallStackOnError ? Thread.callStackSymbols : []
-
-                let observer = AnonymousObserver<E> { event in
-                    
-                    synchronizationTracker.register(synchronizationErrorMessage: .default)
-                    defer { synchronizationTracker.unregister() }
-                    
-                    switch event {
-                    case .next(let value):
-                        onNext?(value)
-                    case .error(let error):
-                        if let onError = onError {
-                            onError(error)
-                        }
-                        else {
-                            Hooks.defaultErrorHandler(callStack, error)
-                        }
-                        disposable.dispose()
-                    case .completed:
-                        onCompleted?()
-                        disposable.dispose()
-                    }
-                }
-                return Disposables.create(
-                    self.asObservable().subscribe(observer),
-                    disposable
-                )
-            #else
-                let disposable: Disposable
-                
-                if let disposed = onDisposed {
-                    disposable = Disposables.create(with: disposed)
-                }
-                else {
-                    disposable = Disposables.create()
-                }
-                
-                let observer = AnonymousObserver<E> { event in
-                    switch event {
-                    case .next(let value):
-                        onNext?(value)
-                    case .error(let error):
-                        if let onError = onError {
-                            onError(error)
-                        }
-                        else {
-                            Hooks.defaultErrorHandler([], error)
-                        }
-                        disposable.dispose()
-                    case .completed:
-                        onCompleted?()
-                        disposable.dispose()
-                    }
-                }
-                return Disposables.create(
-                    self.asObservable().subscribe(observer),
-                    disposable
-                )
             #endif
             
+            let callStack = Hooks.subscriptionCallstackGenerationHandler()
+            
+            let observer = AnonymousObserver<E> { event in
+                
+                #if DEBUG
+                    synchronizationTracker.register(synchronizationErrorMessage: .default)
+                    defer { synchronizationTracker.unregister() }
+                #endif
+                
+                switch event {
+                case .next(let value):
+                    onNext?(value)
+                case .error(let error):
+                    if let onError = onError {
+                        onError(error)
+                    }
+                    else {
+                        Hooks.defaultErrorHandler(callStack, error)
+                    }
+                    disposable.dispose()
+                case .completed:
+                    onCompleted?()
+                    disposable.dispose()
+                }
+            }
+            return Disposables.create(
+                self.asObservable().subscribe(observer),
+                disposable
+            )
     }
 }
 
@@ -117,12 +87,21 @@ import class Foundation.NSRecursiveLock
 
 extension Hooks {
     public typealias DefaultErrorHandler = (_ subscriptionCallStack: [String], _ error: Error) -> ()
+    public typealias SubscriptionCallstackGenerationHandler = () -> [String]
 
     fileprivate static let _lock = RecursiveLock()
+    fileprivate static let _subscriptionCallstackLock = RecursiveLock()
     fileprivate static var _defaultErrorHandler: DefaultErrorHandler = { subscriptionCallStack, error in
         #if DEBUG
             let serializedCallStack = subscriptionCallStack.joined(separator: "\n")
             print("Unhandled error happened: \(error)\n subscription called from:\n\(serializedCallStack)")
+        #endif
+    }
+    fileprivate static var _subscriptionCallstackGenerationHandler: SubscriptionCallstackGenerationHandler = {
+        #if DEBUG
+            return Hooks.recordCallStackOnError ? Thread.callStackSymbols : []
+        #else
+            return []
         #endif
     }
 
@@ -135,6 +114,18 @@ extension Hooks {
         set {
             _lock.lock(); defer { _lock.unlock() }
             _defaultErrorHandler = newValue
+        }
+    }
+    
+    /// Subscription callstack handler to fetch custom callstack information.
+    public static var subscriptionCallstackGenerationHandler: SubscriptionCallstackGenerationHandler {
+        get {
+            _subscriptionCallstackLock.lock(); defer { _subscriptionCallstackLock.unlock() }
+            return _subscriptionCallstackGenerationHandler
+        }
+        set {
+            _subscriptionCallstackLock.lock(); defer { _subscriptionCallstackLock.unlock() }
+            _subscriptionCallstackGenerationHandler = newValue
         }
     }
 }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1306,7 +1306,7 @@ final class ObservableSubscriptionTest_ : ObservableSubscriptionTest, RxTestCase
 
     static var allTests: [(String, (ObservableSubscriptionTest_) -> () -> ())] { return [
     ("testDefaultErrorHandler", ObservableSubscriptionTest.testDefaultErrorHandler),
-    ("testCustomSubscriptionCallstackGeneration", ObservableSubscriptionTest.testCustomSubscriptionCallstackGeneration),
+    ("testSubscriptionCallstackHandler", ObservableSubscriptionTest.testSubscriptionCallstackHandler),
     ] }
 }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1306,7 +1306,7 @@ final class ObservableSubscriptionTest_ : ObservableSubscriptionTest, RxTestCase
 
     static var allTests: [(String, (ObservableSubscriptionTest_) -> () -> ())] { return [
     ("testDefaultErrorHandler", ObservableSubscriptionTest.testDefaultErrorHandler),
-    ("testSubscriptionCallstackHandler", ObservableSubscriptionTest.testSubscriptionCallstackHandler),
+    ("testCustomCaptureSubscriptionCallstack", ObservableSubscriptionTest.testCustomCaptureSubscriptionCallstack),
     ] }
 }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1306,6 +1306,7 @@ final class ObservableSubscriptionTest_ : ObservableSubscriptionTest, RxTestCase
 
     static var allTests: [(String, (ObservableSubscriptionTest_) -> () -> ())] { return [
     ("testDefaultErrorHandler", ObservableSubscriptionTest.testDefaultErrorHandler),
+    ("testCustomSubscriptionCallstackGeneration", ObservableSubscriptionTest.testCustomSubscriptionCallstackGeneration),
     ] }
 }
 

--- a/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
+++ b/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
@@ -35,5 +35,28 @@ extension ObservableSubscriptionTest {
         _ = Observable<Int>.error(testError).subscribe()
         XCTAssertEqual(loggedErrors, [testError])
     }
+    
+    func testCustomSubscriptionCallstackGeneration() {
+        var resultCallstack = [String]()
+        
+        Hooks.defaultErrorHandler = { callstack, _ in
+            resultCallstack = callstack
+        }
+        
+        _ = Observable<Int>.error(testError).subscribe()
+        XCTAssertEqual(resultCallstack, [])
+        
+        Hooks.subscriptionCallstackGenerationHandler = {
+            return ["frame1"]
+        }
+        _ = Observable<Int>.error(testError).subscribe()
+        XCTAssertEqual(resultCallstack, ["frame1"])
+        
+        Hooks.subscriptionCallstackGenerationHandler = {
+            return ["frame1", "frame2"]
+        }
+        _ = Observable<Int>.error(testError).subscribe()
+        XCTAssertEqual(resultCallstack, ["frame1", "frame2"])
+    }
 }
 

--- a/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
+++ b/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
@@ -36,7 +36,7 @@ extension ObservableSubscriptionTest {
         XCTAssertEqual(loggedErrors, [testError])
     }
     
-    func testSubscriptionCallstackHandler() {
+    func testCustomCaptureSubscriptionCallstack() {
         var resultCallstack = [String]()
         
         Hooks.defaultErrorHandler = { callstack, _ in
@@ -45,7 +45,7 @@ extension ObservableSubscriptionTest {
         _ = Observable<Int>.error(testError).subscribe()
         XCTAssertEqual(resultCallstack, [])
         
-        Hooks.subscriptionCallstackHandler = {
+        Hooks.customCaptureSubscriptionCallstack = {
             return ["frame1"]
         }
         _ = Observable<Int>.error(testError).subscribe()
@@ -55,7 +55,7 @@ extension ObservableSubscriptionTest {
         _ = Observable<Int>.error(testError).subscribe()
         XCTAssertEqual(resultCallstack, ["frame1"])
         
-        Hooks.subscriptionCallstackHandler = {
+        Hooks.customCaptureSubscriptionCallstack = {
             return ["frame1", "frame2"]
         }
         _ = Observable<Int>.error(testError).subscribe()

--- a/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
+++ b/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
@@ -36,7 +36,7 @@ extension ObservableSubscriptionTest {
         XCTAssertEqual(loggedErrors, [testError])
     }
     
-    func testCustomSubscriptionCallstackGeneration() {
+    func testSubscriptionCallstackHandler() {
         var resultCallstack = [String]()
         
         Hooks.defaultErrorHandler = { callstack, _ in

--- a/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
+++ b/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
@@ -42,17 +42,20 @@ extension ObservableSubscriptionTest {
         Hooks.defaultErrorHandler = { callstack, _ in
             resultCallstack = callstack
         }
-        
         _ = Observable<Int>.error(testError).subscribe()
         XCTAssertEqual(resultCallstack, [])
         
-        Hooks.subscriptionCallstackGenerationHandler = {
+        Hooks.subscriptionCallstackHandler = {
             return ["frame1"]
         }
         _ = Observable<Int>.error(testError).subscribe()
+        XCTAssertEqual(resultCallstack, [])
+        
+        Hooks.recordCallStackOnError = true
+        _ = Observable<Int>.error(testError).subscribe()
         XCTAssertEqual(resultCallstack, ["frame1"])
         
-        Hooks.subscriptionCallstackGenerationHandler = {
+        Hooks.subscriptionCallstackHandler = {
             return ["frame1", "frame2"]
         }
         _ = Observable<Int>.error(testError).subscribe()

--- a/Tests/RxTest.swift
+++ b/Tests/RxTest.swift
@@ -88,7 +88,7 @@ extension RxTest {
 
     func setUpActions(){
         _ = Hooks.defaultErrorHandler // lazy load resource so resource count matches
-        _ = Hooks.subscriptionCallstackHandler // lazy load resource so resource count matches
+        _ = Hooks.customCaptureSubscriptionCallstack // lazy load resource so resource count matches
         #if TRACE_RESOURCES
             self.startResourceCount = Resources.total
             //registerMallocHooks()

--- a/Tests/RxTest.swift
+++ b/Tests/RxTest.swift
@@ -88,6 +88,7 @@ extension RxTest {
 
     func setUpActions(){
         _ = Hooks.defaultErrorHandler // lazy load resource so resource count matches
+        _ = Hooks.subscriptionCallstackGenerationHandler // lazy load resource so resource count matches
         #if TRACE_RESOURCES
             self.startResourceCount = Resources.total
             //registerMallocHooks()

--- a/Tests/RxTest.swift
+++ b/Tests/RxTest.swift
@@ -88,7 +88,7 @@ extension RxTest {
 
     func setUpActions(){
         _ = Hooks.defaultErrorHandler // lazy load resource so resource count matches
-        _ = Hooks.subscriptionCallstackGenerationHandler // lazy load resource so resource count matches
+        _ = Hooks.subscriptionCallstackHandler // lazy load resource so resource count matches
         #if TRACE_RESOURCES
             self.startResourceCount = Resources.total
             //registerMallocHooks()


### PR DESCRIPTION
This pull request adds a hook to allow for a custom handler to generate callstacks at subscribe time. This is useful to allow for callstacks to be generated at runtime in production to track subscriptions not handling errors. A handler is provided to maintain the current default behavior.