### PR TITLE
Refactor self usage

### DIFF
--- a/RxSwift/Observables/Amb.swift
+++ b/RxSwift/Observables/Amb.swift
@@ -35,7 +35,7 @@ extension ObservableType {
     public func amb<O2: ObservableType>
         (_ right: O2)
         -> Observable<E> where O2.E == E {
-        return Amb(left: asObservable(), right: right.asObservable())
+        return Amb(left: self.asObservable(), right: right.asObservable())
     }
 }
 

--- a/RxSwift/Observables/Catch.swift
+++ b/RxSwift/Observables/Catch.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func catchError(_ handler: @escaping (Swift.Error) throws -> Observable<E>)
         -> Observable<E> {
-        return Catch(source: asObservable(), handler: handler)
+        return Catch(source: self.asObservable(), handler: handler)
     }
 
     /**
@@ -31,7 +31,7 @@ extension ObservableType {
      */
     public func catchErrorJustReturn(_ element: E)
         -> Observable<E> {
-        return Catch(source: asObservable(), handler: { _ in Observable.just(element) })
+        return Catch(source: self.asObservable(), handler: { _ in Observable.just(element) })
     }
     
 }

--- a/RxSwift/Observables/ElementAt.swift
+++ b/RxSwift/Observables/ElementAt.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func elementAt(_ index: Int)
         -> Observable<E> {
-        return ElementAt(source: asObservable(), index: index, throwOnEmpty: true)
+        return ElementAt(source: self.asObservable(), index: index, throwOnEmpty: true)
     }
 }
 

--- a/RxSwift/Observables/Filter.swift
+++ b/RxSwift/Observables/Filter.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func filter(_ predicate: @escaping (E) throws -> Bool)
         -> Observable<E> {
-        return Filter(source: asObservable(), predicate: predicate)
+        return Filter(source: self.asObservable(), predicate: predicate)
     }
 }
 

--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func flatMap<O: ObservableConvertibleType>(_ selector: @escaping (E) throws -> O)
         -> Observable<O.E> {
-            return FlatMap(source: asObservable(), selector: selector)
+            return FlatMap(source: self.asObservable(), selector: selector)
     }
 
 }
@@ -36,7 +36,7 @@ extension ObservableType {
      */
     public func flatMapFirst<O: ObservableConvertibleType>(_ selector: @escaping (E) throws -> O)
         -> Observable<O.E> {
-            return FlatMapFirst(source: asObservable(), selector: selector)
+            return FlatMapFirst(source: self.asObservable(), selector: selector)
     }
 }
 
@@ -50,7 +50,7 @@ extension ObservableType where E : ObservableConvertibleType {
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
     public func merge() -> Observable<E.E> {
-        return Merge(source: asObservable())
+        return Merge(source: self.asObservable())
     }
 
     /**
@@ -63,7 +63,7 @@ extension ObservableType where E : ObservableConvertibleType {
      */
     public func merge(maxConcurrent: Int)
         -> Observable<E.E> {
-        return MergeLimited(source: asObservable(), maxConcurrent: maxConcurrent)
+        return MergeLimited(source: self.asObservable(), maxConcurrent: maxConcurrent)
     }
 }
 
@@ -132,7 +132,7 @@ extension ObservableType {
     
     public func concatMap<O: ObservableConvertibleType>(_ selector: @escaping (E) throws -> O)
         -> Observable<O.E> {
-            return ConcatMap(source: asObservable(), selector: selector)
+            return ConcatMap(source: self.asObservable(), selector: selector)
     }
 }
 

--- a/RxSwift/Observables/SingleAsync.swift
+++ b/RxSwift/Observables/SingleAsync.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func single()
         -> Observable<E> {
-        return SingleAsync(source: asObservable())
+        return SingleAsync(source: self.asObservable())
     }
 
     /**
@@ -32,7 +32,7 @@ extension ObservableType {
      */
     public func single(_ predicate: @escaping (E) throws -> Bool)
         -> Observable<E> {
-        return SingleAsync(source: asObservable(), predicate: predicate)
+        return SingleAsync(source: self.asObservable(), predicate: predicate)
     }
 }
 

--- a/RxSwift/Observables/Skip.swift
+++ b/RxSwift/Observables/Skip.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func skip(_ count: Int)
         -> Observable<E> {
-        return SkipCount(source: asObservable(), count: count)
+        return SkipCount(source: self.asObservable(), count: count)
     }
 }
 

--- a/RxSwift/Observables/SkipUntil.swift
+++ b/RxSwift/Observables/SkipUntil.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func skipUntil<O: ObservableType>(_ other: O)
         -> Observable<E> {
-        return SkipUntil(source: asObservable(), other: other.asObservable())
+        return SkipUntil(source: self.asObservable(), other: other.asObservable())
     }
 }
 

