### PR TITLE
Fix build for new arm64_32 architecture 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * Performance enhancement reduces Bag dispatch inline code size by 12%.
 * Adds `customCaptureSubscriptionCallstack` hook to allow custom subscription callstacks to be generated.
 * Remove usage of `Variable` from Playground, Example projects and Tests.
+* Add `XCTAssertRecordedElements` to `XCTest+Rx`.
 
 #### Anomalies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file.
 
 #### Anomalies
 
+* Fix build issues on new arm64_32 architecture (watchOS 5).
+
 ## [4.X.X](https://github.com/ReactiveX/RxSwift/releases/tag/4.X.X)
 
 * Adds new `insert` extension to collect and add multiple disposables to `DisposeBag`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ## [4.X.X](https://github.com/ReactiveX/RxSwift/releases/tag/4.X.X)
 
 * Adds new `insert` extension to collect and add multiple disposables to `DisposeBag`.
+* Removes string interpolation warning
 
 ## [4.2.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * Adds `queuePriority` parameter (defaults to `.normal`) to `OperationQueueScheduler`.
 * Performance enhancement reduces Bag dispatch inline code size by 12%.
 * Adds `customCaptureSubscriptionCallstack` hook to allow custom subscription callstacks to be generated.
+* Remove usage of `Variable` from Playground, Example projects and Tests.
 
 #### Anomalies
 

--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -286,7 +286,7 @@ let cancel = searchForMe
 
 There are a lot of ways to create your own `Observable` sequence. The easiest way is probably to use the `create` function.
 
-Let's write a function that creates a sequence which returns one element upon subscription. That function is called 'just'.
+RxSwift provides a method that creates a sequence which returns one element upon subscription. That method is called `just`. Let's write our own implementation of it:
 
 *This is the actual implementation*
 

