### PR TITLE
Change the url of RayWenderlich.com Book

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ $ git submodule add git@github.com:ReactiveX/RxSwift.git
 
 * [http://reactivex.io/](http://reactivex.io/)
 * [Reactive Extensions GitHub (GitHub)](https://github.com/Reactive-Extensions)
-* [RxSwift RayWenderlich.com Book](https://store.raywenderlich.com/products/rxswift)
+* [RxSwift RayWenderlich.com Book](https://store.raywenderlich.com/products/rxswift-reactive-programming-with-swift)
 * [Boxue.io RxSwift Online Course](https://boxueio.com/series/rxswift-101) (Chinese 🇨🇳)
 * [Erik Meijer (Wikipedia)](http://en.wikipedia.org/wiki/Erik_Meijer_%28computer_scientist%29)
 * [Expert to Expert: Brian Beckman and Erik Meijer - Inside the .NET Reactive Framework (Rx) (video)](https://youtu.be/looJcaeboBY)


### PR DESCRIPTION
Fix RxSwift eBook in `RayWenderlich` url not working problem.