--- a/RxSwift/Observables/SkipWhile.swift
+++ b/RxSwift/Observables/SkipWhile.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
      */
     public func skipWhile(_ predicate: @escaping (E) throws -> Bool) -> Observable<E> {
-        return SkipWhile(source: asObservable(), predicate: predicate)
+        return SkipWhile(source: self.asObservable(), predicate: predicate)
     }
 }
 

--- a/RxSwift/Observables/Switch.swift
+++ b/RxSwift/Observables/Switch.swift
@@ -21,7 +21,7 @@ extension ObservableType {
      */
     public func flatMapLatest<O: ObservableConvertibleType>(_ selector: @escaping (E) throws -> O)
         -> Observable<O.E> {
-            return FlatMapLatest(source: asObservable(), selector: selector)
+            return FlatMapLatest(source: self.asObservable(), selector: selector)
     }
 }
 
@@ -39,7 +39,7 @@ extension ObservableType where E : ObservableConvertibleType {
      - returns: The observable sequence that at any point in time produces the elements of the most recent inner observable sequence that has been received.
      */
     public func switchLatest() -> Observable<E.E> {
-        return Switch(source: asObservable())
+        return Switch(source: self.asObservable())
     }
 }
 

--- a/RxSwift/Observables/SwitchIfEmpty.swift
+++ b/RxSwift/Observables/SwitchIfEmpty.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
     public func ifEmpty(switchTo other: Observable<E>) -> Observable<E> {
-        return SwitchIfEmpty(source: asObservable(), ifEmpty: other)
+        return SwitchIfEmpty(source: self.asObservable(), ifEmpty: other)
     }
 }
 

--- a/RxSwift/Observables/Take.swift
+++ b/RxSwift/Observables/Take.swift
@@ -22,7 +22,7 @@ extension ObservableType {
             return Observable.empty()
         }
         else {
-            return TakeCount(source: asObservable(), count: count)
+            return TakeCount(source: self.asObservable(), count: count)
         }
     }
 }

--- a/RxSwift/Observables/TakeLast.swift
+++ b/RxSwift/Observables/TakeLast.swift
@@ -20,7 +20,7 @@ extension ObservableType {
      */
     public func takeLast(_ count: Int)
         -> Observable<E> {
-        return TakeLast(source: asObservable(), count: count)
+        return TakeLast(source: self.asObservable(), count: count)
     }
 }
 

--- a/RxSwift/Observables/TakeUntil.swift
+++ b/RxSwift/Observables/TakeUntil.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func takeUntil<O: ObservableType>(_ other: O)
         -> Observable<E> {
-        return TakeUntil(source: asObservable(), other: other.asObservable())
+        return TakeUntil(source: self.asObservable(), other: other.asObservable())
     }
 }
 

--- a/RxSwift/Observables/TakeWhile.swift
+++ b/RxSwift/Observables/TakeWhile.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      */
     public func takeWhile(_ predicate: @escaping (E) throws -> Bool)
         -> Observable<E> {
-        return TakeWhile(source: asObservable(), predicate: predicate)
+        return TakeWhile(source: self.asObservable(), predicate: predicate)
     }
 }
 

--- a/RxSwift/Observables/WithLatestFrom.swift
+++ b/RxSwift/Observables/WithLatestFrom.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
      */
     public func withLatestFrom<SecondO: ObservableConvertibleType, ResultType>(_ second: SecondO, resultSelector: @escaping (E, SecondO.E) throws -> ResultType) -> Observable<ResultType> {
-        return WithLatestFrom(first: asObservable(), second: second.asObservable(), resultSelector: resultSelector)
+        return WithLatestFrom(first: self.asObservable(), second: second.asObservable(), resultSelector: resultSelector)
     }
 
     /**
@@ -30,7 +30,7 @@ extension ObservableType {
      - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
      */
     public func withLatestFrom<SecondO: ObservableConvertibleType>(_ second: SecondO) -> Observable<SecondO.E> {
-        return WithLatestFrom(first: asObservable(), second: second.asObservable(), resultSelector: { $1 })
+        return WithLatestFrom(first: self.asObservable(), second: second.asObservable(), resultSelector: { $1 })
     }
 }
 


### PR DESCRIPTION
Refactor 72 self usage cases
```swift
// as is
with(self.asObservable())(curriedArgument)
return BlockingObservable(timeout: timeout, source: self.asObservable())
return Observable.concat([self.asObservable(), second.asObservable()])

// to be
with(asObservable())(curriedArgument)
return BlockingObservable(timeout: timeout, source: asObservable())
return Observable.concat([asObservable(), second.asObservable()])

and so on
```

- Always using self. to access instance members and functions. 
- Using self. only when the compiler needs it. 
- All Unit test passed

#### Swift evolution
https://github.com/apple/swift-evolution/blob/master/proposals/0009-require-self-for-accessing-instance-members.md#counter-argument

#### Clean code
http://thebugcode.github.io/when-to-self-in-swift-and-when-not-to-2/