### PR TITLE
Remove duplicated subscription in example

### DIFF
--- a/RxExample/RxExample/Examples/APIWrappers/APIWrappersViewController.swift
+++ b/RxExample/RxExample/Examples/APIWrappers/APIWrappersViewController.swift
@@ -152,12 +152,6 @@ class APIWrappersViewController: ViewController {
                 })
                 .disposed(by: disposeBag)
 
-            textValue.asObservable()
-                .subscribe(onNext: { [weak self] x in
-                    self?.debug("UITextField text \(x)")
-                })
-                .disposed(by: disposeBag)
-
             let attributedTextValue = BehaviorRelay<NSAttributedString?>(value: NSAttributedString(string: ""))
             _ = textField2.rx.attributedText <-> attributedTextValue
 


### PR DESCRIPTION
In the example "APIWrappers", text value from text field as an observable is subscribed twice
```
textValue.asObservable()
    .subscribe(onNext: { [weak self] x in
        self?.debug("UITextField text \(x)")
    })
    .disposed(by: disposeBag)

textValue.asObservable()
    .subscribe(onNext: { [weak self] x in
        self?.debug("UITextField text \(x)")
    })
    .disposed(by: disposeBag)

```
resulting in not only two pieces of identical code, but also two lines of log fired on text change. Can't see any point in written twice, thus request to remove one of them.