### PR TITLE
Rename some class name for iOS 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+* Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
 * Performance enhancement reduces Bag dispatch inline code size by 12%.
 
 #### Anomalies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,404 +1,409 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 ---
+
 ## Master
 
-* Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
-* Performance enhancement reduces Bag dispatch inline code size by 12%.
+- Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
+- Performance enhancement reduces Bag dispatch inline code size by 12%.
 
 #### Anomalies
 
 ## [4.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.2.0)
 
-* Adds Smart Key Path subscripting to create a binder for property of object.
-* Adds `UICollectionView` extensions:
-    * `prefetchItems`
-    * cancelPrefetchingForItems
-* Adds `UITableView` extensions:
-    * `prefetchRows`
-    * `cancelPrefetchingForRows`
-* Fixes various spelling mistakes and missing parameters.
-* Adds `UISegmentedControlExtensions`:
-    * `titleForSegment(at:)`
-    * `imageForSegment(at:)`
-* Adds `Maybe.ifEmpty(default:)` operator.
-* Adds `Maybe.ifEmpty(switchTo:)` operator.
-* Adds `Maybe.catchErrorJustReturn(_:)` operator.
-* Add  `Single.flatMapMaybe(_:)` operator.
-* Add  `Single.flatMapCompletable(_:)` operator.
-* Add  `Single.zip(_:)` operator.
-* Add  `Single.catchErrorJustReturn(_:)` operator.
-* Add  `Single.asMaybe(_:)` operator.
-* Add  `Single.asCompletable(_:)` operator.
+- Adds Smart Key Path subscripting to create a binder for property of object.
+- Adds `UICollectionView` extensions:
+  - `prefetchItems`
+  - cancelPrefetchingForItems
+- Adds `UITableView` extensions:
+  - `prefetchRows`
+  - `cancelPrefetchingForRows`
+- Fixes various spelling mistakes and missing parameters.
+- Adds `UISegmentedControlExtensions`:
+  - `titleForSegment(at:)`
+  - `imageForSegment(at:)`
+- Adds `Maybe.ifEmpty(default:)` operator.
+- Adds `Maybe.ifEmpty(switchTo:)` operator.
+- Adds `Maybe.catchErrorJustReturn(_:)` operator.
+- Add `Single.flatMapMaybe(_:)` operator.
+- Add `Single.flatMapCompletable(_:)` operator.
+- Add `Single.zip(_:)` operator.
+- Add `Single.catchErrorJustReturn(_:)` operator.
+- Add `Single.asMaybe(_:)` operator.
+- Add `Single.asCompletable(_:)` operator.
 
 #### Anomalies
 
-* Lower macOS Deployment Target to 10.9
-* Deprecates `UISegmentedControl.enabled(forSegmentAt:)` in favor of `UISegmentedControl.enabledForSegment(at:)`.
+- Lower macOS Deployment Target to 10.9
+- Deprecates `UISegmentedControl.enabled(forSegmentAt:)` in favor of `UISegmentedControl.enabledForSegment(at:)`.
 
 ## [4.1.2](https://github.com/ReactiveX/RxSwift/releases/tag/4.1.2)
 
-* Adds deprecation warner.
+- Adds deprecation warner.
 
 #### Anomalies
 
-* Fixes ambiguity issue with  `Single.do(onNext:onError:onSubscribe:onSubscribed:onDispose:)` and `Single.do(onSuccess:onError:onSubscribe:onSubscribed:onDispose:)`.
+- Fixes ambiguity issue with `Single.do(onNext:onError:onSubscribe:onSubscribed:onDispose:)` and `Single.do(onSuccess:onError:onSubscribe:onSubscribed:onDispose:)`.
 
 ## [4.1.1](https://github.com/ReactiveX/RxSwift/releases/tag/4.1.1)
 
 #### Anomalies
 
-* Fixes compilation issue with  Xcode 9.1.
-* Deprecates `Single.do(onNext:onError:onSubscribe:onSubscribed:onDispose:)` in favor of `Single.do(onSuccess:onError:onSubscribe:onSubscribed:onDispose:)`.
+- Fixes compilation issue with Xcode 9.1.
+- Deprecates `Single.do(onNext:onError:onSubscribe:onSubscribed:onDispose:)` in favor of `Single.do(onSuccess:onError:onSubscribe:onSubscribed:onDispose:)`.
 
 ## [4.1.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.1.0)
 
-* Adds `Recorded<Event<T>>` array factory method in **RxTest**. #1531
-* Replaces global functions `next`, `error`, `completed` with `Recorded.next`, `Recorded.error`, `Recorded.completed` in **RxTest**. #1510
-* Removes `AnyObject` constraint from `Delegate` parameter on `DelegateProxy`. #1442
-* Adds `ObservableType.bind(to:)` overloads for `PublishRelay` and `BehaviorRelay`.
-* Adds `ControlEvent.asSignal()`.
-* Adds `UISegmentedControl.rx.enabled(forSegmentAt:)` extension.
-* Adds `UIStepper.rx.stepValue` extension.
-* Adds error handling Hook to `Single`, `Maybe` and `Completable`. #1532
-* Adds `recordCallStackOnError` to improve performance of `DEBUG` configuration.
+- Adds `Recorded<Event<T>>` array factory method in **RxTest**. #1531
+- Replaces global functions `next`, `error`, `completed` with `Recorded.next`, `Recorded.error`, `Recorded.completed` in **RxTest**. #1510
+- Removes `AnyObject` constraint from `Delegate` parameter on `DelegateProxy`. #1442
+- Adds `ObservableType.bind(to:)` overloads for `PublishRelay` and `BehaviorRelay`.
+- Adds `ControlEvent.asSignal()`.
+- Adds `UISegmentedControl.rx.enabled(forSegmentAt:)` extension.
+- Adds `UIStepper.rx.stepValue` extension.
+- Adds error handling Hook to `Single`, `Maybe` and `Completable`. #1532
+- Adds `recordCallStackOnError` to improve performance of `DEBUG` configuration.
 
 #### Anomalies
 
-* Changes return value of blocking version of `single` operator from `E?` to `E`. #1525
-* Removes deprecation attribute from `asSharedSequence`.
+- Changes return value of blocking version of `single` operator from `E?` to `E`. #1525
+- Removes deprecation attribute from `asSharedSequence`.
 
 ## [4.0.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.0.0)
 
-* Adds global Hooks and implements error handling hook.
-* Deprecates `asSharedSequence` extensions on `ObservableType`.
-* Publicly exposes `controlProperty`.
+- Adds global Hooks and implements error handling hook.
+- Deprecates `asSharedSequence` extensions on `ObservableType`.
+- Publicly exposes `controlProperty`.
 
 #### Anomalies
 
-* Changes `Observable` extensions to `ObservableType` extensions.
-* Changes `didUpdateFocusInContextWithAnimationCoordinator` `UITableView` extension argument to `UITableViewFocusUpdateContext`.
-* Changes access modifier of `DelegateProxy.setForwardToDelegate` to `open`.
+- Changes `Observable` extensions to `ObservableType` extensions.
+- Changes `didUpdateFocusInContextWithAnimationCoordinator` `UITableView` extension argument to `UITableViewFocusUpdateContext`.
+- Changes access modifier of `DelegateProxy.setForwardToDelegate` to `open`.
 
 ## [4.0.0-rc.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.0.0-rc.0)
 
-* Deprecates `image(transitionType:)` in favor of `image`.
-* Changes return type of `ignoreElements` to `Completable`. #1436
-* Removes warning of sequence completion from `Binder`. #1431
-* Deprecates `Variable` in favor of `BehaviorRelay`.
+- Deprecates `image(transitionType:)` in favor of `image`.
+- Changes return type of `ignoreElements` to `Completable`. #1436
+- Removes warning of sequence completion from `Binder`. #1431
+- Deprecates `Variable` in favor of `BehaviorRelay`.
 
 ## [4.0.0-beta.1](https://github.com/ReactiveX/RxSwift/releases/tag/4.0.0-beta.1)
 
-* Adds `attributedText` to `UITextField`. #1249
-* Adds `attributedText` to `UITextView`. #1249
-* Deprecates `shareReplayLatestWhileConnected` and `shareReplay` in favor of `share(replay:scope:)`. #1430
-* Changes `publish`, `replay`, `replayAll` to clear state in case of sequence termination to be more consistent with other Rx implementations and enable retries. #1430
-* Replaces `share` with default implementation of `share(replay:scope:)`. #1430
-* Adds `HasDelegate` and `HasDataSource` protocols.
-* Updates package version to v4 format. #1418
+- Adds `attributedText` to `UITextField`. #1249
+- Adds `attributedText` to `UITextView`. #1249
+- Deprecates `shareReplayLatestWhileConnected` and `shareReplay` in favor of `share(replay:scope:)`. #1430
+- Changes `publish`, `replay`, `replayAll` to clear state in case of sequence termination to be more consistent with other Rx implementations and enable retries. #1430
+- Replaces `share` with default implementation of `share(replay:scope:)`. #1430
+- Adds `HasDelegate` and `HasDataSource` protocols.
+- Updates package version to v4 format. #1418
 
 #### Anomalies
 
-* Adds deprecated warnings to API parts that were missing it. #1427
-* Improves memory handling in `isScheduleRequiredKey`. #1428
-* Removes pre-release identifier from bundle version to enable `TestFlight` submissions. #1424
-* Removes code coverage to enable `TestFlight` submissions. #1423
-* Fixes Xcode warnings. #1421
+- Adds deprecated warnings to API parts that were missing it. #1427
+- Improves memory handling in `isScheduleRequiredKey`. #1428
+- Removes pre-release identifier from bundle version to enable `TestFlight` submissions. #1424
+- Removes code coverage to enable `TestFlight` submissions. #1423
+- Fixes Xcode warnings. #1421
 
 ## [4.0.0-beta.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.0.0-beta.0)
 
-* Adds `materialize()` operator for RxBlocking's `BlockingObservable`. #1383
-* Adds `first` operator to `ObservableType`.
-* Deprecates `UIBindingObserver` in favor of `Binder`. #1411
-* Adds another specialization of `SharedSequence` called `Signal`.
-* Refactors `DelegateProxy` to be type safe.
-* Changes nested `SharedSequence` strategy to use inner sharing strategy for result.
+- Adds `materialize()` operator for RxBlocking's `BlockingObservable`. #1383
+- Adds `first` operator to `ObservableType`.
+- Deprecates `UIBindingObserver` in favor of `Binder`. #1411
+- Adds another specialization of `SharedSequence` called `Signal`.
+- Refactors `DelegateProxy` to be type safe.
+- Changes nested `SharedSequence` strategy to use inner sharing strategy for result.
 
 #### Anomalies
 
-* Call `controlTextDidChange(…)` as an optional method. #1406
-* Fixed issue with `NSControl.rx.value` regarding multiple observers. #1399
-* Removes useless extensions from `PrimitiveSequence`. #1248
+- Call `controlTextDidChange(…)` as an optional method. #1406
+- Fixed issue with `NSControl.rx.value` regarding multiple observers. #1399
+- Removes useless extensions from `PrimitiveSequence`. #1248
 
 ## [4.0.0-alpha.1](https://github.com/ReactiveX/RxSwift/releases/tag/4.0.0-alpha.1)
 
-* Merge of `3.6.1` changes.
-* Adds `UIScrollView.willEndDragging` extension. #1365
-* Adds `enumerated` operator (deprecates `skipWhileWithIndex`, `takeWhileWithIndex`, `flatMapWithIndex`, `mapWithIndex`).
+- Merge of `3.6.1` changes.
+- Adds `UIScrollView.willEndDragging` extension. #1365
+- Adds `enumerated` operator (deprecates `skipWhileWithIndex`, `takeWhileWithIndex`, `flatMapWithIndex`, `mapWithIndex`).
 
 #### Anomalies
-* Fixes gesture recognizer extensions crash. #1382
-* Adds `onSubscribed` parameter to `SharedSequence` extensions.
+
+- Fixes gesture recognizer extensions crash. #1382
+- Adds `onSubscribed` parameter to `SharedSequence` extensions.
 
 ## [4.0.0-alpha.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.0.0-alpha.0)
-* Swift 4.0 compatibility
-* Changes delegate proxy to use plugin architecture. 
+
+- Swift 4.0 compatibility
+- Changes delegate proxy to use plugin architecture.
 
 #### Anomalies
-* Fixes public interface leakage of `NSKeyValueObservingOptions`. #1164
+
+- Fixes public interface leakage of `NSKeyValueObservingOptions`. #1164
 
 ## [3.6.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.6.1)
 
 #### Anomalies
 
-* Fixes compilation issue with Xcode 9b3. #1341
-* Fixes issues with `andThen` operator. #1347
-* Improves locking behavior of `merge` and `switch` operators. #1344
+- Fixes compilation issue with Xcode 9b3. #1341
+- Fixes issues with `andThen` operator. #1347
+- Improves locking behavior of `merge` and `switch` operators. #1344
 
 ## [3.6.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.6.0)
 
-* Adds `timeout` operator to `PrimitiveSequence` (`Single`, `Maybe`, `Observable`)
-* Adds `delay` operator to `SharedSequence`.
-* Adds `andThen` operator to `Completeable`.
-* Adds `concat` operator to `Completeable`.
-* Adds `RxPickerViewDataSourceType`
-* Adds `UIPickerView` extensions:
-    * `modelSelected`
-    * `itemTitles`
-    * `itemAttributedTitles`
-    * `items`
-* Adds `UITableView` extensions:
-    * `modelDeleted`
-* Adds `UICollectionView` extensions:
-    * `itemHighlighted`
-    * `itemUnhighlighted`
-    * `willDisplayCell`
-    * `didEndDisplayingCell`
-    * `willDisplaySupplementaryView`
-    * `didEndDisplayingSupplementaryView`
-* Adds `UIScrollView` extensions:
-    * `willBeginDecelerating`
-    * `willBeginDragging`
-    * `willBeginZooming`
-    * `didEndZooming`
+- Adds `timeout` operator to `PrimitiveSequence` (`Single`, `Maybe`, `Observable`)
+- Adds `delay` operator to `SharedSequence`.
+- Adds `andThen` operator to `Completeable`.
+- Adds `concat` operator to `Completeable`.
+- Adds `RxPickerViewDataSourceType`
+- Adds `UIPickerView` extensions:
+  - `modelSelected`
+  - `itemTitles`
+  - `itemAttributedTitles`
+  - `items`
+- Adds `UITableView` extensions:
+  - `modelDeleted`
+- Adds `UICollectionView` extensions:
+  - `itemHighlighted`
+  - `itemUnhighlighted`
+  - `willDisplayCell`
+  - `didEndDisplayingCell`
+  - `willDisplaySupplementaryView`
+  - `didEndDisplayingSupplementaryView`
+- Adds `UIScrollView` extensions:
+  - `willBeginDecelerating`
+  - `willBeginDragging`
+  - `willBeginZooming`
+  - `didEndZooming`
 
 #### Anomalies
 
-* Fixes deadlock anomaly in `shareReplayWhileLatest`. #1323
-* Removes duplicated events swallowing in `NSControl` on macOS.
+- Fixes deadlock anomaly in `shareReplayWhileLatest`. #1323
+- Removes duplicated events swallowing in `NSControl` on macOS.
 
 ## [3.5.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.5.0)
 
-* Adds `from` operator on "SharedSequence"
-* Adds `concat` operator on "Completable"
-* Adds `merge` operator on "Completable"
-* Adds `using` operator on "PrimitiveSequence"
-* Adds `concatMap` operator.
-* Adds `share(replay:scope:)` operator.
-* Adds `multicast(makeSubject:)` operator.
-* Adds `UIButton.image(for:)` extension.
-* Adds `UIButton.backgroundImage(for:)` extension.
-* fixes typos
+- Adds `from` operator on "SharedSequence"
+- Adds `concat` operator on "Completable"
+- Adds `merge` operator on "Completable"
+- Adds `using` operator on "PrimitiveSequence"
+- Adds `concatMap` operator.
+- Adds `share(replay:scope:)` operator.
+- Adds `multicast(makeSubject:)` operator.
+- Adds `UIButton.image(for:)` extension.
+- Adds `UIButton.backgroundImage(for:)` extension.
+- fixes typos
 
 #### Anomalies
 
-* Improves reentrancy and synchronization checks.
-* Issues with `share()` and `shareReplay(_:)`. #1111
-* `.share()` inconsistent in behavior. #1242
-* Fixes issues with `Driver` sometimes sending initial element async. #1253
+- Improves reentrancy and synchronization checks.
+- Issues with `share()` and `shareReplay(_:)`. #1111
+- `.share()` inconsistent in behavior. #1242
+- Fixes issues with `Driver` sometimes sending initial element async. #1253
 
 ## [3.4.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.4.1) (Xcode 8.3.1 / Swift 3.1 compatible)
 
-* Adds `UINavigationController` delegate proxy and extensions:
-    * `willShow`
-    * `didShow`
-* Deprecates `TestScheduler.start(_:create:)` in favor of `TestScheduler.start(disposed:create:)`.
-* Deprecates `TestScheduler.start(_:subscribed:disposed:create:)` in favor of `TestScheduler.start(created:subscribed:disposed:create:)`.
+- Adds `UINavigationController` delegate proxy and extensions:
+  - `willShow`
+  - `didShow`
+- Deprecates `TestScheduler.start(_:create:)` in favor of `TestScheduler.start(disposed:create:)`.
+- Deprecates `TestScheduler.start(_:subscribed:disposed:create:)` in favor of `TestScheduler.start(created:subscribed:disposed:create:)`.
 
 #### Anomalies
 
-* Fixes observable sequence completion in case of empty arrays for `combineLatest` and `zip`. #1205
-* Fixes array version of `merge` operator completing immediately in case one of the observable sequences is empty. #1221
-* Adds RxTest to SPM. #1215
-* Adds tuple version of operator `SharedSequence.zip` (collection).
-* Adds tuple version of operator `SharedSequence.zip`.
-* Adds tuple version of operator `SharedSequence.combineLatest` (collection).
-* Adds tuple version of operator `SharedSequence.combineLatest`.
-* Adds missing `trimOutput` parameter to `SharedSequence.debug`.
-* Makes `RxImagePickerDelegateProxy` subclass of `RxNavigationControllerDelegateProxy`.
-
+- Fixes observable sequence completion in case of empty arrays for `combineLatest` and `zip`. #1205
+- Fixes array version of `merge` operator completing immediately in case one of the observable sequences is empty. #1221
+- Adds RxTest to SPM. #1215
+- Adds tuple version of operator `SharedSequence.zip` (collection).
+- Adds tuple version of operator `SharedSequence.zip`.
+- Adds tuple version of operator `SharedSequence.combineLatest` (collection).
+- Adds tuple version of operator `SharedSequence.combineLatest`.
+- Adds missing `trimOutput` parameter to `SharedSequence.debug`.
+- Makes `RxImagePickerDelegateProxy` subclass of `RxNavigationControllerDelegateProxy`.
 
 ## [3.4.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.4.0) (Xcode 8.3.1 / Swift 3.1 compatible)
 
