### PR TITLE
Refactor Bag.swift

### DIFF
--- a/Platform/DataStructures/Bag.swift
+++ b/Platform/DataStructures/Bag.swift
@@ -8,125 +8,113 @@
 
 import Swift
 
-let arrayDictionaryMaxSize = 30
-
 struct BagKey {
-    /**
-    Unique identifier for object added to `Bag`.
-     
-    It's underlying type is UInt64. If we assume there in an idealized CPU that works at 4GHz,
-     it would take ~150 years of continuous running time for it to overflow.
-    */
+
+    /// Unique identifier for object added to `Bag`.
+    ///
+    /// Its underlying type is `UInt64`. If we assume there is an idealized CPU
+    /// that works at 4GHz, it would take ~150 years of continuous running time
+    /// for it to overflow.
     fileprivate let rawValue: UInt64
 }
 
-/**
-Data structure that represents a bag of elements typed `T`.
 
-Single element can be stored multiple times.
-
-Time and space complexity of insertion and deletion is O(n). 
-
-It is suitable for storing small number of elements.
-*/
+/// Data structure that represents a bag of elements typed `T`.
+///
+/// Single element can be stored multiple times.
+///
+/// Space complexity of insertion and deletion is O(n). Time complexity of
+/// insertion is O(1), of deletion is O(n).
+///
+/// It is suitable for storing small number of elements.
 struct Bag<T> : CustomDebugStringConvertible {
+
     /// Type of identifier for inserted elements.
     typealias KeyType = BagKey
     
     typealias Entry = (key: BagKey, value: T)
- 
-    fileprivate var _nextKey: BagKey = BagKey(rawValue: 0)
+
+    private var _nextKey = BagKey(rawValue: 0)
 
     // data
 
     // first fill inline variables
-    var _key0: BagKey? = nil
-    var _value0: T? = nil
+    var _key: BagKey?
+    var _value: T?
 
     // then fill "array dictionary"
-    var _pairs = ContiguousArray<Entry>()
-
-    // last is sparse dictionary
-    var _dictionary: [BagKey : T]? = nil
-
-    var _onlyFastPath = true
+    var _pairs: ContiguousArray<Entry>?
 
     /// Creates new empty `Bag`.
-    init() {
-    }
-    
-    /**
-    Inserts `value` into bag.
-    
-    - parameter element: Element to insert.
-    - returns: Key that can be used to remove element from bag.
-    */
+    init() { }
+
+    /// Inserts `element` into bag.
+    ///
+    /// - Parameter element: Element to insert.
+    /// - Returns: Key that can be used to remove element from bag.
     mutating func insert(_ element: T) -> BagKey {
         let key = _nextKey
 
         _nextKey = BagKey(rawValue: _nextKey.rawValue &+ 1)
 
-        if _key0 == nil {
-            _key0 = key
-            _value0 = element
+        if _key == nil {
+            _key = key
+            _value = element
             return key
         }
 
-        _onlyFastPath = false
-
-        if _dictionary != nil {
-            _dictionary![key] = element
-            return key
+        if _pairs == nil {
+            _pairs = [(key: key, value: element)]
+        } else {
+            _pairs!.append((key: key, value: element))
         }
 
-        if _pairs.count < arrayDictionaryMaxSize {
-            _pairs.append((key: key, value: element))
-            return key
-        }
-        
-        _dictionary = [key: element]
-        
         return key
     }
-    
-    /// - returns: Number of elements in bag.
+
+    /// Number of elements in bag.
     var count: Int {
-        let dictionaryCount: Int = _dictionary?.count ?? 0
-        return (_value0 != nil ? 1 : 0) + _pairs.count + dictionaryCount
+        return (_value != nil ? 1 : 0) + (_pairs?.count ?? 0)
     }
     
     /// Removes all elements from bag and clears capacity.
     mutating func removeAll() {
-        _key0 = nil
-        _value0 = nil
+        _key = nil
+        _value = nil
 
-        _pairs.removeAll(keepingCapacity: false)
-        _dictionary?.removeAll(keepingCapacity: false)
+        _pairs = []
     }
-    
-    /**
-    Removes element with a specific `key` from bag.
-    
-    - parameter key: Key that identifies element to remove from bag.
-    - returns: Element that bag contained, or nil in case element was already removed.
-    */
+
+    /// Removes element with a specific `key` from bag.
+    ///
+    /// Parameter key: Key that identifies element to remove from bag.
+    /// Returns: Element that bag contained, or nil in case element was already removed.
     mutating func removeKey(_ key: BagKey) -> T? {
-        if _key0 == key {
-            _key0 = nil
-            let value = _value0!
-            _value0 = nil
-            return value
+        if key == _key {
+            defer { _key = nil; _value = nil }
+            return _value
         }
 
-        if let existingObject = _dictionary?.removeValue(forKey: key) {
-            return existingObject
-        }
+        if _pairs == nil { return nil }
 
-        for i in 0 ..< _pairs.count {
-            if _pairs[i].key == key {
-                let value = _pairs[i].value
-                _pairs.remove(at: i)
-                return value
+        var left = 0, right = _pairs!.count - 1
+
+        while left <= right {
+            if _pairs![left].key == key {
+                return _pairs!.remove(at: left).value
+            }
+
+            if _pairs![right].key == key {
+                return _pairs!.remove(at: right).value
+            }
+
+            let mid = (left + right) / 2
+            if _pairs![mid].key == key {
+                return _pairs!.remove(at: mid).value
+            } else if _pairs![mid].key > key {
+                right = mid - 1
+            } else {
+                left = mid + 1
             }
         }
 
@@ -136,7 +124,7 @@ struct Bag<T> : CustomDebugStringConvertible {
 
 extension Bag {
     /// A textual representation of `self`, suitable for debugging.
-    var debugDescription : String {
+    var debugDescription: String {
         return "\(self.count) elements in Bag"
     }
 }
@@ -144,40 +132,31 @@ extension Bag {
 extension Bag {
     /// Enumerates elements inside the bag.
     ///
-    /// - parameter action: Enumeration closure.
+    /// - Parameter action: Enumeration closure.
     func forEach(_ action: (T) -> Void) {
-        if _onlyFastPath {
-            if let value0 = _value0 {
-                action(value0)
-            }
-            return
-        }
+        if _value != nil { action(_value!) }
 
-        let value0 = _value0
-        let dictionary = _dictionary
-
-        if let value0 = value0 {
-            action(value0)
-        }
-
-        for i in 0 ..< _pairs.count {
-            action(_pairs[i].value)
-        }
-
-        if dictionary?.count ?? 0 > 0 {
-            for element in dictionary!.values {
-                action(element)
+        if _pairs != nil {
+            for i in _pairs!.indices {
+                action(_pairs![i].value)
             }
         }
     }
 }
 
 extension BagKey: Hashable {
+
     var hashValue: Int {
         return rawValue.hashValue
     }
+
+    static func == (lhs: BagKey, rhs: BagKey) -> Bool {
+        return lhs.rawValue == rhs.rawValue
+    }
+
+    fileprivate static func > (lhs: BagKey, rhs: BagKey) -> Bool {
+        return lhs.rawValue > rhs.rawValue
+    }
 }
 
-func ==(lhs: BagKey, rhs: BagKey) -> Bool {
-    return lhs.rawValue == rhs.rawValue
-}
+

--- a/RxSwift/Extensions/Bag+Rx.swift
+++ b/RxSwift/Extensions/Bag+Rx.swift
@@ -15,10 +15,9 @@ func dispatch<E>(_ bag: Bag<(Event<E>) -> ()>, _ event: Event<E>) {
         bag._value!(event)
     }
 
-    let _pairs = bag._pairs
-    if _pairs != nil {
-        for i in _pairs!.indices {
-            _pairs![i].value(event)
+    if bag._pairs != nil {
+        for i in bag._pairs!.indices {
+            bag._pairs![i].value(event)
         }
     }
 }
@@ -29,10 +28,9 @@ func disposeAll(in bag: Bag<Disposable>) {
         bag._value!.dispose()
     }
 
-    let _pairs = bag._pairs
-    if _pairs != nil {
-        for i in _pairs!.indices {
-            _pairs![i].value.dispose()
+    if bag._pairs != nil {
+        for i in bag._pairs!.indices {
+            bag._pairs![i].value.dispose()
         }
     }
 }

--- a/RxSwift/Extensions/Bag+Rx.swift
+++ b/RxSwift/Extensions/Bag+Rx.swift
@@ -11,40 +11,28 @@
 
 @inline(__always)
 func dispatch<E>(_ bag: Bag<(Event<E>) -> ()>, _ event: Event<E>) {
-    bag._value0?(event)
-
-    if bag._onlyFastPath {
-        return
+    if bag._value != nil {
+        bag._value!(event)
     }
 
-    let pairs = bag._pairs
-    for i in 0 ..< pairs.count {
-        pairs[i].value(event)
-    }
-
-    if let dictionary = bag._dictionary {
-        for element in dictionary.values {
-            element(event)
+    let _pairs = bag._pairs
+    if _pairs != nil {
+        for i in _pairs!.indices {
+            _pairs![i].value(event)
         }
     }
 }
 
 /// Dispatches `dispose` to all disposables contained inside bag.
 func disposeAll(in bag: Bag<Disposable>) {
-    bag._value0?.dispose()
-
-    if bag._onlyFastPath {
-        return
+    if bag._value != nil {
+        bag._value!.dispose()
     }
 
-    let pairs = bag._pairs
-    for i in 0 ..< pairs.count {
-        pairs[i].value.dispose()
-    }
-
-    if let dictionary = bag._dictionary {
-        for element in dictionary.values {
-            element.dispose()
+    let _pairs = bag._pairs
+    if _pairs != nil {
+        for i in _pairs!.indices {
+            _pairs![i].value.dispose()
         }
     }
 }


### PR DESCRIPTION
The main change is the removal of dictionary, use dichotomy to speed up the search for the target key.

I wrote a simple benchmark project [here](https://github.com/jianstm/RxSwift-BagBenchmark), and the result looks good(RxBag is before, Bag is after):

<img width="307" alt="2018-09-08 11 28 23" src="https://user-images.githubusercontent.com/18638838/45255945-aef2ae00-b3c1-11e8-8587-26a389134c0b.png">
<img width="301" alt="2018-09-08 11 28 33" src="https://user-images.githubusercontent.com/18638838/45255948-ba45d980-b3c1-11e8-9029-4044fce8f352.png">

As you can see, the enumeration performance has been significantly improved, and the removal performance is hardly affected when `count` is less than 1000. As the comment said, *Bag is suitable for storing small number of elements*, so I think the change is acceptable.

I also organized comments using the swift official comment style. It is my first attempt to contribute my code to such a popular open source project, any suggestion is welcome!
