### PR TITLE
Fixes unused parameter in UIControl+Rx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 * Add  `Single.catchErrorJustReturn(_:)` operator.
 * Add  `Single.asMaybe(_:)` operator.
 * Add  `Single.asCompletable(_:)` operator.
+* Fixes unused parameter in `UIControl+Rx`
 
 #### Anomalies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ All notable changes to this project will be documented in this file.
 * Add  `Single.catchErrorJustReturn(_:)` operator.
 * Add  `Single.asMaybe(_:)` operator.
 * Add  `Single.asCompletable(_:)` operator.
-* Fixes unused parameter in `UIControl+Rx`
+* Use `editingEvents` argument in `controlPropertyWithDefaultEvents`.
 
 #### Anomalies
 

--- a/RxCocoa/iOS/UIControl+Rx.swift
+++ b/RxCocoa/iOS/UIControl+Rx.swift
@@ -84,7 +84,7 @@ extension Reactive where Base: UIControl {
         return ControlProperty<T>(values: source, valueSink: bindingObserver)
     }
 
-    /// This is a separate method is to better communicate to public consumers that
+    /// This is a separate method to better communicate to public consumers that
     /// an `editingEvent` needs to fire for control property to be updated.
     internal func controlPropertyWithDefaultEvents<T>(
         editingEvents: UIControlEvents = [.allEditingEvents, .valueChanged],
@@ -92,7 +92,7 @@ extension Reactive where Base: UIControl {
         setter: @escaping (Base, T) -> ()
         ) -> ControlProperty<T> {
         return controlProperty(
-            editingEvents: [.allEditingEvents, .valueChanged],
+            editingEvents: editingEvents,
             getter: getter,
             setter: setter
         )


### PR DESCRIPTION
Simple fix I came across while debugging some other stuff.
Seems like the idea was to have a parameter with a default value but that parameter isn't actually being used, this PR fixes that