### PR TITLE
Add `scan(into:accumulator:)` operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+* Adds `scan(into:accumulator:)`.
 * Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
 * Performance enhancement reduces Bag dispatch inline code size by 12%.
 

--- a/RxSwift/Observables/Scan.swift
+++ b/RxSwift/Observables/Scan.swift
@@ -43,7 +43,7 @@ final fileprivate class ScanSink<ElementType, O: ObserverType> : Sink<O>, Observ
         switch event {
         case .next(let element):
             do {
-                _accumulate = try _parent._accumulator(_accumulate, element)
+                try _parent._accumulator(&_accumulate, element)
                 forwardOn(.next(_accumulate))
             }
             catch let error {
@@ -62,7 +62,7 @@ final fileprivate class ScanSink<ElementType, O: ObserverType> : Sink<O>, Observ
 }
 
 final fileprivate class Scan<Element, Accumulate>: Producer<Accumulate> {
-    typealias Accumulator = (Accumulate, Element) throws -> Accumulate
+    typealias Accumulator = (inout Accumulate, Element) throws -> ()
     
     fileprivate let _source: Observable<Element>
     fileprivate let _seed: Accumulate

--- a/RxSwift/Observables/Scan.swift
+++ b/RxSwift/Observables/Scan.swift
@@ -19,9 +19,28 @@ extension ObservableType {
      - parameter accumulator: An accumulator function to be invoked on each element.
      - returns: An observable sequence containing the accumulated values.
      */
-    public func scan<A>(_ seed: A, accumulator: @escaping (A, E) throws -> A)
+    public func scan<A>(into seed: A, accumulator: @escaping (inout A, E) throws -> ())
         -> Observable<A> {
         return Scan(source: self.asObservable(), seed: seed, accumulator: accumulator)
+    }
+
+    /**
+     Applies an accumulator function over an observable sequence and returns each intermediate result. The specified seed value is used as the initial accumulator value.
+
+     For aggregation behavior with no intermediate results, see `reduce`.
+
+     - seealso: [scan operator on reactivex.io](http://reactivex.io/documentation/operators/scan.html)
+
+     - parameter seed: The initial accumulator value.
+     - parameter accumulator: An accumulator function to be invoked on each element.
+     - returns: An observable sequence containing the accumulated values.
+     */
+    public func scan<A>(_ seed: A, accumulator: @escaping (A, E) throws -> A)
+        -> Observable<A> {
+        return Scan(source: self.asObservable(), seed: seed) { acc, element in
+            let currentAcc = acc
+            acc = try accumulator(currentAcc, element)
+        }
     }
 }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1151,11 +1151,17 @@ final class ObservableScanTest_ : ObservableScanTest, RxTestCase {
 
     static var allTests: [(String, (ObservableScanTest_) -> () -> ())] { return [
     ("testScan_Seed_Never", ObservableScanTest.testScan_Seed_Never),
+    ("testScan_Into_Never", ObservableScanTest.testScan_Into_Never),
     ("testScan_Seed_Empty", ObservableScanTest.testScan_Seed_Empty),
+    ("testScan_Into_Empty", ObservableScanTest.testScan_Into_Empty),
     ("testScan_Seed_Return", ObservableScanTest.testScan_Seed_Return),
+    ("testScan_Into_Accumulate", ObservableScanTest.testScan_Into_Accumulate),
     ("testScan_Seed_Throw", ObservableScanTest.testScan_Seed_Throw),
+    ("testScan_Into_Throw", ObservableScanTest.testScan_Into_Throw),
     ("testScan_Seed_SomeData", ObservableScanTest.testScan_Seed_SomeData),
+    ("testScan_Into_SomeData", ObservableScanTest.testScan_Into_SomeData),
     ("testScan_Seed_AccumulatorThrows", ObservableScanTest.testScan_Seed_AccumulatorThrows),
+    ("testScan_Into_AccumulatorThrows", ObservableScanTest.testScan_Into_AccumulatorThrows),
     ] }
 }
 

--- a/Tests/RxCocoaTests/UIStepper+RxTests.swift
+++ b/Tests/RxCocoaTests/UIStepper+RxTests.swift
@@ -28,10 +28,10 @@ import XCTest
             let stepValue: Double = 0.42
 
             stepper.stepValue = 1.0
-            XCTAssertEqualWithAccuracy(stepper.stepValue, 1.0, accuracy: 0.0001)
+            XCTAssertEqual(stepper.stepValue, 1.0, accuracy: 0.0001)
 
             Observable.just(stepValue).bind(to: stepper.rx.stepValue).dispose()
-            XCTAssertEqualWithAccuracy(stepper.stepValue, stepValue, accuracy: 0.0001)
+            XCTAssertEqual(stepper.stepValue, stepValue, accuracy: 0.0001)
         }
     }
 

