### PR TITLE
Add `record` and `bind` to TestScheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
 * Performance enhancement reduces Bag dispatch inline code size by 12%.
 * Adds `customCaptureSubscriptionCallstack` hook to allow custom subscription callstacks to be generated.
+* Add `record(source:duration:`) and `bind(_:to:duration:)` to `TestScheduler`.
 
 #### Anomalies
 

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -164,6 +164,21 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
 
         return observer
     }
+
+    /**
+     Builds a hot observable with predefined events, binds it's result to given observer and sets up disposal.
+
+     - parameter events: Array of recorded events to emit over the scheduled observable.
+     - parameter target: Observer to bind to.
+    */
+    public func bind<O: ObserverType>(_ events: [Recorded<Event<O.E>>], to target: O, duration: TestTime = 100000) {
+        let driver = self.createHotObservable(events)
+        let disposable = driver.asObservable().subscribe(target)
+
+        self.scheduleAt(duration) {
+            disposable.dispose()
+        }
+    }
 }
 
 

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -147,6 +147,23 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
     public func start<Element>(_ create: @escaping () -> Observable<Element>) -> TestableObserver<Element> {
         return start(created: Defaults.created, subscribed: Defaults.subscribed, disposed: Defaults.disposed, create: create)
     }
+
+    /**
+     Builds testable observer for a specific observable sequence, binds it's results and sets up disposal.
+
+     - parameter source: Observable sequence to observe.
+     - returns: Observer that records all events for observable sequence.
+     */
+    func record<O: ObservableConvertibleType>(source: O, duration: TestTime = 100000) -> TestableObserver<O.E> {
+        let observer = self.createObserver(O.E.self)
+        let disposable = source.asObservable().subscribe(observer)
+
+        self.scheduleAt(duration) {
+            disposable.dispose()
+        }
+
+        return observer
+    }
 }
 
 


### PR DESCRIPTION
The `record` method is part of the `RxExample` project. I (and many others I know) find myself copying this over to every project I work on, mainly since it cuts out a lot of the boilerplate, and highly simplifies the mental load by just “recording” a stream of events. I think it highly fits being part of the core repo.

The `bind` method is from RxTestExt by @mosamer - I think it fits with the same family of test helpers. It’s useful mainly for driving fake inputs to ViewModels or any other kind of Observer.