### PR TITLE
Fix compilation by moving KeyValueObservingOptions

### DIFF
--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -397,6 +397,20 @@ fileprivate final class KVOObservable<Element>
 
 }
 
+fileprivate extension KeyValueObservingOptions {
+    fileprivate var nsOptions: NSKeyValueObservingOptions {
+        var result: UInt = 0
+        if self.contains(.new) {
+            result |= NSKeyValueObservingOptions.new.rawValue
+        }
+        if self.contains(.initial) {
+            result |= NSKeyValueObservingOptions.initial.rawValue
+        }
+        
+        return NSKeyValueObservingOptions(rawValue: result)
+    }
+}
+
 #endif
 
 #if !DISABLE_SWIZZLING && !os(Linux)
@@ -438,20 +452,6 @@ fileprivate final class KVOObservable<Element>
         }
     }
 
-    fileprivate extension KeyValueObservingOptions {
-        fileprivate var nsOptions: NSKeyValueObservingOptions {
-            var result: UInt = 0
-            if self.contains(.new) {
-                result |= NSKeyValueObservingOptions.new.rawValue
-            }
-            if self.contains(.initial) {
-                result |= NSKeyValueObservingOptions.initial.rawValue
-            }
-
-            return NSKeyValueObservingOptions(rawValue: result)
-        }
-    }
-    
     fileprivate func observeWeaklyKeyPathFor(
         _ target: NSObject,
         keyPathSections: [String],


### PR DESCRIPTION
In order to be able to compile RxCocoa when DISABLE_SWIZZLING is enabled, I moved the KeyValueObservingOptions so it's available also when DISABLE_SWIZZLING is enabled.
This extension contains a some utility to transform KeyValueObservingOptions to NSKeyValueObservingOptions so it's safe to move out of DISABLE_SWIZZLING section. This will fix: 
https://github.com/ReactiveX/RxSwift/issues/1770

No unit test has being added since this change it only fixes compilation.
