### PR TITLE
Remove compiler conditionals that support swift 3.0

### DIFF
--- a/RxCocoa/macOS/NSButton+Rx.swift
+++ b/RxCocoa/macOS/NSButton+Rx.swift
@@ -17,30 +17,17 @@ extension Reactive where Base: NSButton {
     public var tap: ControlEvent<Void> {
         return controlEvent
     }
-
-    #if swift(>=4.0)
-       /// Reactive wrapper for `state` property`.
-        public var state: ControlProperty<NSControl.StateValue> {
-            return base.rx.controlProperty(
-                getter: { control in
-                    return control.state
-                }, setter: { (control: NSButton, state: NSControl.StateValue) in
-                    control.state = state
-                }
-            )
-        }
-    #else
-        /// Reactive wrapper for `state` property`.
-        public var state: ControlProperty<Int> {
-            return base.rx.controlProperty(
-                getter: { control in
-                    return control.state
-                }, setter: { (control: NSButton, state: Int) in
-                    control.state = state
-                }
-            )
-        }
-    #endif
+    
+    /// Reactive wrapper for `state` property`.
+    public var state: ControlProperty<NSControl.StateValue> {
+        return base.rx.controlProperty(
+            getter: { control in
+                return control.state
+            }, setter: { (control: NSButton, state: NSControl.StateValue) in
+                control.state = state
+            }
+        )
+    }
 }
 
 #endif

--- a/RxExample/RxExample/Services/Wireframe.swift
+++ b/RxExample/RxExample/Services/Wireframe.swift
@@ -32,11 +32,7 @@ class DefaultWireframe: Wireframe {
         #if os(iOS)
             UIApplication.shared.openURL(url)
         #elseif os(macOS)
-            #if swift(>=4.0)
-                NSWorkspace.shared.open(url)
-            #else
-                NSWorkspace.shared.open(url)
-            #endif
+            NSWorkspace.shared.open(url)
         #endif
     }
 

--- a/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
+++ b/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
@@ -43,11 +43,7 @@ extension DispatchQueueConfiguration {
         let compositeDisposable = CompositeDisposable()
 
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        #if swift(>=4.0)
-            timer.schedule(deadline: deadline, leeway: leeway)
-        #else
-            timer.scheduleOneshot(deadline: deadline, leeway: leeway)
-        #endif
+        timer.schedule(deadline: deadline, leeway: leeway)
 
         // TODO:
         // This looks horrible, and yes, it is.
@@ -81,11 +77,7 @@ extension DispatchQueueConfiguration {
         var timerState = state
 
         let timer = DispatchSource.makeTimerSource(queue: queue)
-        #if swift(>=4.0)
-            timer.schedule(deadline: initial, repeating: dispatchInterval(period), leeway: leeway)
-        #else
-            timer.scheduleRepeating(deadline: initial, interval: dispatchInterval(period), leeway: leeway)
-        #endif
+        timer.schedule(deadline: initial, repeating: dispatchInterval(period), leeway: leeway)
         
         // TODO:
         // This looks horrible, and yes, it is.

--- a/RxSwift/SwiftSupport/SwiftSupport.swift
+++ b/RxSwift/SwiftSupport/SwiftSupport.swift
@@ -8,22 +8,11 @@
 
 import Foundation
 
-#if swift(>=4.0)
-    typealias IntMax = Int64
-    public typealias RxAbstractInteger = FixedWidthInteger
-    
-    extension SignedInteger {
-        func toIntMax() -> IntMax {
-            return IntMax(self)
-        }
+typealias IntMax = Int64
+public typealias RxAbstractInteger = FixedWidthInteger
+
+extension SignedInteger {
+    func toIntMax() -> IntMax {
+        return IntMax(self)
     }
-#else
-    public typealias RxAbstractInteger = SignedInteger
-  
-    extension Array {
-        public mutating func swapAt(_ i: Int, _ j: Int) {
-            swap(&self[i], &self[j])
-        }
-    }
-  
-#endif
+}

--- a/scripts/package-spm.swift
+++ b/scripts/package-spm.swift
@@ -160,11 +160,7 @@ func buildAllTestsTarget(_ testsPath: String) throws {
         let matchIndexes = classMatches
             .map { $0.range.location }
 
-        #if swift(>=4.0)
-            let classNames = classMatches.map { (testContent as NSString).substring(with: $0.range(at: 1)) as NSString }
-        #else
-            let classNames = classMatches.map { (testContent as NSString).substring(with: $0.rangeAt(1)) as NSString }
-        #endif
+        let classNames = classMatches.map { (testContent as NSString).substring(with: $0.range(at: 1)) as NSString }
 
         let ranges = zip([0] + matchIndexes, matchIndexes + [testContent.count]).map { NSRange(location: $0, length: $1 - $0) }
         let classRanges = ranges[1 ..< ranges.count]
@@ -179,11 +175,7 @@ func buildAllTestsTarget(_ testsPath: String) throws {
 
             let methodMatches = testMethodsExpression.matches(in: classCode as String, options: [], range: NSRange(location: 0, length: classCode.length))
 
-            #if swift(>=4.0)
-                let methodNameRanges = methodMatches.map { $0.range(at: 1) }
-            #else
-                let methodNameRanges = methodMatches.map { $0.rangeAt(1) }
-            #endif
+            let methodNameRanges = methodMatches.map { $0.range(at: 1) }
 
             let testMethodNames = methodNameRanges
                 .map { classCode.substring(with: $0) }

--- a/scripts/validate-headers.swift
+++ b/scripts/validate-headers.swift
@@ -90,12 +90,7 @@ func validateRegexMatches(regularExpression: NSRegularExpression, content: Strin
 
     return (matches[0 ..< matches.count].flatMap { m -> [String] in
         return (1 ..< m.numberOfRanges).map { index in
-
-#if swift(>=4.0)
             let range = m.range(at: index)
-#else
-            let range = m.rangeAt(index)
-#endif
             return (content as NSString).substring(with: range)
         }
     }, true)


### PR DESCRIPTION
Diven that RxSwift do not support swift 3.x version, that repetition of code is unnecessary. Removing benefits reading.