### PR TITLE
Add explicit Swift version declaration to Podspecs

### DIFF
--- a/RxBlocking.podspec
+++ b/RxBlocking.podspec
@@ -22,6 +22,8 @@ Waiting for observable sequence to complete before exiting command line applicat
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
+  s.swift_version = '4.0'
+
   s.source_files          = 'RxBlocking/**/*.swift', 'Platform/**/*.swift'
   s.exclude_files         = 'RxBlocking/Platform/**/*.swift'
 

--- a/RxCocoa.podspec
+++ b/RxCocoa.podspec
@@ -19,6 +19,8 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
+  s.swift_version = '4.0'
+
   s.source_files          = 'RxCocoa/RxCocoa.h', 'RxCocoa/*.swift', 'RxCocoa/Common/**/*.{swift,h,m}', 'RxCocoa/Traits/**/*.{swift,h,m}', 'RxCocoa/Foundation/**/*.{swift,h,m}', 'RxCocoa/Runtime/**/*.{swift,h,m}', 'Platform/**/*.swift'
   s.exclude_files         = 'RxCocoa/Platform/**/*.swift'
 

--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -32,6 +32,8 @@ gitDiff().grep("bug").less          // sequences of swift objects
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
 
+  s.swift_version = '4.0'
+
   s.source_files          = 'RxSwift/**/*.swift', 'Platform/**/*.swift'
   s.exclude_files         = 'RxSwift/Platform/**/*.swift'
 end

--- a/RxTest.podspec
+++ b/RxTest.podspec
@@ -51,6 +51,8 @@ func testMap() {
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'
 
+  s.swift_version = '4.0'
+
   s.source_files          = 'RxTest/**/*.swift', 'Platform/**/*.swift'
   s.exclude_files         = 'RxTest/Platform/**/*.swift'
 


### PR DESCRIPTION
By default, CocoaPods will attempt to compile pods using the same Swift version as your project. This creates issues for projects migrating to Swift 4.2, as RxCocoa currently doesn't build under that version. By explicitly specifying the version of Swift to use, we can avoid these issues and ensure that we're always building against the correct version of Swift.