### PR TITLE
Add `PublishRelay.asDriver()`

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -45,6 +45,7 @@ custom_categories:
   - Driver+Subscription
   - Driver
   - ObservableConvertibleType+Driver
+  - PublishRelay+Driver
 - name: RxCocoa/Traits/SharedSequence
   children:
   - ObservableConvertibleType+SharedSequence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ## [4.X.X](https://github.com/ReactiveX/RxSwift/releases/tag/4.X.X)
 
 * Adds `Event`, `SingleEvent`, `MaybeEvent` and `Recorded` conditional conformance to `Equatable` where their `Element` is equatable on `RXTest` for clients that are using Swift >= 4.1. 
+* Adds `PublishRelay.asDriver()`
 
 ## [4.3.1](https://github.com/ReactiveX/RxSwift/releases/tag/4.3.1)
 

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -35,6 +35,10 @@
 		25F6ECC91F48C407008552FA /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F6ECBF1F48C37C008552FA /* Single.swift */; };
 		271A97411CFC996B00D64125 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
 		271A97441CFC9F7B00D64125 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
+		2D9B1ECB21746A20006351AD /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B1ECA21746A20006351AD /* PublishRelay+Driver.swift */; };
+		2D9B1ECC21746A20006351AD /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B1ECA21746A20006351AD /* PublishRelay+Driver.swift */; };
+		2D9B1ECD21746A20006351AD /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B1ECA21746A20006351AD /* PublishRelay+Driver.swift */; };
+		2D9B1ECE21746A20006351AD /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B1ECA21746A20006351AD /* PublishRelay+Driver.swift */; };
 		4583D8231FE94BBA00AA1BB1 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
 		4583D8241FE94BBB00AA1BB1 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
 		4583D8251FE94BBC00AA1BB1 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
@@ -1770,6 +1774,7 @@
 		25F6ECBF1F48C37C008552FA /* Single.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Single.swift; sourceTree = "<group>"; };
 		271A97401CFC996B00D64125 /* UIViewController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
 		271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+RxTests.swift"; sourceTree = "<group>"; };
+		2D9B1ECA21746A20006351AD /* PublishRelay+Driver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublishRelay+Driver.swift"; sourceTree = "<group>"; };
 		4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Recorded+Event.swift"; sourceTree = "<group>"; };
 		4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+RxTests.swift"; sourceTree = "<group>"; };
 		461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+Rx.swift"; sourceTree = "<group>"; };
@@ -3144,6 +3149,7 @@
 				C8C8BCD31F89459300501D4D /* BehaviorRelay+Driver.swift */,
 				C89AB1AE1DAAC3350065FBE6 /* ControlEvent+Driver.swift */,
 				C89AB1AF1DAAC3350065FBE6 /* ControlProperty+Driver.swift */,
+				2D9B1ECA21746A20006351AD /* PublishRelay+Driver.swift */,
 				C89AB1B01DAAC3350065FBE6 /* Driver+Subscription.swift */,
 				C89AB1B11DAAC3350065FBE6 /* Driver.swift */,
 				C89AB1B21DAAC3350065FBE6 /* ObservableConvertibleType+Driver.swift */,
@@ -4158,6 +4164,7 @@
 				C8091C571FAA39C1001DB32A /* ControlEvent+Signal.swift in Sources */,
 				C882542D1B8A752B00B02D69 /* UIImageView+Rx.swift in Sources */,
 				A520FFFC1F0D291500573734 /* RxPickerViewDataSourceProxy.swift in Sources */,
+				2D9B1ECB21746A20006351AD /* PublishRelay+Driver.swift in Sources */,
 				C882542A1B8A752B00B02D69 /* UIControl+Rx.swift in Sources */,
 				C8E65EFB1F6E91D1004478C3 /* Binder.swift in Sources */,
 				C8D132441C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */,
@@ -4300,6 +4307,7 @@
 				C8D132451C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */,
 				C80D33901B91EF9E0014629D /* Observable+Bind.swift in Sources */,
 				C89AB1EB1DAAC3350065FBE6 /* SharedSequence+Operators+arity.swift in Sources */,