--- a/Tests/RxSwiftTests/Observable+ScanTests.swift
+++ b/Tests/RxSwiftTests/Observable+ScanTests.swift
@@ -35,6 +35,27 @@ extension ObservableScanTest {
             ])
     }
 
+    func testScan_Into_Never() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            .next(0, 0)
+            ])
+
+        let seed = 42
+
+        let res = scheduler.start {
+            xs.scan(into: seed) { $0 += $1 }
+        }
+
+        XCTAssertEqual(res.events, [
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 1000)
+            ])
+    }
+
     func testScan_Seed_Empty() {
         let scheduler = TestScheduler(initialClock: 0)
 
@@ -47,6 +68,29 @@ extension ObservableScanTest {
 
         let res = scheduler.start {
             xs.scan(seed) { $0 + $1 }
+        }
+
+        XCTAssertEqual(res.events, [
+            .completed(250)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+            ])
+    }
+
+    func testScan_Into_Empty() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .completed(250)
+            ])
+
+        let seed = 42
+
+        let res = scheduler.start {
+            xs.scan(into: seed) { $0 += $1 }
         }
 
         XCTAssertEqual(res.events, [
@@ -83,6 +127,31 @@ extension ObservableScanTest {
             ])
     }
 
+    func testScan_Into_Accumulate() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(220, 2),
+            .completed(250)
+            ])
+
+        let seed = 42
+
+        let res = scheduler.start {
+            xs.scan(into: seed) { $0 += $1 }
+        }
+
+        XCTAssertEqual(res.events, [
+            .next(220, seed + 2),
+            .completed(250)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+            ])
+    }
+
     func testScan_Seed_Throw() {
         let scheduler = TestScheduler(initialClock: 0)
 
@@ -95,6 +164,29 @@ extension ObservableScanTest {
 
         let res = scheduler.start {
             xs.scan(seed) { $0 + $1 }
+        }
+
+        XCTAssertEqual(res.events, [
+            .error(250, testError)
+            ])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+            ])
+    }
+
+    func testScan_Into_Throw() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .error(250, testError)
+            ])
+
+        let seed = 42
+
+        let res = scheduler.start {
+            xs.scan(into: seed) { $0 += $1 }
         }
 
         XCTAssertEqual(res.events, [
@@ -122,6 +214,39 @@ extension ObservableScanTest {
 
         let res = scheduler.start {
             xs.scan(seed) { $0 + $1 }
+        }
+
+        let messages = Recorded.events(
+            .next(210, seed + 2),
+            .next(220, seed + 2 + 3),
+            .next(230, seed + 2 + 3 + 4),
+            .next(240, seed + 2 + 3 + 4 + 5),
+            .completed(250)
+        )
+
+        XCTAssertEqual(res.events, messages)
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+            ])
+    }
+
+    func testScan_Into_SomeData() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .next(230, 4),
+            .next(240, 5),
+            .completed(250)
+            ])
+
+        let seed = 42
+
+        let res = scheduler.start {
+            xs.scan(into: seed) { $0 += $1 }
         }
 
         let messages = Recorded.events(
@@ -173,6 +298,42 @@ extension ObservableScanTest {
             Subscription(200, 230)
             ])
     }
+
+    func testScan_Into_AccumulatorThrows() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .next(230, 4),
+            .next(240, 5),
+            .completed(250)
+            ])
+
+        let seed = 42
+
+        let res = scheduler.start {
+            xs.scan(into: seed) { a, e in
+                if e == 4 {
+                    throw testError
+                } else {
+                    a += e
+                }
+            }
+        }
+
+        XCTAssertEqual(res.events, [
+            .next(210, seed + 2),
+            .next(220, seed + 2 + 3),
+            .error(230, testError)
+            ] as [Recorded<Event<Int>>])
+
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 230)
+            ])
+    }
+
 
     #if TRACE_RESOURCES
         func testScanReleasesResourcesOnComplete() {


### PR DESCRIPTION
Fixes #1667. 

This PR adds `scan(into:accumulator:)` operator where the `accumulator`'s first argument is `inout`, similar to [`reduce(into:)` in stdlib](https://developer.apple.com/documentation/swift/array/2924692-reduce). 

The existing `scan(_ seed: accumulator:)` preserves its existing behavior as a fallback, by using the new operator.