### PR TITLE
Adding RxCocoa reactive extension badgeColor on UITabBarItem 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [4.X.X](https://github.com/ReactiveX/RxSwift/releases/tag/4.X.X)
 
 * Adds `Event`, `SingleEvent`, `MaybeEvent` and `Recorded` conditional conformance to `Equatable` where their `Element` is equatable on `RXTest` for clients that are using Swift >= 4.1. 
+* Adds `RxCocoa` reactive extension `badgeColor` on `UITabBarItem` available for iOS 10+ and tvOS 10+. 
 
 ## [4.3.1](https://github.com/ReactiveX/RxSwift/releases/tag/4.3.1)
 

--- a/RxCocoa/iOS/UITabBarItem+Rx.swift
+++ b/RxCocoa/iOS/UITabBarItem+Rx.swift
@@ -20,6 +20,14 @@ extension Reactive where Base: UITabBarItem {
         }
     }
     
+    /// Bindable sink for `badgeColor` property.
+    @available(tvOS 10.0, iOS 10.0, *)
+    public var badgeColor: Binder<UIColor?> {
+        return Binder(self.base) { tabBarItem, badgeColor in
+            tabBarItem.badgeColor = badgeColor
+        }
+    }
+    
 }
     
 #endif

--- a/Tests/RxCocoaTests/UITabBarItem+RxTests.swift
+++ b/Tests/RxCocoaTests/UITabBarItem+RxTests.swift
@@ -15,17 +15,36 @@ final class UITabBarItemTests : RxTest {
 }
 
 extension UITabBarItemTests {
-    func testBadgetValue_Text() {
+    func testBadgeValue_Text() {
         let subject = UITabBarItem(tabBarSystemItem: .more, tag: 0)
         Observable.just("5").subscribe(subject.rx.badgeValue).dispose()
         
         XCTAssertTrue(subject.badgeValue == "5")
     }
     
-    func testBadgetValue_Empty() {
+    func testBadgeValue_Empty() {
         let subject = UITabBarItem(tabBarSystemItem: .more, tag: 0)
         Observable.just(nil).subscribe(subject.rx.badgeValue).dispose()
         
-        XCTAssertTrue(subject.badgeValue == nil)
+        XCTAssertNil(subject.badgeValue)
+    }
+    
+}
+
+@available(tvOS 10.0, iOS 10.0, *)
+extension UITabBarItemTests {
+    
+    func testBadgeColor_Color() {
+        let subject = UITabBarItem(tabBarSystemItem: .more, tag: 0)
+        let color = UIColor.blue
+        Observable.just(color).subscribe(subject.rx.badgeColor).dispose()
+        XCTAssertTrue(subject.badgeColor === color)
+    }
+    
+    func testBadgeColor_Empty() {
+        let subject = UITabBarItem(tabBarSystemItem: .more, tag: 0)
+        Observable.just(nil).subscribe(subject.rx.badgeColor).dispose()
+        
+        XCTAssertNil(subject.badgeColor)
     }
 }


### PR DESCRIPTION
Adding RxCocoa reactive extension badgeColor on UITabBarItem  available for iOS 10+ and tvOS 10+.