+				2D9B1ECC21746A20006351AD /* PublishRelay+Driver.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5459,6 +5467,7 @@
 				C8B0F7181F530F5A00548EBE /* PublishRelay+Signal.swift in Sources */,
 				C8F0C0311BBBFBB9001B112F /* DelegateProxy.swift in Sources */,
 				C8F0C0331BBBFBB9001B112F /* UISwitch+Rx.swift in Sources */,
+				2D9B1ECE21746A20006351AD /* PublishRelay+Driver.swift in Sources */,
 				C8F0C0351BBBFBB9001B112F /* UICollectionView+Rx.swift in Sources */,
 				C8F0C0361BBBFBB9001B112F /* RxCollectionViewDataSourceType.swift in Sources */,
 				C89AB1F91DAAC3350065FBE6 /* SharedSequence.swift in Sources */,
@@ -5515,6 +5524,7 @@
 			files = (
 				D203C4F71BB9C53100D02D00 /* RxTableViewDataSourceType.swift in Sources */,
 				D203C50E1BB9C53E00D02D00 /* UISlider+Rx.swift in Sources */,
+				2D9B1ECD21746A20006351AD /* PublishRelay+Driver.swift in Sources */,
 				D2138C991BB9BEEE00339B5C /* RxTarget.swift in Sources */,
 				D203C5081BB9C53E00D02D00 /* UIGestureRecognizer+Rx.swift in Sources */,
 				88D98F2F1CE7549A00D50457 /* RxTabBarDelegateProxy.swift in Sources */,

--- a/RxCocoa/Traits/Driver/PublishRelay+Driver.swift
+++ b/RxCocoa/Traits/Driver/PublishRelay+Driver.swift
@@ -1,0 +1,20 @@
+//
+//  PublishRelay+Driver.swift
+//  RxCocoa
+//
+//  Created by Damian Malarczyk on 15/10/2018.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+import RxSwift
+
+extension PublishRelay {
+    /// Converts `PublishRelay` to `Driver`.
+    ///
+    /// - returns: Observable sequence.
+    public func asDriver() -> Driver<Element> {
+        let source = self.asObservable()
+            .observeOn(DriverSharingStrategy.scheduler)
+        return SharedSequence(source)
+    }
+}

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -213,6 +213,7 @@ final class DriverTest_ : DriverTest, RxTestCase {
     ("testDriverSharing_WhenErroring", DriverTest.testDriverSharing_WhenErroring),
     ("testDriverSharing_WhenCompleted", DriverTest.testDriverSharing_WhenCompleted),
     ("testBehaviorRelayAsDriver", DriverTest.testBehaviorRelayAsDriver),
+    ("testPublishRelayAsDriver", DriverTest.testPublishRelayAsDriver),
     ("testVariableAsDriver", DriverTest.testVariableAsDriver),
     ("testAsDriver_onErrorJustReturn", DriverTest.testAsDriver_onErrorJustReturn),
     ("testAsDriver_onErrorDriveWith", DriverTest.testAsDriver_onErrorDriveWith),

--- a/Sources/RxCocoa/PublishRelay+Driver.swift
+++ b/Sources/RxCocoa/PublishRelay+Driver.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/Traits/Driver/PublishRelay+Driver.swift

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -177,6 +177,21 @@ extension DriverTest {
         XCTAssertEqual(results, [0, 1, 2])
     }
 
+    func testPublishRelayAsDriver() {
+        let hotObservable: PublishRelay<Int> = PublishRelay()
+        let xs = Driver.zip(hotObservable.asDriver(), Driver.of(0, 0, 0)) { x, _ in
+            return x
+        }
+
+        let results = subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription(xs, expectationFulfilled: { $0 == 2 }) {
+            hotObservable.accept(0)
+            hotObservable.accept(1)
+            hotObservable.accept(2)
+        }
+
+        XCTAssertEqual(results, [0, 1, 2])
+    }
+
     func testVariableAsDriver() {
         var hotObservable: Variable<Int>? = Variable(1)
         let xs = Driver.zip(hotObservable!.asDriver(), Driver.of(0, 0)) { (optInt, int) in


### PR DESCRIPTION
This PR adds `PublishRelay.asDriver()` method. 
Seems like `PublishRelay` is the only trait that's missing such conversion. All `BehaviorRelay`, `ControlEvent` and `ControlProperty` already implement `asDriver`.