--- a/Documentation/UnitTests.md
+++ b/Documentation/UnitTests.md
@@ -55,6 +55,26 @@ func testMap_Range() {
     }
 ```
 
+In the case of non-terminating sequences where you don't necessarily care about the event times, You may also use `RxTest`'s `XCTAssertRecordedElements` to assert specific elements have been emitted.
+A terminating stop event (e.g. `completed` or `error`) will cause the test to fail.
+
+```swift
+func testElementsEmitted() {
+    let scheduler = TestScheduler(initialClock: 0)
+
+    let xs = scheduler.createHotObservable([
+        next(210, "RxSwift"),
+        next(220, "is"),
+        next(230, "pretty"),
+        next(240, "awesome")
+    ])
+
+    let res = scheduler.start { xs.asObservable() }
+
+    XCTAssertRecordedElements(res.events, ["RxSwift", "is", "pretty", "awesome"])
+}
+```
+
 ## Testing operator compositions (view models, components)
 
 Examples of how to test operator compositions are contained inside `Rx.xcworkspace` > `RxExample-iOSTests` target.

--- a/Rx.playground/Pages/Combining_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Combining_Operators.xcplaygroundpage/Contents.swift
@@ -137,9 +137,9 @@ example("switchLatest") {
     let subject1 = BehaviorSubject(value: "⚽️")
     let subject2 = BehaviorSubject(value: "🍎")
     
-    let variable = Variable(subject1)
+    let subjectsSubject = BehaviorSubject(value: subject1)
         
-    variable.asObservable()
+    subjectsSubject.asObservable()
         .switchLatest()
         .subscribe(onNext: { print($0) })
         .disposed(by: disposeBag)
@@ -147,14 +147,14 @@ example("switchLatest") {
     subject1.onNext("🏈")
     subject1.onNext("🏀")
     
-    variable.value = subject2
+    subjectsSubject.onNext(subject2)
     
     subject1.onNext("⚾️")
     
     subject2.onNext("🍐")
 }
 /*:
- > In this example, adding ⚾️ onto `subject1` after setting `variable.value` to `subject2` has no effect, because only the most recent inner `Observable` sequence (`subject2`) will emit elements.
+ > In this example, adding ⚾️ onto `subject1` after adding `subject2` to `subjectsSubject` has no effect, because only the most recent inner `Observable` sequence (`subject2`) will emit elements.
  */
 
 //: [Next](@next) - [Table of Contents](Table_of_Contents)

--- a/Rx.playground/Pages/Debugging_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Debugging_Operators.xcplaygroundpage/Contents.swift
@@ -57,13 +57,13 @@ example("RxSwift.Resources.total") {
     
     print(RxSwift.Resources.total)
     
-    let variable = Variable("🍎")
+    let subject = BehaviorSubject(value: "🍎")
     
-    let subscription1 = variable.asObservable().subscribe(onNext: { print($0) })
+    let subscription1 = subject.subscribe(onNext: { print($0) })
     
     print(RxSwift.Resources.total)
     
-    let subscription2 = variable.asObservable().subscribe(onNext: { print($0) })
+    let subscription2 = subject.subscribe(onNext: { print($0) })
     
     print(RxSwift.Resources.total)
     

--- a/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage/Contents.swift
@@ -179,7 +179,7 @@ example("skip") {
  */
 example("skipWhile") {
     let disposeBag = DisposeBag()
-    
+
     Observable.of(1, 2, 3, 4, 5, 6)
         .skipWhile { $0 < 4 }
         .subscribe(onNext: { print($0) })

--- a/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Mathematical_and_Aggregate_Operators.xcplaygroundpage/Contents.swift
@@ -49,9 +49,9 @@ example("concat") {
     let subject1 = BehaviorSubject(value: "🍎")
     let subject2 = BehaviorSubject(value: "🐶")
     
-    let variable = Variable(subject1)
+    let subjectsSubject = BehaviorSubject(value: subject1)
     
-    variable.asObservable()
+    subjectsSubject.asObservable()
         .concat()
         .subscribe { print($0) }
         .disposed(by: disposeBag)
@@ -59,7 +59,7 @@ example("concat") {
     subject1.onNext("🍐")
     subject1.onNext("🍊")
     
-    variable.value = subject2
+    subjectsSubject.onNext(subject2)
     
     subject2.onNext("I would be ignored")
     subject2.onNext("🐱")

--- a/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Transforming_Operators.xcplaygroundpage/Contents.swift
@@ -32,26 +32,30 @@ example("flatMap and flatMapLatest") {
     let disposeBag = DisposeBag()
     
     struct Player {
-        var score: Variable<Int>
+        init(score: Int) {
+            self.score = BehaviorSubject(value: score)
+        }
+
+        let score: BehaviorSubject<Int>
     }
     
-    let 👦🏻 = Player(score: Variable(80))
-    let 👧🏼 = Player(score: Variable(90))
+    let 👦🏻 = Player(score: 80)
+    let 👧🏼 = Player(score: 90)
     
-    let player = Variable(👦🏻)
+    let player = BehaviorSubject(value: 👦🏻)
     
     player.asObservable()
         .flatMap { $0.score.asObservable() } // Change flatMap to flatMapLatest and observe change in printed output
         .subscribe(onNext: { print($0) })
         .disposed(by: disposeBag)
     
-    👦🏻.score.value = 85
+    👦🏻.score.onNext(85)
     
-    player.value = 👧🏼
+    player.onNext(👧🏼)
     
-    👦🏻.score.value = 95 // Will be printed when using flatMap, but will not be printed when using flatMapLatest
+    👦🏻.score.onNext(95) // Will be printed when using flatMap, but will not be printed when using flatMapLatest
     
-    👧🏼.score.value = 100
+    👧🏼.score.onNext(100)
 }
 /*:
  > In this example, using `flatMap` may have unintended consequences. After assigning 👧🏼 to `player.value`, `👧🏼.score` will begin to emit elements, but the previous inner `Observable` sequence (`👦🏻.score`) will also still emit elements. By changing `flatMap` to `flatMapLatest`, only the most recent inner `Observable` sequence (`👧🏼.score`) will emit elements, i.e., setting `👦🏻.score.value` to `95` has no effect.

--- a/Rx.playground/Pages/Working_with_Subjects.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Working_with_Subjects.xcplaygroundpage/Contents.swift
@@ -89,22 +89,6 @@ example("BehaviorSubject") {
 }
 /*:
  > Notice what's missing in these previous examples? A Completed event. `PublishSubject`, `ReplaySubject`, and `BehaviorSubject` do not automatically emit Completed events when they are about to be disposed of.
- ----
- ## Variable
- Wraps a `BehaviorSubject`, so it will emit the most recent (or initial) value to new subscribers. And `Variable` also maintains current value state. `Variable` will never emit an Error event. However, it will automatically emit a Completed event and terminate on `deinit`.
 */
-example("Variable") {
-    let disposeBag = DisposeBag()
-    let variable = Variable("🔴")
-    
-    variable.asObservable().addObserver("1").disposed(by: disposeBag)
-    variable.value = "🐶"
-    variable.value = "🐱"
-    
-    variable.asObservable().addObserver("2").disposed(by: disposeBag)
-    variable.value = "🅰️"
-    variable.value = "🅱️"
-}
-//:  > Call `asObservable()` on a `Variable` instance in order to access its underlying `BehaviorSubject` sequence. `Variable`s do not implement the `on` operator (or, e.g., `onNext(_:)`), but instead expose a `value` property that can be used to get the current value, and also set a new value. Setting a new value will also add that value onto its underlying `BehaviorSubject` sequence.
 
 //: [Next](@next) - [Table of Contents](Table_of_Contents)

--- a/RxCocoa/Foundation/KVORepresentable+CoreGraphics.swift
+++ b/RxCocoa/Foundation/KVORepresentable+CoreGraphics.swift
@@ -17,7 +17,7 @@ import class Foundation.NSValue
 	let CGRectType = "{CGRect={CGPoint=dd}{CGSize=dd}}"
     let CGSizeType = "{CGSize=dd}"
     let CGPointType = "{CGPoint=dd}"
-#elseif arch(i386) || arch(arm)
+#elseif arch(i386) || arch(arm) || arch(arm64_32)
     let CGRectType = "{CGRect={CGPoint=ff}{CGSize=ff}}"
     let CGSizeType = "{CGSize=ff}"
     let CGPointType = "{CGPoint=ff}"

--- a/RxCocoa/RxCocoa.swift
+++ b/RxCocoa/RxCocoa.swift
@@ -132,7 +132,7 @@ func castOrFatalError<T>(_ value: AnyObject!, message: String) -> T {
 func castOrFatalError<T>(_ value: Any!) -> T {
     let maybeResult: T? = value as? T
     guard let result = maybeResult else {
-        rxFatalError("Failure converting from \(value) to \(T.self)")
+        rxFatalError("Failure converting from \(String(describing: value)) to \(T.self)")
     }
     
     return result

--- a/RxCocoa/Traits/PublishRelay.swift
+++ b/RxCocoa/Traits/PublishRelay.swift
@@ -21,7 +21,7 @@ public final class PublishRelay<Element>: ObservableType {
         _subject.onNext(event)
     }
     
-    /// Initializes variable with initial value.
+    /// Initializes with internal empty subject.
     public init() {
         _subject = PublishSubject()
     }

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -56,10 +56,10 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     }
     
     /**
-     Creates new subscription and sends elements to variable.
+     Creates new subscription and sends elements to relay.
 
      - parameter relay: Target relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer from the variable.
+     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func emit(to relay: PublishRelay<E>) -> Disposable {
         return emit(onNext: { e in
@@ -68,10 +68,10 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     }
 
     /**
-     Creates new subscription and sends elements to variable.
+     Creates new subscription and sends elements to relay.
 
      - parameter to: Target relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer from the variable.
+     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func emit(to relay: PublishRelay<E?>) -> Disposable {
         return emit(onNext: { e in

--- a/RxExample/RxExample/Examples/APIWrappers/APIWrappersViewController.swift
+++ b/RxExample/RxExample/Examples/APIWrappers/APIWrappersViewController.swift
@@ -71,7 +71,7 @@ class APIWrappersViewController: ViewController {
         // MARK: UISegmentedControl
 
         // also test two way binding
-        let segmentedValue = Variable(0)
+        let segmentedValue = BehaviorRelay(value: 0)
         _ = segmentedControl.rx.value <-> segmentedValue
 
         segmentedValue.asObservable()
@@ -84,7 +84,7 @@ class APIWrappersViewController: ViewController {
         // MARK: UISwitch
 
         // also test two way binding
-        let switchValue = Variable(true)
+        let switchValue = BehaviorRelay(value: true)
         _ = switcher.rx.value <-> switchValue
 
         switchValue.asObservable()
@@ -111,7 +111,7 @@ class APIWrappersViewController: ViewController {
         // MARK: UISlider
 
         // also test two way binding
-        let sliderValue = Variable<Float>(1.0)
+        let sliderValue = BehaviorRelay<Float>(value: 1.0)
         _ = slider.rx.value <-> sliderValue
 
         sliderValue.asObservable()
@@ -124,7 +124,7 @@ class APIWrappersViewController: ViewController {
         // MARK: UIDatePicker
 
         // also test two way binding
-        let dateValue = Variable(Date(timeIntervalSince1970: 0))
+        let dateValue = BehaviorRelay(value: Date(timeIntervalSince1970: 0))
         _ = datePicker.rx.date <-> dateValue
 
 
@@ -143,7 +143,7 @@ class APIWrappersViewController: ViewController {
         // let textField = UITextFieldSubclass(frame: .zero)
         if #available(iOS 11.2, *) {
             // also test two way binding
-            let textValue = Variable("")
+            let textValue = BehaviorRelay(value: "")
             _ = textField.rx.textInput <-> textValue
 
             textValue.asObservable()
@@ -158,7 +158,7 @@ class APIWrappersViewController: ViewController {
                 })
                 .disposed(by: disposeBag)
 
-            let attributedTextValue = Variable<NSAttributedString?>(NSAttributedString(string: ""))
+            let attributedTextValue = BehaviorRelay<NSAttributedString?>(value: NSAttributedString(string: ""))
             _ = textField2.rx.attributedText <-> attributedTextValue
 
             attributedTextValue.asObservable()
@@ -180,7 +180,7 @@ class APIWrappersViewController: ViewController {
         // MARK: UITextView
 
         // also test two way binding
-        let textViewValue = Variable("")
+        let textViewValue = BehaviorRelay(value: "")
         _ = textView.rx.textInput <-> textViewValue
 
         textViewValue.asObservable()
@@ -189,7 +189,7 @@ class APIWrappersViewController: ViewController {
             })
             .disposed(by: disposeBag)
 
-        let attributedTextViewValue = Variable<NSAttributedString?>(NSAttributedString(string: ""))
+        let attributedTextViewValue = BehaviorRelay<NSAttributedString?>(value: NSAttributedString(string: ""))
         _ = textView2.rx.attributedText <-> attributedTextViewValue
 
         attributedTextViewValue.asObservable()

--- a/RxExample/RxExample/Examples/TableViewPartialUpdates/PartialUpdatesViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewPartialUpdates/PartialUpdatesViewController.swift
@@ -43,7 +43,7 @@ class PartialUpdatesViewController : ViewController {
 
     var generator = Randomizer(rng: PseudoRandomGenerator(4, 3), sections: initialValue)
 
-    var sections = Variable([NumberSection]())
+    var sections = BehaviorRelay(value: [NumberSection]())
 
     /**
      Code for reactive data sources is packed in [RxDataSources](https://github.com/RxSwiftCommunity/RxDataSources) project.
@@ -75,7 +75,7 @@ class PartialUpdatesViewController : ViewController {
             timer = NSTimer.scheduledTimerWithTimeInterval(0.6, target: self, selector: "randomize", userInfo: nil, repeats: true)
         #endif
 
-        self.sections.value = generator.sections
+        self.sections.accept(generator.sections)
 
         let (configureCell, titleForSection) = PartialUpdatesViewController.tableViewDataSourceUI()
         let tvAnimatedDataSource = RxTableViewSectionedAnimatedDataSource<NumberSection>(
@@ -157,7 +157,7 @@ class PartialUpdatesViewController : ViewController {
 
         //print(values)
 
-        sections.value = values
+        sections.accept(values)
     }
 }
 

--- a/RxExample/RxExample/Examples/macOS simple example/IntroductionExampleViewController.swift
+++ b/RxExample/RxExample/Examples/macOS simple example/IntroductionExampleViewController.swift
@@ -18,7 +18,6 @@ class IntroductionExampleViewController : ViewController {
 
     @IBOutlet var leftTextView: NSTextView!
     @IBOutlet var rightTextView: NSTextView!
-    let textViewTruth = Variable<String>("System Truth")
     
     @IBOutlet var speechEnabled: NSButton!
     @IBOutlet var slider: NSSlider!

--- a/RxExample/RxExample/Operators.swift
+++ b/RxExample/RxExample/Operators.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxCocoa
 import UIKit
 
-// Two way binding operator between control property and variable, that's all it takes {
+// Two way binding operator between control property and relay, that's all it takes.
 
 infix operator <-> : DefaultPrecedence
 
@@ -35,10 +35,10 @@ func nonMarkedText(_ textInput: UITextInput) -> String? {
     return (textInput.text(in: startRange) ?? "") + (textInput.text(in: endRange) ?? "")
 }
 
-func <-> <Base>(textInput: TextInput<Base>, variable: Variable<String>) -> Disposable {
-    let bindToUIDisposable = variable.asObservable()
-        .bind(to: textInput.text)
-    let bindToVariable = textInput.text
+func <-> <Base>(textInput: TextInput<Base>, relay: BehaviorRelay<String>) -> Disposable {
+    let bindToUIDisposable = relay.bind(to: textInput.text)
+
+    let bindToRelay = textInput.text
         .subscribe(onNext: { [weak base = textInput.base] n in
             guard let base = base else {
                 return
@@ -51,43 +51,42 @@ func <-> <Base>(textInput: TextInput<Base>, variable: Variable<String>) -> Dispo
              value is not nil. This appears to be an Apple bug. If it's not, and we are doing something wrong, please let us know.
              The can be reproed easily if replace bottom code with 
              
-             if nonMarkedTextValue != variable.value {
-                variable.value = nonMarkedTextValue ?? ""
+             if nonMarkedTextValue != relay.value {
+                relay.accept(nonMarkedTextValue ?? "")
              }
 
              and you hit "Done" button on keyboard.
              */
-            if let nonMarkedTextValue = nonMarkedTextValue, nonMarkedTextValue != variable.value {
-                variable.value = nonMarkedTextValue
+            if let nonMarkedTextValue = nonMarkedTextValue, nonMarkedTextValue != relay.value {
+                relay.accept(nonMarkedTextValue)
             }
         }, onCompleted:  {
             bindToUIDisposable.dispose()
         })
 
-    return Disposables.create(bindToUIDisposable, bindToVariable)
+    return CompositeDisposable(bindToUIDisposable, bindToRelay)
 }
 
-func <-> <T>(property: ControlProperty<T>, variable: Variable<T>) -> Disposable {
+func <-> <T>(property: ControlProperty<T>, relay: BehaviorRelay<T>) -> Disposable {
     if T.self == String.self {
 #if DEBUG
-        fatalError("It is ok to delete this message, but this is here to warn that you are maybe trying to bind to some `rx.text` property directly to variable.\n" +
+        fatalError("It is ok to delete this message, but this is here to warn that you are maybe trying to bind to some `rx.text` property directly to relay.\n" +
             "That will usually work ok, but for some languages that use IME, that simplistic method could cause unexpected issues because it will return intermediate results while text is being inputed.\n" +
-            "REMEDY: Just use `textField <-> variable` instead of `textField.rx.text <-> variable`.\n" +
+            "REMEDY: Just use `textField <-> relay` instead of `textField.rx.text <-> relay`.\n" +
             "Find out more here: https://github.com/ReactiveX/RxSwift/issues/649\n"
             )
 #endif
     }
 
-    let bindToUIDisposable = variable.asObservable()
-        .bind(to: property)
-    let bindToVariable = property
+    let bindToUIDisposable = relay.bind(to: property)
+    let bindToRelay = property
         .subscribe(onNext: { n in
-            variable.value = n
+            relay.accept(n)
         }, onCompleted:  {
             bindToUIDisposable.dispose()
         })
 
-    return Disposables.create(bindToUIDisposable, bindToVariable)
+    return CompositeDisposable(bindToUIDisposable, bindToRelay)
 }
 
 // }

--- a/RxExample/RxExample/Operators.swift
+++ b/RxExample/RxExample/Operators.swift
@@ -64,7 +64,7 @@ func <-> <Base>(textInput: TextInput<Base>, relay: BehaviorRelay<String>) -> Dis
             bindToUIDisposable.dispose()
         })
 
-    return CompositeDisposable(bindToUIDisposable, bindToRelay)
+    return Disposables.create(bindToUIDisposable, bindToRelay)
 }
 
 func <-> <T>(property: ControlProperty<T>, relay: BehaviorRelay<T>) -> Disposable {
@@ -86,7 +86,7 @@ func <-> <T>(property: ControlProperty<T>, relay: BehaviorRelay<T>) -> Disposabl
             bindToUIDisposable.dispose()
         })
 
-    return CompositeDisposable(bindToUIDisposable, bindToRelay)
+    return Disposables.create(bindToUIDisposable, bindToRelay)
 }
 
 // }

--- a/RxExample/RxExample/Services/ActivityIndicator.swift
+++ b/RxExample/RxExample/Services/ActivityIndicator.swift
@@ -38,11 +38,11 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
     public typealias SharingStrategy = DriverSharingStrategy
 
     private let _lock = NSRecursiveLock()
-    private let _variable = Variable(0)
+    private let _relay = BehaviorRelay(value: 0)
     private let _loading: SharedSequence<SharingStrategy, Bool>
 
     public init() {
-        _loading = _variable.asDriver()
+        _loading = _relay.asDriver()
             .map { $0 > 0 }
             .distinctUntilChanged()
     }
@@ -58,13 +58,13 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
 
     private func increment() {
         _lock.lock()
-        _variable.value = _variable.value + 1
+        _relay.accept(_relay.value + 1)
         _lock.unlock()
     }
 
     private func decrement() {
         _lock.lock()
-        _variable.value = _variable.value - 1
+        _relay.accept(_relay.value - 1)
         _lock.unlock()
     }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -222,10 +222,10 @@ final class DriverTest_ : DriverTest, RxTestCase {
     ("testDriveObserver", DriverTest.testDriveObserver),
     ("testDriveOptionalObserver", DriverTest.testDriveOptionalObserver),
     ("testDriveNoAmbiguity", DriverTest.testDriveNoAmbiguity),
-    ("testDriveVariable", DriverTest.testDriveVariable),
-    ("testDriveOptionalVariable1", DriverTest.testDriveOptionalVariable1),
-    ("testDriveOptionalVariable2", DriverTest.testDriveOptionalVariable2),
-    ("testDriveVariableNoAmbiguity", DriverTest.testDriveVariableNoAmbiguity),
+    ("testDriveRelay", DriverTest.testDriveRelay),
+    ("testDriveOptionalRelay1", DriverTest.testDriveOptionalRelay1),
+    ("testDriveOptionalRelay2", DriverTest.testDriveOptionalRelay2),
+    ("testDriveRelayNoAmbiguity", DriverTest.testDriveRelayNoAmbiguity),
     ("testDriveBehaviorRelay", DriverTest.testDriveBehaviorRelay),
     ("testDriveBehaviorRelay1", DriverTest.testDriveBehaviorRelay1),
     ("testDriveBehaviorRelay2", DriverTest.testDriveBehaviorRelay2),
@@ -1862,7 +1862,7 @@ final class SignalTests_ : SignalTests, RxTestCase {
     ("testSignalRelay", SignalTests.testSignalRelay),
     ("testSignalOptionalRelay1", SignalTests.testSignalOptionalRelay1),
     ("testSignalOptionalRelay2", SignalTests.testSignalOptionalRelay2),
-    ("testDriveVariableNoAmbiguity", SignalTests.testDriveVariableNoAmbiguity),
+    ("testDriveRelayNoAmbiguity", SignalTests.testDriveRelayNoAmbiguity),
     ] }
 }
 

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -262,22 +262,22 @@ extension DriverTest {
         var disposeBag = DisposeBag()
         let scheduler = TestScheduler(initialClock: 0)
         let observer = scheduler.createObserver(String.self)
-        let variable = Variable("initial")
+        let relay = BehaviorRelay(value: "initial")
 
-        variable.asDriver()
+        relay.asDriver()
             .drive(observer)
             .disposed(by: disposeBag)
 
         prepareSampleDriver(with: "first")
-            .drive(variable)
+            .drive(relay)
             .disposed(by: disposeBag)
 
         prepareSampleDriver(with: "second")
-            .drive(variable)
+            .drive(relay)
             .disposed(by: disposeBag)
 
         Observable.just("third")
-            .bind(to: variable)
+            .bind(to: relay)
             .disposed(by: disposeBag)
 
         disposeBag = DisposeBag()
@@ -293,8 +293,8 @@ extension DriverTest {
 
     func testDrivingOrderOfSynchronousSubscriptions2() {
         var latestValue: Int?
-        let state = Variable(1)
-        _ = state.asDriver()
+        let state = BehaviorSubject(value: 1)
+        let subscription = state.asDriver(onErrorJustReturn: 0)
             .flatMapLatest { x in
                 return Driver.just(x * 2)
             }
@@ -310,6 +310,8 @@ extension DriverTest {
             .drive(onNext: { element in
                 latestValue = element
             })
+
+        subscription.dispose()
 
         XCTAssertEqual(latestValue, 2)
     }
@@ -356,40 +358,40 @@ extension DriverTest {
     }
 }
 
-// MARK: drive variable
+// MARK: drive relay
 
 extension DriverTest {
-    func testDriveVariable() {
-        let variable = Variable<Int>(0)
+    func testDriveRelay() {
+        let relay = BehaviorRelay<Int>(value: 0)
 
-        _ = (Driver.just(1) as Driver<Int>).drive(variable)
+        _ = (Driver.just(1) as Driver<Int>).drive(relay)
 
-        XCTAssertEqual(variable.value, 1)
+        XCTAssertEqual(relay.value, 1)
     }
 
-    func testDriveOptionalVariable1() {
-        let variable = Variable<Int?>(0)
+    func testDriveOptionalRelay1() {
+        let relay = BehaviorRelay<Int?>(value: 0)
 
-        _ = (Driver.just(1) as Driver<Int>).drive(variable)
+        _ = (Driver.just(1) as Driver<Int>).drive(relay)
 
-        XCTAssertEqual(variable.value, 1)
+        XCTAssertEqual(relay.value, 1)
     }
 
-    func testDriveOptionalVariable2() {
-        let variable = Variable<Int?>(0)
+    func testDriveOptionalRelay2() {
+        let relay = BehaviorRelay<Int?>(value: 0)
 
-        _ = (Driver.just(1) as Driver<Int?>).drive(variable)
+        _ = (Driver.just(1) as Driver<Int?>).drive(relay)
 
-        XCTAssertEqual(variable.value, 1)
+        XCTAssertEqual(relay.value, 1)
     }
 
-    func testDriveVariableNoAmbiguity() {
-        let variable = Variable<Int?>(0)
+    func testDriveRelayNoAmbiguity() {
+        let relay = BehaviorRelay<Int?>(value: 0)
 
         // shouldn't cause compile time error
-        _ = Driver.just(1).drive(variable)
+        _ = Driver.just(1).drive(relay)
 
-        XCTAssertEqual(variable.value, 1)
+        XCTAssertEqual(relay.value, 1)
     }
 }
 

--- a/Tests/RxCocoaTests/RxTest+Controls.swift
+++ b/Tests/RxCocoaTests/RxTest+Controls.swift
@@ -18,7 +18,7 @@ extension RxTest {
 
     func ensurePropertyDeallocated<C, T>(_ createControl: () -> C, _ initialValue: T, comparer: (T, T) -> Bool, file: StaticString = #file, line: UInt = #line, _ propertySelector: (C) -> ControlProperty<T>) where C: NSObject  {
 
-        let variable = Variable(initialValue)
+        let relay = BehaviorRelay(value: initialValue)
 
         var completed = false
         var deallocated = false
@@ -29,7 +29,7 @@ extension RxTest {
 
             let property = propertySelector(control)
 
-            let disposable = variable.asObservable().bind(to: property)
+            let disposable = relay.bind(to: property)
 
             _ = property.subscribe(onNext: { n in
                 lastReturnedPropertyValue = n

--- a/Tests/RxCocoaTests/Signal+Test.swift
+++ b/Tests/RxCocoaTests/Signal+Test.swift
@@ -324,7 +324,7 @@ extension SignalTests {
     }
 }
 
-// MARK: emit variable
+// MARK: Emit to relay
 
 extension SignalTests {
     func testSignalRelay() {
@@ -366,7 +366,7 @@ extension SignalTests {
         XCTAssertEqual(latest, 1)
     }
 
-    func testDriveVariableNoAmbiguity() {
+    func testDriveRelayNoAmbiguity() {
         let relay = PublishRelay<Int?>()
 
         var latest: Int? = nil

--- a/Tests/RxCocoaTests/UIActivityIndicatorView+RxTests.swift
+++ b/Tests/RxCocoaTests/UIActivityIndicatorView+RxTests.swift
@@ -17,20 +17,20 @@ final class UIActivityIndicatorViewTests: RxTest {
 
 extension UIActivityIndicatorViewTests {
     func testActivityIndicator_HasWeakReference() {
-        ensureControlObserverHasWeakReference(UIActivityIndicatorView(), { (view: UIActivityIndicatorView) -> AnyObserver<Bool> in view.rx.isAnimating.asObserver() }, { Variable<Bool>(true).asObservable() })
+        ensureControlObserverHasWeakReference(UIActivityIndicatorView(), { (view: UIActivityIndicatorView) -> AnyObserver<Bool> in view.rx.isAnimating.asObserver() }, { BehaviorRelay<Bool>(value: true).asObservable() })
     }
 
     func testActivityIndicator_NextElementsSetsValue() {
         let subject = UIActivityIndicatorView()
-        let boolSequence = Variable<Bool>(false)
+        let boolSequence = BehaviorRelay<Bool>(value: false)
 
         let disposable = boolSequence.asObservable().bind(to: subject.rx.isAnimating)
         defer { disposable.dispose() }
 
-        boolSequence.value = true
+        boolSequence.accept(true)
         XCTAssertTrue(subject.isAnimating, "Expected animation to be started")
 
-        boolSequence.value = false
+        boolSequence.accept(false)
         XCTAssertFalse(subject.isAnimating, "Expected animation to be stopped")
     }
 }

--- a/Tests/RxCocoaTests/UIProgressView+RxTests.swift
+++ b/Tests/RxCocoaTests/UIProgressView+RxTests.swift
@@ -17,16 +17,16 @@ final class UIProgressViewTests: RxTest {
 
 extension UIProgressViewTests {
     func testProgressView_HasWeakReference() {
-        ensureControlObserverHasWeakReference(UIProgressView(), { (progressView: UIProgressView) -> AnyObserver<Float> in progressView.rx.progress.asObserver() }, { Variable<Float>(0.0).asObservable() })
+        ensureControlObserverHasWeakReference(UIProgressView(), { (progressView: UIProgressView) -> AnyObserver<Float> in progressView.rx.progress.asObserver() }, { BehaviorRelay<Float>(value: 0.0).asObservable() })
     }
 
     func testProgressView_NextElementsSetsValue() {
         let subject = UIProgressView()
-        let progressSequence = Variable<Float>(0.0)
+        let progressSequence = BehaviorRelay<Float>(value: 0.0)
         let disposable = progressSequence.asObservable().bind(to: subject.rx.progress)
         defer { disposable.dispose() }
 
-        progressSequence.value = 1.0
+        progressSequence.accept(1.0)
         XCTAssert(subject.progress == progressSequence.value, "Expected progress to have been set")
     }
 }


### PR DESCRIPTION
## What ?

Seems like watchOS 5 introduces a new `arm64_32` architecture which causes build failures in KVORepresentable+CoreGraphics.swift. 

## How ?
Running a test watchOS app on the latest 44mm simulator with the following code:
```swift
print(String.init(cString: NSValue(cgRect: contentFrame).objCType))
```

Prints out:
```
{CGRect={CGPoint=ff}{CGSize=ff}}
```

The build conditional has been adjusted accordingly.