-* Xcode 8.3.1 / Swift 3.1 compatibility.
-* Add subscription closures for Single, Maybe and Completable (`onSuccess`, `onError`, `onCompleted`).
-* Rename Units as Traits and update the documentation for Single, Completable & Maybe.
-* Deprecates `bindTo` in favor of `bind(to:)`.
-* Adds [`materialize`](http://reactivex.io/documentation/operators/materialize-dematerialize.html) operator
-* Adds [`dematerialize`](http://reactivex.io/documentation/operators/materialize-dematerialize.html) operator
-* Adds `latest` parameter to `SharedSequence.throttle` operator.
-* Adds `debug` operator to `PrimitiveSequence`.
+- Xcode 8.3.1 / Swift 3.1 compatibility.
+- Add subscription closures for Single, Maybe and Completable (`onSuccess`, `onError`, `onCompleted`).
+- Rename Units as Traits and update the documentation for Single, Completable & Maybe.
+- Deprecates `bindTo` in favor of `bind(to:)`.
+- Adds [`materialize`](http://reactivex.io/documentation/operators/materialize-dematerialize.html) operator
+- Adds [`dematerialize`](http://reactivex.io/documentation/operators/materialize-dematerialize.html) operator
+- Adds `latest` parameter to `SharedSequence.throttle` operator.
+- Adds `debug` operator to `PrimitiveSequence`.
 
 #### Anomalies
 
-* Fixes problem with `UICollectionView` data source caching and disposal logic. #1154
+- Fixes problem with `UICollectionView` data source caching and disposal logic. #1154
 
 ## [3.3.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.3.1) (Xcode 8 / Swift 3.0 compatible)
 
 #### Anomalies
 
-* Fixes misspelled `Completeable` to `Completable`. #1134 
+- Fixes misspelled `Completeable` to `Completable`. #1134
 
 ## [3.3.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.3.0) (Xcode 8 / Swift 3.0 compatible)
 
-* Adds `Single`, `Maybe`, `Completable` traits inspired by RxJava (operators):
-    * `create`
-    * `deferred`
-    * `just`
-    * `error`
-    * `never`
-    * `delaySubscription`
-    * `delay`
-    * `do`
-    * `filter`
-    * `map`
-    * `flatMap`
-    * `observeOn`
-    * `subscribeOn`
-    * `catchError`
-    * `retry`
-    * `retryWhen`
-    * `zip`
-* Adds `asSingle()` operator on `ObservableType`.
-* Adds `asMaybe()` operator on `ObservableType`.
-* Adds `asCompletable()` operator on `ObservableType`.
-* Adds variadic `combineLatest` and `zip` overloads without result selector (defaults to tuple).
-* Adds array `combineLatest` and `zip` overloads with result selector (defaults to array of elements)
-* Adds optimized synchronous `merge` operator to observable sequence (variadic, array, collection). #579
-* Adds optimized synchronous `merge` operator to shared sequence (variadic, array, collection).
-* Adds `AsyncSubject` implementation.
-* Adds `XCTAssertEqual` overloads to `RxTest`.
-* Adds `countDownDuration` to `UIDatePicker`.
-* Adds `attributedTitle(for:)` to `UIButton`.
-* Adds `onSubscribed` to `do` operator.
-* Adds `isUserInteractionEnabled` to `UIView`.
+- Adds `Single`, `Maybe`, `Completable` traits inspired by RxJava (operators):
+  - `create`
+  - `deferred`
+  - `just`
+  - `error`
+  - `never`
+  - `delaySubscription`
+  - `delay`
+  - `do`
+  - `filter`
+  - `map`
+  - `flatMap`
+  - `observeOn`
+  - `subscribeOn`
+  - `catchError`
+  - `retry`
+  - `retryWhen`
+  - `zip`
+- Adds `asSingle()` operator on `ObservableType`.
+- Adds `asMaybe()` operator on `ObservableType`.
+- Adds `asCompletable()` operator on `ObservableType`.
+- Adds variadic `combineLatest` and `zip` overloads without result selector (defaults to tuple).
+- Adds array `combineLatest` and `zip` overloads with result selector (defaults to array of elements)
+- Adds optimized synchronous `merge` operator to observable sequence (variadic, array, collection). #579
+- Adds optimized synchronous `merge` operator to shared sequence (variadic, array, collection).
+- Adds `AsyncSubject` implementation.
+- Adds `XCTAssertEqual` overloads to `RxTest`.
+- Adds `countDownDuration` to `UIDatePicker`.
+- Adds `attributedTitle(for:)` to `UIButton`.
+- Adds `onSubscribed` to `do` operator.
+- Adds `isUserInteractionEnabled` to `UIView`.
 
 #### Anomalies
-* Improves DelegateProxy `responds(to:)` selector logic to only respond to used selectors. #1081, #1087
-* Deprecates `from()` in favor of `from(optional:)` to avoid issues with implicit conversions to optional.
-* Fixes thread sanitizer reporting issues with `merge` operator. #1063
-* Calls `collectionViewLayout.invalidateLayout()` after `reloadData()` as a workaround for iOS 10 bug.
-* Changes `UICollectionView.rx.didUpdateFocusInContextWithAnimationCoordinator` context parameter type to `UICollectionViewFocusUpdateContext`
+
+- Improves DelegateProxy `responds(to:)` selector logic to only respond to used selectors. #1081, #1087
+- Deprecates `from()` in favor of `from(optional:)` to avoid issues with implicit conversions to optional.
+- Fixes thread sanitizer reporting issues with `merge` operator. #1063
+- Calls `collectionViewLayout.invalidateLayout()` after `reloadData()` as a workaround for iOS 10 bug.
+- Changes `UICollectionView.rx.didUpdateFocusInContextWithAnimationCoordinator` context parameter type to `UICollectionViewFocusUpdateContext`
 
 ## [3.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.2.0) (Xcode 8 / Swift 3.0 compatible)
 
-* Adds `groupBy` operator
-* Adds `ifEmpty(switchTo:)` operator
-* Adds [`ifEmpty(default:)`]((http://reactivex.io/documentation/operators/defaultifempty.html)) operator
-* Adds `Disposable` extension `disposed(by:)` equivalent to `addDisposableTo` that is meant to replace it in future 4.0 version.
-* Consolidates atomic operations on Linux and Darwin platform.
-* Adds DEBUG mode concurrent asserts for `Variable` and `Observable.create`.
-* Adds DEBUG mode concurrent asserts for `Sink`.
-* Small performance optimizations for subjects.
-* Adaptations for Xcode 8.3 beta.
-* Adds `numberOfPages` to `UIPageControl`.
-* Adds additional resources cleanup unit tests for cases where operators are used without `DisposeBag`s. 
-* Chroes:
-    * Adds `final` keyword wherever applicable.
-    * Remove unnecessary `import Foundation` statements.
-    * Examples cleanup.
+- Adds `groupBy` operator
+- Adds `ifEmpty(switchTo:)` operator
+- Adds [`ifEmpty(default:)`](<(http://reactivex.io/documentation/operators/defaultifempty.html)>) operator
+- Adds `Disposable` extension `disposed(by:)` equivalent to `addDisposableTo` that is meant to replace it in future 4.0 version.
+- Consolidates atomic operations on Linux and Darwin platform.
+- Adds DEBUG mode concurrent asserts for `Variable` and `Observable.create`.
+- Adds DEBUG mode concurrent asserts for `Sink`.
+- Small performance optimizations for subjects.
+- Adaptations for Xcode 8.3 beta.
+- Adds `numberOfPages` to `UIPageControl`.
+- Adds additional resources cleanup unit tests for cases where operators are used without `DisposeBag`s.
+- Chroes:
+  - Adds `final` keyword wherever applicable.
+  - Remove unnecessary `import Foundation` statements.
+  - Examples cleanup.
 
 #### Anomalies
 
-* Improves behavior of `shareReplayWhileConnected` by making sure that events emitted after disconnect are ignored even in case of fast reconnect.
-* Fixes a couple of operators that were not cleaning up resources on terminal events when used without `DisposeBag`s.
-* Fixes delegate proxy interaction with subclassing of `UISearchController`.
-* Fixes delegate proxy interaction with subclassing of `NSTextStorage`.
-* Fixes delegate proxy interaction with subclassing of `UIWebView`.
-* Fixes delegate proxy interaction with subclassing of `UIPickerView`.
+- Improves behavior of `shareReplayWhileConnected` by making sure that events emitted after disconnect are ignored even in case of fast reconnect.
+- Fixes a couple of operators that were not cleaning up resources on terminal events when used without `DisposeBag`s.
+- Fixes delegate proxy interaction with subclassing of `UISearchController`.
+- Fixes delegate proxy interaction with subclassing of `NSTextStorage`.
+- Fixes delegate proxy interaction with subclassing of `UIWebView`.
+- Fixes delegate proxy interaction with subclassing of `UIPickerView`.
 
 ## [3.1.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.1.0) (Xcode 8 / Swift 3.0 compatible)
 
-* Adds `changed` property to `ControlProperty` that returns `ControlEvent` of user generated changes.
-  * `textField.text.changed.map { "User changed text to \($0)" }`
-* Adds optional overloads for `from` operator. `let num: Int? = 3; let sequence = Observable.from(num)`
-* Improves `UIBindingObserver` by tolerating binding from non main dispatch queue. In case binding is attempted
+- Adds `changed` property to `ControlProperty` that returns `ControlEvent` of user generated changes.
+  - `textField.text.changed.map { "User changed text to \($0)" }`
+- Adds optional overloads for `from` operator. `let num: Int? = 3; let sequence = Observable.from(num)`
+- Improves `UIBindingObserver` by tolerating binding from non main dispatch queue. In case binding is attempted
   from non main dispatch queue it will be automagically dispathed async to main queue.
-* Makes control property naming consistent for `UIDatePicker`, `UISearchBar`, `UISegmentedControl`, `UISwitch`, `UITextField`, `UITextView` (`value` property + value alias name).
-* Adds missing extension to `UIScrollView`. 
-    * `didScroll` 
-    * `didZoom`
-    * `didEndDecelerating`
-    * `didEndDragging`
-    * `didScrollToTop`
-* Renames `refreshing` to `isRefreshing`.
-* adds `UIWebView` extensions:
-    * `didStartLoad`
-    * `didFinishLoad`
-    * `didFailLoad`
-* Adds `UITabBarController` extensions
-    * `willBeginCustomizing`
-    * `willEndCustomizing`
-    * `didEndCustomizing` 
-    * `didSelect`
-* Adds `UIBarButtonItem` extensions
-    * `title`
-* Performance optimizations
-* Improves data source behavior by clearing data source proxy when forwarding delegate is `nil`.
+- Makes control property naming consistent for `UIDatePicker`, `UISearchBar`, `UISegmentedControl`, `UISwitch`, `UITextField`, `UITextView` (`value` property + value alias name).
+- Adds missing extension to `UIScrollView`.
+  - `didScroll`
+  - `didZoom`
+  - `didEndDecelerating`
+  - `didEndDragging`
+  - `didScrollToTop`
+- Renames `refreshing` to `isRefreshing`.
+- adds `UIWebView` extensions:
+  - `didStartLoad`
+  - `didFinishLoad`
+  - `didFailLoad`
+- Adds `UITabBarController` extensions
+  - `willBeginCustomizing`
+  - `willEndCustomizing`
+  - `didEndCustomizing`
+  - `didSelect`
+- Adds `UIBarButtonItem` extensions
+  - `title`
+- Performance optimizations
+- Improves data source behavior by clearing data source proxy when forwarding delegate is `nil`.
 
 #### Anomalies
 
-* Fixes anomaly caused by `UITableView` invalid state caching of previous data source even after the change.
+- Fixes anomaly caused by `UITableView` invalid state caching of previous data source even after the change.
   Binding of reactive data source now triggers `layoutIfNeeded` that invalidates that internal cached state.
-* Fixes issue with race in `AnyRecursiveScheduler`. #995
+- Fixes issue with race in `AnyRecursiveScheduler`. #995
 
 ## [3.0.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.0.1) (Xcode 8 / Swift 3.0 compatible)
 
 #### Anomalies
 
-* Fixes RxCocoa problems on macOS (`TextInput` now uses `NSTextInputClient`)
-* Hides accidentally exposed `BagKey` structure.
-* Makes `notification` extension `name` parameter optional.
+- Fixes RxCocoa problems on macOS (`TextInput` now uses `NSTextInputClient`)
+- Hides accidentally exposed `BagKey` structure.
+- Makes `notification` extension `name` parameter optional.
 
 ## [3.0.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.0.0) (Xcode 8 / Swift 3.0 compatible)
 
-* Prefixes boolean properties with `is` and makes `String?` properties consistent.
-    * `rx.hidden` -> `rx.isHidden`
-    * `rx.enabled` -> `rx.isEnabled`
+- Prefixes boolean properties with `is` and makes `String?` properties consistent.
+  - `rx.hidden` -> `rx.isHidden`
+  - `rx.enabled` -> `rx.isEnabled`
     ...
     also ...
-    * since `rx.text` has now type `String?` to be consistent with UIKit, in case `String` is needed
-    there is `rx.text.orEmpty` that has `String` type.   
-* Renames `title(controlState:)` on `UIButton` to `title(for:)`.
-* All data structures are now internal (`Bag`, `Queue`, `PriorityQueue` ...)
-* Improves performance of `Bag`.
-* Polishes RxCocoa `URLSession` extensions
-    * `JSON` -> `json`
-    * return type is `Any` instead of `AnyObject`
-    * replaces response tuple parameters, now it's `(HTTPResponse, Data)`
-    * removes name hiding for `request` parameter
-* Migrates `Driver` and `NSNotification` tests to `Linux`.
-* Removes RxTest from OSX + SPM integration until usable XCTest support on OSX.
-* Renames `ObserverType.map` to `OberverType.mapObserver` because of possible ambigutites with subjects.
-* Improves dispatch queue detection logic and replaces concept of threads in favor of dispatch queues (solves a lot
+  - since `rx.text` has now type `String?` to be consistent with UIKit, in case `String` is needed
+    there is `rx.text.orEmpty` that has `String` type.
+- Renames `title(controlState:)` on `UIButton` to `title(for:)`.
+- All data structures are now internal (`Bag`, `Queue`, `PriorityQueue` ...)
+- Improves performance of `Bag`.
+- Polishes RxCocoa `URLSession` extensions
+  - `JSON` -> `json`
+  - return type is `Any` instead of `AnyObject`
+  - replaces response tuple parameters, now it's `(HTTPResponse, Data)`
+  - removes name hiding for `request` parameter
+- Migrates `Driver` and `NSNotification` tests to `Linux`.
+- Removes RxTest from OSX + SPM integration until usable XCTest support on OSX.
+- Renames `ObserverType.map` to `OberverType.mapObserver` because of possible ambigutites with subjects.
+- Improves dispatch queue detection logic and replaces concept of threads in favor of dispatch queues (solves a lot
   of problems on Linux environment).
-* Replaces `SectionedViewDataSourceType.model(_:)` with `SectionedViewDataSourceType.model(at:)`
-* Renames `OSX` to `macOS` across the project.
+- Replaces `SectionedViewDataSourceType.model(_:)` with `SectionedViewDataSourceType.model(at:)`
+- Renames `OSX` to `macOS` across the project.
 
 #### Anomalies
 
-* Fixes wrong casing in `#import "include/_RXObjCRuntime.h"` (was creating issues for people with
+- Fixes wrong casing in `#import "include/_RXObjCRuntime.h"` (was creating issues for people with
   case sensitive file system). #949
-* Fixes issues with locking strategy for subjects. #936
-* Fixes code example in comments of RxTableViewExtensions that didn't compile. #947
-* Adds `.swift-version` to help package managers to detect Swift 3 version.
+- Fixes issues with locking strategy for subjects. #936
+- Fixes code example in comments of RxTableViewExtensions that didn't compile. #947
+- Adds `.swift-version` to help package managers to detect Swift 3 version.
 
 ## [3.0.0-rc.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.0.0-rc.1) (Xcode 8 / Swift 3.0 compatible)
 
-* Renames `RxTests` library to `RxTest` because of problems with Swift Package Manager.
-* Adds Swift Package Manager support
-* Adds Linux support
-* Replaces `AnyObserver` with `UIBindingObserver` in public interface.
-* Renames `resourceCount` to `Resources.total`.
-* Makes `rx.text` type consistent with UIKit `String?` type.
+- Renames `RxTests` library to `RxTest` because of problems with Swift Package Manager.
+- Adds Swift Package Manager support
+- Adds Linux support
+- Replaces `AnyObserver` with `UIBindingObserver` in public interface.
+- Renames `resourceCount` to `Resources.total`.
+- Makes `rx.text` type consistent with UIKit `String?` type.
 
 ```swift
 textField.rx.text          // <- now has type `ControlProperty<String?>`
 textField.rx.text.orEmpty  // <- now has type `ControlProperty<String>`
 ```
 
-* Adds optional overloads for `bindTo` and `drive`. Now the following works:
+- Adds optional overloads for `bindTo` and `drive`. Now the following works:
 
 ```swift
 let text: Observable<String> = Observable.just("")
@@ -415,206 +420,202 @@ text.drive(label.rx.text)
    .disposed(by: disposeBag)
 ```
 
-* Adds trim output parameter to `debug` operator. #930
-* Renames `NSDate` to `Date` everywhere.
-* Renames scheduler init param `globalConcurrentQueueQOS` to `qos` and removes custom enum wrapper.
-* Adds setter to `rx` property to enable mutation of base object.
+- Adds trim output parameter to `debug` operator. #930
+- Renames `NSDate` to `Date` everywhere.
+- Renames scheduler init param `globalConcurrentQueueQOS` to `qos` and removes custom enum wrapper.
+- Adds setter to `rx` property to enable mutation of base object.
 
 ## [3.0.0-beta.2](https://github.com/ReactiveX/RxSwift/releases/tag/3.0.0-beta.2) (Xcode 8 / Swift 3.0 compatible)
 
-* Subscription disposables now only create strong references to sinks until being disposed or sequence terminates. #573
+- Subscription disposables now only create strong references to sinks until being disposed or sequence terminates. #573
 
-* Introduces `SharedSequence` and makes `Driver` just a specialization of `SharedSequence`.
+- Introduces `SharedSequence` and makes `Driver` just a specialization of `SharedSequence`.
   That means `Driver` is now just one specific `SharedSequence` and it is now possible to easily create new concepts
   that have another compile time guarantees in a couple of lines of code.
   E.g. choosing a background scheduler on which elements are delivered, or choosing `share` as a sharing strategy instead of `shareReplayLatestWhileConnected`.
 
-* Moves `Reactive` struct and `ReactiveCompatible` from `RxCocoa` to `RxSwift` to enable third party consumers to remove `RxCocoa` dependency.
+- Moves `Reactive` struct and `ReactiveCompatible` from `RxCocoa` to `RxSwift` to enable third party consumers to remove `RxCocoa` dependency.
 
-* Add `rx.` extensions on Types.
+- Add `rx.` extensions on Types.
 
-* Moves `UIImagePickerViewController` and `CLLocationManager` out of `RxCocoa` to `RxExample` project because of App Store submissions issues
+- Moves `UIImagePickerViewController` and `CLLocationManager` out of `RxCocoa` to `RxExample` project because of App Store submissions issues
   on iOS 10.
 
-* Adds `sentMessage` got its equivalent sequence `methodInvoked` that produces elements after method is invoked (vs before method is invoked).
+- Adds `sentMessage` got its equivalent sequence `methodInvoked` that produces elements after method is invoked (vs before method is invoked).
 
-* Deprecates `observe` method on `DelegateProxy` in favor of `sentMessage`.
-* Adds simetric `methodInvoked` method on `DelegateProxy` that enables observing after method is invoked.
+- Deprecates `observe` method on `DelegateProxy` in favor of `sentMessage`.
+- Adds simetric `methodInvoked` method on `DelegateProxy` that enables observing after method is invoked.
 
-* Moves all delegate extensions from using `sentMessage` to using `methodInvoked` (that fixes some problem with editing data sources)
+- Moves all delegate extensions from using `sentMessage` to using `methodInvoked` (that fixes some problem with editing data sources)
 
-* Fixes problem with `RxTableViewDataSourceProxy` source enabling editing of table view cells (swipe on delete) even if there weren't
-any observers or `forwardToDelegate` wasn't implementing `UITableViewDataSource.tableView(_:commit:forRowAt:)`. #907
+- Fixes problem with `RxTableViewDataSourceProxy` source enabling editing of table view cells (swipe on delete) even if there weren't
+  any observers or `forwardToDelegate` wasn't implementing `UITableViewDataSource.tableView(_:commit:forRowAt:)`. #907
 
-* Makes `DelegateProxy` open. #884
+- Makes `DelegateProxy` open. #884
 
-* Deprecates extensions that were polluting Swift collection namespaces and moves them to static functions on `Observable`
-    * `Observable.combineLatest`
-    * `Observable.zip`
-    * `Observable.concat`
-    * `Observable.catchError` (sequence version)
-    * `Observable.amb`
+- Deprecates extensions that were polluting Swift collection namespaces and moves them to static functions on `Observable`
 
-* Deprecates extensions that were polluting Swift collection namespaces and moves them to static functions on `Driver`
-    * `Driver.combineLatest`
-    * `Driver.zip`
-    * `Driver.concat`
-    * `Driver.catchError` (sequence version)
-    * `Driver.amb`
+  - `Observable.combineLatest`
+  - `Observable.zip`
+  - `Observable.concat`
+  - `Observable.catchError` (sequence version)
+  - `Observable.amb`
 
-* Update Getting Started document, section on creating an observable that performs work to Swift 3.0.
+- Deprecates extensions that were polluting Swift collection namespaces and moves them to static functions on `Driver`
 
-* Removes stale installation instructions.
+  - `Driver.combineLatest`
+  - `Driver.zip`
+  - `Driver.concat`
+  - `Driver.catchError` (sequence version)
+  - `Driver.amb`
+
+- Update Getting Started document, section on creating an observable that performs work to Swift 3.0.
+
+- Removes stale installation instructions.
 
 ## [3.0.0-beta.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.0.0-beta.1) (Xcode 8 GM compatible 8A218a)
 
-* Adapts to new Swift 3.0 syntax.
-* Corrects `throttle` operator behavior to be more consistent with other platforms. Adds `latest` flag that controls should latest element
+- Adapts to new Swift 3.0 syntax.
+- Corrects `throttle` operator behavior to be more consistent with other platforms. Adds `latest` flag that controls should latest element
   be emitted after dueTime.
-* Adds `delay` operator.
-* Adds `UISearchBar` extensions:
-  * `bookmarkButtonClicked`
-  * `resultsListButtonClicked`
-  * `textDidBeginEditing`
-  * `textDidEndEditing`
-* Moves `CLLocationManager` and `UIImagePickerViewController` extensions from RxCocoa to RxExample project. #874
-* Adds matrix CI builds.
-=======
+- Adds `delay` operator.
+- Adds `UISearchBar` extensions:
+  - `bookmarkButtonClicked`
+  - `resultsListButtonClicked`
+  - `textDidBeginEditing`
+  - `textDidEndEditing`
+- Moves `CLLocationManager` and `UIImagePickerViewController` extensions from RxCocoa to RxExample project. #874
+- # Adds matrix CI builds.
 
 ## [3.0.0.alpha.1](https://github.com/ReactiveX/RxSwift/releases/tag/3.0.0.alpha.1) (Xcode 8 beta 6 compatible 8S201h)
 
 #### Features
 
-* Modernizes API to be more consistent with Swift 3.0 API Design Guidelines
-* Replaces `rx_*` prefix with `rx.*` extensions. (Inspired by `.lazy` collections API). We've tried annotate deprecated APIs with `@available(*, deprecated, renamed: "new method")` but trivial replacements aren't annotated.
-	* `rx_text` -> `rx.text`
-	* `rx_tap` -> `rx.tap`
-	* `rx_date` -> `rx.date`
-	* ...
-* Deprecates `subscribeNext`, `subscribeError`, `subscribeCompleted` in favor of `subscribe(onNext:onError:onCompleted:onDisposed)` (The downsides of old extensions were inconsistencies with Swift API guidelines. They also weren't expressing that calling them actually performes additional subscriptions and thus potentially additional work beside just registering observers).
-* Deprecates `doOnNext`, `doOnCompleted`, `doOnError` in favor of `do(onNext:onCompleted:onError:onSubscribe:onDisposed:)`
-* Adds `onSubscribe` and `onDisposed` to `do` operator.
-* Adds namespace for immutable disposables called `Disposables`
-	* Deprecates `AnonymousDisposable` in favor of `Disposables.create(with:)`
-	* Deprecates `NopDisposable` in favor of `Disposables.create()`
-	* Deprecates `BinaryDisposable` in favor of `Disposables.create(_:_:)`
-* Deprecates `toObservable` in favor of `Observable.from()`.
-* Replaces old javascript automation tests with Swift UI Tests.
-* ...
+- Modernizes API to be more consistent with Swift 3.0 API Design Guidelines
+- Replaces `rx_*` prefix with `rx.*` extensions. (Inspired by `.lazy` collections API). We've tried annotate deprecated APIs with `@available(*, deprecated, renamed: "new method")` but trivial replacements aren't annotated.
+  _ `rx_text` -> `rx.text`
+  _ `rx_tap` -> `rx.tap`
+  _ `rx_date` -> `rx.date`
+  _ ...
+- Deprecates `subscribeNext`, `subscribeError`, `subscribeCompleted` in favor of `subscribe(onNext:onError:onCompleted:onDisposed)` (The downsides of old extensions were inconsistencies with Swift API guidelines. They also weren't expressing that calling them actually performes additional subscriptions and thus potentially additional work beside just registering observers).
+- Deprecates `doOnNext`, `doOnCompleted`, `doOnError` in favor of `do(onNext:onCompleted:onError:onSubscribe:onDisposed:)`
+- Adds `onSubscribe` and `onDisposed` to `do` operator.
+- Adds namespace for immutable disposables called `Disposables`
+  _ Deprecates `AnonymousDisposable` in favor of `Disposables.create(with:)`
+  _ Deprecates `NopDisposable` in favor of `Disposables.create()` \* Deprecates `BinaryDisposable` in favor of `Disposables.create(_:_:)`
+- Deprecates `toObservable` in favor of `Observable.from()`.
+- Replaces old javascript automation tests with Swift UI Tests.
+- ...
 
 #### Anomalies
 
-* There is a problem using `UISwitch` extensions because it seems that a bug exists in UIKit that causes all `UISwitch` instances to leak. https://github.com/ReactiveX/RxSwift/issues/842
+- There is a problem using `UISwitch` extensions because it seems that a bug exists in UIKit that causes all `UISwitch` instances to leak. https://github.com/ReactiveX/RxSwift/issues/842
 
 ## [2.6.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.6.0)
 
 #### Features
 
-* Adds Swift 2.3 compatibility.
-* Adds `UIViewController.rx_title` extension.
-* Adds `UIScrollView.rx_scrollEnabled` extension.
-* Resolve static analysis issues relating to non-use of an assigned value, and potential null dereferences in RxCocoa's Objective-C classes.
-* Changes `forwardDelegate` property type on `DelegateProxy` from `assign` to `weak`.
-* Simplifies UITable/CollectionView data source generic parameters.
-* Adds simple usage examples to UITable/CollectionView data source extensions.
-* Documents UITable/CollectionView data source extensions memory management and adds unit tests to cover that documentation.
-* Adds `.jazzy.yml`
-* Adds `UITabBar` extensions and delegate proxy wrapper
-    * rx_didSelectItem
-    * rx_willBeginCustomizing
-    * rx_didBeginCustomizing
-    * rx_willEndCustomizing
-    * rx_didEndCustomizing
-* Adds `UIPickerView` delegate proxy and extensions:
-    * rx_itemSelected
-* Adds `UIAlertAction.rx_enabled` extension.
-* Adds `UIButton.rx_title(controlState: UIControlState = .Normal)` extension.
-* Adds `UIPageControl.rx_currentPage` extension.
-* Adds `hasObservers` property to `*Subject`.
+- Adds Swift 2.3 compatibility.
+- Adds `UIViewController.rx_title` extension.
+- Adds `UIScrollView.rx_scrollEnabled` extension.
+- Resolve static analysis issues relating to non-use of an assigned value, and potential null dereferences in RxCocoa's Objective-C classes.
+- Changes `forwardDelegate` property type on `DelegateProxy` from `assign` to `weak`.
+- Simplifies UITable/CollectionView data source generic parameters.
+- Adds simple usage examples to UITable/CollectionView data source extensions.
+- Documents UITable/CollectionView data source extensions memory management and adds unit tests to cover that documentation.
+- Adds `.jazzy.yml`
+- Adds `UITabBar` extensions and delegate proxy wrapper
+  - rx_didSelectItem
+  - rx_willBeginCustomizing
+  - rx_didBeginCustomizing
+  - rx_willEndCustomizing
+  - rx_didEndCustomizing
+- Adds `UIPickerView` delegate proxy and extensions:
+  - rx_itemSelected
+- Adds `UIAlertAction.rx_enabled` extension.
+- Adds `UIButton.rx_title(controlState: UIControl.State = .Normal)` extension.
+- Adds `UIPageControl.rx_currentPage` extension.
+- Adds `hasObservers` property to `*Subject`.
 
 #### Anomalies
 
-* Fixes problem with UITable/CollectionView releasing of data sources when result subscription disposable wasn't retained.
-* Fixes all Xcode analyzer warnings
-
+- Fixes problem with UITable/CollectionView releasing of data sources when result subscription disposable wasn't retained.
+- Fixes all Xcode analyzer warnings
 
 ## [2.5.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.5.0)
 
 #### Features
 
-* Exposes `installForwardDelegate`.
-* Adds `proxyForObject` as protocol extension and deprecates global function version.
-* Improves `installForwardDelegate` assert messaging.
-* Improves gesture recognizer extensions to use typed gesture recognizers in `rx_event`.
-* Adds `RxTextInput` protocol to enable creating reactive extensions for `UITextInput/NSTextInput`.
-* Adds `rx_willDisplayCell` and `rx_didEndDisplayingCell` extensions to `UITableView`.
-* Improves playgrounds.
-
+- Exposes `installForwardDelegate`.
+- Adds `proxyForObject` as protocol extension and deprecates global function version.
+- Improves `installForwardDelegate` assert messaging.
+- Improves gesture recognizer extensions to use typed gesture recognizers in `rx_event`.
+- Adds `RxTextInput` protocol to enable creating reactive extensions for `UITextInput/NSTextInput`.
+- Adds `rx_willDisplayCell` and `rx_didEndDisplayingCell` extensions to `UITableView`.
+- Improves playgrounds.
 
 #### Anomalies
 
-* Fixes in documentation.
-* Turns off Bitcode for `RxTests` CocoaPods integration.
-* Fixes `UITextField.rx_text` and `UITextView.rx_text` integrations to be more robust when used with two way binding.
-* Fixes two way binding example code so it now properly handles IME used in Asian cultures and adds explanations how to properly perform two way bindings. https://github.com/ReactiveX/RxSwift/issues/649
-* Removes `distinctUntilChanged` from control extensions. https://github.com/ReactiveX/RxSwift/issues/626
-
+- Fixes in documentation.
+- Turns off Bitcode for `RxTests` CocoaPods integration.
+- Fixes `UITextField.rx_text` and `UITextView.rx_text` integrations to be more robust when used with two way binding.
+- Fixes two way binding example code so it now properly handles IME used in Asian cultures and adds explanations how to properly perform two way bindings. https://github.com/ReactiveX/RxSwift/issues/649
+- Removes `distinctUntilChanged` from control extensions. https://github.com/ReactiveX/RxSwift/issues/626
 
 ## [2.4.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.4)
 
 #### Features
 
-* adds `Driver.drive` with `Variable` parameter.
-* exposes `RxSearchBarDelegateProxy`
-* adds `rx_cancelButtonClicked` to `UISearchBar`.
-* adds `rx_searchButtonClicked` to `UISearchBar`.
-* adds `UISearchController` extensions:
-  * `rx_didDismiss`
-  * `rx_didPresent`
-  * `rx_present`
-  * `rx_willDismiss`
-  * `rx_willPresent`
-
+- adds `Driver.drive` with `Variable` parameter.
+- exposes `RxSearchBarDelegateProxy`
+- adds `rx_cancelButtonClicked` to `UISearchBar`.
+- adds `rx_searchButtonClicked` to `UISearchBar`.
+- adds `UISearchController` extensions:
+  - `rx_didDismiss`
+  - `rx_didPresent`
+  - `rx_present`
+  - `rx_willDismiss`
+  - `rx_willPresent`
 
 #### Anomalies
 
-* Fixes anomaly with `multicast` disposing subscription.
-* Small grammar fixes in code.
-* Fixes in documentation.
+- Fixes anomaly with `multicast` disposing subscription.
+- Small grammar fixes in code.
+- Fixes in documentation.
 
 ## [2.3.1](https://github.com/ReactiveX/RxSwift/releases/tag/2.3.1)
 
 #### Features
 
-* Xcode 7.3 / Swift 2.2 support
+- Xcode 7.3 / Swift 2.2 support
 
 ## [2.3.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.3.0)
 
 #### Features
 
-* Adds `rx_badgeValue` to `UITabBarItem`.
-* Adds `rx_progress` to `UIProgresView`.
-* Adds `rx_selectedScopeButtonIndex` to `UISearchBar`.
-* Adds `asyncInstance` to `MainScheduler`.
-* Makes `name` parmeter optional for `rx_notification` extension.
-* Adds `UnitTests.md`.
-* Adds `Tips.md`.
-* Updates playground inline documentation with running instructions.
-* Synchronizes copy of `RxDataSources` source files inside example project to `0.6` release.
+- Adds `rx_badgeValue` to `UITabBarItem`.
+- Adds `rx_progress` to `UIProgresView`.
+- Adds `rx_selectedScopeButtonIndex` to `UISearchBar`.
+- Adds `asyncInstance` to `MainScheduler`.
+- Makes `name` parmeter optional for `rx_notification` extension.
+- Adds `UnitTests.md`.
+- Adds `Tips.md`.
+- Updates playground inline documentation with running instructions.
+- Synchronizes copy of `RxDataSources` source files inside example project to `0.6` release.
 
 #### Anomalies
 
-* Fixes anomaly with synchronization in disposable setter of `SingleAssignmentDisposable`.
-* Improves `DelegateProxy` memory management.
-* Fixes anomaly during two way binding of `UITextView` text value.
-* Improves `single` operator so it handles reentrancy better.
+- Fixes anomaly with synchronization in disposable setter of `SingleAssignmentDisposable`.
+- Improves `DelegateProxy` memory management.
+- Fixes anomaly during two way binding of `UITextView` text value.
+- Improves `single` operator so it handles reentrancy better.
 
 ## [2.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.2.0)
 
 #### Public Interface anomalies
 
-* Fixes problem with `timer` operator. Changes return type from `Observable<Int64>` to `Observable<T>`. This could potentially cause code breakage, but it was an API anomaly.
-* Curried functions were marked deprecated so they were replaced in `UITableView` and `UICollectionView` extensions with equivalent lambdas. This shouldn't break anyone's code, but it is a change in public interface.
+- Fixes problem with `timer` operator. Changes return type from `Observable<Int64>` to `Observable<T>`. This could potentially cause code breakage, but it was an API anomaly.
+- Curried functions were marked deprecated so they were replaced in `UITableView` and `UICollectionView` extensions with equivalent lambdas. This shouldn't break anyone's code, but it is a change in public interface.
 
 This is example of those changes:
 
@@ -627,7 +628,7 @@ This is example of those changes:
       -> (cellFactory: (UITableView, Int, S.Iterator.Element) -> UITableViewCell) -> Disposable
 ```
 
-* Fixes anomaly in `CLLocationManager` extensions
+- Fixes anomaly in `CLLocationManager` extensions
 
 ```swift
 -    public var rx_didFinishDeferredUpdatesWithError: RxSwift.Observable<NSError> { get }
@@ -636,74 +637,75 @@ This is example of those changes:
 
 #### Features
 
-* Adds `UIBindingObserver`.
-* Adds `doOnNext` convenience operator (also added to `Driver`).
-* Adds `doOnError` convenience operator.
-* Adds `doOnCompleted` convenience operator (also added to `Driver`).
-* Adds `skip`, `startWith` to `Driver`.
-* Adds `rx_active` extension to `NSLayoutConstraint`.
-* Adds `rx_refreshing` extension to `UIRefreshControl`.
-* Adds `interval` and `timer` to `Driver`.
-* Adds `rx_itemAccessoryButtonTapped` to `UITableView` extensions.
-* Adds `rx_networkActivityIndicatorVisible` to `UIApplication`.
-* Adds `rx_selected` to `UIControl`.
+- Adds `UIBindingObserver`.
+- Adds `doOnNext` convenience operator (also added to `Driver`).
+- Adds `doOnError` convenience operator.
+- Adds `doOnCompleted` convenience operator (also added to `Driver`).
+- Adds `skip`, `startWith` to `Driver`.
+- Adds `rx_active` extension to `NSLayoutConstraint`.
+- Adds `rx_refreshing` extension to `UIRefreshControl`.
+- Adds `interval` and `timer` to `Driver`.
+- Adds `rx_itemAccessoryButtonTapped` to `UITableView` extensions.
+- Adds `rx_networkActivityIndicatorVisible` to `UIApplication`.
+- Adds `rx_selected` to `UIControl`.
 
 #### Anomalies
 
-* Fixes anomaly with registering multiple observers to `UIBarButtonItem`.
-* Fixes anomaly with blocking operators possibly over-stopping the `RunLoop`.
+- Fixes anomaly with registering multiple observers to `UIBarButtonItem`.
+- Fixes anomaly with blocking operators possibly over-stopping the `RunLoop`.
 
 ## [2.1.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.1.0)
 
 #### Features
 
-* Adds `UIImagePickerController` delegate wrappers.
-* Adds `SectionedViewDataSourceType` that enables third party data sources to use existing `rx_modelSelected`/`rx_modelDeselected` wrappers.
-* Adds `rx_modelDeselected` to `UITableView`
-* Adds `rx_itemDeselected` to `UITableView`
-* Adds `rx_modelDeselected` to `UICollectionView`
-* Adds `rx_itemDeselected` to `UICollectionView`
-* Adds `rx_state` to `NSButton`
-* Adds `rx_enabled` to `NSControl`
-* Adds `UIImagePickerController` usage example to Example app.
+- Adds `UIImagePickerController` delegate wrappers.
+- Adds `SectionedViewDataSourceType` that enables third party data sources to use existing `rx_modelSelected`/`rx_modelDeselected` wrappers.
+- Adds `rx_modelDeselected` to `UITableView`
+- Adds `rx_itemDeselected` to `UITableView`
+- Adds `rx_modelDeselected` to `UICollectionView`
+- Adds `rx_itemDeselected` to `UICollectionView`
+- Adds `rx_state` to `NSButton`
+- Adds `rx_enabled` to `NSControl`
+- Adds `UIImagePickerController` usage example to Example app.
 
 #### Anomalies
 
-* Removes usage of `OSSpinLock`s from all `Darwin` platforms because of problems with inversion of priority on iOS. [Original thread on swift mailing list is here](https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151214/000321.html)
-* Reduces verbose output from `RxCocoa` project in debug mode. `TRACE_RESOURCES` is now also treated as a verbosity level setting. It is possible to get old output by using `TRACE_RESOURCES` with verbosity level `>= 2`. [#397](https://github.com/ReactiveX/RxSwift/issues/397)
-* Fixes anomaly with logging of HTTP body of requests in `RxCocoa` project.
+- Removes usage of `OSSpinLock`s from all `Darwin` platforms because of problems with inversion of priority on iOS. [Original thread on swift mailing list is here](https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20151214/000321.html)
+- Reduces verbose output from `RxCocoa` project in debug mode. `TRACE_RESOURCES` is now also treated as a verbosity level setting. It is possible to get old output by using `TRACE_RESOURCES` with verbosity level `>= 2`. [#397](https://github.com/ReactiveX/RxSwift/issues/397)
+- Fixes anomaly with logging of HTTP body of requests in `RxCocoa` project.
 
 ## [2.0.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0)
 
 #### Features
 
-* Changes package names to `io.rx.[library]`
-* Packages data sources from `RxDataSourceStarterKit` into it's own repository [RxDataSources](https://github.com/RxSwiftCommunity/RxDataSources) under `RxSwiftCommunity`.
-* Removes deprecated APIs.
+- Changes package names to `io.rx.[library]`
+- Packages data sources from `RxDataSourceStarterKit` into it's own repository [RxDataSources](https://github.com/RxSwiftCommunity/RxDataSources) under `RxSwiftCommunity`.
+- Removes deprecated APIs.
 
 #### Anomalies
 
-* Replaces hacky code that solved anomaly caused by interaction between autocorrect and text controls notification mechanism with proper solution. #333
+- Replaces hacky code that solved anomaly caused by interaction between autocorrect and text controls notification mechanism with proper solution. #333
 
 ## [2.0.0-rc.0](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-rc.0)
 
 #### Features
 
-* Adds generic `public func rx_sentMessage(selector: Selector) -> Observable<[AnyObject]>` that enables observing of messages
- sent to any object. (This is enabled if DISABLE_SWIZZLING isn't set).
-  * use cases like `cell.rx_sentMessage("prepareForReuse")` are now supported.
-* Linux support (proof of concept, but single threaded mode works)
-  * more info in [Documentation/Linux.md](https://github.com/ReactiveX/RxSwift/blob/master/Documentation/Linux.md)
-* Initial support for `Swift Package Manager`
-  * works on `Linux` (`RxSwift`, `RxBlocking`, `RxTests`)
-  * doesn't work on OSX because it can't compile `RxCocoa` and `RxTests` (because of inclusion of `XCTest` extensions), but OSX has two other package managers and manual method.
-  * Project content is linked to `Sources` automagically using custom tool
-  * more info in [Documentation/Linux.md](https://github.com/ReactiveX/RxSwift/blob/master/Documentation/Linux.md)
-* Adds `VirtualTimeScheduler` to `RxSwift`
-* Adds `HistoricalScheduler` to `RxSwift`
-* Improves performance of virtual schedulers using priority queue.
-* Adds new `RxTests` library to enable testing of custom Rx operators.
-This library contains everything needed to write unit tests in the following way:
+- Adds generic `public func rx_sentMessage(selector: Selector) -> Observable<[AnyObject]>` that enables observing of messages
+  sent to any object. (This is enabled if DISABLE_SWIZZLING isn't set).
+  - use cases like `cell.rx_sentMessage("prepareForReuse")` are now supported.
+- Linux support (proof of concept, but single threaded mode works)
+  - more info in [Documentation/Linux.md](https://github.com/ReactiveX/RxSwift/blob/master/Documentation/Linux.md)
+- Initial support for `Swift Package Manager`
+  - works on `Linux` (`RxSwift`, `RxBlocking`, `RxTests`)
+  - doesn't work on OSX because it can't compile `RxCocoa` and `RxTests` (because of inclusion of `XCTest` extensions), but OSX has two other package managers and manual method.
+  - Project content is linked to `Sources` automagically using custom tool
+  - more info in [Documentation/Linux.md](https://github.com/ReactiveX/RxSwift/blob/master/Documentation/Linux.md)
+- Adds `VirtualTimeScheduler` to `RxSwift`
+- Adds `HistoricalScheduler` to `RxSwift`
+- Improves performance of virtual schedulers using priority queue.
+- Adds new `RxTests` library to enable testing of custom Rx operators.
+  This library contains everything needed to write unit tests in the following way:
+
 ```swift
 func testMap() {
     let scheduler = TestScheduler(initialClock: 0)
@@ -736,7 +738,8 @@ func testMap() {
 }
 ```
 
-* Adds test project for `RxExample-iOS` that demonstrates how to easily write marble tests using `RxTests` project.
+- Adds test project for `RxExample-iOS` that demonstrates how to easily write marble tests using `RxTests` project.
+
 ```swift
 let (
     usernameEvents,
@@ -757,30 +760,30 @@ let (
 )
 ```
 
-* Adds example app for GitHub signup example that shows the same example written with and without `Driver`.
-* Documents idea behind units and `Driver` in `Units.md`.
-* Example of table view with editing is polished to use more functional approach.
-* Adds `deferred` to `Driver` unit.
-* Removes implicitly unwrapped optionals from `CLLocationManager` extensions.
-* Removes implicitly unwrapped optionals from `NSURLSession` extensions.
-* Polishes the `debug` operator format.
-* Adds optional `cellType` parameter to Table/Collection view `rx_itemsWithCellIdentifier` method.
-* Polish for calculator example in `RxExample` app.
-* Documents and adds unit tests for tail recursive optimizations of `concat` operator.
-* Moves `Event` equality operator to `RxTests` project.
-* Adds `seealso` references to `reactivex.io`.
-* Polishes headers in source files and adds tests to enforce standard header format.
-* Adds `driveOnScheduler` to enable scheduler mocking for `Driver` during unit tests.
-* Adds assertions to `drive*` family of functions that makes sure they are always called from main thread.
-* Refactoring and polishing of internal ObjC runtime interception architecture.
+- Adds example app for GitHub signup example that shows the same example written with and without `Driver`.
+- Documents idea behind units and `Driver` in `Units.md`.
+- Example of table view with editing is polished to use more functional approach.
+- Adds `deferred` to `Driver` unit.
+- Removes implicitly unwrapped optionals from `CLLocationManager` extensions.
+- Removes implicitly unwrapped optionals from `NSURLSession` extensions.
+- Polishes the `debug` operator format.
+- Adds optional `cellType` parameter to Table/Collection view `rx_itemsWithCellIdentifier` method.
+- Polish for calculator example in `RxExample` app.
+- Documents and adds unit tests for tail recursive optimizations of `concat` operator.
+- Moves `Event` equality operator to `RxTests` project.
+- Adds `seealso` references to `reactivex.io`.
+- Polishes headers in source files and adds tests to enforce standard header format.
+- Adds `driveOnScheduler` to enable scheduler mocking for `Driver` during unit tests.
+- Adds assertions to `drive*` family of functions that makes sure they are always called from main thread.
+- Refactoring and polishing of internal ObjC runtime interception architecture.
 
 #### Deprecated
 
-* Changes `ConnectableObservable`, generic argument is now type of elements in observable sequence and not type of underlying subject. (BREAKING CHANGE)
-* Removes `RxBox` and `RxMutable` box from public interface. (BREAKING CHANGE)
-* `SchedulerType` now isn't parametrized on `Time` and `TimeInterval`.
-* Deprecates `Variable` implementing `ObservableType` in favor of `asObservable()`.
-  * Now variable also sends `.Completed` to observable sequence returned from `asObservable` when deallocated.
+- Changes `ConnectableObservable`, generic argument is now type of elements in observable sequence and not type of underlying subject. (BREAKING CHANGE)
+- Removes `RxBox` and `RxMutable` box from public interface. (BREAKING CHANGE)
+- `SchedulerType` now isn't parametrized on `Time` and `TimeInterval`.
+- Deprecates `Variable` implementing `ObservableType` in favor of `asObservable()`.
+  - Now variable also sends `.Completed` to observable sequence returned from `asObservable` when deallocated.
     If you were (mis)using variable to return single value
     ```
     Variable(1).map { x in ... }
@@ -789,252 +792,252 @@ let (
     ```
     Observable.just(1).map { x in ... }
     ```
-* Deprecates free functions in favor of `Observable` factory methods, and deprecates versions of operators with hidden external parameters (scheduler, count) in favor of ones with explicit parameter names.
-    E.g.
+- Deprecates free functions in favor of `Observable` factory methods, and deprecates versions of operators with hidden external parameters (scheduler, count) in favor of ones with explicit parameter names.
+  E.g.
 
-    `Observable.just(1)` instead of `just(1)`
+  `Observable.just(1)` instead of `just(1)`
 
-    `Observable.empty()` instead of `empty()`
+  `Observable.empty()` instead of `empty()`
 
-    `Observable.error()` instead of `failWith()`
+  `Observable.error()` instead of `failWith()`
 
-    `Observable.of(1, 2, 3)` instead of `sequenceOf(1, 2, 3)`
+  `Observable.of(1, 2, 3)` instead of `sequenceOf(1, 2, 3)`
 
-    `.debounce(0.2, scheduler: MainScheduler.sharedInstance)` instead of `.debounce(0.2, MainScheduler.sharedInstance)`
+  `.debounce(0.2, scheduler: MainScheduler.sharedInstance)` instead of `.debounce(0.2, MainScheduler.sharedInstance)`
 
-    `Observable.range(start:0, count: 10)` instead of `range(0, 10)`
+  `Observable.range(start:0, count: 10)` instead of `range(0, 10)`
 
-    `Observable.generate(initialState: 0, condition: { $0 < 10 }) { $0 + 1 }` instead of `generate(0, condition: { $0 < 10 }) { $0 + 1 }`
+  `Observable.generate(initialState: 0, condition: { $0 < 10 }) { $0 + 1 }` instead of `generate(0, condition: { $0 < 10 }) { $0 + 1 }`
 
-    `Observable<Int>.interval(1, scheduler: MainScheduler.sharedInstance)` instead of `interval(1, MainScheduler.sharedInstance)`
+  `Observable<Int>.interval(1, scheduler: MainScheduler.sharedInstance)` instead of `interval(1, MainScheduler.sharedInstance)`
 
-    ...
+  ...
 
-    If you want to continue using free functions form, you can define your free function aliases for `Observable` factory methods (basically copy deprecated methods).
-* Deprecates `UIAlertView` extensions.
-  * These extensions could be stored locally if needed.
-* Deprecates `UIActionSheet` extensions.
-  * These extensions could be stored locally if needed.
-* Deprecates `rx_controlEvents` in favor of `rx_controlEvent`.
-* Deprecates `MainScheduler.sharedInstance` in favor of `MainScheduler.instance`
-* Deprecates `ConcurrentMainScheduler.sharedInstance` in favor of `ConcurrentMainScheduler.instance`
-* Deprecates factory methods from `Drive` in favor of `Driver` factory methods.
-* Deprecates `sampleLatest` in favor of `withLatestFrom`.
-* Deprecates `ScopedDisposable` and `scopedDispose()` in favor of `DisposeBag`.
+  If you want to continue using free functions form, you can define your free function aliases for `Observable` factory methods (basically copy deprecated methods).
+
+- Deprecates `UIAlertView` extensions.
+  - These extensions could be stored locally if needed.
+- Deprecates `UIActionSheet` extensions.
+  - These extensions could be stored locally if needed.
+- Deprecates `rx_controlEvents` in favor of `rx_controlEvent`.
+- Deprecates `MainScheduler.sharedInstance` in favor of `MainScheduler.instance`
+- Deprecates `ConcurrentMainScheduler.sharedInstance` in favor of `ConcurrentMainScheduler.instance`
+- Deprecates factory methods from `Drive` in favor of `Driver` factory methods.
+- Deprecates `sampleLatest` in favor of `withLatestFrom`.
+- Deprecates `ScopedDisposable` and `scopedDispose()` in favor of `DisposeBag`.
 
 #### Fixed
 
-* Improves and documents resource leak code in `RxExample`.
-* Replaces `unowned` reference with `weak` references in `RxCocoa` project.
-* Fixes `debug` operator not using `__FILE__` and `__LINE__` properly.
-* Fixes anomaly with `timeout` operator.
-* Fixes problem with spell-checker and `UIText*` losing focus.
+- Improves and documents resource leak code in `RxExample`.
+- Replaces `unowned` reference with `weak` references in `RxCocoa` project.
+- Fixes `debug` operator not using `__FILE__` and `__LINE__` properly.
+- Fixes anomaly with `timeout` operator.
+- Fixes problem with spell-checker and `UIText*` losing focus.
 
 ## [2.0.0-beta.4](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-beta.4)
 
 #### Updated
 
-* Adds `ignoreElements` operator.
-* Adds `timeout` operator (2 overloads).
-* Adds `shareReplayLatestWhileConnected` operator.
-* Changes `Driver` to internally use `shareReplayLatestWhileConnected` for subscription sharing instead of `shareReplay(1)`.
-* Adds `flatMapFirst` to `Driver` unit.
-* Adds `replayAll` operator.
-* Adds `createUnbounded` factory method to `ReplaySubject`.
-* Adds optional type hints to `empty`, `failWith` and `never` (`empty(Int)` now works and means empty observable sequence of `Int`s).
-* Adds `rx_hidden` to `UIView`.
-* Adds `rx_alpha` to `UIView`.
-* Adds `rx_attributedText` to `UILabel`.
-* Adds `rx_animating` to `UIActivityIndicatorView`.
-* Adds `rx_constant` to `NSLayoutConstraint`.
-* Removes implicitly unwrapped optional from `NSURLSession.rx_response`.
-* Exposes `rx_createDataSourceProxy`, `rx_createDelegateProxy` on `UITableView`/`UICollectionView`.
-* Exposes `rx_createDelegateProxy` on `UITextView`.
-* Exposes `rx_createDelegateProxy` on `UIScrollView`.
-* Exposes `RxCollectionViewDataSourceProxy`.
-* Exposes `RxCollectionViewDelegateProxy`.
-* Exposes `RxScrollViewDelegateProxy`.
-* Exposes `RxTableViewDataSourceProxy`.
-* Exposes `RxTableViewDelegateProxy`.
-* Deprecates `proxyForObject` in favor of `proxyForObject<P : DelegateProxyType>(type: P.Type, _ object: AnyObject) -> P`.
-* Deprecates `rx_modelSelected<T>()` in favor of `rx_modelSelected<T>(modelType: T.Type)`.
-* Adds `func bindTo(variable: Variable<E>) -> Disposable` extension to `ObservableType`.
-* Exposes `ControlEvent` init.
-* Exposes `ControlProperty` init.
-* Refactoring of example app
-  * Divides examples into sections
-  * Adds really simple examples of how to do simple calculated bindings with vanilla Rx.
-  * Adds really simple examples of table view extensions (sectioned and non sectioned version).
-  * Refactoring of `GitHub sign in example` to use MVVM paradigm.
+- Adds `ignoreElements` operator.
+- Adds `timeout` operator (2 overloads).
+- Adds `shareReplayLatestWhileConnected` operator.
+- Changes `Driver` to internally use `shareReplayLatestWhileConnected` for subscription sharing instead of `shareReplay(1)`.
+- Adds `flatMapFirst` to `Driver` unit.
+- Adds `replayAll` operator.
+- Adds `createUnbounded` factory method to `ReplaySubject`.
+- Adds optional type hints to `empty`, `failWith` and `never` (`empty(Int)` now works and means empty observable sequence of `Int`s).
+- Adds `rx_hidden` to `UIView`.
+- Adds `rx_alpha` to `UIView`.
+- Adds `rx_attributedText` to `UILabel`.
+- Adds `rx_animating` to `UIActivityIndicatorView`.
+- Adds `rx_constant` to `NSLayoutConstraint`.
+- Removes implicitly unwrapped optional from `NSURLSession.rx_response`.
+- Exposes `rx_createDataSourceProxy`, `rx_createDelegateProxy` on `UITableView`/`UICollectionView`.
+- Exposes `rx_createDelegateProxy` on `UITextView`.
+- Exposes `rx_createDelegateProxy` on `UIScrollView`.
+- Exposes `RxCollectionViewDataSourceProxy`.
+- Exposes `RxCollectionViewDelegateProxy`.
+- Exposes `RxScrollViewDelegateProxy`.
+- Exposes `RxTableViewDataSourceProxy`.
+- Exposes `RxTableViewDelegateProxy`.
+- Deprecates `proxyForObject` in favor of `proxyForObject<P : DelegateProxyType>(type: P.Type, _ object: AnyObject) -> P`.
+- Deprecates `rx_modelSelected<T>()` in favor of `rx_modelSelected<T>(modelType: T.Type)`.
+- Adds `func bindTo(variable: Variable<E>) -> Disposable` extension to `ObservableType`.
+- Exposes `ControlEvent` init.
+- Exposes `ControlProperty` init.
+- Refactoring of example app
+  - Divides examples into sections
+  - Adds really simple examples of how to do simple calculated bindings with vanilla Rx.
+  - Adds really simple examples of table view extensions (sectioned and non sectioned version).
+  - Refactoring of `GitHub sign in example` to use MVVM paradigm.
 
 #### Fixed
 
-* Fixes documentation for `flatMapFirst`
-* Fixes problem with delegate proxies not detecting all delegate methods in delegate proxy hierarchy.
+- Fixes documentation for `flatMapFirst`
+- Fixes problem with delegate proxies not detecting all delegate methods in delegate proxy hierarchy.
 
 ## [2.0.0-beta.3](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-beta.3)
 
 #### Updated
 
-* Improves KVO mechanism.
-  * Type of observed object is now first argument `view.rx_observe(CGRect.self, "frame")`
-  * Support for observing ObjC bridged enums and `RawRepresentable` protocol
-  * Support for easier extending of KVO using `KVORepresentable` protocol
-  * Deprecates KVO extensions that don't accept type as first argument in favor of ones that do.
-* Adds `flatMapLatest` (also added to `Driver` unit).
-* Adds `flatMapFirst` operator (also added to `Driver` unit).
-* Adds `retryWhen` operator.
-* Adds `window` operator.
-* Adds `single` operator.
-* Adds `single` (blocking version) operator.
-* Adds `rx_primaryAction` on `UIButton` for `tvOS`.
-* Transforms error types in `RxSwift`/`RxCocoa` projects from `NSError`s to Swift enum types.
-  * `RxError`
-  * `RxCocoaError`
-  * `RxCocoaURLError`
-  * ...
-* `NSURLSession` extensions now return `Observable<(NSData!, NSHTTPURLResponse)>` instead of `Observable<(NSData!, NSURLResponse!)>`.
-* Optimizes consecutive map operators. For example `map(validate1).map(validate2).map(parse)` is now internally optimized to one `map` operator.
-* Adds overloads for `just`, `sequenceOf`, `toObservable` that accept scheduler.
-* Deprecates `asObservable` extension of `Sequence` in favor of `toObservable`.
-* Adds `toObservable` extension to `Array`.
-* Improves table view animated data source example.
-* Polishing of `RxDataSourceStarterKit`
-  * `differentiateForSectionedView` operator
-  * `rx_itemsAnimatedWithDataSource` extension
-* Makes blocking operators run current thread's runloop while blocking and thus disabling deadlocks.
+- Improves KVO mechanism.
+  - Type of observed object is now first argument `view.rx_observe(CGRect.self, "frame")`
+  - Support for observing ObjC bridged enums and `RawRepresentable` protocol
+  - Support for easier extending of KVO using `KVORepresentable` protocol
+  - Deprecates KVO extensions that don't accept type as first argument in favor of ones that do.
+- Adds `flatMapLatest` (also added to `Driver` unit).
+- Adds `flatMapFirst` operator (also added to `Driver` unit).
+- Adds `retryWhen` operator.
+- Adds `window` operator.
+- Adds `single` operator.
+- Adds `single` (blocking version) operator.
+- Adds `rx_primaryAction` on `UIButton` for `tvOS`.
+- Transforms error types in `RxSwift`/`RxCocoa` projects from `NSError`s to Swift enum types.
+  - `RxError`
+  - `RxCocoaError`
+  - `RxCocoaURLError`
+  - ...
+- `NSURLSession` extensions now return `Observable<(NSData!, NSHTTPURLResponse)>` instead of `Observable<(NSData!, NSURLResponse!)>`.
+- Optimizes consecutive map operators. For example `map(validate1).map(validate2).map(parse)` is now internally optimized to one `map` operator.
+- Adds overloads for `just`, `sequenceOf`, `toObservable` that accept scheduler.
+- Deprecates `asObservable` extension of `Sequence` in favor of `toObservable`.
+- Adds `toObservable` extension to `Array`.
+- Improves table view animated data source example.
+- Polishing of `RxDataSourceStarterKit`
+  - `differentiateForSectionedView` operator
+  - `rx_itemsAnimatedWithDataSource` extension
+- Makes blocking operators run current thread's runloop while blocking and thus disabling deadlocks.
 
 #### Fixed
 
-* Fixes example with `Variable` in playgrounds so it less confusing regarding memory management.
-* Fixes `UIImageView` extensions to use `UIImage?` instead of `UIImage!`.
-* Fixes improper usage of `CustomStringConvertible` and replaces it with `CustomDebugStringConvertible`.
+- Fixes example with `Variable` in playgrounds so it less confusing regarding memory management.
+- Fixes `UIImageView` extensions to use `UIImage?` instead of `UIImage!`.
+- Fixes improper usage of `CustomStringConvertible` and replaces it with `CustomDebugStringConvertible`.
 
 ## [2.0.0-beta.2](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-beta.2)
 
 #### Updated
 
-* Optimizations. System now performs significantly fewer allocations and is several times faster then 2.0.0-beta.1
-* Makes `AnonymousObservable` private in favor of `create` method.
-* Adds `toArray` operator (non blocking version).
-* Adds `withLatestFrom` operator, and also extends `Driver` with that operation.
-* Adds `elementAt` operator (non blocking version).
-* Adds `takeLast` operator.
-* Improves `RxExample` app. Adds retries example when network becomes available again.
-* Adds composite extensions to `Bag` (`on`, `disposeAllIn`).
-* Renames mistyped extension on `ObserverType` from `onComplete` to `onCompleted`.
+- Optimizations. System now performs significantly fewer allocations and is several times faster then 2.0.0-beta.1
+- Makes `AnonymousObservable` private in favor of `create` method.
+- Adds `toArray` operator (non blocking version).
+- Adds `withLatestFrom` operator, and also extends `Driver` with that operation.
+- Adds `elementAt` operator (non blocking version).
+- Adds `takeLast` operator.
+- Improves `RxExample` app. Adds retries example when network becomes available again.
+- Adds composite extensions to `Bag` (`on`, `disposeAllIn`).
+- Renames mistyped extension on `ObserverType` from `onComplete` to `onCompleted`.
 
 #### Fixed
 
-* Fixes minimal platform version in OSX version of library to 10.9
+- Fixes minimal platform version in OSX version of library to 10.9
 
 ## [2.0.0-beta.1](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-beta.1)
 
 #### Updated
 
-* Adds `Driver` unit. This unit uses Swift compiler to prove certain properties about observable sequences. Specifically
-  * that fallback error handling is put in place
-  * results are observed on main thread
-  * work is performed only when there is a need (at least one subscriber)
-  * computation results are shared between different observers (replay latest element)
-* Renames `ObserverOf` to `AnyObserver`.
-* Adds new interface `ObservableConvertibleType`.
-* Adds `BlockingObservable` to `RxBlocking` and makes it more consistent with `RxJava`.
-* Renames `func subscribe(next:error:completed:disposed:)` to `func subscribe(onNext:onError:onCompleted:onDisposed:)`
-* Adds concat convenience method `public func concat<O : ObservableConvertibleType where O.E == E>(second: O) -> RxSwift.Observable<Self.E>`
-* Adds `skipUntil` operator.
-* Adds `takeWhile` operator.
-* Renames `takeWhile` indexed version to `takeWhileWithIndex`
-* Adds `skipWhile` operator.
-* Adds `skipWhileWithIndex` operator.
-* Adds `using` operator.
-* Renames `func doOn(next:error:completed:)` to `func doOn(onNext:onError:onCompleted:)`.
-* Makes `RecursiveImmediateSchedulerOf` private.
-* Makes `RecursiveSchedulerOf` private.
-* Adds `ConcurrentMainScheduler`.
-* Adds overflow error so now in case of overflow, operators will return `RxErrorCode.Overflow`.
-* Adds `rx_modelAtIndexPath` to `UITableView` and `UICollectionView`.
-* Adds `var rx_didUpdateFocusInContextWithAnimationCoordinator: ControlEvent<(context:animationCoordinator:)>` to `UITableView` and `UICollectionView`
-* Makes `resultSelector` argument in `combineLatest` explicit `func combineLatest<O1, O2, R>(source1: O1, _ source2: O2, resultSelector: (O1.E, O2.E) throws -> R) -> RxSwift.Observable<R>`.
-* Makes `resultSelector` argument in `zip` explicit `func combineLatest<O1, O2, R>(source1: O1, _ source2: O2, resultSelector: (O1.E, O2.E) throws -> R) -> RxSwift.Observable<R>`.
-* Adds activity indicator example in `RxExample` app.
-* Adds two way binding example in `RxExample` app.
-* many other small features
+- Adds `Driver` unit. This unit uses Swift compiler to prove certain properties about observable sequences. Specifically
+  - that fallback error handling is put in place
+  - results are observed on main thread
+  - work is performed only when there is a need (at least one subscriber)
+  - computation results are shared between different observers (replay latest element)
+- Renames `ObserverOf` to `AnyObserver`.
+- Adds new interface `ObservableConvertibleType`.
+- Adds `BlockingObservable` to `RxBlocking` and makes it more consistent with `RxJava`.
+- Renames `func subscribe(next:error:completed:disposed:)` to `func subscribe(onNext:onError:onCompleted:onDisposed:)`
+- Adds concat convenience method `public func concat<O : ObservableConvertibleType where O.E == E>(second: O) -> RxSwift.Observable<Self.E>`
+- Adds `skipUntil` operator.
+- Adds `takeWhile` operator.
+- Renames `takeWhile` indexed version to `takeWhileWithIndex`
+- Adds `skipWhile` operator.
+- Adds `skipWhileWithIndex` operator.
+- Adds `using` operator.
+- Renames `func doOn(next:error:completed:)` to `func doOn(onNext:onError:onCompleted:)`.
+- Makes `RecursiveImmediateSchedulerOf` private.
+- Makes `RecursiveSchedulerOf` private.
+- Adds `ConcurrentMainScheduler`.
+- Adds overflow error so now in case of overflow, operators will return `RxErrorCode.Overflow`.
+- Adds `rx_modelAtIndexPath` to `UITableView` and `UICollectionView`.
+- Adds `var rx_didUpdateFocusInContextWithAnimationCoordinator: ControlEvent<(context:animationCoordinator:)>` to `UITableView` and `UICollectionView`
+- Makes `resultSelector` argument in `combineLatest` explicit `func combineLatest<O1, O2, R>(source1: O1, _ source2: O2, resultSelector: (O1.E, O2.E) throws -> R) -> RxSwift.Observable<R>`.
+- Makes `resultSelector` argument in `zip` explicit `func combineLatest<O1, O2, R>(source1: O1, _ source2: O2, resultSelector: (O1.E, O2.E) throws -> R) -> RxSwift.Observable<R>`.
+- Adds activity indicator example in `RxExample` app.
+- Adds two way binding example in `RxExample` app.
+- many other small features
 
 #### Fixed
 
-* Problem with xcodebuild 7.0.1 treating tvOS shared schemes as osx schemes.
+- Problem with xcodebuild 7.0.1 treating tvOS shared schemes as osx schemes.
 
 ## [2.0.0-alpha.4](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-alpha.4)
 
 #### Updated
 
-* Adds `tvOS` support
-* Adds `watchOS` support
-* Adds auto loading example to example app
-* Restores old `Variable` behavior. Variable doesn't send anything on dealloc.
-* Adds performance tests target.
-* Adds more detailed resource tracing during unit tests (important for further optimizations).
-* Adds `UIStepper` extensions.
-* Adds `UIBarButtonItem` enabled property wrapper.
-* Adds response data to userInfo of error for `rx_response` extensions of `NSURLSession`.
-* Adds `onNext`, `onError` and `onCompleted` convenience methods to `ObserverType`.
+- Adds `tvOS` support
+- Adds `watchOS` support
+- Adds auto loading example to example app
+- Restores old `Variable` behavior. Variable doesn't send anything on dealloc.
+- Adds performance tests target.
+- Adds more detailed resource tracing during unit tests (important for further optimizations).
+- Adds `UIStepper` extensions.
+- Adds `UIBarButtonItem` enabled property wrapper.
+- Adds response data to userInfo of error for `rx_response` extensions of `NSURLSession`.
+- Adds `onNext`, `onError` and `onCompleted` convenience methods to `ObserverType`.
 
 #### Fixed
 
-* Fixes problem on some systems with unregistering `CurrentThreadScheduler` from current thread.
-* Fixes retry parameter naming (`maxAttemptCount`).
-* Fixes a lot of unit test warnings.
-* Removes embedding of Swift library with built frameworks.
+- Fixes problem on some systems with unregistering `CurrentThreadScheduler` from current thread.
+- Fixes retry parameter naming (`maxAttemptCount`).
+- Fixes a lot of unit test warnings.
+- Removes embedding of Swift library with built frameworks.
 
 ## [2.0.0-alpha.3](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-alpha.3)
 
 #### Updated
 
-* Renames `ImmediateScheduler` protocol to `ImmediateSchedulerType`
-* Renames `Scheduler` protocol to `SchedulerType`
-* Adds `CurrentThreadScheduler`
-* Adds `generate` operator
-* Cleanup of dead observer code.
-* Removes `SpinLock`s in disposables in favor of more performant `OSAtomicCompareAndSwap32`.
-* Adds `buffer` operator (version with time and count).
-* Adds `range` operator.
-* Adds `repeat` operator.
+- Renames `ImmediateScheduler` protocol to `ImmediateSchedulerType`
+- Renames `Scheduler` protocol to `SchedulerType`
+- Adds `CurrentThreadScheduler`
+- Adds `generate` operator
+- Cleanup of dead observer code.
+- Removes `SpinLock`s in disposables in favor of more performant `OSAtomicCompareAndSwap32`.
+- Adds `buffer` operator (version with time and count).
+- Adds `range` operator.
+- Adds `repeat` operator.
 
 ## [2.0.0-alpha.2](https://github.com/ReactiveX/RxSwift/releases/tag/2.0.0-alpha.2)
 
 #### Updated
 
-* Renames `ScopedDispose` to `ScopedDisposable`
-* Deprecates `observeSingleOn` in favor of `observeOn`
-* Adds inline documentation
-* Renames `from` to `asObservable` extension method on `Sequence`
-* Renames `catchErrorResumeNext` in favor of `catchErrorJustReturn`
-* Deprecates `catchErrorToResult`, the preferred way is to use Swift `do/try/catch` mechanism.
-* Deprecates `RxResult`, the preferred way is to use Swift `do/try/catch` mechanism.
-* Deprecates `sendNext` on `Variable` in favor of just using `value` setter.
-* Renames `rx_searchText` to `rx_text` on `UISearchBar+Rx`.
-* Changes parameter type for `rx_imageAnimated` to be transitionType (kCATransitionFade, kCATransitionMoveIn, ...).
+- Renames `ScopedDispose` to `ScopedDisposable`
+- Deprecates `observeSingleOn` in favor of `observeOn`
+- Adds inline documentation
+- Renames `from` to `asObservable` extension method on `Sequence`
+- Renames `catchErrorResumeNext` in favor of `catchErrorJustReturn`
+- Deprecates `catchErrorToResult`, the preferred way is to use Swift `do/try/catch` mechanism.
+- Deprecates `RxResult`, the preferred way is to use Swift `do/try/catch` mechanism.
+- Deprecates `sendNext` on `Variable` in favor of just using `value` setter.
+- Renames `rx_searchText` to `rx_text` on `UISearchBar+Rx`.
+- Changes parameter type for `rx_imageAnimated` to be transitionType (kCATransitionFade, kCATransitionMoveIn, ...).
 
 ## [2.0.0-alpha.1](https://github.com/ReactiveX/RxSwift/releases/tag/2.0-alpha.1)
 
 #### Fixed
 
-* Problem in RxExample with missing `observeOn` for images.
+- Problem in RxExample with missing `observeOn` for images.
 
 #### Updated
 
-* Removes deprecated APIs
-* Adds `ObservableType`
-* Moved from using `>-` operator to protocol extensions
-* Change from `disposeBag.addDisposable` to `disposable.addDisposableTo`
-* Changes in RxCocoa extensions to enable fluent style
-* Rename of `do*` to `doOn*`
-* Deprecates `returnElement` in favor of `just`
-* Deprecates `aggregate` in favor of `reduce`
-* Deprecates `variable` in favor of `shareReplay(1)` (to be consistent with RxJS version)
-* Method `next` on `Variable` in favor of `sendNext`
-
+- Removes deprecated APIs
+- Adds `ObservableType`
+- Moved from using `>-` operator to protocol extensions
+- Change from `disposeBag.addDisposable` to `disposable.addDisposableTo`
+- Changes in RxCocoa extensions to enable fluent style
+- Rename of `do*` to `doOn*`
+- Deprecates `returnElement` in favor of `just`
+- Deprecates `aggregate` in favor of `reduce`
+- Deprecates `variable` in favor of `shareReplay(1)` (to be consistent with RxJS version)
+- Method `next` on `Variable` in favor of `sendNext`
 
 #### Fixed
 
@@ -1042,9 +1045,9 @@ let (
 
 #### Updated
 
-* Adds Calculator example app
-* Performance improvements for Queue
+- Adds Calculator example app
+- Performance improvements for Queue
 
 #### Fixed
 
-* Crash in `rx_didChangeAuthorizationStatus`. [#89](https://github.com/ReactiveX/RxSwift/issues/89)
+- Crash in `rx_didChangeAuthorizationStatus`. [#89](https://github.com/ReactiveX/RxSwift/issues/89)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+* Performance enhancement reduces Bag dispatch inline code size by 12%.
+
 #### Anomalies
 
 ## [4.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.2.0)
@@ -33,7 +35,6 @@ All notable changes to this project will be documented in this file.
 
 * Lower macOS Deployment Target to 10.9
 * Deprecates `UISegmentedControl.enabled(forSegmentAt:)` in favor of `UISegmentedControl.enabledForSegment(at:)`.
-
 
 ## [4.1.2](https://github.com/ReactiveX/RxSwift/releases/tag/4.1.2)
 

--- a/RxCocoa/Common/ControlTarget.swift
+++ b/RxCocoa/Common/ControlTarget.swift
@@ -14,7 +14,7 @@ import RxSwift
     import UIKit
 
     typealias Control = UIKit.UIControl
-    typealias ControlEvents = UIKit.UIControlEvents
+    typealias ControlEvents = UIKit.UIControl.Event
 #elseif os(macOS)
     import Cocoa
 
@@ -29,11 +29,11 @@ final class ControlTarget: RxTarget {
 
     weak var control: Control?
 #if os(iOS) || os(tvOS)
-    let controlEvents: UIControlEvents
+    let controlEvents: UIControl.Event
 #endif
     var callback: Callback?
     #if os(iOS) || os(tvOS)
-    init(control: Control, controlEvents: UIControlEvents, callback: @escaping Callback) {
+    init(control: Control, controlEvents: UIControl.Event, callback: @escaping Callback) {
         MainScheduler.ensureExecutingOnScheduler()
 
         self.control = control

--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -355,8 +355,8 @@ extension Reactive where Base: UIImageView {
                 if image != nil {
                     let transition = CATransition()
                     transition.duration = 0.25
-                    transition.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-                    transition.type = transitionType
+                    transition.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+                    transition.type = CATransitionType(rawValue: transitionType)
                     imageView.layer.add(transition, forKey: kCATransition)
                 }
             }
@@ -390,8 +390,8 @@ extension Reactive where Base: UISegmentedControl {
                     if value != nil {
                         let transition = CATransition()
                         transition.duration = 0.25
-                        transition.timingFunction = CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-                        transition.type = transitionType
+                        transition.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+                        transition.type = CATransitionType(rawValue: transitionType)
                         control.layer?.add(transition, forKey: kCATransition)
                     }
                 }

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -44,8 +44,8 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     Creates new subscription and sends elements to `BehaviorRelay`.
     This method can be only called from `MainThread`.
 
-    - parameter variable: Target variable for sequence elements.
-    - returns: Disposable object that can be used to unsubscribe the observer from the variable.
+    - parameter relay: Target relay for sequence elements.
+    - returns: Disposable object that can be used to unsubscribe the observer from the relay.
     */
     public func drive(_ relay: BehaviorRelay<E>) -> Disposable {
         MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
@@ -55,11 +55,11 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     }
 
     /**
-     Creates new subscription and sends elements to variable.
+     Creates new subscription and sends elements to `BehaviorRelay`.
      This method can be only called from `MainThread`.
 
-     - parameter variable: Target variable for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer from the variable.
+     - parameter relay: Target relay for sequence elements.
+     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func drive(_ relay: BehaviorRelay<E?>) -> Disposable {
         MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)

--- a/RxCocoa/iOS/NSTextStorage+Rx.swift
+++ b/RxCocoa/iOS/NSTextStorage+Rx.swift
@@ -20,11 +20,11 @@
         }
 
         /// Reactive wrapper for `delegate` message.
-        public var didProcessEditingRangeChangeInLength: Observable<(editedMask:NSTextStorageEditActions, editedRange:NSRange, delta:Int)> {
+        public var didProcessEditingRangeChangeInLength: Observable<(editedMask:NSTextStorage.EditActions, editedRange:NSRange, delta:Int)> {
             return delegate
                 .methodInvoked(#selector(NSTextStorageDelegate.textStorage(_:didProcessEditing:range:changeInLength:)))
                 .map { a in
-                    let editedMask = NSTextStorageEditActions(rawValue: try castOrThrow(UInt.self, a[1]) )
+                    let editedMask = NSTextStorage.EditActions(rawValue: try castOrThrow(UInt.self, a[1]) )
                     let editedRange = try castOrThrow(NSValue.self, a[2]).rangeValue
                     let delta = try castOrThrow(Int.self, a[3])
                     

--- a/RxCocoa/iOS/UIButton+Rx.swift
+++ b/RxCocoa/iOS/UIButton+Rx.swift
@@ -45,21 +45,21 @@ import UIKit
 extension Reactive where Base: UIButton {
     
     /// Reactive wrapper for `setTitle(_:for:)`
-    public func title(for controlState: UIControlState = []) -> Binder<String?> {
+    public func title(for controlState: UIControl.State = []) -> Binder<String?> {
         return Binder(self.base) { (button, title) -> () in
             button.setTitle(title, for: controlState)
         }
     }
 
     /// Reactive wrapper for `setImage(_:for:)`
-    public func image(for controlState: UIControlState = []) -> Binder<UIImage?> {
+    public func image(for controlState: UIControl.State = []) -> Binder<UIImage?> {
         return Binder(self.base) { (button, image) -> () in
             button.setImage(image, for: controlState)
         }
     }
 
     /// Reactive wrapper for `setBackgroundImage(_:for:)`
-    public func backgroundImage(for controlState: UIControlState = []) -> Binder<UIImage?> {
+    public func backgroundImage(for controlState: UIControl.State = []) -> Binder<UIImage?> {
         return Binder(self.base) { (button, image) -> () in
             button.setBackgroundImage(image, for: controlState)
         }
@@ -76,7 +76,7 @@ extension Reactive where Base: UIButton {
     extension Reactive where Base: UIButton {
         
         /// Reactive wrapper for `setAttributedTitle(_:controlState:)`
-        public func attributedTitle(for controlState: UIControlState = []) -> Binder<NSAttributedString?> {
+        public func attributedTitle(for controlState: UIControl.State = []) -> Binder<NSAttributedString?> {
             return Binder(self.base) { (button, attributedTitle) -> () in
                 button.setAttributedTitle(attributedTitle, for: controlState)
             }

--- a/RxCocoa/iOS/UIControl+Rx.swift
+++ b/RxCocoa/iOS/UIControl+Rx.swift
@@ -30,7 +30,7 @@ extension Reactive where Base: UIControl {
     /// Reactive wrapper for target action pattern.
     ///
     /// - parameter controlEvents: Filter for observed event types.
-    public func controlEvent(_ controlEvents: UIControlEvents) -> ControlEvent<()> {
+    public func controlEvent(_ controlEvents: UIControl.Event) -> ControlEvent<()> {
         let source: Observable<Void> = Observable.create { [weak control = self.base] observer in
                 MainScheduler.ensureExecutingOnScheduler()
 
@@ -57,7 +57,7 @@ extension Reactive where Base: UIControl {
     /// - parameter getter: Property value getter.
     /// - parameter setter: Property value setter.
     public func controlProperty<T>(
-        editingEvents: UIControlEvents,
+        editingEvents: UIControl.Event,
         getter: @escaping (Base) -> T,
         setter: @escaping (Base, T) -> ()
     ) -> ControlProperty<T> {
@@ -87,7 +87,7 @@ extension Reactive where Base: UIControl {
     /// This is a separate method is to better communicate to public consumers that
     /// an `editingEvent` needs to fire for control property to be updated.
     internal func controlPropertyWithDefaultEvents<T>(
-        editingEvents: UIControlEvents = [.allEditingEvents, .valueChanged],
+        editingEvents: UIControl.Event = [.allEditingEvents, .valueChanged],
         getter: @escaping (Base) -> T,
         setter: @escaping (Base, T) -> ()
         ) -> ControlProperty<T> {

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -231,7 +231,7 @@ extension Reactive where Base: UITableView {
     public var itemInserted: ControlEvent<IndexPath> {
         let source = self.dataSource.methodInvoked(#selector(UITableViewDataSource.tableView(_:commit:forRowAt:)))
             .filter { a in
-                return UITableViewCellEditingStyle(rawValue: (try castOrThrow(NSNumber.self, a[1])).intValue) == .insert
+                return UITableViewCell.EditingStyle(rawValue: (try castOrThrow(NSNumber.self, a[1])).intValue) == .insert
             }
             .map { a in
                 return (try castOrThrow(IndexPath.self, a[2]))
@@ -246,7 +246,7 @@ extension Reactive where Base: UITableView {
     public var itemDeleted: ControlEvent<IndexPath> {
         let source = self.dataSource.methodInvoked(#selector(UITableViewDataSource.tableView(_:commit:forRowAt:)))
             .filter { a in
-                return UITableViewCellEditingStyle(rawValue: (try castOrThrow(NSNumber.self, a[1])).intValue) == .delete
+                return UITableViewCell.EditingStyle(rawValue: (try castOrThrow(NSNumber.self, a[1])).intValue) == .delete
             }
             .map { a in
                 return try castOrThrow(IndexPath.self, a[2])

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
@@ -61,18 +61,10 @@ extension GitHubSearchRepositoriesState {
 import RxSwift
 import RxCocoa
 
-struct GithubQuery {
+struct GithubQuery: Equatable {
     let searchText: String;
     let shouldLoadNextPage: Bool;
     let nextURL: URL?
-}
-
-extension GithubQuery: Equatable {
-    static func == (lhs: GithubQuery, rhs: GithubQuery) -> Bool {
-        return lhs.nextURL == rhs.nextURL
-            && lhs.searchText == rhs.searchText
-            && lhs.nextURL == rhs.nextURL
-    }
 }
 
 /**

--- a/RxExample/RxExample/Examples/SimpleTableViewExampleSectioned/SimpleTableViewExampleSectionedViewController.swift
+++ b/RxExample/RxExample/Examples/SimpleTableViewExampleSectioned/SimpleTableViewExampleSectionedViewController.swift
@@ -70,7 +70,7 @@ class SimpleTableViewExampleSectionedViewController
     }
 
     // to prevent swipe to delete behavior
-    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCellEditingStyle {
+    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
         return .none
     }
     

--- a/RxSwift/Extensions/Bag+Rx.swift
+++ b/RxSwift/Extensions/Bag+Rx.swift
@@ -11,16 +11,10 @@
 
 @inline(__always)
 func dispatch<E>(_ bag: Bag<(Event<E>) -> ()>, _ event: Event<E>) {
+    bag._value0?(event)
+
     if bag._onlyFastPath {
-        bag._value0?(event)
         return
-    }
-
-    let value0 = bag._value0
-    let dictionary = bag._dictionary
-
-    if let value0 = value0 {
-        value0(event)
     }
 
     let pairs = bag._pairs
@@ -28,7 +22,7 @@ func dispatch<E>(_ bag: Bag<(Event<E>) -> ()>, _ event: Event<E>) {
         pairs[i].value(event)
     }
 
-    if let dictionary = dictionary {
+    if let dictionary = bag._dictionary {
         for element in dictionary.values {
             element(event)
         }
@@ -37,16 +31,10 @@ func dispatch<E>(_ bag: Bag<(Event<E>) -> ()>, _ event: Event<E>) {
 
 /// Dispatches `dispose` to all disposables contained inside bag.
 func disposeAll(in bag: Bag<Disposable>) {
+    bag._value0?.dispose()
+
     if bag._onlyFastPath {
-        bag._value0?.dispose()
         return
-    }
-
-    let value0 = bag._value0
-    let dictionary = bag._dictionary
-
-    if let value0 = value0 {
-        value0.dispose()
     }
 
     let pairs = bag._pairs
@@ -54,7 +42,7 @@ func disposeAll(in bag: Bag<Disposable>) {
         pairs[i].value.dispose()
     }
 
-    if let dictionary = dictionary {
+    if let dictionary = bag._dictionary {
         for element in dictionary.values {
             element.dispose()
         }

--- a/RxSwift/Schedulers/OperationQueueScheduler.swift
+++ b/RxSwift/Schedulers/OperationQueueScheduler.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import class Foundation.Operation
 import class Foundation.OperationQueue
 import class Foundation.BlockOperation
 import Dispatch
@@ -15,12 +16,15 @@ import Dispatch
 /// This scheduler is suitable for cases when there is some bigger chunk of work that needs to be performed in background and you want to fine tune concurrent processing using `maxConcurrentOperationCount`.
 public class OperationQueueScheduler: ImmediateSchedulerType {
     public let operationQueue: OperationQueue
+    public let queuePriority: Operation.QueuePriority
     
     /// Constructs new instance of `OperationQueueScheduler` that performs work on `operationQueue`.
     ///
     /// - parameter operationQueue: Operation queue targeted to perform work on.
-    public init(operationQueue: OperationQueue) {
+    /// - parameter queuePriority: Queue priority which will be assigned to new operations.
+    public init(operationQueue: OperationQueue, queuePriority: Operation.QueuePriority = .normal) {
         self.operationQueue = operationQueue
+        self.queuePriority = queuePriority
     }
     
     /**
@@ -41,6 +45,8 @@ public class OperationQueueScheduler: ImmediateSchedulerType {
 
             cancel.setDisposable(action(state))
         }
+
+        operation.queuePriority = self.queuePriority
 
         self.operationQueue.addOperation(operation)
         

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -192,7 +192,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    @available(*, deprecated, message: "Use do(onSuccess:onError:onSubscribe:onSubcribed:onDispose:) instead", renamed: "do(onSuccess:onError:onSubscribe:onSubcribed:onDispose:)")
+    @available(*, deprecated, renamed: "do(onSuccess:onError:onSubscribe:onSubscribed:onDispose:)")
     public func `do`(onNext: ((ElementType) throws -> Void)?,
                      onError: ((Swift.Error) throws -> Void)? = nil,
                      onSubscribe: (() -> ())? = nil,

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -12,40 +12,6 @@ protocol RxTestCase {
 }
 
 
-final class ObservableWithLatestFromTest_ : ObservableWithLatestFromTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableWithLatestFromTest_) -> () -> ())] { return [
-    ("testWithLatestFrom_Simple1", ObservableWithLatestFromTest.testWithLatestFrom_Simple1),
-    ("testWithLatestFrom_TwoObservablesWithImmediateValues", ObservableWithLatestFromTest.testWithLatestFrom_TwoObservablesWithImmediateValues),
-    ("testWithLatestFrom_Simple2", ObservableWithLatestFromTest.testWithLatestFrom_Simple2),
-    ("testWithLatestFrom_Simple3", ObservableWithLatestFromTest.testWithLatestFrom_Simple3),
-    ("testWithLatestFrom_Error1", ObservableWithLatestFromTest.testWithLatestFrom_Error1),
-    ("testWithLatestFrom_Error2", ObservableWithLatestFromTest.testWithLatestFrom_Error2),
-    ("testWithLatestFrom_Error3", ObservableWithLatestFromTest.testWithLatestFrom_Error3),
-    ("testWithLatestFrom_MakeSureDefaultOverloadTakesSecondSequenceValues", ObservableWithLatestFromTest.testWithLatestFrom_MakeSureDefaultOverloadTakesSecondSequenceValues),
-    ] }
-}
-
-final class ObservableOptionalTest_ : ObservableOptionalTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableOptionalTest_) -> () -> ())] { return [
-    ("testFromOptionalSome_immediate", ObservableOptionalTest.testFromOptionalSome_immediate),
-    ("testFromOptionalNone_immediate", ObservableOptionalTest.testFromOptionalNone_immediate),
-    ("testFromOptionalSome_basic_testScheduler", ObservableOptionalTest.testFromOptionalSome_basic_testScheduler),
-    ("testFromOptionalNone_basic_testScheduler", ObservableOptionalTest.testFromOptionalNone_basic_testScheduler),
-    ] }
-}
-
 final class AnomaliesTest_ : AnomaliesTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -61,292 +27,66 @@ final class AnomaliesTest_ : AnomaliesTest, RxTestCase {
     ] }
 }
 
-final class ObservableTakeLastTest_ : ObservableTakeLastTest, RxTestCase {
+final class AsyncSubjectTests_ : AsyncSubjectTests, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (ObservableTakeLastTest_) -> () -> ())] { return [
-    ("testTakeLast_Complete_Less", ObservableTakeLastTest.testTakeLast_Complete_Less),
-    ("testTakeLast_Complete_Same", ObservableTakeLastTest.testTakeLast_Complete_Same),
-    ("testTakeLast_Complete_More", ObservableTakeLastTest.testTakeLast_Complete_More),
-    ("testTakeLast_Error_Less", ObservableTakeLastTest.testTakeLast_Error_Less),
-    ("testTakeLast_Error_Same", ObservableTakeLastTest.testTakeLast_Error_Same),
-    ("testTakeLast_Error_More", ObservableTakeLastTest.testTakeLast_Error_More),
-    ("testTakeLast_0_DefaultScheduler", ObservableTakeLastTest.testTakeLast_0_DefaultScheduler),
-    ("testTakeLast_TakeLast1", ObservableTakeLastTest.testTakeLast_TakeLast1),
-    ("testTakeLast_DecrementCountsFirst", ObservableTakeLastTest.testTakeLast_DecrementCountsFirst),
+    static var allTests: [(String, (AsyncSubjectTests_) -> () -> ())] { return [
+    ("test_hasObserversManyObserver", AsyncSubjectTests.test_hasObserversManyObserver),
+    ("test_infinite", AsyncSubjectTests.test_infinite),
+    ("test_finite", AsyncSubjectTests.test_finite),
+    ("test_error", AsyncSubjectTests.test_error),
+    ("test_empty", AsyncSubjectTests.test_empty),
     ] }
 }
 
-final class VirtualSchedulerTest_ : VirtualSchedulerTest, RxTestCase {
+final class BehaviorSubjectTest_ : BehaviorSubjectTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (VirtualSchedulerTest_) -> () -> ())] { return [
-    ("testVirtualScheduler_initialClock", VirtualSchedulerTest.testVirtualScheduler_initialClock),
-    ("testVirtualScheduler_start", VirtualSchedulerTest.testVirtualScheduler_start),
-    ("testVirtualScheduler_disposeStart", VirtualSchedulerTest.testVirtualScheduler_disposeStart),
-    ("testVirtualScheduler_advanceToAfter", VirtualSchedulerTest.testVirtualScheduler_advanceToAfter),
-    ("testVirtualScheduler_advanceToBefore", VirtualSchedulerTest.testVirtualScheduler_advanceToBefore),
-    ("testVirtualScheduler_disposeAdvanceTo", VirtualSchedulerTest.testVirtualScheduler_disposeAdvanceTo),
-    ("testVirtualScheduler_stop", VirtualSchedulerTest.testVirtualScheduler_stop),
-    ("testVirtualScheduler_sleep", VirtualSchedulerTest.testVirtualScheduler_sleep),
-    ("testVirtualScheduler_stress", VirtualSchedulerTest.testVirtualScheduler_stress),
+    static var allTests: [(String, (BehaviorSubjectTest_) -> () -> ())] { return [
+    ("test_Infinite", BehaviorSubjectTest.test_Infinite),
+    ("test_Finite", BehaviorSubjectTest.test_Finite),
+    ("test_Error", BehaviorSubjectTest.test_Error),
+    ("test_Canceled", BehaviorSubjectTest.test_Canceled),
+    ("test_hasObserversNoObservers", BehaviorSubjectTest.test_hasObserversNoObservers),
+    ("test_hasObserversOneObserver", BehaviorSubjectTest.test_hasObserversOneObserver),
+    ("test_hasObserversManyObserver", BehaviorSubjectTest.test_hasObserversManyObserver),
     ] }
 }
 
-final class ObservableBlockingTest_ : ObservableBlockingTest, RxTestCase {
+final class CompletableAndThenTest_ : CompletableAndThenTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (ObservableBlockingTest_) -> () -> ())] { return [
-    ("testToArray_empty", ObservableBlockingTest.testToArray_empty),
-    ("testToArray_return", ObservableBlockingTest.testToArray_return),
-    ("testToArray_fail", ObservableBlockingTest.testToArray_fail),
-    ("testToArray_someData", ObservableBlockingTest.testToArray_someData),
-    ("testToArray_withRealScheduler", ObservableBlockingTest.testToArray_withRealScheduler),
-    ("testToArray_independent", ObservableBlockingTest.testToArray_independent),
-    ("testToArray_timeout", ObservableBlockingTest.testToArray_timeout),
-    ("testFirst_empty", ObservableBlockingTest.testFirst_empty),
-    ("testFirst_return", ObservableBlockingTest.testFirst_return),
-    ("testFirst_fail", ObservableBlockingTest.testFirst_fail),
-    ("testFirst_someData", ObservableBlockingTest.testFirst_someData),
-    ("testFirst_withRealScheduler", ObservableBlockingTest.testFirst_withRealScheduler),
-    ("testFirst_independent", ObservableBlockingTest.testFirst_independent),
-    ("testFirst_timeout", ObservableBlockingTest.testFirst_timeout),
-    ("testLast_empty", ObservableBlockingTest.testLast_empty),
-    ("testLast_return", ObservableBlockingTest.testLast_return),
-    ("testLast_fail", ObservableBlockingTest.testLast_fail),
-    ("testLast_someData", ObservableBlockingTest.testLast_someData),
-    ("testLast_withRealScheduler", ObservableBlockingTest.testLast_withRealScheduler),
-    ("testLast_independent", ObservableBlockingTest.testLast_independent),
-    ("testLast_timeout", ObservableBlockingTest.testLast_timeout),
-    ("testSingle_empty", ObservableBlockingTest.testSingle_empty),
-    ("testSingle_return", ObservableBlockingTest.testSingle_return),
-    ("testSingle_two", ObservableBlockingTest.testSingle_two),
-    ("testSingle_someData", ObservableBlockingTest.testSingle_someData),
-    ("testSingle_fail", ObservableBlockingTest.testSingle_fail),
-    ("testSingle_withRealScheduler", ObservableBlockingTest.testSingle_withRealScheduler),
-    ("testSingle_predicate_empty", ObservableBlockingTest.testSingle_predicate_empty),
-    ("testSingle_predicate_return", ObservableBlockingTest.testSingle_predicate_return),
-    ("testSingle_predicate_someData_one_match", ObservableBlockingTest.testSingle_predicate_someData_one_match),
-    ("testSingle_predicate_someData_two_match", ObservableBlockingTest.testSingle_predicate_someData_two_match),
-    ("testSingle_predicate_none", ObservableBlockingTest.testSingle_predicate_none),
-    ("testSingle_predicate_throws", ObservableBlockingTest.testSingle_predicate_throws),
-    ("testSingle_predicate_fail", ObservableBlockingTest.testSingle_predicate_fail),
-    ("testSingle_predicate_withRealScheduler", ObservableBlockingTest.testSingle_predicate_withRealScheduler),
-    ("testSingle_independent", ObservableBlockingTest.testSingle_independent),
-    ("testSingle_timeout", ObservableBlockingTest.testSingle_timeout),
-    ("testSinglePredicate_timeout", ObservableBlockingTest.testSinglePredicate_timeout),
-    ("testMaterialize_empty", ObservableBlockingTest.testMaterialize_empty),
-    ("testMaterialize_empty_fail", ObservableBlockingTest.testMaterialize_empty_fail),
-    ("testMaterialize_someData", ObservableBlockingTest.testMaterialize_someData),
-    ("testMaterialize_someData_fail", ObservableBlockingTest.testMaterialize_someData_fail),
-    ] }
-}
-
-final class ObservableRetryWhenTest_ : ObservableRetryWhenTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableRetryWhenTest_) -> () -> ())] { return [
-    ("testRetryWhen_Never", ObservableRetryWhenTest.testRetryWhen_Never),
-    ("testRetryWhen_ObservableNever", ObservableRetryWhenTest.testRetryWhen_ObservableNever),
-    ("testRetryWhen_ObservableNeverComplete", ObservableRetryWhenTest.testRetryWhen_ObservableNeverComplete),
-    ("testRetryWhen_ObservableEmpty", ObservableRetryWhenTest.testRetryWhen_ObservableEmpty),
-    ("testRetryWhen_ObservableNextError", ObservableRetryWhenTest.testRetryWhen_ObservableNextError),
-    ("testRetryWhen_ObservableComplete", ObservableRetryWhenTest.testRetryWhen_ObservableComplete),
-    ("testRetryWhen_ObservableNextComplete", ObservableRetryWhenTest.testRetryWhen_ObservableNextComplete),
-    ("testRetryWhen_ObservableInfinite", ObservableRetryWhenTest.testRetryWhen_ObservableInfinite),
-    ("testRetryWhen_Incremental_BackOff", ObservableRetryWhenTest.testRetryWhen_Incremental_BackOff),
-    ("testRetryWhen_IgnoresDifferentErrorTypes", ObservableRetryWhenTest.testRetryWhen_IgnoresDifferentErrorTypes),
-    ("testRetryWhen_tailRecursiveOptimizationsTest", ObservableRetryWhenTest.testRetryWhen_tailRecursiveOptimizationsTest),
-    ] }
-}
-
-final class ObservableDelaySubscriptionTest_ : ObservableDelaySubscriptionTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableDelaySubscriptionTest_) -> () -> ())] { return [
-    ("testDelaySubscription_TimeSpan_Simple", ObservableDelaySubscriptionTest.testDelaySubscription_TimeSpan_Simple),
-    ("testDelaySubscription_TimeSpan_Error", ObservableDelaySubscriptionTest.testDelaySubscription_TimeSpan_Error),
-    ("testDelaySubscription_TimeSpan_Dispose", ObservableDelaySubscriptionTest.testDelaySubscription_TimeSpan_Dispose),
-    ] }
-}
-
-final class ObservableDistinctUntilChangedTest_ : ObservableDistinctUntilChangedTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableDistinctUntilChangedTest_) -> () -> ())] { return [
-    ("testDistinctUntilChanged_allChanges", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_allChanges),
-    ("testDistinctUntilChanged_someChanges", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_someChanges),
-    ("testDistinctUntilChanged_allEqual", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_allEqual),
-    ("testDistinctUntilChanged_allDifferent", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_allDifferent),
-    ("testDistinctUntilChanged_keySelector_Div2", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_keySelector_Div2),
-    ("testDistinctUntilChanged_keySelectorThrows", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_keySelectorThrows),
-    ("testDistinctUntilChanged_comparerThrows", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_comparerThrows),
-    ] }
-}
-
-final class ObservableObserveOnTest_ : ObservableObserveOnTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableObserveOnTest_) -> () -> ())] { return [
-    ("testObserveOnDispatchQueue_DoesPerformWorkOnQueue", ObservableObserveOnTest.testObserveOnDispatchQueue_DoesPerformWorkOnQueue),
-    ("testObserveOnDispatchQueue_DeadlockErrorImmediately", ObservableObserveOnTest.testObserveOnDispatchQueue_DeadlockErrorImmediately),
-    ("testObserveOnDispatchQueue_DeadlockEmpty", ObservableObserveOnTest.testObserveOnDispatchQueue_DeadlockEmpty),
-    ("testObserveOnDispatchQueue_Never", ObservableObserveOnTest.testObserveOnDispatchQueue_Never),
-    ("testObserveOnDispatchQueue_Simple", ObservableObserveOnTest.testObserveOnDispatchQueue_Simple),
-    ("testObserveOnDispatchQueue_Empty", ObservableObserveOnTest.testObserveOnDispatchQueue_Empty),
-    ("testObserveOnDispatchQueue_Error", ObservableObserveOnTest.testObserveOnDispatchQueue_Error),
-    ("testObserveOnDispatchQueue_Dispose", ObservableObserveOnTest.testObserveOnDispatchQueue_Dispose),
-    ] }
-}
-
-final class ObservableSkipWhileTest_ : ObservableSkipWhileTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSkipWhileTest_) -> () -> ())] { return [
-    ("testSkipWhile_Complete_Before", ObservableSkipWhileTest.testSkipWhile_Complete_Before),
-    ("testSkipWhile_Complete_After", ObservableSkipWhileTest.testSkipWhile_Complete_After),
-    ("testSkipWhile_Error_Before", ObservableSkipWhileTest.testSkipWhile_Error_Before),
-    ("testSkipWhile_Error_After", ObservableSkipWhileTest.testSkipWhile_Error_After),
-    ("testSkipWhile_Dispose_Before", ObservableSkipWhileTest.testSkipWhile_Dispose_Before),
-    ("testSkipWhile_Dispose_After", ObservableSkipWhileTest.testSkipWhile_Dispose_After),
-    ("testSkipWhile_Zero", ObservableSkipWhileTest.testSkipWhile_Zero),
-    ("testSkipWhile_Throw", ObservableSkipWhileTest.testSkipWhile_Throw),
-    ] }
-}
-
-final class ObservableSwitchTest_ : ObservableSwitchTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSwitchTest_) -> () -> ())] { return [
-    ("testSwitch_Data", ObservableSwitchTest.testSwitch_Data),
-    ("testSwitch_InnerThrows", ObservableSwitchTest.testSwitch_InnerThrows),
-    ("testSwitch_OuterThrows", ObservableSwitchTest.testSwitch_OuterThrows),
-    ("testFlatMapLatest_Data", ObservableSwitchTest.testFlatMapLatest_Data),
-    ("testFlatMapLatest_InnerThrows", ObservableSwitchTest.testFlatMapLatest_InnerThrows),
-    ("testFlatMapLatest_OuterThrows", ObservableSwitchTest.testFlatMapLatest_OuterThrows),
-    ("testFlatMapLatest_SelectorThrows", ObservableSwitchTest.testFlatMapLatest_SelectorThrows),
-    ] }
-}
-
-final class ObservableSkipTest_ : ObservableSkipTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSkipTest_) -> () -> ())] { return [
-    ("testSkip_Complete_After", ObservableSkipTest.testSkip_Complete_After),
-    ("testSkip_Complete_Some", ObservableSkipTest.testSkip_Complete_Some),
-    ("testSkip_Complete_Before", ObservableSkipTest.testSkip_Complete_Before),
-    ("testSkip_Complete_Zero", ObservableSkipTest.testSkip_Complete_Zero),
-    ("testSkip_Error_After", ObservableSkipTest.testSkip_Error_After),
-    ("testSkip_Error_Same", ObservableSkipTest.testSkip_Error_Same),
-    ("testSkip_Error_Before", ObservableSkipTest.testSkip_Error_Before),
-    ("testSkip_Dispose_Before", ObservableSkipTest.testSkip_Dispose_Before),
-    ("testSkip_Dispose_After", ObservableSkipTest.testSkip_Dispose_After),
-    ("testSkip_Zero", ObservableSkipTest.testSkip_Zero),
-    ("testSkip_Some", ObservableSkipTest.testSkip_Some),
-    ("testSkip_Late", ObservableSkipTest.testSkip_Late),
-    ("testSkip_Error", ObservableSkipTest.testSkip_Error),
-    ("testSkip_Never", ObservableSkipTest.testSkip_Never),
-    ] }
-}
-
-final class ObservableTest_ : ObservableTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableTest_) -> () -> ())] { return [
-    ("testAnonymousObservable_detachesOnDispose", ObservableTest.testAnonymousObservable_detachesOnDispose),
-    ("testAnonymousObservable_detachesOnComplete", ObservableTest.testAnonymousObservable_detachesOnComplete),
-    ("testAnonymousObservable_detachesOnError", ObservableTest.testAnonymousObservable_detachesOnError),
-    ("testAsObservable_asObservable", ObservableTest.testAsObservable_asObservable),
-    ("testAsObservable_hides", ObservableTest.testAsObservable_hides),
-    ("testAsObservable_never", ObservableTest.testAsObservable_never),
-    ] }
-}
-
-final class ObservableRangeTest_ : ObservableRangeTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableRangeTest_) -> () -> ())] { return [
-    ("testRange_Boundaries", ObservableRangeTest.testRange_Boundaries),
-    ("testRange_Dispose", ObservableRangeTest.testRange_Dispose),
-    ] }
-}
-
-final class ObservableScanTest_ : ObservableScanTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableScanTest_) -> () -> ())] { return [
-    ("testScan_Seed_Never", ObservableScanTest.testScan_Seed_Never),
-    ("testScan_Seed_Empty", ObservableScanTest.testScan_Seed_Empty),
-    ("testScan_Seed_Return", ObservableScanTest.testScan_Seed_Return),
-    ("testScan_Seed_Throw", ObservableScanTest.testScan_Seed_Throw),
-    ("testScan_Seed_SomeData", ObservableScanTest.testScan_Seed_SomeData),
-    ("testScan_Seed_AccumulatorThrows", ObservableScanTest.testScan_Seed_AccumulatorThrows),
-    ] }
-}
-
-final class ReplaySubjectTest_ : ReplaySubjectTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ReplaySubjectTest_) -> () -> ())] { return [
-    ("test_hasObserversNoObservers", ReplaySubjectTest.test_hasObserversNoObservers),
-    ("test_hasObserversOneObserver", ReplaySubjectTest.test_hasObserversOneObserver),
-    ("test_hasObserversManyObserver", ReplaySubjectTest.test_hasObserversManyObserver),
+    static var allTests: [(String, (CompletableAndThenTest_) -> () -> ())] { return [
+    ("testCompletableEmpty_CompletableCompleted", CompletableAndThenTest.testCompletableEmpty_CompletableCompleted),
+    ("testCompletableCompleted_CompletableCompleted", CompletableAndThenTest.testCompletableCompleted_CompletableCompleted),
+    ("testCompletableError_CompletableCompleted", CompletableAndThenTest.testCompletableError_CompletableCompleted),
+    ("testCompletableCompleted_CompletableError", CompletableAndThenTest.testCompletableCompleted_CompletableError),
+    ("testCompletableEmpty_SingleCompleted", CompletableAndThenTest.testCompletableEmpty_SingleCompleted),
+    ("testCompletableCompleted_SingleNormal", CompletableAndThenTest.testCompletableCompleted_SingleNormal),
+    ("testCompletableError_SingleNormal", CompletableAndThenTest.testCompletableError_SingleNormal),
+    ("testCompletableCompleted_SingleError", CompletableAndThenTest.testCompletableCompleted_SingleError),
+    ("testCompletableEmpty_MaybeCompleted", CompletableAndThenTest.testCompletableEmpty_MaybeCompleted),
+    ("testCompletableCompleted_MaybeNormal", CompletableAndThenTest.testCompletableCompleted_MaybeNormal),
+    ("testCompletableError_MaybeNormal", CompletableAndThenTest.testCompletableError_MaybeNormal),
+    ("testCompletableCompleted_MaybeError", CompletableAndThenTest.testCompletableCompleted_MaybeError),
+    ("testCompletableCompleted_MaybeEmpty", CompletableAndThenTest.testCompletableCompleted_MaybeEmpty),
+    ("testCompletableEmpty_ObservableCompleted", CompletableAndThenTest.testCompletableEmpty_ObservableCompleted),
+    ("testCompletableCompleted_ObservableNormal", CompletableAndThenTest.testCompletableCompleted_ObservableNormal),
+    ("testCompletableError_ObservableNormal", CompletableAndThenTest.testCompletableError_ObservableNormal),
+    ("testCompletableCompleted_ObservableError", CompletableAndThenTest.testCompletableCompleted_ObservableError),
+    ("testCompletableCompleted_ObservableEmpty", CompletableAndThenTest.testCompletableCompleted_ObservableEmpty),
     ] }
 }
 
@@ -392,32 +132,33 @@ final class CompletableTest_ : CompletableTest, RxTestCase {
     ] }
 }
 
-final class CompletableAndThenTest_ : CompletableAndThenTest, RxTestCase {
+final class ConcurrentDispatchQueueSchedulerTests_ : ConcurrentDispatchQueueSchedulerTests, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (CompletableAndThenTest_) -> () -> ())] { return [
-    ("testCompletableEmpty_CompletableCompleted", CompletableAndThenTest.testCompletableEmpty_CompletableCompleted),
-    ("testCompletableCompleted_CompletableCompleted", CompletableAndThenTest.testCompletableCompleted_CompletableCompleted),
-    ("testCompletableError_CompletableCompleted", CompletableAndThenTest.testCompletableError_CompletableCompleted),
-    ("testCompletableCompleted_CompletableError", CompletableAndThenTest.testCompletableCompleted_CompletableError),
-    ("testCompletableEmpty_SingleCompleted", CompletableAndThenTest.testCompletableEmpty_SingleCompleted),
-    ("testCompletableCompleted_SingleNormal", CompletableAndThenTest.testCompletableCompleted_SingleNormal),
-    ("testCompletableError_SingleNormal", CompletableAndThenTest.testCompletableError_SingleNormal),
-    ("testCompletableCompleted_SingleError", CompletableAndThenTest.testCompletableCompleted_SingleError),
-    ("testCompletableEmpty_MaybeCompleted", CompletableAndThenTest.testCompletableEmpty_MaybeCompleted),
-    ("testCompletableCompleted_MaybeNormal", CompletableAndThenTest.testCompletableCompleted_MaybeNormal),
-    ("testCompletableError_MaybeNormal", CompletableAndThenTest.testCompletableError_MaybeNormal),
-    ("testCompletableCompleted_MaybeError", CompletableAndThenTest.testCompletableCompleted_MaybeError),
-    ("testCompletableCompleted_MaybeEmpty", CompletableAndThenTest.testCompletableCompleted_MaybeEmpty),
-    ("testCompletableEmpty_ObservableCompleted", CompletableAndThenTest.testCompletableEmpty_ObservableCompleted),
-    ("testCompletableCompleted_ObservableNormal", CompletableAndThenTest.testCompletableCompleted_ObservableNormal),
-    ("testCompletableError_ObservableNormal", CompletableAndThenTest.testCompletableError_ObservableNormal),
-    ("testCompletableCompleted_ObservableError", CompletableAndThenTest.testCompletableCompleted_ObservableError),
-    ("testCompletableCompleted_ObservableEmpty", CompletableAndThenTest.testCompletableCompleted_ObservableEmpty),
+    static var allTests: [(String, (ConcurrentDispatchQueueSchedulerTests_) -> () -> ())] { return [
+    ("test_scheduleRelative", ConcurrentDispatchQueueSchedulerTests.test_scheduleRelative),
+    ("test_scheduleRelativeCancel", ConcurrentDispatchQueueSchedulerTests.test_scheduleRelativeCancel),
+    ("test_schedulePeriodic", ConcurrentDispatchQueueSchedulerTests.test_schedulePeriodic),
+    ("test_schedulePeriodicCancel", ConcurrentDispatchQueueSchedulerTests.test_schedulePeriodicCancel),
+    ] }
+}
+
+final class CurrentThreadSchedulerTest_ : CurrentThreadSchedulerTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (CurrentThreadSchedulerTest_) -> () -> ())] { return [
+    ("testCurrentThreadScheduler_scheduleRequired", CurrentThreadSchedulerTest.testCurrentThreadScheduler_scheduleRequired),
+    ("testCurrentThreadScheduler_basicScenario", CurrentThreadSchedulerTest.testCurrentThreadScheduler_basicScenario),
+    ("testCurrentThreadScheduler_disposing1", CurrentThreadSchedulerTest.testCurrentThreadScheduler_disposing1),
+    ("testCurrentThreadScheduler_disposing2", CurrentThreadSchedulerTest.testCurrentThreadScheduler_disposing2),
     ] }
 }
 
@@ -444,65 +185,6 @@ final class DisposableTest_ : DisposableTest, RxTestCase {
     ("testSingleAssignmentDisposable_firstDisposedThenSet", DisposableTest.testSingleAssignmentDisposable_firstDisposedThenSet),
     ("testSingleAssignmentDisposable_firstSetThenDisposed", DisposableTest.testSingleAssignmentDisposable_firstSetThenDisposed),
     ("testSingleAssignmentDisposable_stress", DisposableTest.testSingleAssignmentDisposable_stress),
-    ] }
-}
-
-final class RecursiveLockTests_ : RecursiveLockTests, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (RecursiveLockTests_) -> () -> ())] { return [
-    ("testSynchronizes", RecursiveLockTests.testSynchronizes),
-    ("testIsReentrant", RecursiveLockTests.testIsReentrant),
-    ] }
-}
-
-final class ObservableEnumeratedTest_ : ObservableEnumeratedTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableEnumeratedTest_) -> () -> ())] { return [
-    ("test_Infinite", ObservableEnumeratedTest.test_Infinite),
-    ("test_Completed", ObservableEnumeratedTest.test_Completed),
-    ("test_Error", ObservableEnumeratedTest.test_Error),
-    ] }
-}
-
-final class SharingSchedulerTest_ : SharingSchedulerTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (SharingSchedulerTest_) -> () -> ())] { return [
-    ("testSharingSchedulerMockMake", SharingSchedulerTest.testSharingSchedulerMockMake),
-    ("testSharingSchedulerMockInstance", SharingSchedulerTest.testSharingSchedulerMockInstance),
-    ] }
-}
-
-final class ObservableSequenceTest_ : ObservableSequenceTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSequenceTest_) -> () -> ())] { return [
-    ("testFromArray_complete_immediate", ObservableSequenceTest.testFromArray_complete_immediate),
-    ("testFromArray_complete", ObservableSequenceTest.testFromArray_complete),
-    ("testFromArray_dispose", ObservableSequenceTest.testFromArray_dispose),
-    ("testSequenceOf_complete_immediate", ObservableSequenceTest.testSequenceOf_complete_immediate),
-    ("testSequenceOf_complete", ObservableSequenceTest.testSequenceOf_complete),
-    ("testSequenceOf_dispose", ObservableSequenceTest.testSequenceOf_dispose),
-    ("testFromAnySequence_basic_immediate", ObservableSequenceTest.testFromAnySequence_basic_immediate),
-    ("testToObservableAnySequence_basic_testScheduler", ObservableSequenceTest.testToObservableAnySequence_basic_testScheduler),
     ] }
 }
 
@@ -537,373 +219,6 @@ final class DriverTest_ : DriverTest, RxTestCase {
     ] }
 }
 
-final class ObservableMapTest_ : ObservableMapTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableMapTest_) -> () -> ())] { return [
-    ("testMap_Never", ObservableMapTest.testMap_Never),
-    ("testMap_Empty", ObservableMapTest.testMap_Empty),
-    ("testMap_Range", ObservableMapTest.testMap_Range),
-    ("testMap_Error", ObservableMapTest.testMap_Error),
-    ("testMap_Dispose", ObservableMapTest.testMap_Dispose),
-    ("testMap_SelectorThrows", ObservableMapTest.testMap_SelectorThrows),
-    ("testMapCompose_Never", ObservableMapTest.testMapCompose_Never),
-    ("testMapCompose_Empty", ObservableMapTest.testMapCompose_Empty),
-    ("testMapCompose_Range", ObservableMapTest.testMapCompose_Range),
-    ("testMapCompose_Error", ObservableMapTest.testMapCompose_Error),
-    ("testMapCompose_Dispose", ObservableMapTest.testMapCompose_Dispose),
-    ("testMapCompose_Selector1Throws", ObservableMapTest.testMapCompose_Selector1Throws),
-    ("testMapCompose_Selector2Throws", ObservableMapTest.testMapCompose_Selector2Throws),
-    ] }
-}
-
-final class CurrentThreadSchedulerTest_ : CurrentThreadSchedulerTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (CurrentThreadSchedulerTest_) -> () -> ())] { return [
-    ("testCurrentThreadScheduler_scheduleRequired", CurrentThreadSchedulerTest.testCurrentThreadScheduler_scheduleRequired),
-    ("testCurrentThreadScheduler_basicScenario", CurrentThreadSchedulerTest.testCurrentThreadScheduler_basicScenario),
-    ("testCurrentThreadScheduler_disposing1", CurrentThreadSchedulerTest.testCurrentThreadScheduler_disposing1),
-    ("testCurrentThreadScheduler_disposing2", CurrentThreadSchedulerTest.testCurrentThreadScheduler_disposing2),
-    ] }
-}
-
-final class ObservableSubscribeOnTest_ : ObservableSubscribeOnTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSubscribeOnTest_) -> () -> ())] { return [
-    ("testSubscribeOn_SchedulerSleep", ObservableSubscribeOnTest.testSubscribeOn_SchedulerSleep),
-    ("testSubscribeOn_SchedulerCompleted", ObservableSubscribeOnTest.testSubscribeOn_SchedulerCompleted),
-    ("testSubscribeOn_SchedulerError", ObservableSubscribeOnTest.testSubscribeOn_SchedulerError),
-    ("testSubscribeOn_SchedulerDispose", ObservableSubscribeOnTest.testSubscribeOn_SchedulerDispose),
-    ] }
-}
-
-final class ObservableWindowTest_ : ObservableWindowTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableWindowTest_) -> () -> ())] { return [
-    ("testWindowWithTimeOrCount_Basic", ObservableWindowTest.testWindowWithTimeOrCount_Basic),
-    ("testWindowWithTimeOrCount_Error", ObservableWindowTest.testWindowWithTimeOrCount_Error),
-    ("testWindowWithTimeOrCount_Disposed", ObservableWindowTest.testWindowWithTimeOrCount_Disposed),
-    ] }
-}
-
-final class SharedSequenceOperatorTests_ : SharedSequenceOperatorTests, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (SharedSequenceOperatorTests_) -> () -> ())] { return [
-    ("testAsDriver_deferred", SharedSequenceOperatorTests.testAsDriver_deferred),
-    ("testAsDriver_map", SharedSequenceOperatorTests.testAsDriver_map),
-    ("testAsDriver_filter", SharedSequenceOperatorTests.testAsDriver_filter),
-    ("testAsDriver_switchLatest", SharedSequenceOperatorTests.testAsDriver_switchLatest),
-    ("testAsDriver_flatMapLatest", SharedSequenceOperatorTests.testAsDriver_flatMapLatest),
-    ("testAsDriver_flatMapFirst", SharedSequenceOperatorTests.testAsDriver_flatMapFirst),
-    ("testAsDriver_doOn", SharedSequenceOperatorTests.testAsDriver_doOn),
-    ("testAsDriver_doOnNext", SharedSequenceOperatorTests.testAsDriver_doOnNext),
-    ("testAsDriver_doOnCompleted", SharedSequenceOperatorTests.testAsDriver_doOnCompleted),
-    ("testAsDriver_distinctUntilChanged1", SharedSequenceOperatorTests.testAsDriver_distinctUntilChanged1),
-    ("testAsDriver_distinctUntilChanged2", SharedSequenceOperatorTests.testAsDriver_distinctUntilChanged2),
-    ("testAsDriver_distinctUntilChanged3", SharedSequenceOperatorTests.testAsDriver_distinctUntilChanged3),
-    ("testAsDriver_distinctUntilChanged4", SharedSequenceOperatorTests.testAsDriver_distinctUntilChanged4),
-    ("testAsDriver_flatMap", SharedSequenceOperatorTests.testAsDriver_flatMap),
-    ("testAsDriver_mergeSync", SharedSequenceOperatorTests.testAsDriver_mergeSync),
-    ("testAsDriver_merge", SharedSequenceOperatorTests.testAsDriver_merge),
-    ("testAsDriver_merge2", SharedSequenceOperatorTests.testAsDriver_merge2),
-    ("testAsDriver_debug", SharedSequenceOperatorTests.testAsDriver_debug),
-    ("testAsDriver_debounce", SharedSequenceOperatorTests.testAsDriver_debounce),
-    ("testAsDriver_throttle", SharedSequenceOperatorTests.testAsDriver_throttle),
-    ("testAsDriver_throttle2", SharedSequenceOperatorTests.testAsDriver_throttle2),
-    ("testAsDriver_scan", SharedSequenceOperatorTests.testAsDriver_scan),
-    ("testAsDriver_concat_sequenceType", SharedSequenceOperatorTests.testAsDriver_concat_sequenceType),
-    ("testAsDriver_concat", SharedSequenceOperatorTests.testAsDriver_concat),
-    ("testAsDriver_combineLatest_array", SharedSequenceOperatorTests.testAsDriver_combineLatest_array),
-    ("testAsDriver_combineLatest", SharedSequenceOperatorTests.testAsDriver_combineLatest),
-    ("testAsDriver_zip_array", SharedSequenceOperatorTests.testAsDriver_zip_array),
-    ("testAsDriver_zip", SharedSequenceOperatorTests.testAsDriver_zip),
-    ("testAsDriver_withLatestFrom", SharedSequenceOperatorTests.testAsDriver_withLatestFrom),
-    ("testAsDriver_withLatestFromDefaultOverload", SharedSequenceOperatorTests.testAsDriver_withLatestFromDefaultOverload),
-    ("testAsDriver_skip", SharedSequenceOperatorTests.testAsDriver_skip),
-    ("testAsDriver_startWith", SharedSequenceOperatorTests.testAsDriver_startWith),
-    ("testAsDriver_delay", SharedSequenceOperatorTests.testAsDriver_delay),
-    ("testAsDriver_interval", SharedSequenceOperatorTests.testAsDriver_interval),
-    ("testAsDriver_timer", SharedSequenceOperatorTests.testAsDriver_timer),
-    ("testDriverFromOptional", SharedSequenceOperatorTests.testDriverFromOptional),
-    ("testDriverFromOptionalWhenNil", SharedSequenceOperatorTests.testDriverFromOptionalWhenNil),
-    ("testDriverFromSequence", SharedSequenceOperatorTests.testDriverFromSequence),
-    ("testDriverFromArray", SharedSequenceOperatorTests.testDriverFromArray),
-    ] }
-}
-
-final class SingleTest_ : SingleTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (SingleTest_) -> () -> ())] { return [
-    ("testZip2_selector", SingleTest.testZip2_selector),
-    ("testZip2_tuple", SingleTest.testZip2_tuple),
-    ("testZip3_selector", SingleTest.testZip3_selector),
-    ("testZip3_tuple", SingleTest.testZip3_tuple),
-    ("testZip4_selector", SingleTest.testZip4_selector),
-    ("testZip4_tuple", SingleTest.testZip4_tuple),
-    ("testZip5_selector", SingleTest.testZip5_selector),
-    ("testZip5_tuple", SingleTest.testZip5_tuple),
-    ("testZip6_selector", SingleTest.testZip6_selector),
-    ("testZip6_tuple", SingleTest.testZip6_tuple),
-    ("testZip7_selector", SingleTest.testZip7_selector),
-    ("testZip7_tuple", SingleTest.testZip7_tuple),
-    ("testZip8_selector", SingleTest.testZip8_selector),
-    ("testZip8_tuple", SingleTest.testZip8_tuple),
-    ("testSingle_Subscription_success", SingleTest.testSingle_Subscription_success),
-    ("testSingle_Subscription_error", SingleTest.testSingle_Subscription_error),
-    ("testSingle_create_success", SingleTest.testSingle_create_success),
-    ("testSingle_create_error", SingleTest.testSingle_create_error),
-    ("testSingle_create_disposing", SingleTest.testSingle_create_disposing),
-    ("test_just_producesElement", SingleTest.test_just_producesElement),
-    ("test_just2_producesElement", SingleTest.test_just2_producesElement),
-    ("test_error_fails", SingleTest.test_error_fails),
-    ("test_never_producesElement", SingleTest.test_never_producesElement),
-    ("test_deferred", SingleTest.test_deferred),
-    ("test_delay", SingleTest.test_delay),
-    ("test_delaySubscription", SingleTest.test_delaySubscription),
-    ("test_observeOn", SingleTest.test_observeOn),
-    ("test_subscribeOn", SingleTest.test_subscribeOn),
-    ("test_catchError", SingleTest.test_catchError),
-    ("test_catchErrorJustReturn", SingleTest.test_catchErrorJustReturn),
-    ("test_retry", SingleTest.test_retry),
-    ("test_retryWhen1", SingleTest.test_retryWhen1),
-    ("test_retryWhen2", SingleTest.test_retryWhen2),
-    ("test_debug", SingleTest.test_debug),
-    ("test_using", SingleTest.test_using),
-    ("test_timeout", SingleTest.test_timeout),
-    ("test_timeout_other", SingleTest.test_timeout_other),
-    ("test_timeout_succeeds", SingleTest.test_timeout_succeeds),
-    ("test_timeout_other_succeeds", SingleTest.test_timeout_other_succeeds),
-    ("test_timer", SingleTest.test_timer),
-    ("test_do", SingleTest.test_do),
-    ("test_filter", SingleTest.test_filter),
-    ("test_map", SingleTest.test_map),
-    ("test_flatMap", SingleTest.test_flatMap),
-    ("test_flatMapMaybe", SingleTest.test_flatMapMaybe),
-    ("test_flatMapCompletable", SingleTest.test_flatMapCompletable),
-    ("test_asMaybe", SingleTest.test_asMaybe),
-    ("test_asCompletable", SingleTest.test_asCompletable),
-    ("test_asCompletableError", SingleTest.test_asCompletableError),
-    ("test_zip_tuple", SingleTest.test_zip_tuple),
-    ("test_zip_resultSelector", SingleTest.test_zip_resultSelector),
-    ("testZipCollection_selector", SingleTest.testZipCollection_selector),
-    ("testZipCollection_selector_when_empty", SingleTest.testZipCollection_selector_when_empty),
-    ("testZipCollection_tuple", SingleTest.testZipCollection_tuple),
-    ("testZipCollection_tuple_when_empty", SingleTest.testZipCollection_tuple_when_empty),
-    ("testDefaultErrorHandler", SingleTest.testDefaultErrorHandler),
-    ] }
-}
-
-final class ObservableZipTest_ : ObservableZipTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableZipTest_) -> () -> ())] { return [
-    ("testZip_ImmediateSchedule2", ObservableZipTest.testZip_ImmediateSchedule2),
-    ("testZip_Never2", ObservableZipTest.testZip_Never2),
-    ("testZip_Empty2", ObservableZipTest.testZip_Empty2),
-    ("testZip_SymmetricReturn2", ObservableZipTest.testZip_SymmetricReturn2),
-    ("testZip_AllCompleted2", ObservableZipTest.testZip_AllCompleted2),
-    ("testZip_ImmediateSchedule3", ObservableZipTest.testZip_ImmediateSchedule3),
-    ("testZip_Never3", ObservableZipTest.testZip_Never3),
-    ("testZip_Empty3", ObservableZipTest.testZip_Empty3),
-    ("testZip_SymmetricReturn3", ObservableZipTest.testZip_SymmetricReturn3),
-    ("testZip_AllCompleted3", ObservableZipTest.testZip_AllCompleted3),
-    ("testZip_ImmediateSchedule4", ObservableZipTest.testZip_ImmediateSchedule4),
-    ("testZip_Never4", ObservableZipTest.testZip_Never4),
-    ("testZip_Empty4", ObservableZipTest.testZip_Empty4),
-    ("testZip_SymmetricReturn4", ObservableZipTest.testZip_SymmetricReturn4),
-    ("testZip_AllCompleted4", ObservableZipTest.testZip_AllCompleted4),
-    ("testZip_ImmediateSchedule5", ObservableZipTest.testZip_ImmediateSchedule5),
-    ("testZip_Never5", ObservableZipTest.testZip_Never5),
-    ("testZip_Empty5", ObservableZipTest.testZip_Empty5),
-    ("testZip_SymmetricReturn5", ObservableZipTest.testZip_SymmetricReturn5),
-    ("testZip_AllCompleted5", ObservableZipTest.testZip_AllCompleted5),
-    ("testZip_ImmediateSchedule6", ObservableZipTest.testZip_ImmediateSchedule6),
-    ("testZip_Never6", ObservableZipTest.testZip_Never6),
-    ("testZip_Empty6", ObservableZipTest.testZip_Empty6),
-    ("testZip_SymmetricReturn6", ObservableZipTest.testZip_SymmetricReturn6),
-    ("testZip_AllCompleted6", ObservableZipTest.testZip_AllCompleted6),
-    ("testZip_ImmediateSchedule7", ObservableZipTest.testZip_ImmediateSchedule7),
-    ("testZip_Never7", ObservableZipTest.testZip_Never7),
-    ("testZip_Empty7", ObservableZipTest.testZip_Empty7),
-    ("testZip_SymmetricReturn7", ObservableZipTest.testZip_SymmetricReturn7),
-    ("testZip_AllCompleted7", ObservableZipTest.testZip_AllCompleted7),
-    ("testZip_ImmediateSchedule8", ObservableZipTest.testZip_ImmediateSchedule8),
-    ("testZip_Never8", ObservableZipTest.testZip_Never8),
-    ("testZip_Empty8", ObservableZipTest.testZip_Empty8),
-    ("testZip_SymmetricReturn8", ObservableZipTest.testZip_SymmetricReturn8),
-    ("testZip_AllCompleted8", ObservableZipTest.testZip_AllCompleted8),
-    ("testZip_NeverEmpty", ObservableZipTest.testZip_NeverEmpty),
-    ("testZip_EmptyNever", ObservableZipTest.testZip_EmptyNever),
-    ("testZip_EmptyNonEmpty", ObservableZipTest.testZip_EmptyNonEmpty),
-    ("testZip_NonEmptyEmpty", ObservableZipTest.testZip_NonEmptyEmpty),
-    ("testZip_NeverNonEmpty", ObservableZipTest.testZip_NeverNonEmpty),
-    ("testZip_NonEmptyNever", ObservableZipTest.testZip_NonEmptyNever),
-    ("testZip_NonEmptyNonEmpty", ObservableZipTest.testZip_NonEmptyNonEmpty),
-    ("testZip_EmptyError", ObservableZipTest.testZip_EmptyError),
-    ("testZip_ErrorEmpty", ObservableZipTest.testZip_ErrorEmpty),
-    ("testZip_NeverError", ObservableZipTest.testZip_NeverError),
-    ("testZip_ErrorNever", ObservableZipTest.testZip_ErrorNever),
-    ("testZip_ErrorError", ObservableZipTest.testZip_ErrorError),
-    ("testZip_SomeError", ObservableZipTest.testZip_SomeError),
-    ("testZip_ErrorSome", ObservableZipTest.testZip_ErrorSome),
-    ("testZip_LeftCompletesFirst", ObservableZipTest.testZip_LeftCompletesFirst),
-    ("testZip_RightCompletesFirst", ObservableZipTest.testZip_RightCompletesFirst),
-    ("testZip_LeftTriggersSelectorError", ObservableZipTest.testZip_LeftTriggersSelectorError),
-    ("testZip_RightTriggersSelectorError", ObservableZipTest.testZip_RightTriggersSelectorError),
-    ("testZip_NAry_emptyArray", ObservableZipTest.testZip_NAry_emptyArray),
-    ("testZip_NAry_symmetric", ObservableZipTest.testZip_NAry_symmetric),
-    ("testZip_NAry_asymmetric", ObservableZipTest.testZip_NAry_asymmetric),
-    ("testZip_NAry_error", ObservableZipTest.testZip_NAry_error),
-    ("testZip_NAry_atLeastOneErrors4", ObservableZipTest.testZip_NAry_atLeastOneErrors4),
-    ] }
-}
-
-final class ObservableSubscriptionTest_ : ObservableSubscriptionTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSubscriptionTest_) -> () -> ())] { return [
-    ("testDefaultErrorHandler", ObservableSubscriptionTest.testDefaultErrorHandler),
-    ] }
-}
-
-final class ObservableSkipUntilTest_ : ObservableSkipUntilTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSkipUntilTest_) -> () -> ())] { return [
-    ("testSkipUntil_SomeData_Next", ObservableSkipUntilTest.testSkipUntil_SomeData_Next),
-    ("testSkipUntil_SomeData_Error", ObservableSkipUntilTest.testSkipUntil_SomeData_Error),
-    ("testSkipUntil_Error_SomeData", ObservableSkipUntilTest.testSkipUntil_Error_SomeData),
-    ("testSkipUntil_SomeData_Empty", ObservableSkipUntilTest.testSkipUntil_SomeData_Empty),
-    ("testSkipUntil_Never_Next", ObservableSkipUntilTest.testSkipUntil_Never_Next),
-    ("testSkipUntil_Never_Error1", ObservableSkipUntilTest.testSkipUntil_Never_Error1),
-    ("testSkipUntil_SomeData_Error2", ObservableSkipUntilTest.testSkipUntil_SomeData_Error2),
-    ("testSkipUntil_SomeData_Never", ObservableSkipUntilTest.testSkipUntil_SomeData_Never),
-    ("testSkipUntil_Never_Empty", ObservableSkipUntilTest.testSkipUntil_Never_Empty),
-    ("testSkipUntil_Never_Never", ObservableSkipUntilTest.testSkipUntil_Never_Never),
-    ("testSkipUntil_HasCompletedCausesDisposal", ObservableSkipUntilTest.testSkipUntil_HasCompletedCausesDisposal),
-    ] }
-}
-
-final class ObservableDefaultIfEmptyTest_ : ObservableDefaultIfEmptyTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableDefaultIfEmptyTest_) -> () -> ())] { return [
-    ("testDefaultIfEmpty_Source_Empty", ObservableDefaultIfEmptyTest.testDefaultIfEmpty_Source_Empty),
-    ("testDefaultIfEmpty_Source_Errors", ObservableDefaultIfEmptyTest.testDefaultIfEmpty_Source_Errors),
-    ("testDefaultIfEmpty_Source_Emits", ObservableDefaultIfEmptyTest.testDefaultIfEmpty_Source_Emits),
-    ("testDefaultIfEmpty_Never", ObservableDefaultIfEmptyTest.testDefaultIfEmpty_Never),
-    ] }
-}
-
-final class ObservableFilterTest_ : ObservableFilterTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableFilterTest_) -> () -> ())] { return [
-    ("test_filterComplete", ObservableFilterTest.test_filterComplete),
-    ("test_filterTrue", ObservableFilterTest.test_filterTrue),
-    ("test_filterFalse", ObservableFilterTest.test_filterFalse),
-    ("test_filterDisposed", ObservableFilterTest.test_filterDisposed),
-    ("testIgnoreElements_DoesNotSendValues", ObservableFilterTest.testIgnoreElements_DoesNotSendValues),
-    ] }
-}
-
-final class ObservableAmbTest_ : ObservableAmbTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableAmbTest_) -> () -> ())] { return [
-    ("testAmb_Never2", ObservableAmbTest.testAmb_Never2),
-    ("testAmb_Never3", ObservableAmbTest.testAmb_Never3),
-    ("testAmb_Never_Empty", ObservableAmbTest.testAmb_Never_Empty),
-    ("testAmb_RegularShouldDisposeLoser", ObservableAmbTest.testAmb_RegularShouldDisposeLoser),
-    ("testAmb_WinnerThrows", ObservableAmbTest.testAmb_WinnerThrows),
-    ("testAmb_LoserThrows", ObservableAmbTest.testAmb_LoserThrows),
-    ("testAmb_ThrowsBeforeElectionLeft", ObservableAmbTest.testAmb_ThrowsBeforeElectionLeft),
-    ("testAmb_ThrowsBeforeElectionRight", ObservableAmbTest.testAmb_ThrowsBeforeElectionRight),
-    ] }
-}
-
-final class ObservableConcatTest_ : ObservableConcatTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableConcatTest_) -> () -> ())] { return [
-    ("testConcat_DefaultScheduler", ObservableConcatTest.testConcat_DefaultScheduler),
-    ("testConcat_IEofIO", ObservableConcatTest.testConcat_IEofIO),
-    ("testConcat_EmptyEmpty", ObservableConcatTest.testConcat_EmptyEmpty),
-    ("testConcat_EmptyNever", ObservableConcatTest.testConcat_EmptyNever),
-    ("testConcat_NeverNever", ObservableConcatTest.testConcat_NeverNever),
-    ("testConcat_EmptyThrow", ObservableConcatTest.testConcat_EmptyThrow),
-    ("testConcat_ThrowEmpty", ObservableConcatTest.testConcat_ThrowEmpty),
-    ("testConcat_ThrowThrow", ObservableConcatTest.testConcat_ThrowThrow),
-    ("testConcat_ReturnEmpty", ObservableConcatTest.testConcat_ReturnEmpty),
-    ("testConcat_EmptyReturn", ObservableConcatTest.testConcat_EmptyReturn),
-    ("testConcat_ReturnNever", ObservableConcatTest.testConcat_ReturnNever),
-    ("testConcat_NeverReturn", ObservableConcatTest.testConcat_NeverReturn),
-    ("testConcat_ReturnReturn", ObservableConcatTest.testConcat_ReturnReturn),
-    ("testConcat_ThrowReturn", ObservableConcatTest.testConcat_ThrowReturn),
-    ("testConcat_ReturnThrow", ObservableConcatTest.testConcat_ReturnThrow),
-    ("testConcat_SomeDataSomeData", ObservableConcatTest.testConcat_SomeDataSomeData),
-    ("testConcat_EnumerableTiming", ObservableConcatTest.testConcat_EnumerableTiming),
-    ("testConcat_variadicElementsOverload", ObservableConcatTest.testConcat_variadicElementsOverload),
-    ] }
-}
-
 final class EventTests_ : EventTests, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -919,331 +234,36 @@ final class EventTests_ : EventTests, RxTestCase {
     ] }
 }
 
-final class ObservableMulticastTest_ : ObservableMulticastTest, RxTestCase {
+final class HistoricalSchedulerTest_ : HistoricalSchedulerTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (ObservableMulticastTest_) -> () -> ())] { return [
-    ("testMulticastWhileConnected_connectControlsSourceSubscription", ObservableMulticastTest.testMulticastWhileConnected_connectControlsSourceSubscription),
-    ("testMulticastWhileConnected_connectFirstThenSubscribe", ObservableMulticastTest.testMulticastWhileConnected_connectFirstThenSubscribe),
-    ("testMulticastWhileConnected_completed", ObservableMulticastTest.testMulticastWhileConnected_completed),
-    ("testMulticastWhileConnected_error", ObservableMulticastTest.testMulticastWhileConnected_error),
-    ("testMulticastForever_connectControlsSourceSubscription", ObservableMulticastTest.testMulticastForever_connectControlsSourceSubscription),
-    ("testMulticastForever_connectFirstThenSubscribe", ObservableMulticastTest.testMulticastForever_connectFirstThenSubscribe),
-    ("testMulticastForever_completed", ObservableMulticastTest.testMulticastForever_completed),
-    ("testMulticastForever_error", ObservableMulticastTest.testMulticastForever_error),
-    ("testMulticast_Cold_Completed", ObservableMulticastTest.testMulticast_Cold_Completed),
-    ("testMulticast_Cold_Error", ObservableMulticastTest.testMulticast_Cold_Error),
-    ("testMulticast_Cold_Dispose", ObservableMulticastTest.testMulticast_Cold_Dispose),
-    ("testMulticast_Cold_Zip", ObservableMulticastTest.testMulticast_Cold_Zip),
-    ("testMulticast_SubjectSelectorThrows", ObservableMulticastTest.testMulticast_SubjectSelectorThrows),
-    ("testMulticast_SelectorThrows", ObservableMulticastTest.testMulticast_SelectorThrows),
-    ("testRefCount_DeadlockSimple", ObservableMulticastTest.testRefCount_DeadlockSimple),
-    ("testRefCount_DeadlockErrorAfterN", ObservableMulticastTest.testRefCount_DeadlockErrorAfterN),
-    ("testRefCount_DeadlockErrorImmediately", ObservableMulticastTest.testRefCount_DeadlockErrorImmediately),
-    ("testRefCount_DeadlockEmpty", ObservableMulticastTest.testRefCount_DeadlockEmpty),
-    ("testRefCount_ConnectsOnFirst", ObservableMulticastTest.testRefCount_ConnectsOnFirst),
-    ("testRefCount_DoesntConnectsOnFirstInCaseSynchronousCompleted", ObservableMulticastTest.testRefCount_DoesntConnectsOnFirstInCaseSynchronousCompleted),
-    ("testRefCount_DoesntConnectsOnFirstInCaseSynchronousError", ObservableMulticastTest.testRefCount_DoesntConnectsOnFirstInCaseSynchronousError),
-    ("testRefCount_NotConnected", ObservableMulticastTest.testRefCount_NotConnected),
-    ("testRefCount_Error", ObservableMulticastTest.testRefCount_Error),
-    ("testRefCount_Publish", ObservableMulticastTest.testRefCount_Publish),
-    ("testRefCount_synchronousResubscribingOnErrorWorks", ObservableMulticastTest.testRefCount_synchronousResubscribingOnErrorWorks),
-    ("testRefCount_synchronousResubscribingOnCompletedWorks", ObservableMulticastTest.testRefCount_synchronousResubscribingOnCompletedWorks),
-    ("testReplayCount_Basic", ObservableMulticastTest.testReplayCount_Basic),
-    ("testReplayCount_Error", ObservableMulticastTest.testReplayCount_Error),
-    ("testReplayCount_Complete", ObservableMulticastTest.testReplayCount_Complete),
-    ("testReplayCount_Dispose", ObservableMulticastTest.testReplayCount_Dispose),
-    ("testReplayOneCount_Basic", ObservableMulticastTest.testReplayOneCount_Basic),
-    ("testReplayOneCount_Error", ObservableMulticastTest.testReplayOneCount_Error),
-    ("testReplayOneCount_Complete", ObservableMulticastTest.testReplayOneCount_Complete),
-    ("testReplayOneCount_Dispose", ObservableMulticastTest.testReplayOneCount_Dispose),
-    ("testReplayAll_Basic", ObservableMulticastTest.testReplayAll_Basic),
-    ("testReplayAll_Error", ObservableMulticastTest.testReplayAll_Error),
-    ("testReplayAll_Complete", ObservableMulticastTest.testReplayAll_Complete),
-    ("testReplayAll_Dispose", ObservableMulticastTest.testReplayAll_Dispose),
+    static var allTests: [(String, (HistoricalSchedulerTest_) -> () -> ())] { return [
+    ("testHistoricalScheduler_initialClock", HistoricalSchedulerTest.testHistoricalScheduler_initialClock),
+    ("testHistoricalScheduler_start", HistoricalSchedulerTest.testHistoricalScheduler_start),
+    ("testHistoricalScheduler_disposeStart", HistoricalSchedulerTest.testHistoricalScheduler_disposeStart),
+    ("testHistoricalScheduler_advanceToAfter", HistoricalSchedulerTest.testHistoricalScheduler_advanceToAfter),
+    ("testHistoricalScheduler_advanceToBefore", HistoricalSchedulerTest.testHistoricalScheduler_advanceToBefore),
+    ("testHistoricalScheduler_disposeAdvanceTo", HistoricalSchedulerTest.testHistoricalScheduler_disposeAdvanceTo),
+    ("testHistoricalScheduler_stop", HistoricalSchedulerTest.testHistoricalScheduler_stop),
+    ("testHistoricalScheduler_sleep", HistoricalSchedulerTest.testHistoricalScheduler_sleep),
     ] }
 }
 
-final class ObservableSampleTest_ : ObservableSampleTest, RxTestCase {
+final class MainSchedulerTest_ : MainSchedulerTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (ObservableSampleTest_) -> () -> ())] { return [
-    ("testSample_Sampler_SamplerThrows", ObservableSampleTest.testSample_Sampler_SamplerThrows),
-    ("testSample_Sampler_Simple1", ObservableSampleTest.testSample_Sampler_Simple1),
-    ("testSample_Sampler_Simple2", ObservableSampleTest.testSample_Sampler_Simple2),
-    ("testSample_Sampler_Simple3", ObservableSampleTest.testSample_Sampler_Simple3),
-    ("testSample_Sampler_SourceThrows", ObservableSampleTest.testSample_Sampler_SourceThrows),
-    ] }
-}
-
-final class PublishSubjectTest_ : PublishSubjectTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (PublishSubjectTest_) -> () -> ())] { return [
-    ("test_hasObserversNoObservers", PublishSubjectTest.test_hasObserversNoObservers),
-    ("test_hasObserversOneObserver", PublishSubjectTest.test_hasObserversOneObserver),
-    ("test_hasObserversManyObserver", PublishSubjectTest.test_hasObserversManyObserver),
-    ] }
-}
-
-final class ObservableJustTest_ : ObservableJustTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableJustTest_) -> () -> ())] { return [
-    ("testJust_Immediate", ObservableJustTest.testJust_Immediate),
-    ("testJust_Basic", ObservableJustTest.testJust_Basic),
-    ("testJust_Disposed", ObservableJustTest.testJust_Disposed),
-    ("testJust_DisposeAfterNext", ObservableJustTest.testJust_DisposeAfterNext),
-    ("testJust_DefaultScheduler", ObservableJustTest.testJust_DefaultScheduler),
-    ("testJust_CompilesInMap", ObservableJustTest.testJust_CompilesInMap),
-    ] }
-}
-
-final class ObservableUsingTest_ : ObservableUsingTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableUsingTest_) -> () -> ())] { return [
-    ("testUsing_Complete", ObservableUsingTest.testUsing_Complete),
-    ("testUsing_Error", ObservableUsingTest.testUsing_Error),
-    ("testUsing_Dispose", ObservableUsingTest.testUsing_Dispose),
-    ("testUsing_ThrowResourceSelector", ObservableUsingTest.testUsing_ThrowResourceSelector),
-    ("testUsing_ThrowResourceUsage", ObservableUsingTest.testUsing_ThrowResourceUsage),
-    ] }
-}
-
-final class ObservableTakeWhileTest_ : ObservableTakeWhileTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableTakeWhileTest_) -> () -> ())] { return [
-    ("testTakeWhile_Complete_Before", ObservableTakeWhileTest.testTakeWhile_Complete_Before),
-    ("testTakeWhile_Complete_After", ObservableTakeWhileTest.testTakeWhile_Complete_After),
-    ("testTakeWhile_Error_Before", ObservableTakeWhileTest.testTakeWhile_Error_Before),
-    ("testTakeWhile_Error_After", ObservableTakeWhileTest.testTakeWhile_Error_After),
-    ("testTakeWhile_Dispose_Before", ObservableTakeWhileTest.testTakeWhile_Dispose_Before),
-    ("testTakeWhile_Dispose_After", ObservableTakeWhileTest.testTakeWhile_Dispose_After),
-    ("testTakeWhile_Zero", ObservableTakeWhileTest.testTakeWhile_Zero),
-    ("testTakeWhile_Throw", ObservableTakeWhileTest.testTakeWhile_Throw),
-    ] }
-}
-
-final class AsyncSubjectTests_ : AsyncSubjectTests, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (AsyncSubjectTests_) -> () -> ())] { return [
-    ("test_hasObserversManyObserver", AsyncSubjectTests.test_hasObserversManyObserver),
-    ("test_infinite", AsyncSubjectTests.test_infinite),
-    ("test_finite", AsyncSubjectTests.test_finite),
-    ("test_error", AsyncSubjectTests.test_error),
-    ("test_empty", AsyncSubjectTests.test_empty),
-    ] }
-}
-
-final class ObservableDelayTest_ : ObservableDelayTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableDelayTest_) -> () -> ())] { return [
-    ("testDelay_TimeSpan_Simple1", ObservableDelayTest.testDelay_TimeSpan_Simple1),
-    ("testDelay_TimeSpan_Simple2", ObservableDelayTest.testDelay_TimeSpan_Simple2),
-    ("testDelay_TimeSpan_Simple3", ObservableDelayTest.testDelay_TimeSpan_Simple3),
-    ("testDelay_TimeSpan_Error", ObservableDelayTest.testDelay_TimeSpan_Error),
-    ("testDelay_TimeSpan_Completed", ObservableDelayTest.testDelay_TimeSpan_Completed),
-    ("testDelay_TimeSpan_Error1", ObservableDelayTest.testDelay_TimeSpan_Error1),
-    ("testDelay_TimeSpan_Error2", ObservableDelayTest.testDelay_TimeSpan_Error2),
-    ("testDelay_TimeSpan_Real_Simple", ObservableDelayTest.testDelay_TimeSpan_Real_Simple),
-    ("testDelay_TimeSpan_Real_Error1", ObservableDelayTest.testDelay_TimeSpan_Real_Error1),
-    ("testDelay_TimeSpan_Real_Error2", ObservableDelayTest.testDelay_TimeSpan_Real_Error2),
-    ("testDelay_TimeSpan_Real_Error3", ObservableDelayTest.testDelay_TimeSpan_Real_Error3),
-    ("testDelay_TimeSpan_Positive", ObservableDelayTest.testDelay_TimeSpan_Positive),
-    ("testDelay_TimeSpan_DefaultScheduler", ObservableDelayTest.testDelay_TimeSpan_DefaultScheduler),
-    ] }
-}
-
-final class ObservableRepeatTest_ : ObservableRepeatTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableRepeatTest_) -> () -> ())] { return [
-    ("testRepeat_Element", ObservableRepeatTest.testRepeat_Element),
-    ] }
-}
-
-final class ObservableSingleTest_ : ObservableSingleTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSingleTest_) -> () -> ())] { return [
-    ("testSingle_Empty", ObservableSingleTest.testSingle_Empty),
-    ("testSingle_One", ObservableSingleTest.testSingle_One),
-    ("testSingle_Many", ObservableSingleTest.testSingle_Many),
-    ("testSingle_Error", ObservableSingleTest.testSingle_Error),
-    ("testSinglePredicate_Empty", ObservableSingleTest.testSinglePredicate_Empty),
-    ("testSinglePredicate_One", ObservableSingleTest.testSinglePredicate_One),
-    ("testSinglePredicate_Many", ObservableSingleTest.testSinglePredicate_Many),
-    ("testSinglePredicate_Error", ObservableSingleTest.testSinglePredicate_Error),
-    ("testSinglePredicate_Throws", ObservableSingleTest.testSinglePredicate_Throws),
-    ] }
-}
-
-final class ObservableTakeTest_ : ObservableTakeTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableTakeTest_) -> () -> ())] { return [
-    ("testTake_Complete_After", ObservableTakeTest.testTake_Complete_After),
-    ("testTake_Complete_Same", ObservableTakeTest.testTake_Complete_Same),
-    ("testTake_Complete_Before", ObservableTakeTest.testTake_Complete_Before),
-    ("testTake_Error_After", ObservableTakeTest.testTake_Error_After),
-    ("testTake_Error_Same", ObservableTakeTest.testTake_Error_Same),
-    ("testTake_Error_Before", ObservableTakeTest.testTake_Error_Before),
-    ("testTake_Dispose_Before", ObservableTakeTest.testTake_Dispose_Before),
-    ("testTake_Dispose_After", ObservableTakeTest.testTake_Dispose_After),
-    ("testTake_0_DefaultScheduler", ObservableTakeTest.testTake_0_DefaultScheduler),
-    ("testTake_Take1", ObservableTakeTest.testTake_Take1),
-    ("testTake_DecrementCountsFirst", ObservableTakeTest.testTake_DecrementCountsFirst),
-    ("testTake_TakeZero", ObservableTakeTest.testTake_TakeZero),
-    ("testTake_Some", ObservableTakeTest.testTake_Some),
-    ("testTake_TakeLate", ObservableTakeTest.testTake_TakeLate),
-    ("testTake_TakeError", ObservableTakeTest.testTake_TakeError),
-    ("testTake_TakeNever", ObservableTakeTest.testTake_TakeNever),
-    ("testTake_TakeTwice1", ObservableTakeTest.testTake_TakeTwice1),
-    ("testTake_TakeDefault", ObservableTakeTest.testTake_TakeDefault),
-    ] }
-}
-
-final class ObservableGenerateTest_ : ObservableGenerateTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableGenerateTest_) -> () -> ())] { return [
-    ("testGenerate_Finite", ObservableGenerateTest.testGenerate_Finite),
-    ("testGenerate_ThrowCondition", ObservableGenerateTest.testGenerate_ThrowCondition),
-    ("testGenerate_ThrowIterate", ObservableGenerateTest.testGenerate_ThrowIterate),
-    ("testGenerate_Dispose", ObservableGenerateTest.testGenerate_Dispose),
-    ("testGenerate_take", ObservableGenerateTest.testGenerate_take),
-    ] }
-}
-
-final class ObservableDematerializeTest_ : ObservableDematerializeTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableDematerializeTest_) -> () -> ())] { return [
-    ("testDematerialize_Range1", ObservableDematerializeTest.testDematerialize_Range1),
-    ("testDematerialize_Range2", ObservableDematerializeTest.testDematerialize_Range2),
-    ("testDematerialize_Error", ObservableDematerializeTest.testDematerialize_Error),
-    ("testDematerialize_Error2", ObservableDematerializeTest.testDematerialize_Error2),
-    ("testMaterialize_Dematerialize_Never", ObservableDematerializeTest.testMaterialize_Dematerialize_Never),
-    ("testMaterialize_Dematerialize_Empty", ObservableDematerializeTest.testMaterialize_Dematerialize_Empty),
-    ("testMaterialize_Dematerialize_Return", ObservableDematerializeTest.testMaterialize_Dematerialize_Return),
-    ("testMaterialize_Dematerialize_Throw", ObservableDematerializeTest.testMaterialize_Dematerialize_Throw),
-    ] }
-}
-
-final class VariableTest_ : VariableTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (VariableTest_) -> () -> ())] { return [
-    ("testVariable_initialValues", VariableTest.testVariable_initialValues),
-    ("testVariable_sendsCompletedOnDealloc", VariableTest.testVariable_sendsCompletedOnDealloc),
-    ("testVariable_READMEExample", VariableTest.testVariable_READMEExample),
-    ] }
-}
-
-final class ObservableTimerTest_ : ObservableTimerTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableTimerTest_) -> () -> ())] { return [
-    ("testTimer_Basic", ObservableTimerTest.testTimer_Basic),
-    ("testInterval_TimeSpan_Basic", ObservableTimerTest.testInterval_TimeSpan_Basic),
-    ("testInterval_TimeSpan_Zero", ObservableTimerTest.testInterval_TimeSpan_Zero),
-    ("testInterval_TimeSpan_Zero_DefaultScheduler", ObservableTimerTest.testInterval_TimeSpan_Zero_DefaultScheduler),
-    ("testInterval_TimeSpan_Disposed", ObservableTimerTest.testInterval_TimeSpan_Disposed),
-    ("test_IntervalWithRealScheduler", ObservableTimerTest.test_IntervalWithRealScheduler),
-    ] }
-}
-
-final class ObservableShareReplayScopeTests_ : ObservableShareReplayScopeTests, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableShareReplayScopeTests_) -> () -> ())] { return [
-    ("test_testDefaultArguments", ObservableShareReplayScopeTests.test_testDefaultArguments),
-    ("test_forever_receivesCorrectElements", ObservableShareReplayScopeTests.test_forever_receivesCorrectElements),
-    ("test_whileConnected_receivesCorrectElements", ObservableShareReplayScopeTests.test_whileConnected_receivesCorrectElements),
-    ("test_forever_error", ObservableShareReplayScopeTests.test_forever_error),
-    ("test_whileConnected_error", ObservableShareReplayScopeTests.test_whileConnected_error),
-    ("test_forever_completed", ObservableShareReplayScopeTests.test_forever_completed),
-    ("test_whileConnected_completed", ObservableShareReplayScopeTests.test_whileConnected_completed),
-    ] }
-}
-
-final class ReactiveTests_ : ReactiveTests, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ReactiveTests_) -> () -> ())] { return [
-    ("testEnablesMutations", ReactiveTests.testEnablesMutations),
+    static var allTests: [(String, (MainSchedulerTest_) -> () -> ())] { return [
+    ("testMainScheduler_basicScenario", MainSchedulerTest.testMainScheduler_basicScenario),
+    ("testMainScheduler_disposing1", MainSchedulerTest.testMainScheduler_disposing1),
+    ("testMainScheduler_disposing2", MainSchedulerTest.testMainScheduler_disposing2),
     ] }
 }
 
@@ -1310,21 +330,6 @@ final class MaybeTest_ : MaybeTest, RxTestCase {
     ] }
 }
 
-final class ObservableMaterializeTest_ : ObservableMaterializeTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableMaterializeTest_) -> () -> ())] { return [
-    ("testMaterializeNever", ObservableMaterializeTest.testMaterializeNever),
-    ("testMaterializeEmpty", ObservableMaterializeTest.testMaterializeEmpty),
-    ("testMaterializeEmits", ObservableMaterializeTest.testMaterializeEmits),
-    ("testMaterializeThrow", ObservableMaterializeTest.testMaterializeThrow),
-    ] }
-}
-
 final class NSNotificationCenterTests_ : NSNotificationCenterTests, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1338,36 +343,119 @@ final class NSNotificationCenterTests_ : NSNotificationCenterTests, RxTestCase {
     ] }
 }
 
-final class HistoricalSchedulerTest_ : HistoricalSchedulerTest, RxTestCase {
+final class ObservableAmbTest_ : ObservableAmbTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (HistoricalSchedulerTest_) -> () -> ())] { return [
-    ("testHistoricalScheduler_initialClock", HistoricalSchedulerTest.testHistoricalScheduler_initialClock),
-    ("testHistoricalScheduler_start", HistoricalSchedulerTest.testHistoricalScheduler_start),
-    ("testHistoricalScheduler_disposeStart", HistoricalSchedulerTest.testHistoricalScheduler_disposeStart),
-    ("testHistoricalScheduler_advanceToAfter", HistoricalSchedulerTest.testHistoricalScheduler_advanceToAfter),
-    ("testHistoricalScheduler_advanceToBefore", HistoricalSchedulerTest.testHistoricalScheduler_advanceToBefore),
-    ("testHistoricalScheduler_disposeAdvanceTo", HistoricalSchedulerTest.testHistoricalScheduler_disposeAdvanceTo),
-    ("testHistoricalScheduler_stop", HistoricalSchedulerTest.testHistoricalScheduler_stop),
-    ("testHistoricalScheduler_sleep", HistoricalSchedulerTest.testHistoricalScheduler_sleep),
+    static var allTests: [(String, (ObservableAmbTest_) -> () -> ())] { return [
+    ("testAmb_Never2", ObservableAmbTest.testAmb_Never2),
+    ("testAmb_Never3", ObservableAmbTest.testAmb_Never3),
+    ("testAmb_Never_Empty", ObservableAmbTest.testAmb_Never_Empty),
+    ("testAmb_RegularShouldDisposeLoser", ObservableAmbTest.testAmb_RegularShouldDisposeLoser),
+    ("testAmb_WinnerThrows", ObservableAmbTest.testAmb_WinnerThrows),
+    ("testAmb_LoserThrows", ObservableAmbTest.testAmb_LoserThrows),
+    ("testAmb_ThrowsBeforeElectionLeft", ObservableAmbTest.testAmb_ThrowsBeforeElectionLeft),
+    ("testAmb_ThrowsBeforeElectionRight", ObservableAmbTest.testAmb_ThrowsBeforeElectionRight),
     ] }
 }
 
-final class MainSchedulerTest_ : MainSchedulerTest, RxTestCase {
+final class ObservableBlockingTest_ : ObservableBlockingTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (MainSchedulerTest_) -> () -> ())] { return [
-    ("testMainScheduler_basicScenario", MainSchedulerTest.testMainScheduler_basicScenario),
-    ("testMainScheduler_disposing1", MainSchedulerTest.testMainScheduler_disposing1),
-    ("testMainScheduler_disposing2", MainSchedulerTest.testMainScheduler_disposing2),
+    static var allTests: [(String, (ObservableBlockingTest_) -> () -> ())] { return [
+    ("testToArray_empty", ObservableBlockingTest.testToArray_empty),
+    ("testToArray_return", ObservableBlockingTest.testToArray_return),
+    ("testToArray_fail", ObservableBlockingTest.testToArray_fail),
+    ("testToArray_someData", ObservableBlockingTest.testToArray_someData),
+    ("testToArray_withRealScheduler", ObservableBlockingTest.testToArray_withRealScheduler),
+    ("testToArray_independent", ObservableBlockingTest.testToArray_independent),
+    ("testToArray_timeout", ObservableBlockingTest.testToArray_timeout),
+    ("testFirst_empty", ObservableBlockingTest.testFirst_empty),
+    ("testFirst_return", ObservableBlockingTest.testFirst_return),
+    ("testFirst_fail", ObservableBlockingTest.testFirst_fail),
+    ("testFirst_someData", ObservableBlockingTest.testFirst_someData),
+    ("testFirst_withRealScheduler", ObservableBlockingTest.testFirst_withRealScheduler),
+    ("testFirst_independent", ObservableBlockingTest.testFirst_independent),
+    ("testFirst_timeout", ObservableBlockingTest.testFirst_timeout),
+    ("testLast_empty", ObservableBlockingTest.testLast_empty),
+    ("testLast_return", ObservableBlockingTest.testLast_return),
+    ("testLast_fail", ObservableBlockingTest.testLast_fail),
+    ("testLast_someData", ObservableBlockingTest.testLast_someData),
+    ("testLast_withRealScheduler", ObservableBlockingTest.testLast_withRealScheduler),
+    ("testLast_independent", ObservableBlockingTest.testLast_independent),
+    ("testLast_timeout", ObservableBlockingTest.testLast_timeout),
+    ("testSingle_empty", ObservableBlockingTest.testSingle_empty),
+    ("testSingle_return", ObservableBlockingTest.testSingle_return),
+    ("testSingle_two", ObservableBlockingTest.testSingle_two),
+    ("testSingle_someData", ObservableBlockingTest.testSingle_someData),
+    ("testSingle_fail", ObservableBlockingTest.testSingle_fail),
+    ("testSingle_withRealScheduler", ObservableBlockingTest.testSingle_withRealScheduler),
+    ("testSingle_predicate_empty", ObservableBlockingTest.testSingle_predicate_empty),
+    ("testSingle_predicate_return", ObservableBlockingTest.testSingle_predicate_return),
+    ("testSingle_predicate_someData_one_match", ObservableBlockingTest.testSingle_predicate_someData_one_match),
+    ("testSingle_predicate_someData_two_match", ObservableBlockingTest.testSingle_predicate_someData_two_match),
+    ("testSingle_predicate_none", ObservableBlockingTest.testSingle_predicate_none),
+    ("testSingle_predicate_throws", ObservableBlockingTest.testSingle_predicate_throws),
+    ("testSingle_predicate_fail", ObservableBlockingTest.testSingle_predicate_fail),
+    ("testSingle_predicate_withRealScheduler", ObservableBlockingTest.testSingle_predicate_withRealScheduler),
+    ("testSingle_independent", ObservableBlockingTest.testSingle_independent),
+    ("testSingle_timeout", ObservableBlockingTest.testSingle_timeout),
+    ("testSinglePredicate_timeout", ObservableBlockingTest.testSinglePredicate_timeout),
+    ("testMaterialize_empty", ObservableBlockingTest.testMaterialize_empty),
+    ("testMaterialize_empty_fail", ObservableBlockingTest.testMaterialize_empty_fail),
+    ("testMaterialize_someData", ObservableBlockingTest.testMaterialize_someData),
+    ("testMaterialize_someData_fail", ObservableBlockingTest.testMaterialize_someData_fail),
+    ] }
+}
+
+final class ObservableBufferTest_ : ObservableBufferTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableBufferTest_) -> () -> ())] { return [
+    ("testBufferWithTimeOrCount_Basic", ObservableBufferTest.testBufferWithTimeOrCount_Basic),
+    ("testBufferWithTimeOrCount_Error", ObservableBufferTest.testBufferWithTimeOrCount_Error),
+    ("testBufferWithTimeOrCount_Disposed", ObservableBufferTest.testBufferWithTimeOrCount_Disposed),
+    ("testBufferWithTimeOrCount_Default", ObservableBufferTest.testBufferWithTimeOrCount_Default),
+    ] }
+}
+
+final class ObservableCatchTest_ : ObservableCatchTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableCatchTest_) -> () -> ())] { return [
+    ("testCatch_ErrorSpecific_Caught", ObservableCatchTest.testCatch_ErrorSpecific_Caught),
+    ("testCatch_HandlerThrows", ObservableCatchTest.testCatch_HandlerThrows),
+    ("testCatchSequenceOf_IEofIO", ObservableCatchTest.testCatchSequenceOf_IEofIO),
+    ("testCatchAnySequence_NoErrors", ObservableCatchTest.testCatchAnySequence_NoErrors),
+    ("testCatchAnySequence_Never", ObservableCatchTest.testCatchAnySequence_Never),
+    ("testCatchAnySequence_Empty", ObservableCatchTest.testCatchAnySequence_Empty),
+    ("testCatchSequenceOf_Error", ObservableCatchTest.testCatchSequenceOf_Error),
+    ("testCatchSequenceOf_ErrorNever", ObservableCatchTest.testCatchSequenceOf_ErrorNever),
+    ("testCatchSequenceOf_ErrorError", ObservableCatchTest.testCatchSequenceOf_ErrorError),
+    ("testCatchSequenceOf_Multiple", ObservableCatchTest.testCatchSequenceOf_Multiple),
+    ("testRetry_Basic", ObservableCatchTest.testRetry_Basic),
+    ("testRetry_Infinite", ObservableCatchTest.testRetry_Infinite),
+    ("testRetry_Observable_Error", ObservableCatchTest.testRetry_Observable_Error),
+    ("testRetryCount_Basic", ObservableCatchTest.testRetryCount_Basic),
+    ("testRetryCount_Dispose", ObservableCatchTest.testRetryCount_Dispose),
+    ("testRetryCount_Infinite", ObservableCatchTest.testRetryCount_Infinite),
+    ("testRetryCount_Completed", ObservableCatchTest.testRetryCount_Completed),
+    ("testRetry_tailRecursiveOptimizationsTest", ObservableCatchTest.testRetry_tailRecursiveOptimizationsTest),
     ] }
 }
 
@@ -1465,207 +553,32 @@ final class ObservableCombineLatestTest_ : ObservableCombineLatestTest, RxTestCa
     ] }
 }
 
-final class ObservablePrimitiveSequenceTest_ : ObservablePrimitiveSequenceTest, RxTestCase {
+final class ObservableConcatTest_ : ObservableConcatTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (ObservablePrimitiveSequenceTest_) -> () -> ())] { return [
-    ("testAsSingle_Empty", ObservablePrimitiveSequenceTest.testAsSingle_Empty),
-    ("testAsSingle_One", ObservablePrimitiveSequenceTest.testAsSingle_One),
-    ("testAsSingle_Many", ObservablePrimitiveSequenceTest.testAsSingle_Many),
-    ("testAsSingle_Error", ObservablePrimitiveSequenceTest.testAsSingle_Error),
-    ("testAsSingle_Error2", ObservablePrimitiveSequenceTest.testAsSingle_Error2),
-    ("testAsSingle_subscribeOnSuccess", ObservablePrimitiveSequenceTest.testAsSingle_subscribeOnSuccess),
-    ("testAsSingle_subscribeOnError", ObservablePrimitiveSequenceTest.testAsSingle_subscribeOnError),
-    ("testAsMaybe_Empty", ObservablePrimitiveSequenceTest.testAsMaybe_Empty),
-    ("testAsMaybe_One", ObservablePrimitiveSequenceTest.testAsMaybe_One),
-    ("testAsMaybe_Many", ObservablePrimitiveSequenceTest.testAsMaybe_Many),
-    ("testAsMaybe_Error", ObservablePrimitiveSequenceTest.testAsMaybe_Error),
-    ("testAsMaybe_Error2", ObservablePrimitiveSequenceTest.testAsMaybe_Error2),
-    ("testAsMaybe_subscribeOnSuccess", ObservablePrimitiveSequenceTest.testAsMaybe_subscribeOnSuccess),
-    ("testAsMaybe_subscribeOnError", ObservablePrimitiveSequenceTest.testAsMaybe_subscribeOnError),
-    ("testAsMaybe_subscribeOnCompleted", ObservablePrimitiveSequenceTest.testAsMaybe_subscribeOnCompleted),
-    ("testAsCompletable_Empty", ObservablePrimitiveSequenceTest.testAsCompletable_Empty),
-    ("testAsCompletable_Error", ObservablePrimitiveSequenceTest.testAsCompletable_Error),
-    ("testAsCompletable_subscribeOnCompleted", ObservablePrimitiveSequenceTest.testAsCompletable_subscribeOnCompleted),
-    ("testAsCompletable_subscribeOnError", ObservablePrimitiveSequenceTest.testAsCompletable_subscribeOnError),
-    ("testCompletable_merge", ObservablePrimitiveSequenceTest.testCompletable_merge),
-    ("testCompletable_concat", ObservablePrimitiveSequenceTest.testCompletable_concat),
-    ] }
-}
-
-final class ObservableSubscriptionTests_ : ObservableSubscriptionTests, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableSubscriptionTests_) -> () -> ())] { return [
-    ("testSubscribeOnNext", ObservableSubscriptionTests.testSubscribeOnNext),
-    ("testSubscribeOnError", ObservableSubscriptionTests.testSubscribeOnError),
-    ("testSubscribeOnCompleted", ObservableSubscriptionTests.testSubscribeOnCompleted),
-    ("testDisposed", ObservableSubscriptionTests.testDisposed),
-    ] }
-}
-
-final class ObservableCatchTest_ : ObservableCatchTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableCatchTest_) -> () -> ())] { return [
-    ("testCatch_ErrorSpecific_Caught", ObservableCatchTest.testCatch_ErrorSpecific_Caught),
-    ("testCatch_HandlerThrows", ObservableCatchTest.testCatch_HandlerThrows),
-    ("testCatchSequenceOf_IEofIO", ObservableCatchTest.testCatchSequenceOf_IEofIO),
-    ("testCatchAnySequence_NoErrors", ObservableCatchTest.testCatchAnySequence_NoErrors),
-    ("testCatchAnySequence_Never", ObservableCatchTest.testCatchAnySequence_Never),
-    ("testCatchAnySequence_Empty", ObservableCatchTest.testCatchAnySequence_Empty),
-    ("testCatchSequenceOf_Error", ObservableCatchTest.testCatchSequenceOf_Error),
-    ("testCatchSequenceOf_ErrorNever", ObservableCatchTest.testCatchSequenceOf_ErrorNever),
-    ("testCatchSequenceOf_ErrorError", ObservableCatchTest.testCatchSequenceOf_ErrorError),
-    ("testCatchSequenceOf_Multiple", ObservableCatchTest.testCatchSequenceOf_Multiple),
-    ("testRetry_Basic", ObservableCatchTest.testRetry_Basic),
-    ("testRetry_Infinite", ObservableCatchTest.testRetry_Infinite),
-    ("testRetry_Observable_Error", ObservableCatchTest.testRetry_Observable_Error),
-    ("testRetryCount_Basic", ObservableCatchTest.testRetryCount_Basic),
-    ("testRetryCount_Dispose", ObservableCatchTest.testRetryCount_Dispose),
-    ("testRetryCount_Infinite", ObservableCatchTest.testRetryCount_Infinite),
-    ("testRetryCount_Completed", ObservableCatchTest.testRetryCount_Completed),
-    ("testRetry_tailRecursiveOptimizationsTest", ObservableCatchTest.testRetry_tailRecursiveOptimizationsTest),
-    ] }
-}
-
-final class ObservableToArrayTest_ : ObservableToArrayTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableToArrayTest_) -> () -> ())] { return [
-    ("test_ToArrayWithSingleItem_Return", ObservableToArrayTest.test_ToArrayWithSingleItem_Return),
-    ("test_ToArrayWithMultipleItems_Return", ObservableToArrayTest.test_ToArrayWithMultipleItems_Return),
-    ("test_ToArrayWithNoItems_Empty", ObservableToArrayTest.test_ToArrayWithNoItems_Empty),
-    ("test_ToArrayWithSingleItem_Never", ObservableToArrayTest.test_ToArrayWithSingleItem_Never),
-    ("test_ToArrayWithImmediateError_Throw", ObservableToArrayTest.test_ToArrayWithImmediateError_Throw),
-    ("test_ToArrayWithMultipleItems_Throw", ObservableToArrayTest.test_ToArrayWithMultipleItems_Throw),
-    ] }
-}
-
-final class ObserverTests_ : ObserverTests, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObserverTests_) -> () -> ())] { return [
-    ("testConvenienceOn_Next", ObserverTests.testConvenienceOn_Next),
-    ("testConvenienceOn_Error", ObserverTests.testConvenienceOn_Error),
-    ("testConvenienceOn_Complete", ObserverTests.testConvenienceOn_Complete),
-    ("testMapElement", ObserverTests.testMapElement),
-    ("testMapElementCompleted", ObserverTests.testMapElementCompleted),
-    ("testMapElementError", ObserverTests.testMapElementError),
-    ("testMapElementThrow", ObserverTests.testMapElementThrow),
-    ] }
-}
-
-final class ObservableObserveOnTestConcurrentSchedulerTest_ : ObservableObserveOnTestConcurrentSchedulerTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableObserveOnTestConcurrentSchedulerTest_) -> () -> ())] { return [
-    ("testObserveOn_EnsureTestsAreExecutedWithRealConcurrentScheduler", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_EnsureTestsAreExecutedWithRealConcurrentScheduler),
-    ("testObserveOn_Never", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Never),
-    ("testObserveOn_Simple", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Simple),
-    ("testObserveOn_Empty", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Empty),
-    ("testObserveOn_ConcurrentSchedulerIsSerialized", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_ConcurrentSchedulerIsSerialized),
-    ("testObserveOn_Error", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Error),
-    ("testObserveOn_Dispose", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Dispose),
-    ] }
-}
-
-final class ObservableTimeoutTest_ : ObservableTimeoutTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableTimeoutTest_) -> () -> ())] { return [
-    ("testTimeout_Empty", ObservableTimeoutTest.testTimeout_Empty),
-    ("testTimeout_Error", ObservableTimeoutTest.testTimeout_Error),
-    ("testTimeout_Never", ObservableTimeoutTest.testTimeout_Never),
-    ("testTimeout_Duetime_Simple", ObservableTimeoutTest.testTimeout_Duetime_Simple),
-    ("testTimeout_Duetime_Timeout_Exact", ObservableTimeoutTest.testTimeout_Duetime_Timeout_Exact),
-    ("testTimeout_Duetime_Timeout", ObservableTimeoutTest.testTimeout_Duetime_Timeout),
-    ("testTimeout_Duetime_Disposed", ObservableTimeoutTest.testTimeout_Duetime_Disposed),
-    ("testTimeout_TimeoutOccurs_1", ObservableTimeoutTest.testTimeout_TimeoutOccurs_1),
-    ("testTimeout_TimeoutOccurs_2", ObservableTimeoutTest.testTimeout_TimeoutOccurs_2),
-    ("testTimeout_TimeoutOccurs_Never", ObservableTimeoutTest.testTimeout_TimeoutOccurs_Never),
-    ("testTimeout_TimeoutOccurs_Completed", ObservableTimeoutTest.testTimeout_TimeoutOccurs_Completed),
-    ("testTimeout_TimeoutOccurs_Error", ObservableTimeoutTest.testTimeout_TimeoutOccurs_Error),
-    ("testTimeout_TimeoutOccurs_NextIsError", ObservableTimeoutTest.testTimeout_TimeoutOccurs_NextIsError),
-    ("testTimeout_TimeoutNotOccurs_Completed", ObservableTimeoutTest.testTimeout_TimeoutNotOccurs_Completed),
-    ("testTimeout_TimeoutNotOccurs_Error", ObservableTimeoutTest.testTimeout_TimeoutNotOccurs_Error),
-    ("testTimeout_TimeoutNotOccurs", ObservableTimeoutTest.testTimeout_TimeoutNotOccurs),
-    ] }
-}
-
-final class ConcurrentDispatchQueueSchedulerTests_ : ConcurrentDispatchQueueSchedulerTests, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ConcurrentDispatchQueueSchedulerTests_) -> () -> ())] { return [
-    ("test_scheduleRelative", ConcurrentDispatchQueueSchedulerTests.test_scheduleRelative),
-    ("test_scheduleRelativeCancel", ConcurrentDispatchQueueSchedulerTests.test_scheduleRelativeCancel),
-    ("test_schedulePeriodic", ConcurrentDispatchQueueSchedulerTests.test_schedulePeriodic),
-    ("test_schedulePeriodicCancel", ConcurrentDispatchQueueSchedulerTests.test_schedulePeriodicCancel),
-    ] }
-}
-
-final class ObservableBufferTest_ : ObservableBufferTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (ObservableBufferTest_) -> () -> ())] { return [
-    ("testBufferWithTimeOrCount_Basic", ObservableBufferTest.testBufferWithTimeOrCount_Basic),
-    ("testBufferWithTimeOrCount_Error", ObservableBufferTest.testBufferWithTimeOrCount_Error),
-    ("testBufferWithTimeOrCount_Disposed", ObservableBufferTest.testBufferWithTimeOrCount_Disposed),
-    ("testBufferWithTimeOrCount_Default", ObservableBufferTest.testBufferWithTimeOrCount_Default),
-    ] }
-}
-
-final class BehaviorSubjectTest_ : BehaviorSubjectTest, RxTestCase {
-    #if os(macOS)
-    required override init() {
-        super.init()
-    }
-    #endif
-
-    static var allTests: [(String, (BehaviorSubjectTest_) -> () -> ())] { return [
-    ("test_Infinite", BehaviorSubjectTest.test_Infinite),
-    ("test_Finite", BehaviorSubjectTest.test_Finite),
-    ("test_Error", BehaviorSubjectTest.test_Error),
-    ("test_Canceled", BehaviorSubjectTest.test_Canceled),
-    ("test_hasObserversNoObservers", BehaviorSubjectTest.test_hasObserversNoObservers),
-    ("test_hasObserversOneObserver", BehaviorSubjectTest.test_hasObserversOneObserver),
-    ("test_hasObserversManyObserver", BehaviorSubjectTest.test_hasObserversManyObserver),
+    static var allTests: [(String, (ObservableConcatTest_) -> () -> ())] { return [
+    ("testConcat_DefaultScheduler", ObservableConcatTest.testConcat_DefaultScheduler),
+    ("testConcat_IEofIO", ObservableConcatTest.testConcat_IEofIO),
+    ("testConcat_EmptyEmpty", ObservableConcatTest.testConcat_EmptyEmpty),
+    ("testConcat_EmptyNever", ObservableConcatTest.testConcat_EmptyNever),
+    ("testConcat_NeverNever", ObservableConcatTest.testConcat_NeverNever),
+    ("testConcat_EmptyThrow", ObservableConcatTest.testConcat_EmptyThrow),
+    ("testConcat_ThrowEmpty", ObservableConcatTest.testConcat_ThrowEmpty),
+    ("testConcat_ThrowThrow", ObservableConcatTest.testConcat_ThrowThrow),
+    ("testConcat_ReturnEmpty", ObservableConcatTest.testConcat_ReturnEmpty),
+    ("testConcat_EmptyReturn", ObservableConcatTest.testConcat_EmptyReturn),
+    ("testConcat_ReturnNever", ObservableConcatTest.testConcat_ReturnNever),
+    ("testConcat_NeverReturn", ObservableConcatTest.testConcat_NeverReturn),
+    ("testConcat_ReturnReturn", ObservableConcatTest.testConcat_ReturnReturn),
+    ("testConcat_ThrowReturn", ObservableConcatTest.testConcat_ThrowReturn),
+    ("testConcat_ReturnThrow", ObservableConcatTest.testConcat_ReturnThrow),
+    ("testConcat_SomeDataSomeData", ObservableConcatTest.testConcat_SomeDataSomeData),
+    ("testConcat_EnumerableTiming", ObservableConcatTest.testConcat_EnumerableTiming),
+    ("testConcat_variadicElementsOverload", ObservableConcatTest.testConcat_variadicElementsOverload),
     ] }
 }
 
@@ -1679,6 +592,96 @@ final class ObservableDebugTest_ : ObservableDebugTest, RxTestCase {
     static var allTests: [(String, (ObservableDebugTest_) -> () -> ())] { return [
     ("testDebug_Completed", ObservableDebugTest.testDebug_Completed),
     ("testDebug_Error", ObservableDebugTest.testDebug_Error),
+    ] }
+}
+
+final class ObservableDefaultIfEmptyTest_ : ObservableDefaultIfEmptyTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableDefaultIfEmptyTest_) -> () -> ())] { return [
+    ("testDefaultIfEmpty_Source_Empty", ObservableDefaultIfEmptyTest.testDefaultIfEmpty_Source_Empty),
+    ("testDefaultIfEmpty_Source_Errors", ObservableDefaultIfEmptyTest.testDefaultIfEmpty_Source_Errors),
+    ("testDefaultIfEmpty_Source_Emits", ObservableDefaultIfEmptyTest.testDefaultIfEmpty_Source_Emits),
+    ("testDefaultIfEmpty_Never", ObservableDefaultIfEmptyTest.testDefaultIfEmpty_Never),
+    ] }
+}
+
+final class ObservableDelaySubscriptionTest_ : ObservableDelaySubscriptionTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableDelaySubscriptionTest_) -> () -> ())] { return [
+    ("testDelaySubscription_TimeSpan_Simple", ObservableDelaySubscriptionTest.testDelaySubscription_TimeSpan_Simple),
+    ("testDelaySubscription_TimeSpan_Error", ObservableDelaySubscriptionTest.testDelaySubscription_TimeSpan_Error),
+    ("testDelaySubscription_TimeSpan_Dispose", ObservableDelaySubscriptionTest.testDelaySubscription_TimeSpan_Dispose),
+    ] }
+}
+
+final class ObservableDelayTest_ : ObservableDelayTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableDelayTest_) -> () -> ())] { return [
+    ("testDelay_TimeSpan_Simple1", ObservableDelayTest.testDelay_TimeSpan_Simple1),
+    ("testDelay_TimeSpan_Simple2", ObservableDelayTest.testDelay_TimeSpan_Simple2),
+    ("testDelay_TimeSpan_Simple3", ObservableDelayTest.testDelay_TimeSpan_Simple3),
+    ("testDelay_TimeSpan_Error", ObservableDelayTest.testDelay_TimeSpan_Error),
+    ("testDelay_TimeSpan_Completed", ObservableDelayTest.testDelay_TimeSpan_Completed),
+    ("testDelay_TimeSpan_Error1", ObservableDelayTest.testDelay_TimeSpan_Error1),
+    ("testDelay_TimeSpan_Error2", ObservableDelayTest.testDelay_TimeSpan_Error2),
+    ("testDelay_TimeSpan_Real_Simple", ObservableDelayTest.testDelay_TimeSpan_Real_Simple),
+    ("testDelay_TimeSpan_Real_Error1", ObservableDelayTest.testDelay_TimeSpan_Real_Error1),
+    ("testDelay_TimeSpan_Real_Error2", ObservableDelayTest.testDelay_TimeSpan_Real_Error2),
+    ("testDelay_TimeSpan_Real_Error3", ObservableDelayTest.testDelay_TimeSpan_Real_Error3),
+    ("testDelay_TimeSpan_Positive", ObservableDelayTest.testDelay_TimeSpan_Positive),
+    ("testDelay_TimeSpan_DefaultScheduler", ObservableDelayTest.testDelay_TimeSpan_DefaultScheduler),
+    ] }
+}
+
+final class ObservableDematerializeTest_ : ObservableDematerializeTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableDematerializeTest_) -> () -> ())] { return [
+    ("testDematerialize_Range1", ObservableDematerializeTest.testDematerialize_Range1),
+    ("testDematerialize_Range2", ObservableDematerializeTest.testDematerialize_Range2),
+    ("testDematerialize_Error", ObservableDematerializeTest.testDematerialize_Error),
+    ("testDematerialize_Error2", ObservableDematerializeTest.testDematerialize_Error2),
+    ("testMaterialize_Dematerialize_Never", ObservableDematerializeTest.testMaterialize_Dematerialize_Never),
+    ("testMaterialize_Dematerialize_Empty", ObservableDematerializeTest.testMaterialize_Dematerialize_Empty),
+    ("testMaterialize_Dematerialize_Return", ObservableDematerializeTest.testMaterialize_Dematerialize_Return),
+    ("testMaterialize_Dematerialize_Throw", ObservableDematerializeTest.testMaterialize_Dematerialize_Throw),
+    ] }
+}
+
+final class ObservableDistinctUntilChangedTest_ : ObservableDistinctUntilChangedTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableDistinctUntilChangedTest_) -> () -> ())] { return [
+    ("testDistinctUntilChanged_allChanges", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_allChanges),
+    ("testDistinctUntilChanged_someChanges", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_someChanges),
+    ("testDistinctUntilChanged_allEqual", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_allEqual),
+    ("testDistinctUntilChanged_allDifferent", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_allDifferent),
+    ("testDistinctUntilChanged_keySelector_Div2", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_keySelector_Div2),
+    ("testDistinctUntilChanged_keySelectorThrows", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_keySelectorThrows),
+    ("testDistinctUntilChanged_comparerThrows", ObservableDistinctUntilChangedTest.testDistinctUntilChanged_comparerThrows),
     ] }
 }
 
@@ -1727,6 +730,52 @@ final class ObservableElementAtTest_ : ObservableElementAtTest, RxTestCase {
     ] }
 }
 
+final class ObservableEnumeratedTest_ : ObservableEnumeratedTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableEnumeratedTest_) -> () -> ())] { return [
+    ("test_Infinite", ObservableEnumeratedTest.test_Infinite),
+    ("test_Completed", ObservableEnumeratedTest.test_Completed),
+    ("test_Error", ObservableEnumeratedTest.test_Error),
+    ] }
+}
+
+final class ObservableFilterTest_ : ObservableFilterTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableFilterTest_) -> () -> ())] { return [
+    ("test_filterComplete", ObservableFilterTest.test_filterComplete),
+    ("test_filterTrue", ObservableFilterTest.test_filterTrue),
+    ("test_filterFalse", ObservableFilterTest.test_filterFalse),
+    ("test_filterDisposed", ObservableFilterTest.test_filterDisposed),
+    ("testIgnoreElements_DoesNotSendValues", ObservableFilterTest.testIgnoreElements_DoesNotSendValues),
+    ] }
+}
+
+final class ObservableGenerateTest_ : ObservableGenerateTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableGenerateTest_) -> () -> ())] { return [
+    ("testGenerate_Finite", ObservableGenerateTest.testGenerate_Finite),
+    ("testGenerate_ThrowCondition", ObservableGenerateTest.testGenerate_ThrowCondition),
+    ("testGenerate_ThrowIterate", ObservableGenerateTest.testGenerate_ThrowIterate),
+    ("testGenerate_Dispose", ObservableGenerateTest.testGenerate_Dispose),
+    ("testGenerate_take", ObservableGenerateTest.testGenerate_take),
+    ] }
+}
+
 final class ObservableGroupByTest_ : ObservableGroupByTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1754,67 +803,59 @@ final class ObservableGroupByTest_ : ObservableGroupByTest, RxTestCase {
     ] }
 }
 
-final class ObservableSwitchIfEmptyTest_ : ObservableSwitchIfEmptyTest, RxTestCase {
+final class ObservableJustTest_ : ObservableJustTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (ObservableSwitchIfEmptyTest_) -> () -> ())] { return [
-    ("testSwitchIfEmpty_SourceNotEmpty_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceNotEmpty_SwitchCompletes),
-    ("testSwitchIfEmpty_SourceNotEmptyError_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceNotEmptyError_SwitchCompletes),
-    ("testSwitchIfEmpty_SourceEmptyError_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceEmptyError_SwitchCompletes),
-    ("testSwitchIfEmpty_SourceEmpty_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceEmpty_SwitchCompletes),
-    ("testSwitchIfEmpty_SourceEmpty_SwitchError", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceEmpty_SwitchError),
-    ("testSwitchIfEmpty_Never", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_Never),
+    static var allTests: [(String, (ObservableJustTest_) -> () -> ())] { return [
+    ("testJust_Immediate", ObservableJustTest.testJust_Immediate),
+    ("testJust_Basic", ObservableJustTest.testJust_Basic),
+    ("testJust_Disposed", ObservableJustTest.testJust_Disposed),
+    ("testJust_DisposeAfterNext", ObservableJustTest.testJust_DisposeAfterNext),
+    ("testJust_DefaultScheduler", ObservableJustTest.testJust_DefaultScheduler),
+    ("testJust_CompilesInMap", ObservableJustTest.testJust_CompilesInMap),
     ] }
 }
 
-final class ObservableThrottleTest_ : ObservableThrottleTest, RxTestCase {
+final class ObservableMapTest_ : ObservableMapTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (ObservableThrottleTest_) -> () -> ())] { return [
-    ("test_ThrottleTimeSpan_NotLatest_Completed", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_Completed),
-    ("test_ThrottleTimeSpan_NotLatest_Never", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_Never),
-    ("test_ThrottleTimeSpan_NotLatest_Empty", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_Empty),
-    ("test_ThrottleTimeSpan_NotLatest_Error", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_Error),
-    ("test_ThrottleTimeSpan_NotLatest_NoEnd", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_NoEnd),
-    ("test_ThrottleTimeSpan_NotLatest_WithRealScheduler", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_WithRealScheduler),
-    ("test_ThrottleTimeSpan_Completed", ObservableThrottleTest.test_ThrottleTimeSpan_Completed),
-    ("test_ThrottleTimeSpan_CompletedAfterDueTime", ObservableThrottleTest.test_ThrottleTimeSpan_CompletedAfterDueTime),
-    ("test_ThrottleTimeSpan_Never", ObservableThrottleTest.test_ThrottleTimeSpan_Never),
-    ("test_ThrottleTimeSpan_Empty", ObservableThrottleTest.test_ThrottleTimeSpan_Empty),
-    ("test_ThrottleTimeSpan_Error", ObservableThrottleTest.test_ThrottleTimeSpan_Error),
-    ("test_ThrottleTimeSpan_NoEnd", ObservableThrottleTest.test_ThrottleTimeSpan_NoEnd),
-    ("test_ThrottleTimeSpan_WithRealScheduler", ObservableThrottleTest.test_ThrottleTimeSpan_WithRealScheduler),
+    static var allTests: [(String, (ObservableMapTest_) -> () -> ())] { return [
+    ("testMap_Never", ObservableMapTest.testMap_Never),
+    ("testMap_Empty", ObservableMapTest.testMap_Empty),
+    ("testMap_Range", ObservableMapTest.testMap_Range),
+    ("testMap_Error", ObservableMapTest.testMap_Error),
+    ("testMap_Dispose", ObservableMapTest.testMap_Dispose),
+    ("testMap_SelectorThrows", ObservableMapTest.testMap_SelectorThrows),
+    ("testMapCompose_Never", ObservableMapTest.testMapCompose_Never),
+    ("testMapCompose_Empty", ObservableMapTest.testMapCompose_Empty),
+    ("testMapCompose_Range", ObservableMapTest.testMapCompose_Range),
+    ("testMapCompose_Error", ObservableMapTest.testMapCompose_Error),
+    ("testMapCompose_Dispose", ObservableMapTest.testMapCompose_Dispose),
+    ("testMapCompose_Selector1Throws", ObservableMapTest.testMapCompose_Selector1Throws),
+    ("testMapCompose_Selector2Throws", ObservableMapTest.testMapCompose_Selector2Throws),
     ] }
 }
 
-final class ObservableTakeUntilTest_ : ObservableTakeUntilTest, RxTestCase {
+final class ObservableMaterializeTest_ : ObservableMaterializeTest, RxTestCase {
     #if os(macOS)
     required override init() {
         super.init()
     }
     #endif
 
-    static var allTests: [(String, (ObservableTakeUntilTest_) -> () -> ())] { return [
-    ("testTakeUntil_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntil_Preempt_SomeData_Next),
-    ("testTakeUntil_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntil_Preempt_SomeData_Error),
-    ("testTakeUntil_NoPreempt_SomeData_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_SomeData_Empty),
-    ("testTakeUntil_NoPreempt_SomeData_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_SomeData_Never),
-    ("testTakeUntil_Preempt_Never_Next", ObservableTakeUntilTest.testTakeUntil_Preempt_Never_Next),
-    ("testTakeUntil_Preempt_Never_Error", ObservableTakeUntilTest.testTakeUntil_Preempt_Never_Error),
-    ("testTakeUntil_NoPreempt_Never_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Empty),
-    ("testTakeUntil_NoPreempt_Never_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Never),
-    ("testTakeUntil_Preempt_BeforeFirstProduced", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced),
-    ("testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed),
-    ("testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna", ObservableTakeUntilTest.testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna),
-    ("testTakeUntil_Error_Some", ObservableTakeUntilTest.testTakeUntil_Error_Some),
+    static var allTests: [(String, (ObservableMaterializeTest_) -> () -> ())] { return [
+    ("testMaterializeNever", ObservableMaterializeTest.testMaterializeNever),
+    ("testMaterializeEmpty", ObservableMaterializeTest.testMaterializeEmpty),
+    ("testMaterializeEmits", ObservableMaterializeTest.testMaterializeEmits),
+    ("testMaterializeThrow", ObservableMaterializeTest.testMaterializeThrow),
     ] }
 }
 
@@ -1881,6 +922,152 @@ final class ObservableMergeTest_ : ObservableMergeTest, RxTestCase {
     ] }
 }
 
+final class ObservableMulticastTest_ : ObservableMulticastTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableMulticastTest_) -> () -> ())] { return [
+    ("testMulticastWhileConnected_connectControlsSourceSubscription", ObservableMulticastTest.testMulticastWhileConnected_connectControlsSourceSubscription),
+    ("testMulticastWhileConnected_connectFirstThenSubscribe", ObservableMulticastTest.testMulticastWhileConnected_connectFirstThenSubscribe),
+    ("testMulticastWhileConnected_completed", ObservableMulticastTest.testMulticastWhileConnected_completed),
+    ("testMulticastWhileConnected_error", ObservableMulticastTest.testMulticastWhileConnected_error),
+    ("testMulticastForever_connectControlsSourceSubscription", ObservableMulticastTest.testMulticastForever_connectControlsSourceSubscription),
+    ("testMulticastForever_connectFirstThenSubscribe", ObservableMulticastTest.testMulticastForever_connectFirstThenSubscribe),
+    ("testMulticastForever_completed", ObservableMulticastTest.testMulticastForever_completed),
+    ("testMulticastForever_error", ObservableMulticastTest.testMulticastForever_error),
+    ("testMulticast_Cold_Completed", ObservableMulticastTest.testMulticast_Cold_Completed),
+    ("testMulticast_Cold_Error", ObservableMulticastTest.testMulticast_Cold_Error),
+    ("testMulticast_Cold_Dispose", ObservableMulticastTest.testMulticast_Cold_Dispose),
+    ("testMulticast_Cold_Zip", ObservableMulticastTest.testMulticast_Cold_Zip),
+    ("testMulticast_SubjectSelectorThrows", ObservableMulticastTest.testMulticast_SubjectSelectorThrows),
+    ("testMulticast_SelectorThrows", ObservableMulticastTest.testMulticast_SelectorThrows),
+    ("testRefCount_DeadlockSimple", ObservableMulticastTest.testRefCount_DeadlockSimple),
+    ("testRefCount_DeadlockErrorAfterN", ObservableMulticastTest.testRefCount_DeadlockErrorAfterN),
+    ("testRefCount_DeadlockErrorImmediately", ObservableMulticastTest.testRefCount_DeadlockErrorImmediately),
+    ("testRefCount_DeadlockEmpty", ObservableMulticastTest.testRefCount_DeadlockEmpty),
+    ("testRefCount_ConnectsOnFirst", ObservableMulticastTest.testRefCount_ConnectsOnFirst),
+    ("testRefCount_DoesntConnectsOnFirstInCaseSynchronousCompleted", ObservableMulticastTest.testRefCount_DoesntConnectsOnFirstInCaseSynchronousCompleted),
+    ("testRefCount_DoesntConnectsOnFirstInCaseSynchronousError", ObservableMulticastTest.testRefCount_DoesntConnectsOnFirstInCaseSynchronousError),
+    ("testRefCount_NotConnected", ObservableMulticastTest.testRefCount_NotConnected),
+    ("testRefCount_Error", ObservableMulticastTest.testRefCount_Error),
+    ("testRefCount_Publish", ObservableMulticastTest.testRefCount_Publish),
+    ("testRefCount_synchronousResubscribingOnErrorWorks", ObservableMulticastTest.testRefCount_synchronousResubscribingOnErrorWorks),
+    ("testRefCount_synchronousResubscribingOnCompletedWorks", ObservableMulticastTest.testRefCount_synchronousResubscribingOnCompletedWorks),
+    ("testReplayCount_Basic", ObservableMulticastTest.testReplayCount_Basic),
+    ("testReplayCount_Error", ObservableMulticastTest.testReplayCount_Error),
+    ("testReplayCount_Complete", ObservableMulticastTest.testReplayCount_Complete),
+    ("testReplayCount_Dispose", ObservableMulticastTest.testReplayCount_Dispose),
+    ("testReplayOneCount_Basic", ObservableMulticastTest.testReplayOneCount_Basic),
+    ("testReplayOneCount_Error", ObservableMulticastTest.testReplayOneCount_Error),
+    ("testReplayOneCount_Complete", ObservableMulticastTest.testReplayOneCount_Complete),
+    ("testReplayOneCount_Dispose", ObservableMulticastTest.testReplayOneCount_Dispose),
+    ("testReplayAll_Basic", ObservableMulticastTest.testReplayAll_Basic),
+    ("testReplayAll_Error", ObservableMulticastTest.testReplayAll_Error),
+    ("testReplayAll_Complete", ObservableMulticastTest.testReplayAll_Complete),
+    ("testReplayAll_Dispose", ObservableMulticastTest.testReplayAll_Dispose),
+    ] }
+}
+
+final class ObservableObserveOnTest_ : ObservableObserveOnTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableObserveOnTest_) -> () -> ())] { return [
+    ("testObserveOnDispatchQueue_DoesPerformWorkOnQueue", ObservableObserveOnTest.testObserveOnDispatchQueue_DoesPerformWorkOnQueue),
+    ("testObserveOnDispatchQueue_DeadlockErrorImmediately", ObservableObserveOnTest.testObserveOnDispatchQueue_DeadlockErrorImmediately),
+    ("testObserveOnDispatchQueue_DeadlockEmpty", ObservableObserveOnTest.testObserveOnDispatchQueue_DeadlockEmpty),
+    ("testObserveOnDispatchQueue_Never", ObservableObserveOnTest.testObserveOnDispatchQueue_Never),
+    ("testObserveOnDispatchQueue_Simple", ObservableObserveOnTest.testObserveOnDispatchQueue_Simple),
+    ("testObserveOnDispatchQueue_Empty", ObservableObserveOnTest.testObserveOnDispatchQueue_Empty),
+    ("testObserveOnDispatchQueue_Error", ObservableObserveOnTest.testObserveOnDispatchQueue_Error),
+    ("testObserveOnDispatchQueue_Dispose", ObservableObserveOnTest.testObserveOnDispatchQueue_Dispose),
+    ] }
+}
+
+final class ObservableObserveOnTestConcurrentSchedulerTest_ : ObservableObserveOnTestConcurrentSchedulerTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableObserveOnTestConcurrentSchedulerTest_) -> () -> ())] { return [
+    ("testObserveOn_EnsureTestsAreExecutedWithRealConcurrentScheduler", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_EnsureTestsAreExecutedWithRealConcurrentScheduler),
+    ("testObserveOn_Never", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Never),
+    ("testObserveOn_Simple", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Simple),
+    ("testObserveOn_Empty", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Empty),
+    ("testObserveOn_ConcurrentSchedulerIsSerialized", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_ConcurrentSchedulerIsSerialized),
+    ("testObserveOn_Error", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Error),
+    ("testObserveOn_Dispose", ObservableObserveOnTestConcurrentSchedulerTest.testObserveOn_Dispose),
+    ] }
+}
+
+final class ObservableOptionalTest_ : ObservableOptionalTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableOptionalTest_) -> () -> ())] { return [
+    ("testFromOptionalSome_immediate", ObservableOptionalTest.testFromOptionalSome_immediate),
+    ("testFromOptionalNone_immediate", ObservableOptionalTest.testFromOptionalNone_immediate),
+    ("testFromOptionalSome_basic_testScheduler", ObservableOptionalTest.testFromOptionalSome_basic_testScheduler),
+    ("testFromOptionalNone_basic_testScheduler", ObservableOptionalTest.testFromOptionalNone_basic_testScheduler),
+    ] }
+}
+
+final class ObservablePrimitiveSequenceTest_ : ObservablePrimitiveSequenceTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservablePrimitiveSequenceTest_) -> () -> ())] { return [
+    ("testAsSingle_Empty", ObservablePrimitiveSequenceTest.testAsSingle_Empty),
+    ("testAsSingle_One", ObservablePrimitiveSequenceTest.testAsSingle_One),
+    ("testAsSingle_Many", ObservablePrimitiveSequenceTest.testAsSingle_Many),
+    ("testAsSingle_Error", ObservablePrimitiveSequenceTest.testAsSingle_Error),
+    ("testAsSingle_Error2", ObservablePrimitiveSequenceTest.testAsSingle_Error2),
+    ("testAsSingle_subscribeOnSuccess", ObservablePrimitiveSequenceTest.testAsSingle_subscribeOnSuccess),
+    ("testAsSingle_subscribeOnError", ObservablePrimitiveSequenceTest.testAsSingle_subscribeOnError),
+    ("testAsMaybe_Empty", ObservablePrimitiveSequenceTest.testAsMaybe_Empty),
+    ("testAsMaybe_One", ObservablePrimitiveSequenceTest.testAsMaybe_One),
+    ("testAsMaybe_Many", ObservablePrimitiveSequenceTest.testAsMaybe_Many),
+    ("testAsMaybe_Error", ObservablePrimitiveSequenceTest.testAsMaybe_Error),
+    ("testAsMaybe_Error2", ObservablePrimitiveSequenceTest.testAsMaybe_Error2),
+    ("testAsMaybe_subscribeOnSuccess", ObservablePrimitiveSequenceTest.testAsMaybe_subscribeOnSuccess),
+    ("testAsMaybe_subscribeOnError", ObservablePrimitiveSequenceTest.testAsMaybe_subscribeOnError),
+    ("testAsMaybe_subscribeOnCompleted", ObservablePrimitiveSequenceTest.testAsMaybe_subscribeOnCompleted),
+    ("testAsCompletable_Empty", ObservablePrimitiveSequenceTest.testAsCompletable_Empty),
+    ("testAsCompletable_Error", ObservablePrimitiveSequenceTest.testAsCompletable_Error),
+    ("testAsCompletable_subscribeOnCompleted", ObservablePrimitiveSequenceTest.testAsCompletable_subscribeOnCompleted),
+    ("testAsCompletable_subscribeOnError", ObservablePrimitiveSequenceTest.testAsCompletable_subscribeOnError),
+    ("testCompletable_merge", ObservablePrimitiveSequenceTest.testCompletable_merge),
+    ("testCompletable_concat", ObservablePrimitiveSequenceTest.testCompletable_concat),
+    ] }
+}
+
+final class ObservableRangeTest_ : ObservableRangeTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableRangeTest_) -> () -> ())] { return [
+    ("testRange_Boundaries", ObservableRangeTest.testRange_Boundaries),
+    ("testRange_Dispose", ObservableRangeTest.testRange_Dispose),
+    ] }
+}
+
 final class ObservableReduceTest_ : ObservableReduceTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -1902,6 +1089,718 @@ final class ObservableReduceTest_ : ObservableReduceTest, RxTestCase {
     ("test_ReduceWithSeedAndResult_Range", ObservableReduceTest.test_ReduceWithSeedAndResult_Range),
     ("test_ReduceWithSeedAndResult_AccumulatorThrows", ObservableReduceTest.test_ReduceWithSeedAndResult_AccumulatorThrows),
     ("test_ReduceWithSeedAndResult_SelectorThrows", ObservableReduceTest.test_ReduceWithSeedAndResult_SelectorThrows),
+    ] }
+}
+
+final class ObservableRepeatTest_ : ObservableRepeatTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableRepeatTest_) -> () -> ())] { return [
+    ("testRepeat_Element", ObservableRepeatTest.testRepeat_Element),
+    ] }
+}
+
+final class ObservableRetryWhenTest_ : ObservableRetryWhenTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableRetryWhenTest_) -> () -> ())] { return [
+    ("testRetryWhen_Never", ObservableRetryWhenTest.testRetryWhen_Never),
+    ("testRetryWhen_ObservableNever", ObservableRetryWhenTest.testRetryWhen_ObservableNever),
+    ("testRetryWhen_ObservableNeverComplete", ObservableRetryWhenTest.testRetryWhen_ObservableNeverComplete),
+    ("testRetryWhen_ObservableEmpty", ObservableRetryWhenTest.testRetryWhen_ObservableEmpty),
+    ("testRetryWhen_ObservableNextError", ObservableRetryWhenTest.testRetryWhen_ObservableNextError),
+    ("testRetryWhen_ObservableComplete", ObservableRetryWhenTest.testRetryWhen_ObservableComplete),
+    ("testRetryWhen_ObservableNextComplete", ObservableRetryWhenTest.testRetryWhen_ObservableNextComplete),
+    ("testRetryWhen_ObservableInfinite", ObservableRetryWhenTest.testRetryWhen_ObservableInfinite),
+    ("testRetryWhen_Incremental_BackOff", ObservableRetryWhenTest.testRetryWhen_Incremental_BackOff),
+    ("testRetryWhen_IgnoresDifferentErrorTypes", ObservableRetryWhenTest.testRetryWhen_IgnoresDifferentErrorTypes),
+    ("testRetryWhen_tailRecursiveOptimizationsTest", ObservableRetryWhenTest.testRetryWhen_tailRecursiveOptimizationsTest),
+    ] }
+}
+
+final class ObservableSampleTest_ : ObservableSampleTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSampleTest_) -> () -> ())] { return [
+    ("testSample_Sampler_SamplerThrows", ObservableSampleTest.testSample_Sampler_SamplerThrows),
+    ("testSample_Sampler_Simple1", ObservableSampleTest.testSample_Sampler_Simple1),
+    ("testSample_Sampler_Simple2", ObservableSampleTest.testSample_Sampler_Simple2),
+    ("testSample_Sampler_Simple3", ObservableSampleTest.testSample_Sampler_Simple3),
+    ("testSample_Sampler_SourceThrows", ObservableSampleTest.testSample_Sampler_SourceThrows),
+    ] }
+}
+
+final class ObservableScanTest_ : ObservableScanTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableScanTest_) -> () -> ())] { return [
+    ("testScan_Seed_Never", ObservableScanTest.testScan_Seed_Never),
+    ("testScan_Seed_Empty", ObservableScanTest.testScan_Seed_Empty),
+    ("testScan_Seed_Return", ObservableScanTest.testScan_Seed_Return),
+    ("testScan_Seed_Throw", ObservableScanTest.testScan_Seed_Throw),
+    ("testScan_Seed_SomeData", ObservableScanTest.testScan_Seed_SomeData),
+    ("testScan_Seed_AccumulatorThrows", ObservableScanTest.testScan_Seed_AccumulatorThrows),
+    ] }
+}
+
+final class ObservableSequenceTest_ : ObservableSequenceTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSequenceTest_) -> () -> ())] { return [
+    ("testFromArray_complete_immediate", ObservableSequenceTest.testFromArray_complete_immediate),
+    ("testFromArray_complete", ObservableSequenceTest.testFromArray_complete),
+    ("testFromArray_dispose", ObservableSequenceTest.testFromArray_dispose),
+    ("testSequenceOf_complete_immediate", ObservableSequenceTest.testSequenceOf_complete_immediate),
+    ("testSequenceOf_complete", ObservableSequenceTest.testSequenceOf_complete),
+    ("testSequenceOf_dispose", ObservableSequenceTest.testSequenceOf_dispose),
+    ("testFromAnySequence_basic_immediate", ObservableSequenceTest.testFromAnySequence_basic_immediate),
+    ("testToObservableAnySequence_basic_testScheduler", ObservableSequenceTest.testToObservableAnySequence_basic_testScheduler),
+    ] }
+}
+
+final class ObservableShareReplayScopeTests_ : ObservableShareReplayScopeTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableShareReplayScopeTests_) -> () -> ())] { return [
+    ("test_testDefaultArguments", ObservableShareReplayScopeTests.test_testDefaultArguments),
+    ("test_forever_receivesCorrectElements", ObservableShareReplayScopeTests.test_forever_receivesCorrectElements),
+    ("test_whileConnected_receivesCorrectElements", ObservableShareReplayScopeTests.test_whileConnected_receivesCorrectElements),
+    ("test_forever_error", ObservableShareReplayScopeTests.test_forever_error),
+    ("test_whileConnected_error", ObservableShareReplayScopeTests.test_whileConnected_error),
+    ("test_forever_completed", ObservableShareReplayScopeTests.test_forever_completed),
+    ("test_whileConnected_completed", ObservableShareReplayScopeTests.test_whileConnected_completed),
+    ] }
+}
+
+final class ObservableSingleTest_ : ObservableSingleTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSingleTest_) -> () -> ())] { return [
+    ("testSingle_Empty", ObservableSingleTest.testSingle_Empty),
+    ("testSingle_One", ObservableSingleTest.testSingle_One),
+    ("testSingle_Many", ObservableSingleTest.testSingle_Many),
+    ("testSingle_Error", ObservableSingleTest.testSingle_Error),
+    ("testSinglePredicate_Empty", ObservableSingleTest.testSinglePredicate_Empty),
+    ("testSinglePredicate_One", ObservableSingleTest.testSinglePredicate_One),
+    ("testSinglePredicate_Many", ObservableSingleTest.testSinglePredicate_Many),
+    ("testSinglePredicate_Error", ObservableSingleTest.testSinglePredicate_Error),
+    ("testSinglePredicate_Throws", ObservableSingleTest.testSinglePredicate_Throws),
+    ] }
+}
+
+final class ObservableSkipTest_ : ObservableSkipTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSkipTest_) -> () -> ())] { return [
+    ("testSkip_Complete_After", ObservableSkipTest.testSkip_Complete_After),
+    ("testSkip_Complete_Some", ObservableSkipTest.testSkip_Complete_Some),
+    ("testSkip_Complete_Before", ObservableSkipTest.testSkip_Complete_Before),
+    ("testSkip_Complete_Zero", ObservableSkipTest.testSkip_Complete_Zero),
+    ("testSkip_Error_After", ObservableSkipTest.testSkip_Error_After),
+    ("testSkip_Error_Same", ObservableSkipTest.testSkip_Error_Same),
+    ("testSkip_Error_Before", ObservableSkipTest.testSkip_Error_Before),
+    ("testSkip_Dispose_Before", ObservableSkipTest.testSkip_Dispose_Before),
+    ("testSkip_Dispose_After", ObservableSkipTest.testSkip_Dispose_After),
+    ("testSkip_Zero", ObservableSkipTest.testSkip_Zero),
+    ("testSkip_Some", ObservableSkipTest.testSkip_Some),
+    ("testSkip_Late", ObservableSkipTest.testSkip_Late),
+    ("testSkip_Error", ObservableSkipTest.testSkip_Error),
+    ("testSkip_Never", ObservableSkipTest.testSkip_Never),
+    ] }
+}
+
+final class ObservableSkipUntilTest_ : ObservableSkipUntilTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSkipUntilTest_) -> () -> ())] { return [
+    ("testSkipUntil_SomeData_Next", ObservableSkipUntilTest.testSkipUntil_SomeData_Next),
+    ("testSkipUntil_SomeData_Error", ObservableSkipUntilTest.testSkipUntil_SomeData_Error),
+    ("testSkipUntil_Error_SomeData", ObservableSkipUntilTest.testSkipUntil_Error_SomeData),
+    ("testSkipUntil_SomeData_Empty", ObservableSkipUntilTest.testSkipUntil_SomeData_Empty),
+    ("testSkipUntil_Never_Next", ObservableSkipUntilTest.testSkipUntil_Never_Next),
+    ("testSkipUntil_Never_Error1", ObservableSkipUntilTest.testSkipUntil_Never_Error1),
+    ("testSkipUntil_SomeData_Error2", ObservableSkipUntilTest.testSkipUntil_SomeData_Error2),
+    ("testSkipUntil_SomeData_Never", ObservableSkipUntilTest.testSkipUntil_SomeData_Never),
+    ("testSkipUntil_Never_Empty", ObservableSkipUntilTest.testSkipUntil_Never_Empty),
+    ("testSkipUntil_Never_Never", ObservableSkipUntilTest.testSkipUntil_Never_Never),
+    ("testSkipUntil_HasCompletedCausesDisposal", ObservableSkipUntilTest.testSkipUntil_HasCompletedCausesDisposal),
+    ] }
+}
+
+final class ObservableSkipWhileTest_ : ObservableSkipWhileTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSkipWhileTest_) -> () -> ())] { return [
+    ("testSkipWhile_Complete_Before", ObservableSkipWhileTest.testSkipWhile_Complete_Before),
+    ("testSkipWhile_Complete_After", ObservableSkipWhileTest.testSkipWhile_Complete_After),
+    ("testSkipWhile_Error_Before", ObservableSkipWhileTest.testSkipWhile_Error_Before),
+    ("testSkipWhile_Error_After", ObservableSkipWhileTest.testSkipWhile_Error_After),
+    ("testSkipWhile_Dispose_Before", ObservableSkipWhileTest.testSkipWhile_Dispose_Before),
+    ("testSkipWhile_Dispose_After", ObservableSkipWhileTest.testSkipWhile_Dispose_After),
+    ("testSkipWhile_Zero", ObservableSkipWhileTest.testSkipWhile_Zero),
+    ("testSkipWhile_Throw", ObservableSkipWhileTest.testSkipWhile_Throw),
+    ] }
+}
+
+final class ObservableSubscribeOnTest_ : ObservableSubscribeOnTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSubscribeOnTest_) -> () -> ())] { return [
+    ("testSubscribeOn_SchedulerSleep", ObservableSubscribeOnTest.testSubscribeOn_SchedulerSleep),
+    ("testSubscribeOn_SchedulerCompleted", ObservableSubscribeOnTest.testSubscribeOn_SchedulerCompleted),
+    ("testSubscribeOn_SchedulerError", ObservableSubscribeOnTest.testSubscribeOn_SchedulerError),
+    ("testSubscribeOn_SchedulerDispose", ObservableSubscribeOnTest.testSubscribeOn_SchedulerDispose),
+    ] }
+}
+
+final class ObservableSubscriptionTest_ : ObservableSubscriptionTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSubscriptionTest_) -> () -> ())] { return [
+    ("testDefaultErrorHandler", ObservableSubscriptionTest.testDefaultErrorHandler),
+    ] }
+}
+
+final class ObservableSubscriptionTests_ : ObservableSubscriptionTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSubscriptionTests_) -> () -> ())] { return [
+    ("testSubscribeOnNext", ObservableSubscriptionTests.testSubscribeOnNext),
+    ("testSubscribeOnError", ObservableSubscriptionTests.testSubscribeOnError),
+    ("testSubscribeOnCompleted", ObservableSubscriptionTests.testSubscribeOnCompleted),
+    ("testDisposed", ObservableSubscriptionTests.testDisposed),
+    ] }
+}
+
+final class ObservableSwitchIfEmptyTest_ : ObservableSwitchIfEmptyTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSwitchIfEmptyTest_) -> () -> ())] { return [
+    ("testSwitchIfEmpty_SourceNotEmpty_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceNotEmpty_SwitchCompletes),
+    ("testSwitchIfEmpty_SourceNotEmptyError_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceNotEmptyError_SwitchCompletes),
+    ("testSwitchIfEmpty_SourceEmptyError_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceEmptyError_SwitchCompletes),
+    ("testSwitchIfEmpty_SourceEmpty_SwitchCompletes", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceEmpty_SwitchCompletes),
+    ("testSwitchIfEmpty_SourceEmpty_SwitchError", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_SourceEmpty_SwitchError),
+    ("testSwitchIfEmpty_Never", ObservableSwitchIfEmptyTest.testSwitchIfEmpty_Never),
+    ] }
+}
+
+final class ObservableSwitchTest_ : ObservableSwitchTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableSwitchTest_) -> () -> ())] { return [
+    ("testSwitch_Data", ObservableSwitchTest.testSwitch_Data),
+    ("testSwitch_InnerThrows", ObservableSwitchTest.testSwitch_InnerThrows),
+    ("testSwitch_OuterThrows", ObservableSwitchTest.testSwitch_OuterThrows),
+    ("testFlatMapLatest_Data", ObservableSwitchTest.testFlatMapLatest_Data),
+    ("testFlatMapLatest_InnerThrows", ObservableSwitchTest.testFlatMapLatest_InnerThrows),
+    ("testFlatMapLatest_OuterThrows", ObservableSwitchTest.testFlatMapLatest_OuterThrows),
+    ("testFlatMapLatest_SelectorThrows", ObservableSwitchTest.testFlatMapLatest_SelectorThrows),
+    ] }
+}
+
+final class ObservableTakeLastTest_ : ObservableTakeLastTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableTakeLastTest_) -> () -> ())] { return [
+    ("testTakeLast_Complete_Less", ObservableTakeLastTest.testTakeLast_Complete_Less),
+    ("testTakeLast_Complete_Same", ObservableTakeLastTest.testTakeLast_Complete_Same),
+    ("testTakeLast_Complete_More", ObservableTakeLastTest.testTakeLast_Complete_More),
+    ("testTakeLast_Error_Less", ObservableTakeLastTest.testTakeLast_Error_Less),
+    ("testTakeLast_Error_Same", ObservableTakeLastTest.testTakeLast_Error_Same),
+    ("testTakeLast_Error_More", ObservableTakeLastTest.testTakeLast_Error_More),
+    ("testTakeLast_0_DefaultScheduler", ObservableTakeLastTest.testTakeLast_0_DefaultScheduler),
+    ("testTakeLast_TakeLast1", ObservableTakeLastTest.testTakeLast_TakeLast1),
+    ("testTakeLast_DecrementCountsFirst", ObservableTakeLastTest.testTakeLast_DecrementCountsFirst),
+    ] }
+}
+
+final class ObservableTakeTest_ : ObservableTakeTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableTakeTest_) -> () -> ())] { return [
+    ("testTake_Complete_After", ObservableTakeTest.testTake_Complete_After),
+    ("testTake_Complete_Same", ObservableTakeTest.testTake_Complete_Same),
+    ("testTake_Complete_Before", ObservableTakeTest.testTake_Complete_Before),
+    ("testTake_Error_After", ObservableTakeTest.testTake_Error_After),
+    ("testTake_Error_Same", ObservableTakeTest.testTake_Error_Same),
+    ("testTake_Error_Before", ObservableTakeTest.testTake_Error_Before),
+    ("testTake_Dispose_Before", ObservableTakeTest.testTake_Dispose_Before),
+    ("testTake_Dispose_After", ObservableTakeTest.testTake_Dispose_After),
+    ("testTake_0_DefaultScheduler", ObservableTakeTest.testTake_0_DefaultScheduler),
+    ("testTake_Take1", ObservableTakeTest.testTake_Take1),
+    ("testTake_DecrementCountsFirst", ObservableTakeTest.testTake_DecrementCountsFirst),
+    ("testTake_TakeZero", ObservableTakeTest.testTake_TakeZero),
+    ("testTake_Some", ObservableTakeTest.testTake_Some),
+    ("testTake_TakeLate", ObservableTakeTest.testTake_TakeLate),
+    ("testTake_TakeError", ObservableTakeTest.testTake_TakeError),
+    ("testTake_TakeNever", ObservableTakeTest.testTake_TakeNever),
+    ("testTake_TakeTwice1", ObservableTakeTest.testTake_TakeTwice1),
+    ("testTake_TakeDefault", ObservableTakeTest.testTake_TakeDefault),
+    ] }
+}
+
+final class ObservableTakeUntilTest_ : ObservableTakeUntilTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableTakeUntilTest_) -> () -> ())] { return [
+    ("testTakeUntil_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntil_Preempt_SomeData_Next),
+    ("testTakeUntil_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntil_Preempt_SomeData_Error),
+    ("testTakeUntil_NoPreempt_SomeData_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_SomeData_Empty),
+    ("testTakeUntil_NoPreempt_SomeData_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_SomeData_Never),
+    ("testTakeUntil_Preempt_Never_Next", ObservableTakeUntilTest.testTakeUntil_Preempt_Never_Next),
+    ("testTakeUntil_Preempt_Never_Error", ObservableTakeUntilTest.testTakeUntil_Preempt_Never_Error),
+    ("testTakeUntil_NoPreempt_Never_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Empty),
+    ("testTakeUntil_NoPreempt_Never_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Never),
+    ("testTakeUntil_Preempt_BeforeFirstProduced", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced),
+    ("testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed),
+    ("testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna", ObservableTakeUntilTest.testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna),
+    ("testTakeUntil_Error_Some", ObservableTakeUntilTest.testTakeUntil_Error_Some),
+    ] }
+}
+
+final class ObservableTakeWhileTest_ : ObservableTakeWhileTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableTakeWhileTest_) -> () -> ())] { return [
+    ("testTakeWhile_Complete_Before", ObservableTakeWhileTest.testTakeWhile_Complete_Before),
+    ("testTakeWhile_Complete_After", ObservableTakeWhileTest.testTakeWhile_Complete_After),
+    ("testTakeWhile_Error_Before", ObservableTakeWhileTest.testTakeWhile_Error_Before),
+    ("testTakeWhile_Error_After", ObservableTakeWhileTest.testTakeWhile_Error_After),
+    ("testTakeWhile_Dispose_Before", ObservableTakeWhileTest.testTakeWhile_Dispose_Before),
+    ("testTakeWhile_Dispose_After", ObservableTakeWhileTest.testTakeWhile_Dispose_After),
+    ("testTakeWhile_Zero", ObservableTakeWhileTest.testTakeWhile_Zero),
+    ("testTakeWhile_Throw", ObservableTakeWhileTest.testTakeWhile_Throw),
+    ] }
+}
+
+final class ObservableTest_ : ObservableTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableTest_) -> () -> ())] { return [
+    ("testAnonymousObservable_detachesOnDispose", ObservableTest.testAnonymousObservable_detachesOnDispose),
+    ("testAnonymousObservable_detachesOnComplete", ObservableTest.testAnonymousObservable_detachesOnComplete),
+    ("testAnonymousObservable_detachesOnError", ObservableTest.testAnonymousObservable_detachesOnError),
+    ("testAsObservable_asObservable", ObservableTest.testAsObservable_asObservable),
+    ("testAsObservable_hides", ObservableTest.testAsObservable_hides),
+    ("testAsObservable_never", ObservableTest.testAsObservable_never),
+    ] }
+}
+
+final class ObservableThrottleTest_ : ObservableThrottleTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableThrottleTest_) -> () -> ())] { return [
+    ("test_ThrottleTimeSpan_NotLatest_Completed", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_Completed),
+    ("test_ThrottleTimeSpan_NotLatest_Never", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_Never),
+    ("test_ThrottleTimeSpan_NotLatest_Empty", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_Empty),
+    ("test_ThrottleTimeSpan_NotLatest_Error", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_Error),
+    ("test_ThrottleTimeSpan_NotLatest_NoEnd", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_NoEnd),
+    ("test_ThrottleTimeSpan_NotLatest_WithRealScheduler", ObservableThrottleTest.test_ThrottleTimeSpan_NotLatest_WithRealScheduler),
+    ("test_ThrottleTimeSpan_Completed", ObservableThrottleTest.test_ThrottleTimeSpan_Completed),
+    ("test_ThrottleTimeSpan_CompletedAfterDueTime", ObservableThrottleTest.test_ThrottleTimeSpan_CompletedAfterDueTime),
+    ("test_ThrottleTimeSpan_Never", ObservableThrottleTest.test_ThrottleTimeSpan_Never),
+    ("test_ThrottleTimeSpan_Empty", ObservableThrottleTest.test_ThrottleTimeSpan_Empty),
+    ("test_ThrottleTimeSpan_Error", ObservableThrottleTest.test_ThrottleTimeSpan_Error),
+    ("test_ThrottleTimeSpan_NoEnd", ObservableThrottleTest.test_ThrottleTimeSpan_NoEnd),
+    ("test_ThrottleTimeSpan_WithRealScheduler", ObservableThrottleTest.test_ThrottleTimeSpan_WithRealScheduler),
+    ] }
+}
+
+final class ObservableTimeoutTest_ : ObservableTimeoutTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableTimeoutTest_) -> () -> ())] { return [
+    ("testTimeout_Empty", ObservableTimeoutTest.testTimeout_Empty),
+    ("testTimeout_Error", ObservableTimeoutTest.testTimeout_Error),
+    ("testTimeout_Never", ObservableTimeoutTest.testTimeout_Never),
+    ("testTimeout_Duetime_Simple", ObservableTimeoutTest.testTimeout_Duetime_Simple),
+    ("testTimeout_Duetime_Timeout_Exact", ObservableTimeoutTest.testTimeout_Duetime_Timeout_Exact),
+    ("testTimeout_Duetime_Timeout", ObservableTimeoutTest.testTimeout_Duetime_Timeout),
+    ("testTimeout_Duetime_Disposed", ObservableTimeoutTest.testTimeout_Duetime_Disposed),
+    ("testTimeout_TimeoutOccurs_1", ObservableTimeoutTest.testTimeout_TimeoutOccurs_1),
+    ("testTimeout_TimeoutOccurs_2", ObservableTimeoutTest.testTimeout_TimeoutOccurs_2),
+    ("testTimeout_TimeoutOccurs_Never", ObservableTimeoutTest.testTimeout_TimeoutOccurs_Never),
+    ("testTimeout_TimeoutOccurs_Completed", ObservableTimeoutTest.testTimeout_TimeoutOccurs_Completed),
+    ("testTimeout_TimeoutOccurs_Error", ObservableTimeoutTest.testTimeout_TimeoutOccurs_Error),
+    ("testTimeout_TimeoutOccurs_NextIsError", ObservableTimeoutTest.testTimeout_TimeoutOccurs_NextIsError),
+    ("testTimeout_TimeoutNotOccurs_Completed", ObservableTimeoutTest.testTimeout_TimeoutNotOccurs_Completed),
+    ("testTimeout_TimeoutNotOccurs_Error", ObservableTimeoutTest.testTimeout_TimeoutNotOccurs_Error),
+    ("testTimeout_TimeoutNotOccurs", ObservableTimeoutTest.testTimeout_TimeoutNotOccurs),
+    ] }
+}
+
+final class ObservableTimerTest_ : ObservableTimerTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableTimerTest_) -> () -> ())] { return [
+    ("testTimer_Basic", ObservableTimerTest.testTimer_Basic),
+    ("testInterval_TimeSpan_Basic", ObservableTimerTest.testInterval_TimeSpan_Basic),
+    ("testInterval_TimeSpan_Zero", ObservableTimerTest.testInterval_TimeSpan_Zero),
+    ("testInterval_TimeSpan_Zero_DefaultScheduler", ObservableTimerTest.testInterval_TimeSpan_Zero_DefaultScheduler),
+    ("testInterval_TimeSpan_Disposed", ObservableTimerTest.testInterval_TimeSpan_Disposed),
+    ("test_IntervalWithRealScheduler", ObservableTimerTest.test_IntervalWithRealScheduler),
+    ] }
+}
+
+final class ObservableToArrayTest_ : ObservableToArrayTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableToArrayTest_) -> () -> ())] { return [
+    ("test_ToArrayWithSingleItem_Return", ObservableToArrayTest.test_ToArrayWithSingleItem_Return),
+    ("test_ToArrayWithMultipleItems_Return", ObservableToArrayTest.test_ToArrayWithMultipleItems_Return),
+    ("test_ToArrayWithNoItems_Empty", ObservableToArrayTest.test_ToArrayWithNoItems_Empty),
+    ("test_ToArrayWithSingleItem_Never", ObservableToArrayTest.test_ToArrayWithSingleItem_Never),
+    ("test_ToArrayWithImmediateError_Throw", ObservableToArrayTest.test_ToArrayWithImmediateError_Throw),
+    ("test_ToArrayWithMultipleItems_Throw", ObservableToArrayTest.test_ToArrayWithMultipleItems_Throw),
+    ] }
+}
+
+final class ObservableUsingTest_ : ObservableUsingTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableUsingTest_) -> () -> ())] { return [
+    ("testUsing_Complete", ObservableUsingTest.testUsing_Complete),
+    ("testUsing_Error", ObservableUsingTest.testUsing_Error),
+    ("testUsing_Dispose", ObservableUsingTest.testUsing_Dispose),
+    ("testUsing_ThrowResourceSelector", ObservableUsingTest.testUsing_ThrowResourceSelector),
+    ("testUsing_ThrowResourceUsage", ObservableUsingTest.testUsing_ThrowResourceUsage),
+    ] }
+}
+
+final class ObservableWindowTest_ : ObservableWindowTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableWindowTest_) -> () -> ())] { return [
+    ("testWindowWithTimeOrCount_Basic", ObservableWindowTest.testWindowWithTimeOrCount_Basic),
+    ("testWindowWithTimeOrCount_Error", ObservableWindowTest.testWindowWithTimeOrCount_Error),
+    ("testWindowWithTimeOrCount_Disposed", ObservableWindowTest.testWindowWithTimeOrCount_Disposed),
+    ] }
+}
+
+final class ObservableWithLatestFromTest_ : ObservableWithLatestFromTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableWithLatestFromTest_) -> () -> ())] { return [
+    ("testWithLatestFrom_Simple1", ObservableWithLatestFromTest.testWithLatestFrom_Simple1),
+    ("testWithLatestFrom_TwoObservablesWithImmediateValues", ObservableWithLatestFromTest.testWithLatestFrom_TwoObservablesWithImmediateValues),
+    ("testWithLatestFrom_Simple2", ObservableWithLatestFromTest.testWithLatestFrom_Simple2),
+    ("testWithLatestFrom_Simple3", ObservableWithLatestFromTest.testWithLatestFrom_Simple3),
+    ("testWithLatestFrom_Error1", ObservableWithLatestFromTest.testWithLatestFrom_Error1),
+    ("testWithLatestFrom_Error2", ObservableWithLatestFromTest.testWithLatestFrom_Error2),
+    ("testWithLatestFrom_Error3", ObservableWithLatestFromTest.testWithLatestFrom_Error3),
+    ("testWithLatestFrom_MakeSureDefaultOverloadTakesSecondSequenceValues", ObservableWithLatestFromTest.testWithLatestFrom_MakeSureDefaultOverloadTakesSecondSequenceValues),
+    ] }
+}
+
+final class ObservableZipTest_ : ObservableZipTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableZipTest_) -> () -> ())] { return [
+    ("testZip_ImmediateSchedule2", ObservableZipTest.testZip_ImmediateSchedule2),
+    ("testZip_Never2", ObservableZipTest.testZip_Never2),
+    ("testZip_Empty2", ObservableZipTest.testZip_Empty2),
+    ("testZip_SymmetricReturn2", ObservableZipTest.testZip_SymmetricReturn2),
+    ("testZip_AllCompleted2", ObservableZipTest.testZip_AllCompleted2),
+    ("testZip_ImmediateSchedule3", ObservableZipTest.testZip_ImmediateSchedule3),
+    ("testZip_Never3", ObservableZipTest.testZip_Never3),
+    ("testZip_Empty3", ObservableZipTest.testZip_Empty3),
+    ("testZip_SymmetricReturn3", ObservableZipTest.testZip_SymmetricReturn3),
+    ("testZip_AllCompleted3", ObservableZipTest.testZip_AllCompleted3),
+    ("testZip_ImmediateSchedule4", ObservableZipTest.testZip_ImmediateSchedule4),
+    ("testZip_Never4", ObservableZipTest.testZip_Never4),
+    ("testZip_Empty4", ObservableZipTest.testZip_Empty4),
+    ("testZip_SymmetricReturn4", ObservableZipTest.testZip_SymmetricReturn4),
+    ("testZip_AllCompleted4", ObservableZipTest.testZip_AllCompleted4),
+    ("testZip_ImmediateSchedule5", ObservableZipTest.testZip_ImmediateSchedule5),
+    ("testZip_Never5", ObservableZipTest.testZip_Never5),
+    ("testZip_Empty5", ObservableZipTest.testZip_Empty5),
+    ("testZip_SymmetricReturn5", ObservableZipTest.testZip_SymmetricReturn5),
+    ("testZip_AllCompleted5", ObservableZipTest.testZip_AllCompleted5),
+    ("testZip_ImmediateSchedule6", ObservableZipTest.testZip_ImmediateSchedule6),
+    ("testZip_Never6", ObservableZipTest.testZip_Never6),
+    ("testZip_Empty6", ObservableZipTest.testZip_Empty6),
+    ("testZip_SymmetricReturn6", ObservableZipTest.testZip_SymmetricReturn6),
+    ("testZip_AllCompleted6", ObservableZipTest.testZip_AllCompleted6),
+    ("testZip_ImmediateSchedule7", ObservableZipTest.testZip_ImmediateSchedule7),
+    ("testZip_Never7", ObservableZipTest.testZip_Never7),
+    ("testZip_Empty7", ObservableZipTest.testZip_Empty7),
+    ("testZip_SymmetricReturn7", ObservableZipTest.testZip_SymmetricReturn7),
+    ("testZip_AllCompleted7", ObservableZipTest.testZip_AllCompleted7),
+    ("testZip_ImmediateSchedule8", ObservableZipTest.testZip_ImmediateSchedule8),
+    ("testZip_Never8", ObservableZipTest.testZip_Never8),
+    ("testZip_Empty8", ObservableZipTest.testZip_Empty8),
+    ("testZip_SymmetricReturn8", ObservableZipTest.testZip_SymmetricReturn8),
+    ("testZip_AllCompleted8", ObservableZipTest.testZip_AllCompleted8),
+    ("testZip_NeverEmpty", ObservableZipTest.testZip_NeverEmpty),
+    ("testZip_EmptyNever", ObservableZipTest.testZip_EmptyNever),
+    ("testZip_EmptyNonEmpty", ObservableZipTest.testZip_EmptyNonEmpty),
+    ("testZip_NonEmptyEmpty", ObservableZipTest.testZip_NonEmptyEmpty),
+    ("testZip_NeverNonEmpty", ObservableZipTest.testZip_NeverNonEmpty),
+    ("testZip_NonEmptyNever", ObservableZipTest.testZip_NonEmptyNever),
+    ("testZip_NonEmptyNonEmpty", ObservableZipTest.testZip_NonEmptyNonEmpty),
+    ("testZip_EmptyError", ObservableZipTest.testZip_EmptyError),
+    ("testZip_ErrorEmpty", ObservableZipTest.testZip_ErrorEmpty),
+    ("testZip_NeverError", ObservableZipTest.testZip_NeverError),
+    ("testZip_ErrorNever", ObservableZipTest.testZip_ErrorNever),
+    ("testZip_ErrorError", ObservableZipTest.testZip_ErrorError),
+    ("testZip_SomeError", ObservableZipTest.testZip_SomeError),
+    ("testZip_ErrorSome", ObservableZipTest.testZip_ErrorSome),
+    ("testZip_LeftCompletesFirst", ObservableZipTest.testZip_LeftCompletesFirst),
+    ("testZip_RightCompletesFirst", ObservableZipTest.testZip_RightCompletesFirst),
+    ("testZip_LeftTriggersSelectorError", ObservableZipTest.testZip_LeftTriggersSelectorError),
+    ("testZip_RightTriggersSelectorError", ObservableZipTest.testZip_RightTriggersSelectorError),
+    ("testZip_NAry_emptyArray", ObservableZipTest.testZip_NAry_emptyArray),
+    ("testZip_NAry_symmetric", ObservableZipTest.testZip_NAry_symmetric),
+    ("testZip_NAry_asymmetric", ObservableZipTest.testZip_NAry_asymmetric),
+    ("testZip_NAry_error", ObservableZipTest.testZip_NAry_error),
+    ("testZip_NAry_atLeastOneErrors4", ObservableZipTest.testZip_NAry_atLeastOneErrors4),
+    ] }
+}
+
+final class ObserverTests_ : ObserverTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObserverTests_) -> () -> ())] { return [
+    ("testConvenienceOn_Next", ObserverTests.testConvenienceOn_Next),
+    ("testConvenienceOn_Error", ObserverTests.testConvenienceOn_Error),
+    ("testConvenienceOn_Complete", ObserverTests.testConvenienceOn_Complete),
+    ("testMapElement", ObserverTests.testMapElement),
+    ("testMapElementCompleted", ObserverTests.testMapElementCompleted),
+    ("testMapElementError", ObserverTests.testMapElementError),
+    ("testMapElementThrow", ObserverTests.testMapElementThrow),
+    ] }
+}
+
+final class PublishSubjectTest_ : PublishSubjectTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (PublishSubjectTest_) -> () -> ())] { return [
+    ("test_hasObserversNoObservers", PublishSubjectTest.test_hasObserversNoObservers),
+    ("test_hasObserversOneObserver", PublishSubjectTest.test_hasObserversOneObserver),
+    ("test_hasObserversManyObserver", PublishSubjectTest.test_hasObserversManyObserver),
+    ] }
+}
+
+final class ReactiveTests_ : ReactiveTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ReactiveTests_) -> () -> ())] { return [
+    ("testEnablesMutations", ReactiveTests.testEnablesMutations),
+    ] }
+}
+
+final class RecursiveLockTests_ : RecursiveLockTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (RecursiveLockTests_) -> () -> ())] { return [
+    ("testSynchronizes", RecursiveLockTests.testSynchronizes),
+    ("testIsReentrant", RecursiveLockTests.testIsReentrant),
+    ] }
+}
+
+final class ReplaySubjectTest_ : ReplaySubjectTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ReplaySubjectTest_) -> () -> ())] { return [
+    ("test_hasObserversNoObservers", ReplaySubjectTest.test_hasObserversNoObservers),
+    ("test_hasObserversOneObserver", ReplaySubjectTest.test_hasObserversOneObserver),
+    ("test_hasObserversManyObserver", ReplaySubjectTest.test_hasObserversManyObserver),
+    ] }
+}
+
+final class SharedSequenceOperatorTests_ : SharedSequenceOperatorTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (SharedSequenceOperatorTests_) -> () -> ())] { return [
+    ("testAsDriver_deferred", SharedSequenceOperatorTests.testAsDriver_deferred),
+    ("testAsDriver_map", SharedSequenceOperatorTests.testAsDriver_map),
+    ("testAsDriver_filter", SharedSequenceOperatorTests.testAsDriver_filter),
+    ("testAsDriver_switchLatest", SharedSequenceOperatorTests.testAsDriver_switchLatest),
+    ("testAsDriver_flatMapLatest", SharedSequenceOperatorTests.testAsDriver_flatMapLatest),
+    ("testAsDriver_flatMapFirst", SharedSequenceOperatorTests.testAsDriver_flatMapFirst),
+    ("testAsDriver_doOn", SharedSequenceOperatorTests.testAsDriver_doOn),
+    ("testAsDriver_doOnNext", SharedSequenceOperatorTests.testAsDriver_doOnNext),
+    ("testAsDriver_doOnCompleted", SharedSequenceOperatorTests.testAsDriver_doOnCompleted),
+    ("testAsDriver_distinctUntilChanged1", SharedSequenceOperatorTests.testAsDriver_distinctUntilChanged1),
+    ("testAsDriver_distinctUntilChanged2", SharedSequenceOperatorTests.testAsDriver_distinctUntilChanged2),
+    ("testAsDriver_distinctUntilChanged3", SharedSequenceOperatorTests.testAsDriver_distinctUntilChanged3),
+    ("testAsDriver_distinctUntilChanged4", SharedSequenceOperatorTests.testAsDriver_distinctUntilChanged4),
+    ("testAsDriver_flatMap", SharedSequenceOperatorTests.testAsDriver_flatMap),
+    ("testAsDriver_mergeSync", SharedSequenceOperatorTests.testAsDriver_mergeSync),
+    ("testAsDriver_merge", SharedSequenceOperatorTests.testAsDriver_merge),
+    ("testAsDriver_merge2", SharedSequenceOperatorTests.testAsDriver_merge2),
+    ("testAsDriver_debug", SharedSequenceOperatorTests.testAsDriver_debug),
+    ("testAsDriver_debounce", SharedSequenceOperatorTests.testAsDriver_debounce),
+    ("testAsDriver_throttle", SharedSequenceOperatorTests.testAsDriver_throttle),
+    ("testAsDriver_throttle2", SharedSequenceOperatorTests.testAsDriver_throttle2),
+    ("testAsDriver_scan", SharedSequenceOperatorTests.testAsDriver_scan),
+    ("testAsDriver_concat_sequenceType", SharedSequenceOperatorTests.testAsDriver_concat_sequenceType),
+    ("testAsDriver_concat", SharedSequenceOperatorTests.testAsDriver_concat),
+    ("testAsDriver_combineLatest_array", SharedSequenceOperatorTests.testAsDriver_combineLatest_array),
+    ("testAsDriver_combineLatest", SharedSequenceOperatorTests.testAsDriver_combineLatest),
+    ("testAsDriver_zip_array", SharedSequenceOperatorTests.testAsDriver_zip_array),
+    ("testAsDriver_zip", SharedSequenceOperatorTests.testAsDriver_zip),
+    ("testAsDriver_withLatestFrom", SharedSequenceOperatorTests.testAsDriver_withLatestFrom),
+    ("testAsDriver_withLatestFromDefaultOverload", SharedSequenceOperatorTests.testAsDriver_withLatestFromDefaultOverload),
+    ("testAsDriver_skip", SharedSequenceOperatorTests.testAsDriver_skip),
+    ("testAsDriver_startWith", SharedSequenceOperatorTests.testAsDriver_startWith),
+    ("testAsDriver_delay", SharedSequenceOperatorTests.testAsDriver_delay),
+    ("testAsDriver_interval", SharedSequenceOperatorTests.testAsDriver_interval),
+    ("testAsDriver_timer", SharedSequenceOperatorTests.testAsDriver_timer),
+    ("testDriverFromOptional", SharedSequenceOperatorTests.testDriverFromOptional),
+    ("testDriverFromOptionalWhenNil", SharedSequenceOperatorTests.testDriverFromOptionalWhenNil),
+    ("testDriverFromSequence", SharedSequenceOperatorTests.testDriverFromSequence),
+    ("testDriverFromArray", SharedSequenceOperatorTests.testDriverFromArray),
+    ] }
+}
+
+final class SharingSchedulerTest_ : SharingSchedulerTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (SharingSchedulerTest_) -> () -> ())] { return [
+    ("testSharingSchedulerMockMake", SharingSchedulerTest.testSharingSchedulerMockMake),
+    ("testSharingSchedulerMockInstance", SharingSchedulerTest.testSharingSchedulerMockInstance),
     ] }
 }
 
@@ -1927,6 +1826,107 @@ final class SignalTests_ : SignalTests, RxTestCase {
     ("testSignalOptionalRelay1", SignalTests.testSignalOptionalRelay1),
     ("testSignalOptionalRelay2", SignalTests.testSignalOptionalRelay2),
     ("testDriveVariableNoAmbiguity", SignalTests.testDriveVariableNoAmbiguity),
+    ] }
+}
+
+final class SingleTest_ : SingleTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (SingleTest_) -> () -> ())] { return [
+    ("testZip2_selector", SingleTest.testZip2_selector),
+    ("testZip2_tuple", SingleTest.testZip2_tuple),
+    ("testZip3_selector", SingleTest.testZip3_selector),
+    ("testZip3_tuple", SingleTest.testZip3_tuple),
+    ("testZip4_selector", SingleTest.testZip4_selector),
+    ("testZip4_tuple", SingleTest.testZip4_tuple),
+    ("testZip5_selector", SingleTest.testZip5_selector),
+    ("testZip5_tuple", SingleTest.testZip5_tuple),
+    ("testZip6_selector", SingleTest.testZip6_selector),
+    ("testZip6_tuple", SingleTest.testZip6_tuple),
+    ("testZip7_selector", SingleTest.testZip7_selector),
+    ("testZip7_tuple", SingleTest.testZip7_tuple),
+    ("testZip8_selector", SingleTest.testZip8_selector),
+    ("testZip8_tuple", SingleTest.testZip8_tuple),
+    ("testSingle_Subscription_success", SingleTest.testSingle_Subscription_success),
+    ("testSingle_Subscription_error", SingleTest.testSingle_Subscription_error),
+    ("testSingle_create_success", SingleTest.testSingle_create_success),
+    ("testSingle_create_error", SingleTest.testSingle_create_error),
+    ("testSingle_create_disposing", SingleTest.testSingle_create_disposing),
+    ("test_just_producesElement", SingleTest.test_just_producesElement),
+    ("test_just2_producesElement", SingleTest.test_just2_producesElement),
+    ("test_error_fails", SingleTest.test_error_fails),
+    ("test_never_producesElement", SingleTest.test_never_producesElement),
+    ("test_deferred", SingleTest.test_deferred),
+    ("test_delay", SingleTest.test_delay),
+    ("test_delaySubscription", SingleTest.test_delaySubscription),
+    ("test_observeOn", SingleTest.test_observeOn),
+    ("test_subscribeOn", SingleTest.test_subscribeOn),
+    ("test_catchError", SingleTest.test_catchError),
+    ("test_catchErrorJustReturn", SingleTest.test_catchErrorJustReturn),
+    ("test_retry", SingleTest.test_retry),
+    ("test_retryWhen1", SingleTest.test_retryWhen1),
+    ("test_retryWhen2", SingleTest.test_retryWhen2),
+    ("test_debug", SingleTest.test_debug),
+    ("test_using", SingleTest.test_using),
+    ("test_timeout", SingleTest.test_timeout),
+    ("test_timeout_other", SingleTest.test_timeout_other),
+    ("test_timeout_succeeds", SingleTest.test_timeout_succeeds),
+    ("test_timeout_other_succeeds", SingleTest.test_timeout_other_succeeds),
+    ("test_timer", SingleTest.test_timer),
+    ("test_do", SingleTest.test_do),
+    ("test_filter", SingleTest.test_filter),
+    ("test_map", SingleTest.test_map),
+    ("test_flatMap", SingleTest.test_flatMap),
+    ("test_flatMapMaybe", SingleTest.test_flatMapMaybe),
+    ("test_flatMapCompletable", SingleTest.test_flatMapCompletable),
+    ("test_asMaybe", SingleTest.test_asMaybe),
+    ("test_asCompletable", SingleTest.test_asCompletable),
+    ("test_asCompletableError", SingleTest.test_asCompletableError),
+    ("test_zip_tuple", SingleTest.test_zip_tuple),
+    ("test_zip_resultSelector", SingleTest.test_zip_resultSelector),
+    ("testZipCollection_selector", SingleTest.testZipCollection_selector),
+    ("testZipCollection_selector_when_empty", SingleTest.testZipCollection_selector_when_empty),
+    ("testZipCollection_tuple", SingleTest.testZipCollection_tuple),
+    ("testZipCollection_tuple_when_empty", SingleTest.testZipCollection_tuple_when_empty),
+    ("testDefaultErrorHandler", SingleTest.testDefaultErrorHandler),
+    ] }
+}
+
+final class VariableTest_ : VariableTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (VariableTest_) -> () -> ())] { return [
+    ("testVariable_initialValues", VariableTest.testVariable_initialValues),
+    ("testVariable_sendsCompletedOnDealloc", VariableTest.testVariable_sendsCompletedOnDealloc),
+    ("testVariable_READMEExample", VariableTest.testVariable_READMEExample),
+    ] }
+}
+
+final class VirtualSchedulerTest_ : VirtualSchedulerTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (VirtualSchedulerTest_) -> () -> ())] { return [
+    ("testVirtualScheduler_initialClock", VirtualSchedulerTest.testVirtualScheduler_initialClock),
+    ("testVirtualScheduler_start", VirtualSchedulerTest.testVirtualScheduler_start),
+    ("testVirtualScheduler_disposeStart", VirtualSchedulerTest.testVirtualScheduler_disposeStart),
+    ("testVirtualScheduler_advanceToAfter", VirtualSchedulerTest.testVirtualScheduler_advanceToAfter),
+    ("testVirtualScheduler_advanceToBefore", VirtualSchedulerTest.testVirtualScheduler_advanceToBefore),
+    ("testVirtualScheduler_disposeAdvanceTo", VirtualSchedulerTest.testVirtualScheduler_disposeAdvanceTo),
+    ("testVirtualScheduler_stop", VirtualSchedulerTest.testVirtualScheduler_stop),
+    ("testVirtualScheduler_sleep", VirtualSchedulerTest.testVirtualScheduler_sleep),
+    ("testVirtualScheduler_stress", VirtualSchedulerTest.testVirtualScheduler_stress),
     ] }
 }
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
@@ -1955,87 +1955,87 @@ func XCTMain(_ tests: [() -> ()]) {
 #endif
 
     XCTMain([
-        testCase(ObservableWithLatestFromTest_.allTests),
-        testCase(ObservableOptionalTest_.allTests),
         testCase(AnomaliesTest_.allTests),
-        testCase(ObservableTakeLastTest_.allTests),
-        testCase(VirtualSchedulerTest_.allTests),
-        testCase(ObservableBlockingTest_.allTests),
-        testCase(ObservableRetryWhenTest_.allTests),
-        testCase(ObservableDelaySubscriptionTest_.allTests),
-        testCase(ObservableDistinctUntilChangedTest_.allTests),
-        testCase(ObservableObserveOnTest_.allTests),
-        testCase(ObservableSkipWhileTest_.allTests),
-        testCase(ObservableSwitchTest_.allTests),
-        testCase(ObservableSkipTest_.allTests),
-        testCase(ObservableTest_.allTests),
-        testCase(ObservableRangeTest_.allTests),
-        testCase(ObservableScanTest_.allTests),
-        testCase(ReplaySubjectTest_.allTests),
-        testCase(CompletableTest_.allTests),
-        testCase(CompletableAndThenTest_.allTests),
-        testCase(DisposableTest_.allTests),
-        testCase(RecursiveLockTests_.allTests),
-        testCase(ObservableEnumeratedTest_.allTests),
-        testCase(SharingSchedulerTest_.allTests),
-        testCase(ObservableSequenceTest_.allTests),
-        testCase(DriverTest_.allTests),
-        testCase(ObservableMapTest_.allTests),
-        testCase(CurrentThreadSchedulerTest_.allTests),
-        testCase(ObservableSubscribeOnTest_.allTests),
-        testCase(ObservableWindowTest_.allTests),
-        testCase(SharedSequenceOperatorTests_.allTests),
-        testCase(SingleTest_.allTests),
-        testCase(ObservableZipTest_.allTests),
-        testCase(ObservableSubscriptionTest_.allTests),
-        testCase(ObservableSkipUntilTest_.allTests),
-        testCase(ObservableDefaultIfEmptyTest_.allTests),
-        testCase(ObservableFilterTest_.allTests),
-        testCase(ObservableAmbTest_.allTests),
-        testCase(ObservableConcatTest_.allTests),
-        testCase(EventTests_.allTests),
-        testCase(ObservableMulticastTest_.allTests),
-        testCase(ObservableSampleTest_.allTests),
-        testCase(PublishSubjectTest_.allTests),
-        testCase(ObservableJustTest_.allTests),
-        testCase(ObservableUsingTest_.allTests),
-        testCase(ObservableTakeWhileTest_.allTests),
         testCase(AsyncSubjectTests_.allTests),
-        testCase(ObservableDelayTest_.allTests),
-        testCase(ObservableRepeatTest_.allTests),
-        testCase(ObservableSingleTest_.allTests),
-        testCase(ObservableTakeTest_.allTests),
-        testCase(ObservableGenerateTest_.allTests),
-        testCase(ObservableDematerializeTest_.allTests),
-        testCase(VariableTest_.allTests),
-        testCase(ObservableTimerTest_.allTests),
-        testCase(ObservableShareReplayScopeTests_.allTests),
-        testCase(ReactiveTests_.allTests),
-        testCase(MaybeTest_.allTests),
-        testCase(ObservableMaterializeTest_.allTests),
-        testCase(NSNotificationCenterTests_.allTests),
+        testCase(BehaviorSubjectTest_.allTests),
+        testCase(CompletableAndThenTest_.allTests),
+        testCase(CompletableTest_.allTests),
+        testCase(ConcurrentDispatchQueueSchedulerTests_.allTests),
+        testCase(CurrentThreadSchedulerTest_.allTests),
+        testCase(DisposableTest_.allTests),
+        testCase(DriverTest_.allTests),
+        testCase(EventTests_.allTests),
         testCase(HistoricalSchedulerTest_.allTests),
         testCase(MainSchedulerTest_.allTests),
-        testCase(ObservableCombineLatestTest_.allTests),
-        testCase(ObservablePrimitiveSequenceTest_.allTests),
-        testCase(ObservableSubscriptionTests_.allTests),
-        testCase(ObservableCatchTest_.allTests),
-        testCase(ObservableToArrayTest_.allTests),
-        testCase(ObserverTests_.allTests),
-        testCase(ObservableObserveOnTestConcurrentSchedulerTest_.allTests),
-        testCase(ObservableTimeoutTest_.allTests),
-        testCase(ConcurrentDispatchQueueSchedulerTests_.allTests),
+        testCase(MaybeTest_.allTests),
+        testCase(NSNotificationCenterTests_.allTests),
+        testCase(ObservableAmbTest_.allTests),
+        testCase(ObservableBlockingTest_.allTests),
         testCase(ObservableBufferTest_.allTests),
-        testCase(BehaviorSubjectTest_.allTests),
+        testCase(ObservableCatchTest_.allTests),
+        testCase(ObservableCombineLatestTest_.allTests),
+        testCase(ObservableConcatTest_.allTests),
         testCase(ObservableDebugTest_.allTests),
+        testCase(ObservableDefaultIfEmptyTest_.allTests),
+        testCase(ObservableDelaySubscriptionTest_.allTests),
+        testCase(ObservableDelayTest_.allTests),
+        testCase(ObservableDematerializeTest_.allTests),
+        testCase(ObservableDistinctUntilChangedTest_.allTests),
         testCase(ObservableDoOnTest_.allTests),
         testCase(ObservableElementAtTest_.allTests),
+        testCase(ObservableEnumeratedTest_.allTests),
+        testCase(ObservableFilterTest_.allTests),
+        testCase(ObservableGenerateTest_.allTests),
         testCase(ObservableGroupByTest_.allTests),
-        testCase(ObservableSwitchIfEmptyTest_.allTests),
-        testCase(ObservableThrottleTest_.allTests),
-        testCase(ObservableTakeUntilTest_.allTests),
+        testCase(ObservableJustTest_.allTests),
+        testCase(ObservableMapTest_.allTests),
+        testCase(ObservableMaterializeTest_.allTests),
         testCase(ObservableMergeTest_.allTests),
+        testCase(ObservableMulticastTest_.allTests),
+        testCase(ObservableObserveOnTest_.allTests),
+        testCase(ObservableObserveOnTestConcurrentSchedulerTest_.allTests),
+        testCase(ObservableOptionalTest_.allTests),
+        testCase(ObservablePrimitiveSequenceTest_.allTests),
+        testCase(ObservableRangeTest_.allTests),
         testCase(ObservableReduceTest_.allTests),
+        testCase(ObservableRepeatTest_.allTests),
+        testCase(ObservableRetryWhenTest_.allTests),
+        testCase(ObservableSampleTest_.allTests),
+        testCase(ObservableScanTest_.allTests),
+        testCase(ObservableSequenceTest_.allTests),
+        testCase(ObservableShareReplayScopeTests_.allTests),
+        testCase(ObservableSingleTest_.allTests),
+        testCase(ObservableSkipTest_.allTests),
+        testCase(ObservableSkipUntilTest_.allTests),
+        testCase(ObservableSkipWhileTest_.allTests),
+        testCase(ObservableSubscribeOnTest_.allTests),
+        testCase(ObservableSubscriptionTest_.allTests),
+        testCase(ObservableSubscriptionTests_.allTests),
+        testCase(ObservableSwitchIfEmptyTest_.allTests),
+        testCase(ObservableSwitchTest_.allTests),
+        testCase(ObservableTakeLastTest_.allTests),
+        testCase(ObservableTakeTest_.allTests),
+        testCase(ObservableTakeUntilTest_.allTests),
+        testCase(ObservableTakeWhileTest_.allTests),
+        testCase(ObservableTest_.allTests),
+        testCase(ObservableThrottleTest_.allTests),
+        testCase(ObservableTimeoutTest_.allTests),
+        testCase(ObservableTimerTest_.allTests),
+        testCase(ObservableToArrayTest_.allTests),
+        testCase(ObservableUsingTest_.allTests),
+        testCase(ObservableWindowTest_.allTests),
+        testCase(ObservableWithLatestFromTest_.allTests),
+        testCase(ObservableZipTest_.allTests),
+        testCase(ObserverTests_.allTests),
+        testCase(PublishSubjectTest_.allTests),
+        testCase(ReactiveTests_.allTests),
+        testCase(RecursiveLockTests_.allTests),
+        testCase(ReplaySubjectTest_.allTests),
+        testCase(SharedSequenceOperatorTests_.allTests),
+        testCase(SharingSchedulerTest_.allTests),
         testCase(SignalTests_.allTests),
+        testCase(SingleTest_.allTests),
+        testCase(VariableTest_.allTests),
+        testCase(VirtualSchedulerTest_.allTests),
     ])
 //}

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1688,6 +1688,18 @@ final class ObserverTests_ : ObserverTests, RxTestCase {
     ] }
 }
 
+final class OperationQueueSchedulerTests_ : OperationQueueSchedulerTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (OperationQueueSchedulerTests_) -> () -> ())] { return [
+    ("test_scheduleWithPriority", OperationQueueSchedulerTests.test_scheduleWithPriority),
+    ] }
+}
+
 final class PublishSubjectTest_ : PublishSubjectTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -2027,6 +2039,7 @@ func XCTMain(_ tests: [() -> ()]) {
         testCase(ObservableWithLatestFromTest_.allTests),
         testCase(ObservableZipTest_.allTests),
         testCase(ObserverTests_.allTests),
+        testCase(OperationQueueSchedulerTests_.allTests),
         testCase(PublishSubjectTest_.allTests),
         testCase(ReactiveTests_.allTests),
         testCase(RecursiveLockTests_.allTests),

--- a/Tests/Benchmarks/Benchmarks.swift
+++ b/Tests/Benchmarks/Benchmarks.swift
@@ -40,6 +40,32 @@ class Benchmarks: XCTestCase {
         }
     }
 
+    func testPublishSubjectPumpingTwoSubscriptions() {
+        measure {
+            var sum = 0
+            let subject = PublishSubject<Int>()
+
+            let subscription1 = subject
+                .subscribe(onNext: { x in
+                    sum += x
+                })
+
+            let subscription2 = subject
+                .subscribe(onNext: { x in
+                    sum += x
+                })
+
+            for _ in 0 ..< iterations * 100 {
+                subject.on(.next(1))
+            }
+
+            subscription1.dispose()
+            subscription2.dispose()
+
+            XCTAssertEqual(sum, iterations * 100 * 2)
+        }
+    }
+
     func testPublishSubjectCreating() {
         measure {
             var sum = 0

--- a/Tests/RxCocoaTests/UIControl+RxTests.swift
+++ b/Tests/RxCocoaTests/UIControl+RxTests.swift
@@ -163,7 +163,7 @@ extension UIControlTests {
 }
 
 fileprivate extension UIControl {
-    func forceSendActions(for: UIControlEvents) {
+    func forceSendActions(for: UIControl.Event) {
         for target in self.allTargets {
             for selector in self.actions(forTarget: target, forControlEvent: `for`) ?? [] {
                 (target.base as! NSObject).perform(NSSelectorFromString(selector), with: self)

--- a/Tests/RxCocoaTests/UITableView+RxTests.swift
+++ b/Tests/RxCocoaTests/UITableView+RxTests.swift
@@ -661,7 +661,7 @@ extension UITableViewTests {
         XCTAssertTrue(tableView.dataSource!.responds(to: #selector(UITableViewDataSource.tableView(_:commit:forRowAt:))))
         XCTAssertArraysEqual(setDataSources, [tableView.dataSource, nil, tableView.dataSource] as [UITableViewDataSource?]) { $0 === $1 }
 
-        let deleteEditingStyle: NSNumber = NSNumber(value: UITableViewCellEditingStyle.delete.rawValue)
+        let deleteEditingStyle: NSNumber = NSNumber(value: UITableViewCell.EditingStyle.delete.rawValue)
         let indexPath: NSIndexPath = NSIndexPath(item: 0, section: 0)
         XCTAssertEqual(firstEvents, [] as [Arguments]) { $0 == $1 }
         XCTAssertEqual(secondEvents, [] as [Arguments]) { $0 == $1 }
@@ -718,7 +718,7 @@ extension UITableViewTests {
         XCTAssertTrue(tableView.dataSource!.responds(to: #selector(UITableViewDataSource.tableView(_:commit:forRowAt:))))
         XCTAssertArraysEqual(setDataSources, [tableView.dataSource, nil, tableView.dataSource] as [UITableViewDataSource?]) { $0 === $1 }
 
-        let deleteEditingStyle: NSNumber = NSNumber(value: UITableViewCellEditingStyle.delete.rawValue)
+        let deleteEditingStyle: NSNumber = NSNumber(value: UITableViewCell.EditingStyle.delete.rawValue)
         let indexPath: NSIndexPath = NSIndexPath(item: 0, section: 0)
         XCTAssertEqual(firstEvents, [] as [Arguments]) { $0 == $1 }
         XCTAssertEqual(secondEvents, [] as [Arguments]) { $0 == $1 }
@@ -750,7 +750,7 @@ extension UITableViewTests {
 }
 
 @objc final class TableViewDataSourceThatImplementsCommitForRowAt: NSObject, UITableViewDataSource {
-    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         arc4random_stir()
     }
 

--- a/scripts/package-spm.swift
+++ b/scripts/package-spm.swift
@@ -214,7 +214,8 @@ func buildAllTestsTarget(_ testsPath: String) throws {
     mainContent.append("}")
     mainContent.append("")
 
-    for (name, methods) in reducedMethods {
+    for name in reducedMethods.keys.sorted() {
+        let methods = reducedMethods[name]!
 
         mainContent.append("")
         mainContent.append("final class \(name)_ : \(name), RxTestCase {")
@@ -260,7 +261,7 @@ func buildAllTestsTarget(_ testsPath: String) throws {
     mainContent.append("#endif")
     mainContent.append("")
     mainContent.append("    XCTMain([")
-    for testCase in reducedMethods.keys {
+    for testCase in reducedMethods.keys.sorted() {
         mainContent.append("        testCase(\(testCase)_.allTests),")
     }
     mainContent.append("    ])")


### PR DESCRIPTION
Rebase on develop branch;
"UIControlState" renamed "UIControl.State";
"UIControlEvents" renamed "UIControl.Event";
"UITableViewCellEditingStyle" renamed "UITableViewCell.EditingStyle";
"NSTextStorageEditActions" renamed "NSTextStorage.EditActions";
"kCAMediaTimingFunctionEaseInEaseOut" rename "kCAMediaTimingFunctionEaseInEaseOut";
Initial `CATransitionType` with special initial raw value method;