### PR TITLE
Fix watchOS minimum deployment and deprecation of OSAtomicIncrement32Barrier

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -6425,7 +6425,7 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = "Release-Tests";
 		};
@@ -6841,7 +6841,7 @@
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -6902,7 +6902,7 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};

--- a/RxCocoa/Runtime/_RXObjCRuntime.m
+++ b/RxCocoa/Runtime/_RXObjCRuntime.m
@@ -11,6 +11,7 @@
 #import <objc/runtime.h>
 #import <objc/message.h>
 #import <libkern/OSAtomic.h>
+#import <stdatomic.h>
 
 #import "include/_RX.h"
 #import "include/_RXObjCRuntime.h"
@@ -41,8 +42,8 @@ static SEL       deallocSelector;
 static int RxSwizzlingTargetClassKey = 0;
 
 #if TRACE_RESOURCES
-static int32_t numberOInterceptedMethods = 0;
-static int32_t numberOfForwardedMethods = 0;
+_Atomic static int32_t numberOInterceptedMethods = 0;
+_Atomic static int32_t numberOfForwardedMethods = 0;
 #endif
 
 #define THREADING_HAZARD(class) \
@@ -806,7 +807,7 @@ static NSMutableDictionary<NSString *, RXInterceptWithOptimizedObserver> *optimi
     ALWAYS(![self forwardingSelector:selector forClass:swizzlingImplementorClass], @"Already observing selector for class");
 
 #if TRACE_RESOURCES
-    OSAtomicIncrement32Barrier(&numberOfForwardedMethods);
+    atomic_fetch_add(&numberOfForwardedMethods, 1);
 #endif
     SEL rxSelector = RX_selector(selector);
 
@@ -933,7 +934,7 @@ replacementImplementationGenerator:(IMP (^)(IMP originalImplementation))replacem
     }
 
 #if TRACE_RESOURCES
-    OSAtomicIncrement32Barrier(&numberOInterceptedMethods);
+    atomic_fetch_add(&numberOInterceptedMethods, 1);
 #endif
     
     DLOG(@"Rx is swizzling `%@` for `%@`", NSStringFromSelector(selector), class);


### PR DESCRIPTION
Supersedes #1753.
Fixes #1752. 

This PR:

* Takes @dlewanda's changes for the watchOS 3.0 minimum deployment.
* Fixes the deprecation of `OSAtomicIncrement32Barrier` by switching to `atomic_fetch_add` from `stdatomic.h`. 

As a reminder - we should merge this ASAP as it causes a critical issue when submitting to the App Store with a watchOS target. 