### PR TITLE
Add takeUntil(_ predicate:) and takeUntil(_ element:)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+* Adds `takeUntil(_ behavior:predicate:)`.
+
 ## [4.4.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.4.0)
 
 **This release introduces a new framework `RxAtomic` that enables using C11 atomic primitives in RxSwift as a replacement for deprecated `OSAtomic*` functions.**
@@ -20,6 +22,7 @@ All notable changes to this project will be documented in this file.
 * Fixes problem with canceling events scheduled on serial scheduler through `observeOn` operator.  #1778
 * Fixes problem with `UISearchBar.text` property not triggering update when cancel button is tapped. #1714 
 * Updates watchos minimum target to 3.0. #1752
+
 
 ## [4.3.1](https://github.com/ReactiveX/RxSwift/releases/tag/4.3.1)
 

--- a/RxSwift/Observables/TakeUntil.swift
+++ b/RxSwift/Observables/TakeUntil.swift
@@ -20,8 +20,23 @@ extension ObservableType {
         -> Observable<E> {
         return TakeUntil(source: self.asObservable(), other: other.asObservable())
     }
+
+    /**
+     Returns elements from an observable sequence until the specified condition is true.
+
+     - seealso: [takeUntil operator on reactivex.io](http://reactivex.io/documentation/operators/takeuntil.html)
+
+     - parameter predicate: A function to test each element for a condition.
+     - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test passes.
+     */
+    public func takeUntil(_ predicate: @escaping (E) throws -> Bool)
+        -> Observable<E> {
+        return TakeUntilPredicate(source: asObservable(), predicate: predicate)
+    }
+}
 }
 
+// MARK: - TakeUntil Observable
 final fileprivate class TakeUntilSinkOther<Other, O: ObserverType>
     : ObserverType
     , LockOwnerType
