### PR TITLE
Add XCTAssertEqual for [Recorded<Event<Void>>]

### DIFF
--- a/RxTest/Event+Equatable.swift
+++ b/RxTest/Event+Equatable.swift
@@ -64,14 +64,14 @@ public func == (lhs: Event<Void>, rhs: Event<Void>) -> Bool {
     case (.completed, .completed): return true
     case (.error(let e1), .error(let e2)):
         #if os(Linux)
-        return  "\(e1)" == "\(e2)"
+            return  "\(e1)" == "\(e2)"
         #else
-        let error1 = e1 as NSError
-        let error2 = e2 as NSError
+            let error1 = e1 as NSError
+            let error2 = e2 as NSError
 
-        return error1.domain == error2.domain
-            && error1.code == error2.code
-            && "\(e1)" == "\(e2)"
+            return error1.domain == error2.domain
+                && error1.code == error2.code
+                && "\(e1)" == "\(e2)"
         #endif
     case (.next, .next): return true
     default: return false

--- a/RxTest/Event+Equatable.swift
+++ b/RxTest/Event+Equatable.swift
@@ -55,6 +55,30 @@ public func == <Element: Equatable>(lhs: Event<Element?>, rhs: Event<Element?>) 
     }
 }
 
+/// Compares two events with Void elements. They are equal always.
+///
+/// In case `Error` events are being compared, they are equal in case their `NSError` representations are equal (domain and code)
+/// and their string representations are equal.
+public func == (lhs: Event<Void>, rhs: Event<Void>) -> Bool {
+    switch (lhs, rhs) {
+    case (.completed, .completed): return true
+    case (.error(let e1), .error(let e2)):
+        #if os(Linux)
+        return  "\(e1)" == "\(e2)"
+        #else
+        let error1 = e1 as NSError
+        let error2 = e2 as NSError
+
+        return error1.domain == error2.domain
+            && error1.code == error2.code
+            && "\(e1)" == "\(e2)"
+        #endif
+    case (.next, .next): return true
+    default: return false
+    }
+}
+
+
 /// Compares two events. They are equal if they are both the same member of `Event` enumeration.
 ///
 /// In case `Error` events are being compared, they are equal in case their `NSError` representations are equal (domain and code)

--- a/RxTest/Recorded+Event.swift
+++ b/RxTest/Recorded+Event.swift
@@ -108,3 +108,14 @@ extension Recorded {
     }
 }
 
+extension Recorded where Value == Void {
+    /**
+     Factory method for a `.next` event recorded at a given time.
+
+     - parameter time: Recorded virtual time the `.next` event occurs.
+     - returns: Recorded event in time.
+     */
+    public static func next(_ time: TestTime) -> Recorded<Event<Void>> {
+        return Recorded<Event<Void>>(time: time, value: .next(()))
+    }
+}

--- a/RxTest/Recorded.swift
+++ b/RxTest/Recorded.swift
@@ -43,3 +43,7 @@ public func == <T: Equatable>(lhs: Recorded<Event<T>>, rhs: Recorded<Event<T>>) 
 public func == <T: Equatable>(lhs: Recorded<Event<T?>>, rhs: Recorded<Event<T?>>) -> Bool {
     return lhs.time == rhs.time && lhs.value == rhs.value
 }
+
+public func == (lhs: Recorded<Event<Void>>, rhs: Recorded<Event<Void>>) -> Bool {
+    return lhs.time == rhs.time && lhs.value == rhs.value
+}

--- a/RxTest/XCTest+Rx.swift
+++ b/RxTest/XCTest+Rx.swift
@@ -171,6 +171,36 @@ public func XCTAssertEqual<T: Equatable>(_ lhs: [Recorded<Event<T?>>], _ rhs: [R
 }
 
 /**
+ Asserts two lists of Recorded events with Void elements are equal.
+
+ Recorded events are equal if times are equal and recoreded events are equal.
+
+ Event is considered equal if:
+ * `Next` events are equal always.
+ * `Error` events are equal if errors have same domain and code for `NSError` representation and have equal descriptions.
+ * `Completed` events are always equal.
+
+ - parameter lhs: first set of events.
+ - parameter lhs: second set of events.
+ */
+public func XCTAssertEqual(_ lhs: [Recorded<Event<Void>>], _ rhs: [Recorded<Event<Void>>], file: StaticString = #file, line: UInt = #line) {
+    let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }
+    let rightEquatable = rhs.map { AnyEquatable(target: $0, comparer: ==) }
+    #if os(Linux)
+        XCTAssertEqual(leftEquatable, rightEquatable)
+    #else
+        XCTAssertEqual(leftEquatable, rightEquatable, file: file, line: line)
+    #endif
+
+    if leftEquatable == rightEquatable {
+        return
+    }
+
+    printSequenceDifferences(lhs, rhs, ==)
+}
+
+
+/**
  Assert a list of Recorded events has emitted the provided elements.
  This method does not take event times into consideration.
 


### PR DESCRIPTION
The observer of Void is not testable on RxSwift.
This is a test case for this.
```
        let scheduler = TestScheduler(initialClock: 0)
        let observer = scheduler.createObserver(Void.self)

        scheduler.scheduleAt(100, action: {
            observer.onNext(())
        })

        scheduler.start()

        XCTAssertEqual(observer.events, [
            .next(100, ())
        ])
```

This code fails to compile on latest RxSwift code because XCTAssertEqual is not defined for `Recorded<Event<Void>>>`.

This PR adds XCTAssertEqual method and equatable for related them.

This PR also may fix the issue's problem: https://github.com/ReactiveX/RxSwift/issues/1552