### PR TITLE
Support iOS 11 for Geolocation example 

### DIFF
--- a/RxExample/RxExample/Info-iOS.plist
+++ b/RxExample/RxExample/Info-iOS.plist
@@ -33,6 +33,8 @@
 	<string>We need location</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>We need location</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>We need location</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>We need photo library</string>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
Requesting Always authorization requires NSLocationAlwaysAndWhenInUseUsageDescription for iOS 11.
Without this, iOS will not display the authorization popup.