@@ -126,6 +141,67 @@ final fileprivate class TakeUntil<Element, Other>: Producer<Element> {
     override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
         let sink = TakeUntilSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
+        return (sink: sink, subscription: subscription)
+    }
+}
+
+// MARK: - TakeUntil Predicate
+final fileprivate class TakeUntilPredicateSink<O: ObserverType>
+    : Sink<O>, ObserverType {
+    typealias Element = O.E
+    typealias Parent = TakeUntilPredicate<Element>
+
+    fileprivate let _parent: Parent
+    fileprivate var _running = true
+
+    init(parent: Parent, observer: O, cancel: Cancelable) {
+        _parent = parent
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ event: Event<Element>) {
+        switch event {
+        case .next(let value):
+            if !_running {
+                return
+            }
+
+            do {
+                _running = try !_parent._predicate(value)
+            } catch let e {
+                forwardOn(.error(e))
+                dispose()
+                return
+            }
+
+            if _running {
+                forwardOn(.next(value))
+            } else {
+                forwardOn(.completed)
+                dispose()
+            }
+        case .error, .completed:
+            forwardOn(event)
+            dispose()
+        }
+    }
+
+}
+
+final fileprivate class TakeUntilPredicate<Element>: Producer<Element> {
+    typealias Predicate = (Element) throws -> Bool
+
+    fileprivate let _source: Observable<Element>
+    fileprivate let _predicate: Predicate
+
+    init(source: Observable<Element>, predicate: @escaping Predicate) {
+        _source = source
+        _predicate = predicate
+    }
+
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+        let sink = TakeUntilPredicateSink(parent: self, observer: observer, cancel: cancel)
+        let subscription = _source.subscribe(sink)
         return (sink: sink, subscription: subscription)
     }
 }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1468,14 +1468,14 @@ final class ObservableTakeUntilTest_ : ObservableTakeUntilTest, RxTestCase {
     ("testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperlyDisposed", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperlyDisposed),
     ("testTakeUntil_NoPreempt_AfterLastProduced_ProperlyDisposed", ObservableTakeUntilTest.testTakeUntil_NoPreempt_AfterLastProduced_ProperlyDisposed),
     ("testTakeUntil_Error_Some", ObservableTakeUntilTest.testTakeUntil_Error_Some),
-    ("testTakeUntilPredicate_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntilPredicate_Preempt_SomeData_Next),
-    ("testTakeUntilPredicate_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntilPredicate_Preempt_SomeData_Error),
-    ("testTakeUntilPredicate_AlwaysFailingPredicate", ObservableTakeUntilTest.testTakeUntilPredicate_AlwaysFailingPredicate),
-    ("testTakeUntilPredicate_ImmediatelySuccessfulPredicate", ObservableTakeUntilTest.testTakeUntilPredicate_ImmediatelySuccessfulPredicate),
-    ("testTakeUntilElement_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntilElement_Preempt_SomeData_Next),
-    ("testTakeUntilElement_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntilElement_Preempt_SomeData_Error),
-    ("testTakeUntilElement_AlwaysFailingPredicate", ObservableTakeUntilTest.testTakeUntilElement_AlwaysFailingPredicate),
-    ("testTakeUntilElement_ImmediatelySuccessfulPredicate", ObservableTakeUntilTest.testTakeUntilElement_ImmediatelySuccessfulPredicate),
+    ("testTakeUntilPredicate_Exclusive_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntilPredicate_Exclusive_Preempt_SomeData_Next),
+    ("testTakeUntilPredicate_Exclusive_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntilPredicate_Exclusive_Preempt_SomeData_Error),
+    ("testTakeUntilPredicate_Exclusive_AlwaysFailingPredicate", ObservableTakeUntilTest.testTakeUntilPredicate_Exclusive_AlwaysFailingPredicate),
+    ("testTakeUntilPredicate_Exclusive_ImmediatelySuccessfulPredicate", ObservableTakeUntilTest.testTakeUntilPredicate_Exclusive_ImmediatelySuccessfulPredicate),
+    ("testTakeUntilPredicate_Inclusive_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntilPredicate_Inclusive_Preempt_SomeData_Next),
+    ("testTakeUntilPredicate_Inclusive_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntilPredicate_Inclusive_Preempt_SomeData_Error),
+    ("testTakeUntilPredicate_Inclusive_AlwaysFailingPredicate", ObservableTakeUntilTest.testTakeUntilPredicate_Inclusive_AlwaysFailingPredicate),
+    ("testTakeUntilPredicate_Inclusive_ImmediatelySuccessfulPredicate", ObservableTakeUntilTest.testTakeUntilPredicate_Inclusive_ImmediatelySuccessfulPredicate),
     ] }
 }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1465,9 +1465,17 @@ final class ObservableTakeUntilTest_ : ObservableTakeUntilTest, RxTestCase {
     ("testTakeUntil_NoPreempt_Never_Empty", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Empty),
     ("testTakeUntil_NoPreempt_Never_Never", ObservableTakeUntilTest.testTakeUntil_NoPreempt_Never_Never),
     ("testTakeUntil_Preempt_BeforeFirstProduced", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced),
-    ("testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed),
-    ("testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna", ObservableTakeUntilTest.testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna),
+    ("testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperlyDisposed", ObservableTakeUntilTest.testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperlyDisposed),
+    ("testTakeUntil_NoPreempt_AfterLastProduced_ProperlyDisposed", ObservableTakeUntilTest.testTakeUntil_NoPreempt_AfterLastProduced_ProperlyDisposed),
     ("testTakeUntil_Error_Some", ObservableTakeUntilTest.testTakeUntil_Error_Some),
+    ("testTakeUntilPredicate_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntilPredicate_Preempt_SomeData_Next),
+    ("testTakeUntilPredicate_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntilPredicate_Preempt_SomeData_Error),
+    ("testTakeUntilPredicate_AlwaysFailingPredicate", ObservableTakeUntilTest.testTakeUntilPredicate_AlwaysFailingPredicate),
+    ("testTakeUntilPredicate_ImmediatelySuccessfulPredicate", ObservableTakeUntilTest.testTakeUntilPredicate_ImmediatelySuccessfulPredicate),
+    ("testTakeUntilElement_Preempt_SomeData_Next", ObservableTakeUntilTest.testTakeUntilElement_Preempt_SomeData_Next),
+    ("testTakeUntilElement_Preempt_SomeData_Error", ObservableTakeUntilTest.testTakeUntilElement_Preempt_SomeData_Error),
+    ("testTakeUntilElement_AlwaysFailingPredicate", ObservableTakeUntilTest.testTakeUntilElement_AlwaysFailingPredicate),
+    ("testTakeUntilElement_ImmediatelySuccessfulPredicate", ObservableTakeUntilTest.testTakeUntilElement_ImmediatelySuccessfulPredicate),
     ] }
 }
 

--- a/Tests/RxSwiftTests/Observable+TakeUntilTests.swift
+++ b/Tests/RxSwiftTests/Observable+TakeUntilTests.swift
@@ -308,7 +308,7 @@ extension ObservableTakeUntilTest {
             ])
     }
     
-    func testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperDisposed() {
+    func testTakeUntil_Preempt_BeforeFirstProduced_RemainSilentAndProperlyDisposed() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let l = scheduler.createHotObservable([
@@ -336,7 +336,7 @@ extension ObservableTakeUntilTest {
         XCTAssertFalse(sourceNotDisposed)
     }
     
-    func testTakeUntil_NoPreempt_AfterLastProduced_ProperDisposedSigna() {
+    func testTakeUntil_NoPreempt_AfterLastProduced_ProperlyDisposed() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let l = scheduler.createHotObservable([
@@ -416,4 +416,113 @@ extension ObservableTakeUntilTest {
             scheduler.start()
         }
     #endif
+}
+
+// MARK: TakeUntil Predicate Tests
+extension ObservableTakeUntilTest {
+    func testTakeUntilPredicate_Preempt_SomeData_Next() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let l = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .next(230, 4),
+            .next(240, 5),
+            .completed(250)
+            ])
+
+        let res = scheduler.start {
+            l.takeUntil { $0 == 4 }
+        }
+
+        XCTAssertEqual(res.events, [
+            .next(210, 2),
+            .next(220, 3),
+            .completed(230)
+            ])
+
+        XCTAssertEqual(l.subscriptions, [
+            Subscription(200, 230)
+        ])
+    }
+
+    func testTakeUntilPredicate_Preempt_SomeData_Error() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let l = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .error(225, testError)
+        ])
+
+        let res = scheduler.start {
+            l.takeUntil { $0 == 4 }
+        }
+
+        XCTAssertEqual(res.events, [
+            .next(210, 2),
+            .next(220, 3),
+            .error(225, testError)
+        ])
+
+        XCTAssertEqual(l.subscriptions, [
+            Subscription(200, 225)
+        ])
+    }
+
+    func testTakeUntilPredicate_AlwaysFailingPredicate() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let l = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .next(230, 4),
+            .next(240, 5),
+            .completed(250)
+        ])
+
+        let res = scheduler.start {
+            l.takeUntil { _ in false }
+        }
+
+        XCTAssertEqual(res.events, [
+            .next(210, 2),
+            .next(220, 3),
+            .next(230, 4),
+            .next(240, 5),
+            .completed(250)
+        ])
+
+        XCTAssertEqual(l.subscriptions, [
+            Subscription(200, 250)
+        ])
+    }
+
+    func testTakeUntilPredicate_ImmediatelySuccessfulPredicate() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let l = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .next(230, 4),
+            .next(240, 5),
+            .completed(250)
+        ])
+
+        let res = scheduler.start {
+            l.takeUntil { _ in true }
+        }
+
+        XCTAssertEqual(res.events, [
+            .completed(210)
+        ])
+
+        XCTAssertEqual(l.subscriptions, [
+            Subscription(200, 210)
+        ])
+    }
 }


### PR DESCRIPTION
The first variation - `takeUntil(_ predicate:)` - is the inverse of `takeWhile(_ predicate:)`. 

In RxJava, and other implementations, `takeUntil(predicate:)` is one of the most popular usages of this operator (compared to the `takeUntil(secondObservable)` variation) and I feel I always have to "flip around terms" (or use different terminology compared to android co-workers). I usually wouldn't bother adding operators just for the sake of alignment but in this case I think its quite valuable. 

The second version - `takeUntil(_ element:)` is simply syntactic sugar but I think it's quite helpful. I'm not religious to having it but I think it's an extremely common use case. 

Appreciate any opinions / thoughts :) 