### PR TITLE
Compile Static Frameworks Using Carthage

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -1064,6 +1064,471 @@
 		EF6A58C2219CB7BF00376078 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA1A1DAABBE20079D23B /* Subscription.swift */; };
 		EF6A58C3219CB7BF00376078 /* Any+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA101DAABBE20079D23B /* Any+Equatable.swift */; };
 		EF6A58C4219CB7BF00376078 /* TestSchedulerVirtualTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA191DAABBE20079D23B /* TestSchedulerVirtualTimeConverter.swift */; };
+		EF6A58DD219CBA6500376078 /* Observable+ConcatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9951EB4FF7000D431BC /* Observable+ConcatTests.swift */; };
+		EF6A58DE219CBA6500376078 /* UIScrollView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033C2EF41D081B2A0050C015 /* UIScrollView+RxTests.swift */; };
+		EF6A58DF219CBA6500376078 /* Observable+DelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA111EB5145200D431BC /* Observable+DelayTests.swift */; };
+		EF6A58E0219CBA6500376078 /* Observable+TakeUntilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A11EB5011700D431BC /* Observable+TakeUntilTests.swift */; };
+		EF6A58E1219CBA6500376078 /* Observable+ShareReplayScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8845AD91EDB607800B36836 /* Observable+ShareReplayScopeTests.swift */; };
+		EF6A58E2219CBA6500376078 /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509181C38706D0027C24C /* ObserverTests.swift */; };
+		EF6A58E3219CBA6500376078 /* PrimitiveMockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FD1C38706D0027C24C /* PrimitiveMockObserver.swift */; };
+		EF6A58E4219CBA6500376078 /* SharedSequence+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970E11F532FD20058F2FE /* SharedSequence+Extensions.swift */; };
+		EF6A58E5219CBA6500376078 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F03F4E1DBBAE9400AECC4C /* DispatchQueue+Extensions.swift */; };
+		EF6A58E6219CBA6500376078 /* Observable+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509021C38706D0027C24C /* Observable+Tests.swift */; };
+		EF6A58E7219CBA6500376078 /* UITableView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C217D41CB7100E0038A2E6 /* UITableView+RxTests.swift */; };
+		EF6A58E8219CBA6500376078 /* UIControl+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8802DD31F8CD47F001D677E /* UIControl+RxTests.swift */; };
+		EF6A58E9219CBA6500376078 /* ControlEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DD1C38706D0027C24C /* ControlEventTests.swift */; };
+		EF6A58EA219CBA6500376078 /* UIPickerView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844BC8B71CE5023200F5C7CB /* UIPickerView+RxTests.swift */; };
+		EF6A58EB219CBA6500376078 /* SingleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE351F6EAD3C008DB060 /* SingleTest.swift */; };
+		EF6A58EC219CBA6500376078 /* Observable+CombineLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C896A68A1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift */; };
+		EF6A58ED219CBA6500376078 /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
+		EF6A58EE219CBA6500376078 /* Observable+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A91EB505A800D431BC /* Observable+WithLatestFromTests.swift */; };
+		EF6A58EF219CBA6500376078 /* SharedSequence+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DD1F532FD10058F2FE /* SharedSequence+Test.swift */; };
+		EF6A58F0219CBA6500376078 /* Observable+ReduceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A94D1EB4EC3C00D431BC /* Observable+ReduceTests.swift */; };
+		EF6A58F1219CBA6500376078 /* Observable+RangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9791EB4FA0800D431BC /* Observable+RangeTests.swift */; };
+		EF6A58F2219CBA6500376078 /* RxTest+Controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B290841C94D55600E923D0 /* RxTest+Controls.swift */; };
+		EF6A58F3219CBA6500376078 /* UILabel+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1601DE9CD1600003FA7 /* UILabel+RxTests.swift */; };
+		EF6A58F4219CBA6500376078 /* Observable+GenerateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9751EB4F92100D431BC /* Observable+GenerateTests.swift */; };
+		EF6A58F5219CBA6500376078 /* MessageProcessingStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CDB1DA19BA000BE3F5C /* MessageProcessingStage.swift */; };
+		EF6A58F6219CBA6500376078 /* Observable+WindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA091EB513C800D431BC /* Observable+WindowTests.swift */; };
+		EF6A58F7219CBA6500376078 /* MaybeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE391F6EAD48008DB060 /* MaybeTest.swift */; };
+		EF6A58F8219CBA6500376078 /* UIAlertAction+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F16A1DE9D4C100003FA7 /* UIAlertAction+RxTests.swift */; };
+		EF6A58F9219CBA6500376078 /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
+		EF6A58FA219CBA6500376078 /* Observable+ZipTests+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509111C38706D0027C24C /* Observable+ZipTests+arity.swift */; };
+		EF6A58FB219CBA6500376078 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509191C38706D0027C24C /* QueueTests.swift */; };
+		EF6A58FC219CBA6500376078 /* PerformanceTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E8BA701E2C18AE00A4AC2C /* PerformanceTools.swift */; };
+		EF6A58FD219CBA6500376078 /* UIPageControl+RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914FCD661CCDB82E0058B304 /* UIPageControl+RxTest.swift */; };
+		EF6A58FE219CBA6500376078 /* UIGestureRecognizer+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1641DE9D3FB00003FA7 /* UIGestureRecognizer+RxTests.swift */; };
+		EF6A58FF219CBA6500376078 /* KVOObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E41C38706D0027C24C /* KVOObservableTests.swift */; };
+		EF6A5900219CBA6500376078 /* UISearchBar+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B2908C1C94D6C500E923D0 /* UISearchBar+RxTests.swift */; };
+		EF6A5901219CBA6500376078 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85218001E33FC160015DD38 /* RecursiveLock.swift */; };
+		EF6A5902219CBA6500376078 /* Event+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C822BAC51DB4048F00F98810 /* Event+Test.swift */; };
+		EF6A5903219CBA6500376078 /* MainThreadPrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F81C38706D0027C24C /* MainThreadPrimitiveHotObservable.swift */; };
+		EF6A5904219CBA6500376078 /* Observable+PrimitiveSequenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE491F6EBB84008DB060 /* Observable+PrimitiveSequenceTest.swift */; };
+		EF6A5905219CBA6500376078 /* Observable+CatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9891EB4FBD600D431BC /* Observable+CatchTests.swift */; };
+		EF6A5906219CBA6500376078 /* RuntimeStateSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E91C38706D0027C24C /* RuntimeStateSnapshot.swift */; };
+		EF6A5907219CBA6500376078 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8561B651DFE1169005E97F1 /* ExampleTests.swift */; };
+		EF6A5908219CBA6500376078 /* SchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86B1E211D42BF5200130546 /* SchedulerTests.swift */; };
+		EF6A5909219CBA6500376078 /* Observable+DistinctUntilChangedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D51EB50C5C00D431BC /* Observable+DistinctUntilChangedTests.swift */; };
+		EF6A590A219CBA6500376078 /* Observable+DematerializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9FD1EB5110E00D431BC /* Observable+DematerializeTests.swift */; };
+		EF6A590B219CBA6500376078 /* UIStepper+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1701DE9D68000003FA7 /* UIStepper+RxTests.swift */; };
+		EF6A590C219CBA6500376078 /* Observable+GroupByTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D11EB50B0900D431BC /* Observable+GroupByTests.swift */; };
+		EF6A590D219CBA6500376078 /* MySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FA1C38706D0027C24C /* MySubject.swift */; };
+		EF6A590E219CBA6500376078 /* Observable+SubscriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509161C38706D0027C24C /* Observable+SubscriptionTest.swift */; };
+		EF6A590F219CBA6500376078 /* UICollectionView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C217D61CB710200038A2E6 /* UICollectionView+RxTests.swift */; };
+		EF6A5910219CBA6500376078 /* Observable.Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FB1C38706D0027C24C /* Observable.Extensions.swift */; };
+		EF6A5911219CBA6500376078 /* RXObjCRuntime+Testing.m in Sources */ = {isa = PBXBuildFile; fileRef = C83508EB1C38706D0027C24C /* RXObjCRuntime+Testing.m */; };
+		EF6A5912219CBA6500376078 /* VariableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091B1C38706D0027C24C /* VariableTest.swift */; };
+		EF6A5913219CBA6500376078 /* PrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FC1C38706D0027C24C /* PrimitiveHotObservable.swift */; };
+		EF6A5914219CBA6500376078 /* Observable+DebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9851EB4FB5B00D431BC /* Observable+DebugTests.swift */; };
+		EF6A5915219CBA6500376078 /* Observable+DelaySubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA011EB5134000D431BC /* Observable+DelaySubscriptionTests.swift */; };
+		EF6A5916219CBA6500376078 /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB01B8A72BE0088E94D /* RxMutableBox.swift */; };
+		EF6A5917219CBA6500376078 /* Observable+SingleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9CD1EB50AD400D431BC /* Observable+SingleTests.swift */; };
+		EF6A5918219CBA6500376078 /* UITextField+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F27DAC1CE6710900D5FB4F /* UITextField+RxTests.swift */; };
+		EF6A5919219CBA6500376078 /* DelegateProxyTest+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E01C38706D0027C24C /* DelegateProxyTest+UIKit.swift */; };
+		EF6A591A219CBA6500376078 /* TestConnectableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FE1C38706D0027C24C /* TestConnectableObservable.swift */; };
+		EF6A591B219CBA6500376078 /* XCTest+AllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE21DA19BC500BE3F5C /* XCTest+AllTests.swift */; };
+		EF6A591C219CBA6500376078 /* SharingSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B0F70C1F530A1700548EBE /* SharingSchedulerTests.swift */; };
+		EF6A591D219CBA6500376078 /* UINavigationController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */; };
+		EF6A591E219CBA6500376078 /* Recorded+Timeless.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE01DA19BC500BE3F5C /* Recorded+Timeless.swift */; };
+		EF6A591F219CBA6500376078 /* NotificationCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E61C38706D0027C24C /* NotificationCenterTests.swift */; };
+		EF6A5920219CBA6500376078 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81B6AA91DB2C15C0047CF86 /* Platform.Linux.swift */; };
+		EF6A5921219CBA6500376078 /* Observable+SampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E11EB50D6C00D431BC /* Observable+SampleTests.swift */; };
+		EF6A5922219CBA6500376078 /* UIActivityIndicatorView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1681DE9D48F00003FA7 /* UIActivityIndicatorView+RxTests.swift */; };
+		EF6A5923219CBA6500376078 /* RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA0B1DAAB4670079D23B /* RxTest.swift */; };
+		EF6A5924219CBA6500376078 /* CurrentThreadSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509061C38706D0027C24C /* CurrentThreadSchedulerTest.swift */; };
+		EF6A5925219CBA6500376078 /* Observable+RepeatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A97D1EB4FA5A00D431BC /* Observable+RepeatTests.swift */; };
+		EF6A5926219CBA6500376078 /* Observable+AmbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9491EB4E75E00D431BC /* Observable+AmbTests.swift */; };
+		EF6A5927219CBA6500376078 /* PublishSubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA11CED420A00C310FA /* PublishSubjectTest.swift */; };
+		EF6A5928219CBA6500376078 /* Observable+SkipWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C51EB50A4200D431BC /* Observable+SkipWhileTests.swift */; };
+		EF6A5929219CBA6500376078 /* UIView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F11C38706D0027C24C /* UIView+RxTests.swift */; };
+		EF6A592A219CBA6500376078 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
+		EF6A592B219CBA6500376078 /* BackgroundThreadPrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F71C38706D0027C24C /* BackgroundThreadPrimitiveHotObservable.swift */; };
+		EF6A592C219CBA6500376078 /* UIButton+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8379EF31D1DD326003EF8FC /* UIButton+RxTests.swift */; };
+		EF6A592D219CBA6500376078 /* Observable+MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B51EB5081400D431BC /* Observable+MapTests.swift */; };
+		EF6A592E219CBA6500376078 /* UISlider+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F16E1DE9D5E000003FA7 /* UISlider+RxTests.swift */; };
+		EF6A592F219CBA6500376078 /* Observable+UsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9811EB4FB0400D431BC /* Observable+UsingTests.swift */; };
+		EF6A5930219CBA6500376078 /* Observable+DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9F11EB5109300D431BC /* Observable+DefaultIfEmpty.swift */; };
+		EF6A5931219CBA6500376078 /* Observable+TimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA0D1EB5140100D431BC /* Observable+TimeoutTests.swift */; };
+		EF6A5932219CBA6500376078 /* Anomalies.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F03F401DBB98DB00AECC4C /* Anomalies.swift */; };
+		EF6A5933219CBA6500376078 /* Observable+MulticastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9551EB4ED7C00D431BC /* Observable+MulticastTests.swift */; };
+		EF6A5934219CBA6500376078 /* Observable+TimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E51EB50DB900D431BC /* Observable+TimerTests.swift */; };
+		EF6A5935219CBA6500376078 /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE11DA19BC500BE3F5C /* TestErrors.swift */; };
+		EF6A5936219CBA6500376078 /* Observable+ToArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9511EB4ECC000D431BC /* Observable+ToArrayTests.swift */; };
+		EF6A5937219CBA6500376078 /* CompletableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */; };
+		EF6A5938219CBA6500376078 /* Observable+CombineLatestTests+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835090F1C38706D0027C24C /* Observable+CombineLatestTests+arity.swift */; };
+		EF6A5939219CBA6500376078 /* Completable+AndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A53AE41F09292A00490535 /* Completable+AndThen.swift */; };
+		EF6A593A219CBA6500376078 /* Observable+MergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9991EB5001C00D431BC /* Observable+MergeTests.swift */; };
+		EF6A593B219CBA6500376078 /* VirtualSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091C1C38706D0027C24C /* VirtualSchedulerTest.swift */; };
+		EF6A593C219CBA6500376078 /* UIBarButtonItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F15C1DE9CAEE00003FA7 /* UIBarButtonItem+RxTests.swift */; };
+		EF6A593D219CBA6500376078 /* NSLayoutConstraint+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E51C38706D0027C24C /* NSLayoutConstraint+RxTests.swift */; };
+		EF6A593E219CBA6500376078 /* PrimitiveSequenceTest+zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C898147D1E75AD380035949C /* PrimitiveSequenceTest+zip+arity.swift */; };
+		EF6A593F219CBA6500376078 /* UIProgressView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1621DE9D0A800003FA7 /* UIProgressView+RxTests.swift */; };
+		EF6A5940219CBA6500376078 /* Binder+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A81CA51E05EAF70008DEF4 /* Binder+Tests.swift */; };
+		EF6A5941219CBA6500376078 /* UIWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */; };
+		EF6A5942219CBA6500376078 /* Observable+TakeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B91EB5097700D431BC /* Observable+TakeTests.swift */; };
+		EF6A5943219CBA6500376078 /* AssumptionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509031C38706D0027C24C /* AssumptionsTest.swift */; };
+		EF6A5944219CBA6500376078 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		EF6A5945219CBA6500376078 /* SharedSequence+OperatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970E21F532FD30058F2FE /* SharedSequence+OperatorTest.swift */; };
+		EF6A5946219CBA6500376078 /* Observable+BlockingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C834F6C11DB394E100C29244 /* Observable+BlockingTest.swift */; };
+		EF6A5947219CBA6500376078 /* RecursiveLockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BAA78C1E34F8D400EEC727 /* RecursiveLockTest.swift */; };
+		EF6A5948219CBA6500376078 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
+		EF6A5949219CBA6500376078 /* ElementIndexPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F41C38706D0027C24C /* ElementIndexPair.swift */; };
+		EF6A594A219CBA6500376078 /* Observable+ElementAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C91EB50A7100D431BC /* Observable+ElementAtTests.swift */; };
+		EF6A594B219CBA6500376078 /* NSObject+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E71C38706D0027C24C /* NSObject+RxTests.swift */; };
+		EF6A594C219CBA6500376078 /* Observable+BufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA051EB5139C00D431BC /* Observable+BufferTests.swift */; };
+		EF6A594D219CBA6500376078 /* Observable+SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A96D1EB4F7AC00D431BC /* Observable+SequenceTests.swift */; };
+		EF6A594E219CBA6500376078 /* Observable+BindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A9B6F31DAD752200C9B027 /* Observable+BindTests.swift */; };
+		EF6A594F219CBA6500376078 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
+		EF6A5950219CBA6500376078 /* SubjectConcurrencyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091A1C38706D0027C24C /* SubjectConcurrencyTest.swift */; };
+		EF6A5951219CBA6500376078 /* ObservableType+SubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82FF0EE1F93DD2E00BDB34D /* ObservableType+SubscriptionTests.swift */; };
+		EF6A5952219CBA6500376078 /* Observable+OptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9711EB4F84000D431BC /* Observable+OptionalTests.swift */; };
+		EF6A5953219CBA6500376078 /* UISearchController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E4D3951C9B011000ADFDC9 /* UISearchController+RxTests.swift */; };
+		EF6A5954219CBA6500376078 /* UISwitch+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F15E1DE9CC5B00003FA7 /* UISwitch+RxTests.swift */; };
+		EF6A5955219CBA6500376078 /* UITabBarController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */; };
+		EF6A5956219CBA6500376078 /* Observable+SkipUntilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A51EB5056C00D431BC /* Observable+SkipUntilTests.swift */; };
+		EF6A5957219CBA6500376078 /* UITabBar+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88718D001CE5DE2500D88D60 /* UITabBar+RxTests.swift */; };
+		EF6A5958219CBA6500376078 /* SectionedViewDataSourceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970E01F532FD20058F2FE /* SectionedViewDataSourceMock.swift */; };
+		EF6A5959219CBA6500376078 /* Reactive+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C822BACD1DB424EC00F98810 /* Reactive+Tests.swift */; };
+		EF6A595A219CBA6500376078 /* Observable+TakeLastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9BD1EB509B500D431BC /* Observable+TakeLastTests.swift */; };
+		EF6A595B219CBA6500376078 /* AtomicInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8165AD421891DBE00494BEF /* AtomicInt.swift */; };
+		EF6A595C219CBA6500376078 /* Observable+FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9AD1EB5073E00D431BC /* Observable+FilterTests.swift */; };
+		EF6A595D219CBA6500376078 /* HistoricalSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509081C38706D0027C24C /* HistoricalSchedulerTest.swift */; };
+		EF6A595E219CBA6500376078 /* MainSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509091C38706D0027C24C /* MainSchedulerTests.swift */; };
+		EF6A595F219CBA6500376078 /* BagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509041C38706D0027C24C /* BagTest.swift */; };
+		EF6A5960219CBA6500376078 /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
+		EF6A5961219CBA6500376078 /* Observable+SkipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C11EB509FC00D431BC /* Observable+SkipTests.swift */; };
+		EF6A5962219CBA6500376078 /* Observable+ThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9DD1EB50CF800D431BC /* Observable+ThrottleTests.swift */; };
+		EF6A5963219CBA6500376078 /* Observable+SwitchIfEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9911EB4FD1400D431BC /* Observable+SwitchIfEmptyTests.swift */; };
+		EF6A5964219CBA6500376078 /* SentMessageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F01C38706D0027C24C /* SentMessageTest.swift */; };
+		EF6A5965219CBA6500376078 /* EquatableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F51C38706D0027C24C /* EquatableArray.swift */; };
+		EF6A5966219CBA6500376078 /* Observable+ObserveOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9611EB4EFD300D431BC /* Observable+ObserveOnTests.swift */; };
+		EF6A5967219CBA6500376078 /* Observable+DoOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D91EB50CAA00D431BC /* Observable+DoOnTests.swift */; };
+		EF6A5968219CBA6500376078 /* ControlPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DE1C38706D0027C24C /* ControlPropertyTests.swift */; };
+		EF6A5969219CBA6500376078 /* RxObjCRuntimeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508EC1C38706D0027C24C /* RxObjCRuntimeState.swift */; };
+		EF6A596A219CBA6500376078 /* Observable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FF1C38706D0027C24C /* Observable+Extensions.swift */; };
+		EF6A596B219CBA6500376078 /* UIRefreshControl+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F600F421C5D0D2D00535B1D /* UIRefreshControl+RxTests.swift */; };
+		EF6A596C219CBA6500376078 /* TestVirtualScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509001C38706D0027C24C /* TestVirtualScheduler.swift */; };
+		EF6A596D219CBA6500376078 /* DisposableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509071C38706D0027C24C /* DisposableTest.swift */; };
+		EF6A596E219CBA6500376078 /* BehaviorSubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509051C38706D0027C24C /* BehaviorSubjectTest.swift */; };
+		EF6A596F219CBA6500376078 /* UISegmentedControl+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1661DE9D44600003FA7 /* UISegmentedControl+RxTests.swift */; };
+		EF6A5970219CBA6500376078 /* Observable+SubscribeOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9651EB4F39500D431BC /* Observable+SubscribeOnTests.swift */; };
+		EF6A5971219CBA6500376078 /* Observable+ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9ED1EB50EA100D431BC /* Observable+ScanTests.swift */; };
+		EF6A5972219CBA6500376078 /* Driver+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DE1F532FD20058F2FE /* Driver+Test.swift */; };
+		EF6A5973219CBA6500376078 /* Observable+JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9691EB4F64800D431BC /* Observable+JustTests.swift */; };
+		EF6A5974219CBA6500376078 /* Observable+SwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A98D1EB4FCC400D431BC /* Observable+SwitchTests.swift */; };
+		EF6A5975219CBA6500376078 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81B6AA81DB2C15C0047CF86 /* Platform.Darwin.swift */; };
+		EF6A5976219CBA6500376078 /* Observable+ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81A097C1E6C27A100900B3B /* Observable+ZipTests.swift */; };
+		EF6A5977219CBA6500376078 /* DelegateProxyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E11C38706D0027C24C /* DelegateProxyTest.swift */; };
+		EF6A5978219CBA6500376078 /* ObservableConvertibleType+SharedSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8091C521FAA3588001DB32A /* ObservableConvertibleType+SharedSequence.swift */; };
+		EF6A5979219CBA6500376078 /* AsyncSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA9496B1E224B9C0036DD06 /* AsyncSubjectTests.swift */; };
+		EF6A597A219CBA6500376078 /* UITextView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F27DB11CE6711600D5FB4F /* UITextView+RxTests.swift */; };
+		EF6A597B219CBA6500376078 /* Observable+TakeWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B11EB507D300D431BC /* Observable+TakeWhileTests.swift */; };
+		EF6A597C219CBA6500376078 /* Observable+MaterializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9F91EB510D500D431BC /* Observable+MaterializeTests.swift */; };
+		EF6A597D219CBA6500376078 /* Observable+RetryWhenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E91EB50E3400D431BC /* Observable+RetryWhenTests.swift */; };
+		EF6A597E219CBA6500376078 /* MockDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F91C38706D0027C24C /* MockDisposable.swift */; };
+		EF6A597F219CBA6500376078 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8323A8D1E33FD5200CC0C7F /* Resources.swift */; };
+		EF6A5980219CBA6500376078 /* UIDatePicker+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F16C1DE9D4F400003FA7 /* UIDatePicker+RxTests.swift */; };
+		EF6A5981219CBA6500376078 /* Signal+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DC1F532FD10058F2FE /* Signal+Test.swift */; };
+		EF6A5993219CBA9400376078 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EF6A5810219CB6D200376078 /* RxSwift.framework */; };
+		EF6A599E219CBF5200376078 /* Observable+CombineLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C896A68A1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift */; };
+		EF6A599F219CBF5200376078 /* AssumptionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509031C38706D0027C24C /* AssumptionsTest.swift */; };
+		EF6A59A0219CBF5200376078 /* MySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FA1C38706D0027C24C /* MySubject.swift */; };
+		EF6A59A1219CBF5200376078 /* NSObject+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E71C38706D0027C24C /* NSObject+RxTests.swift */; };
+		EF6A59A2219CBF5200376078 /* Observable+DebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9851EB4FB5B00D431BC /* Observable+DebugTests.swift */; };
+		EF6A59A3219CBF5200376078 /* UITableView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C217D41CB7100E0038A2E6 /* UITableView+RxTests.swift */; };
+		EF6A59A4219CBF5200376078 /* Observable+DematerializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9FD1EB5110E00D431BC /* Observable+DematerializeTests.swift */; };
+		EF6A59A5219CBF5200376078 /* Observable.Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FB1C38706D0027C24C /* Observable.Extensions.swift */; };
+		EF6A59A6219CBF5200376078 /* ControlPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DE1C38706D0027C24C /* ControlPropertyTests.swift */; };
+		EF6A59A7219CBF5200376078 /* TestVirtualScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509001C38706D0027C24C /* TestVirtualScheduler.swift */; };
+		EF6A59A8219CBF5200376078 /* Observable+ReduceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A94D1EB4EC3C00D431BC /* Observable+ReduceTests.swift */; };
+		EF6A59A9219CBF5200376078 /* RxTest+Controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B290841C94D55600E923D0 /* RxTest+Controls.swift */; };
+		EF6A59AA219CBF5200376078 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
+		EF6A59AB219CBF5200376078 /* Observable+SubscribeOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9651EB4F39500D431BC /* Observable+SubscribeOnTests.swift */; };
+		EF6A59AC219CBF5200376078 /* VariableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091B1C38706D0027C24C /* VariableTest.swift */; };
+		EF6A59AD219CBF5200376078 /* Observable+SkipWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C51EB50A4200D431BC /* Observable+SkipWhileTests.swift */; };
+		EF6A59AE219CBF5200376078 /* RecursiveLockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BAA78C1E34F8D400EEC727 /* RecursiveLockTest.swift */; };
+		EF6A59AF219CBF5200376078 /* PrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FC1C38706D0027C24C /* PrimitiveHotObservable.swift */; };
+		EF6A59B0219CBF5200376078 /* UIGestureRecognizer+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1641DE9D3FB00003FA7 /* UIGestureRecognizer+RxTests.swift */; };
+		EF6A59B1219CBF5200376078 /* UIScrollView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033C2EF41D081B2A0050C015 /* UIScrollView+RxTests.swift */; };
+		EF6A59B2219CBF5200376078 /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
+		EF6A59B3219CBF5200376078 /* SharedSequence+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DD1F532FD10058F2FE /* SharedSequence+Test.swift */; };
+		EF6A59B4219CBF5200376078 /* VirtualSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091C1C38706D0027C24C /* VirtualSchedulerTest.swift */; };
+		EF6A59B5219CBF5200376078 /* Observable+TimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E51EB50DB900D431BC /* Observable+TimerTests.swift */; };
+		EF6A59B6219CBF5200376078 /* Observable+RepeatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A97D1EB4FA5A00D431BC /* Observable+RepeatTests.swift */; };
+		EF6A59B7219CBF5200376078 /* UIActivityIndicatorView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1681DE9D48F00003FA7 /* UIActivityIndicatorView+RxTests.swift */; };
+		EF6A59B8219CBF5200376078 /* DelegateProxyTest+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E01C38706D0027C24C /* DelegateProxyTest+UIKit.swift */; };
+		EF6A59B9219CBF5200376078 /* SharedSequence+OperatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970E21F532FD30058F2FE /* SharedSequence+OperatorTest.swift */; };
+		EF6A59BA219CBF5200376078 /* Observable+AmbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9491EB4E75E00D431BC /* Observable+AmbTests.swift */; };
+		EF6A59BB219CBF5200376078 /* Observable+BlockingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C834F6C11DB394E100C29244 /* Observable+BlockingTest.swift */; };
+		EF6A59BC219CBF5200376078 /* RxObjCRuntimeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508EC1C38706D0027C24C /* RxObjCRuntimeState.swift */; };
+		EF6A59BD219CBF5200376078 /* Reactive+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C822BACD1DB424EC00F98810 /* Reactive+Tests.swift */; };
+		EF6A59BE219CBF5200376078 /* UILabel+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1601DE9CD1600003FA7 /* UILabel+RxTests.swift */; };
+		EF6A59BF219CBF5200376078 /* DelegateProxyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E11C38706D0027C24C /* DelegateProxyTest.swift */; };
+		EF6A59C0219CBF5200376078 /* Observable+DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9F11EB5109300D431BC /* Observable+DefaultIfEmpty.swift */; };
+		EF6A59C1219CBF5200376078 /* SingleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE351F6EAD3C008DB060 /* SingleTest.swift */; };
+		EF6A59C2219CBF5200376078 /* Observable+SubscriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509161C38706D0027C24C /* Observable+SubscriptionTest.swift */; };
+		EF6A59C3219CBF5200376078 /* Observable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FF1C38706D0027C24C /* Observable+Extensions.swift */; };
+		EF6A59C4219CBF5200376078 /* UIProgressView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1621DE9D0A800003FA7 /* UIProgressView+RxTests.swift */; };
+		EF6A59C5219CBF5200376078 /* PerformanceTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E8BA701E2C18AE00A4AC2C /* PerformanceTools.swift */; };
+		EF6A59C6219CBF5200376078 /* UIDatePicker+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F16C1DE9D4F400003FA7 /* UIDatePicker+RxTests.swift */; };
+		EF6A59C7219CBF5200376078 /* NSLayoutConstraint+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E51C38706D0027C24C /* NSLayoutConstraint+RxTests.swift */; };
+		EF6A59C8219CBF5200376078 /* Observable+OptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9711EB4F84000D431BC /* Observable+OptionalTests.swift */; };
+		EF6A59C9219CBF5200376078 /* Observable+SwitchIfEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9911EB4FD1400D431BC /* Observable+SwitchIfEmptyTests.swift */; };
+		EF6A59CA219CBF5200376078 /* UITabBar+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88718D001CE5DE2500D88D60 /* UITabBar+RxTests.swift */; };
+		EF6A59CB219CBF5200376078 /* ControlEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DD1C38706D0027C24C /* ControlEventTests.swift */; };
+		EF6A59CC219CBF5200376078 /* MockDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F91C38706D0027C24C /* MockDisposable.swift */; };
+		EF6A59CD219CBF5200376078 /* Observable+GroupByTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D11EB50B0900D431BC /* Observable+GroupByTests.swift */; };
+		EF6A59CE219CBF5200376078 /* Observable+DelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA111EB5145200D431BC /* Observable+DelayTests.swift */; };
+		EF6A59CF219CBF5200376078 /* Observable+WindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA091EB513C800D431BC /* Observable+WindowTests.swift */; };
+		EF6A59D0219CBF5200376078 /* PublishSubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA11CED420A00C310FA /* PublishSubjectTest.swift */; };
+		EF6A59D1219CBF5200376078 /* Observable+ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9ED1EB50EA100D431BC /* Observable+ScanTests.swift */; };
+		EF6A59D2219CBF5200376078 /* MessageProcessingStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CDB1DA19BA000BE3F5C /* MessageProcessingStage.swift */; };
+		EF6A59D3219CBF5200376078 /* Observable+UsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9811EB4FB0400D431BC /* Observable+UsingTests.swift */; };
+		EF6A59D4219CBF5200376078 /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB01B8A72BE0088E94D /* RxMutableBox.swift */; };
+		EF6A59D5219CBF5200376078 /* Observable+MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B51EB5081400D431BC /* Observable+MapTests.swift */; };
+		EF6A59D6219CBF5200376078 /* UINavigationController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD71EA06189002B433B /* UINavigationController+RxTests.swift */; };
+		EF6A59D7219CBF5200376078 /* UIBarButtonItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F15C1DE9CAEE00003FA7 /* UIBarButtonItem+RxTests.swift */; };
+		EF6A59D8219CBF5200376078 /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509181C38706D0027C24C /* ObserverTests.swift */; };
+		EF6A59D9219CBF5200376078 /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
+		EF6A59DA219CBF5200376078 /* ObservableType+SubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82FF0EE1F93DD2E00BDB34D /* ObservableType+SubscriptionTests.swift */; };
+		EF6A59DB219CBF5200376078 /* Observable+ToArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9511EB4ECC000D431BC /* Observable+ToArrayTests.swift */; };
+		EF6A59DC219CBF5200376078 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81B6AA81DB2C15C0047CF86 /* Platform.Darwin.swift */; };
+		EF6A59DD219CBF5200376078 /* MaybeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE391F6EAD48008DB060 /* MaybeTest.swift */; };
+		EF6A59DE219CBF5200376078 /* Observable+CatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9891EB4FBD600D431BC /* Observable+CatchTests.swift */; };
+		EF6A59DF219CBF5200376078 /* TestConnectableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FE1C38706D0027C24C /* TestConnectableObservable.swift */; };
+		EF6A59E0219CBF5200376078 /* BehaviorSubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509051C38706D0027C24C /* BehaviorSubjectTest.swift */; };
+		EF6A59E1219CBF5200376078 /* Observable+RangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9791EB4FA0800D431BC /* Observable+RangeTests.swift */; };
+		EF6A59E2219CBF5200376078 /* UITabBarController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */; };
+		EF6A59E3219CBF5200376078 /* XCTest+AllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE21DA19BC500BE3F5C /* XCTest+AllTests.swift */; };
+		EF6A59E4219CBF5200376078 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85218001E33FC160015DD38 /* RecursiveLock.swift */; };
+		EF6A59E5219CBF5200376078 /* Signal+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DC1F532FD10058F2FE /* Signal+Test.swift */; };
+		EF6A59E6219CBF5200376078 /* Observable+GenerateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9751EB4F92100D431BC /* Observable+GenerateTests.swift */; };
+		EF6A59E7219CBF5200376078 /* MainThreadPrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F81C38706D0027C24C /* MainThreadPrimitiveHotObservable.swift */; };
+		EF6A59E8219CBF5200376078 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F03F4E1DBBAE9400AECC4C /* DispatchQueue+Extensions.swift */; };
+		EF6A59E9219CBF5200376078 /* Observable+TakeLastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9BD1EB509B500D431BC /* Observable+TakeLastTests.swift */; };
+		EF6A59EA219CBF5200376078 /* Observable+ElementAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C91EB50A7100D431BC /* Observable+ElementAtTests.swift */; };
+		EF6A59EB219CBF5200376078 /* Event+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C822BAC51DB4048F00F98810 /* Event+Test.swift */; };
+		EF6A59EC219CBF5200376078 /* Completable+AndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A53AE41F09292A00490535 /* Completable+AndThen.swift */; };
+		EF6A59ED219CBF5200376078 /* Observable+MergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9991EB5001C00D431BC /* Observable+MergeTests.swift */; };
+		EF6A59EE219CBF5200376078 /* SharedSequence+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970E11F532FD20058F2FE /* SharedSequence+Extensions.swift */; };
+		EF6A59EF219CBF5200376078 /* Recorded+Timeless.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE01DA19BC500BE3F5C /* Recorded+Timeless.swift */; };
+		EF6A59F0219CBF5200376078 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509191C38706D0027C24C /* QueueTests.swift */; };
+		EF6A59F1219CBF5200376078 /* Observable+DoOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D91EB50CAA00D431BC /* Observable+DoOnTests.swift */; };
+		EF6A59F2219CBF5200376078 /* Observable+ConcatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9951EB4FF7000D431BC /* Observable+ConcatTests.swift */; };
+		EF6A59F3219CBF5200376078 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		EF6A59F4219CBF5200376078 /* CompletableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */; };
+		EF6A59F5219CBF5200376078 /* PrimitiveSequenceTest+zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C898147D1E75AD380035949C /* PrimitiveSequenceTest+zip+arity.swift */; };
+		EF6A59F6219CBF5200376078 /* RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA0B1DAAB4670079D23B /* RxTest.swift */; };
+		EF6A59F7219CBF5200376078 /* NotificationCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E61C38706D0027C24C /* NotificationCenterTests.swift */; };
+		EF6A59F8219CBF5200376078 /* Observable+SingleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9CD1EB50AD400D431BC /* Observable+SingleTests.swift */; };
+		EF6A59F9219CBF5200376078 /* Observable+DistinctUntilChangedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D51EB50C5C00D431BC /* Observable+DistinctUntilChangedTests.swift */; };
+		EF6A59FA219CBF5200376078 /* Observable+ObserveOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9611EB4EFD300D431BC /* Observable+ObserveOnTests.swift */; };
+		EF6A59FB219CBF5200376078 /* Observable+SwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A98D1EB4FCC400D431BC /* Observable+SwitchTests.swift */; };
+		EF6A59FC219CBF5200376078 /* UITextField+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F27DAC1CE6710900D5FB4F /* UITextField+RxTests.swift */; };
+		EF6A59FD219CBF5200376078 /* Observable+CombineLatestTests+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835090F1C38706D0027C24C /* Observable+CombineLatestTests+arity.swift */; };
+		EF6A59FE219CBF5200376078 /* UISearchController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E4D3951C9B011000ADFDC9 /* UISearchController+RxTests.swift */; };
+		EF6A59FF219CBF5200376078 /* SentMessageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F01C38706D0027C24C /* SentMessageTest.swift */; };
+		EF6A5A00219CBF5200376078 /* UISlider+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F16E1DE9D5E000003FA7 /* UISlider+RxTests.swift */; };
+		EF6A5A01219CBF5200376078 /* AsyncSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA9496B1E224B9C0036DD06 /* AsyncSubjectTests.swift */; };
+		EF6A5A02219CBF5200376078 /* CurrentThreadSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509061C38706D0027C24C /* CurrentThreadSchedulerTest.swift */; };
+		EF6A5A03219CBF5200376078 /* Observable+FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9AD1EB5073E00D431BC /* Observable+FilterTests.swift */; };
+		EF6A5A04219CBF5200376078 /* Observable+ThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9DD1EB50CF800D431BC /* Observable+ThrottleTests.swift */; };
+		EF6A5A05219CBF5200376078 /* PrimitiveMockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FD1C38706D0027C24C /* PrimitiveMockObserver.swift */; };
+		EF6A5A06219CBF5200376078 /* Observable+SkipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C11EB509FC00D431BC /* Observable+SkipTests.swift */; };
+		EF6A5A07219CBF5200376078 /* KVOObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E41C38706D0027C24C /* KVOObservableTests.swift */; };
+		EF6A5A08219CBF5200376078 /* Observable+BindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A9B6F31DAD752200C9B027 /* Observable+BindTests.swift */; };
+		EF6A5A09219CBF5200376078 /* MainSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509091C38706D0027C24C /* MainSchedulerTests.swift */; };
+		EF6A5A0A219CBF5200376078 /* UISwitch+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F15E1DE9CC5B00003FA7 /* UISwitch+RxTests.swift */; };
+		EF6A5A0B219CBF5200376078 /* Observable+DelaySubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA011EB5134000D431BC /* Observable+DelaySubscriptionTests.swift */; };
+		EF6A5A0C219CBF5200376078 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
+		EF6A5A0D219CBF5200376078 /* ObservableConvertibleType+SharedSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8091C521FAA3588001DB32A /* ObservableConvertibleType+SharedSequence.swift */; };
+		EF6A5A0E219CBF5200376078 /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
+		EF6A5A0F219CBF5200376078 /* UIPageControl+RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 914FCD661CCDB82E0058B304 /* UIPageControl+RxTest.swift */; };
+		EF6A5A10219CBF5200376078 /* Binder+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A81CA51E05EAF70008DEF4 /* Binder+Tests.swift */; };
+		EF6A5A11219CBF5200376078 /* EquatableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F51C38706D0027C24C /* EquatableArray.swift */; };
+		EF6A5A12219CBF5200376078 /* DisposableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509071C38706D0027C24C /* DisposableTest.swift */; };
+		EF6A5A13219CBF5200376078 /* UISearchBar+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B2908C1C94D6C500E923D0 /* UISearchBar+RxTests.swift */; };
+		EF6A5A14219CBF5200376078 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8323A8D1E33FD5200CC0C7F /* Resources.swift */; };
+		EF6A5A15219CBF5200376078 /* Anomalies.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F03F401DBB98DB00AECC4C /* Anomalies.swift */; };
+		EF6A5A16219CBF5200376078 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
+		EF6A5A17219CBF5200376078 /* Observable+SkipUntilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A51EB5056C00D431BC /* Observable+SkipUntilTests.swift */; };
+		EF6A5A18219CBF5200376078 /* ElementIndexPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F41C38706D0027C24C /* ElementIndexPair.swift */; };
+		EF6A5A19219CBF5200376078 /* SharingSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B0F70C1F530A1700548EBE /* SharingSchedulerTests.swift */; };
+		EF6A5A1A219CBF5200376078 /* Observable+ShareReplayScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8845AD91EDB607800B36836 /* Observable+ShareReplayScopeTests.swift */; };
+		EF6A5A1B219CBF5200376078 /* SubjectConcurrencyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091A1C38706D0027C24C /* SubjectConcurrencyTest.swift */; };
+		EF6A5A1C219CBF5200376078 /* BackgroundThreadPrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F71C38706D0027C24C /* BackgroundThreadPrimitiveHotObservable.swift */; };
+		EF6A5A1D219CBF5200376078 /* UIView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F11C38706D0027C24C /* UIView+RxTests.swift */; };
+		EF6A5A1E219CBF5200376078 /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE11DA19BC500BE3F5C /* TestErrors.swift */; };
+		EF6A5A1F219CBF5200376078 /* Observable+TakeWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B11EB507D300D431BC /* Observable+TakeWhileTests.swift */; };
+		EF6A5A20219CBF5200376078 /* Observable+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A91EB505A800D431BC /* Observable+WithLatestFromTests.swift */; };
+		EF6A5A21219CBF5200376078 /* Observable+MulticastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9551EB4ED7C00D431BC /* Observable+MulticastTests.swift */; };
+		EF6A5A22219CBF5200376078 /* HistoricalSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509081C38706D0027C24C /* HistoricalSchedulerTest.swift */; };
+		EF6A5A23219CBF5200376078 /* UIButton+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8379EF31D1DD326003EF8FC /* UIButton+RxTests.swift */; };
+		EF6A5A24219CBF5200376078 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81B6AA91DB2C15C0047CF86 /* Platform.Linux.swift */; };
+		EF6A5A25219CBF5200376078 /* Observable+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509021C38706D0027C24C /* Observable+Tests.swift */; };
+		EF6A5A26219CBF5200376078 /* Observable+SampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E11EB50D6C00D431BC /* Observable+SampleTests.swift */; };
+		EF6A5A27219CBF5200376078 /* Driver+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DE1F532FD20058F2FE /* Driver+Test.swift */; };
+		EF6A5A28219CBF5200376078 /* UIRefreshControl+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F600F421C5D0D2D00535B1D /* UIRefreshControl+RxTests.swift */; };
+		EF6A5A29219CBF5200376078 /* Observable+MaterializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9F91EB510D500D431BC /* Observable+MaterializeTests.swift */; };
+		EF6A5A2A219CBF5200376078 /* Observable+PrimitiveSequenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE491F6EBB84008DB060 /* Observable+PrimitiveSequenceTest.swift */; };
+		EF6A5A2B219CBF5200376078 /* Observable+TimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA0D1EB5140100D431BC /* Observable+TimeoutTests.swift */; };
+		EF6A5A2C219CBF5200376078 /* Observable+TakeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B91EB5097700D431BC /* Observable+TakeTests.swift */; };
+		EF6A5A2D219CBF5200376078 /* Observable+JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9691EB4F64800D431BC /* Observable+JustTests.swift */; };
+		EF6A5A2E219CBF5200376078 /* UIAlertAction+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F16A1DE9D4C100003FA7 /* UIAlertAction+RxTests.swift */; };
+		EF6A5A2F219CBF5200376078 /* RXObjCRuntime+Testing.m in Sources */ = {isa = PBXBuildFile; fileRef = C83508EB1C38706D0027C24C /* RXObjCRuntime+Testing.m */; };
+		EF6A5A30219CBF5200376078 /* Observable+ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81A097C1E6C27A100900B3B /* Observable+ZipTests.swift */; };
+		EF6A5A31219CBF5200376078 /* UICollectionView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C217D61CB710200038A2E6 /* UICollectionView+RxTests.swift */; };
+		EF6A5A32219CBF5200376078 /* Observable+SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A96D1EB4F7AC00D431BC /* Observable+SequenceTests.swift */; };
+		EF6A5A33219CBF5200376078 /* AtomicInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8165AD421891DBE00494BEF /* AtomicInt.swift */; };
+		EF6A5A34219CBF5200376078 /* Observable+TakeUntilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A11EB5011700D431BC /* Observable+TakeUntilTests.swift */; };
+		EF6A5A35219CBF5200376078 /* UISegmentedControl+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1661DE9D44600003FA7 /* UISegmentedControl+RxTests.swift */; };
+		EF6A5A36219CBF5200376078 /* Observable+RetryWhenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E91EB50E3400D431BC /* Observable+RetryWhenTests.swift */; };
+		EF6A5A37219CBF5200376078 /* RuntimeStateSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E91C38706D0027C24C /* RuntimeStateSnapshot.swift */; };
+		EF6A5A38219CBF5200376078 /* UIStepper+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1701DE9D68000003FA7 /* UIStepper+RxTests.swift */; };
+		EF6A5A39219CBF5200376078 /* BagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509041C38706D0027C24C /* BagTest.swift */; };
+		EF6A5A3A219CBF5200376078 /* UITextView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F27DB11CE6711600D5FB4F /* UITextView+RxTests.swift */; };
+		EF6A5A3B219CBF5200376078 /* SchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86B1E211D42BF5200130546 /* SchedulerTests.swift */; };
+		EF6A5A3C219CBF5200376078 /* Observable+BufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA051EB5139C00D431BC /* Observable+BufferTests.swift */; };
+		EF6A5A3D219CBF5200376078 /* SectionedViewDataSourceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970E01F532FD20058F2FE /* SectionedViewDataSourceMock.swift */; };
+		EF6A5A3E219CBF5200376078 /* Observable+ZipTests+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509111C38706D0027C24C /* Observable+ZipTests+arity.swift */; };
+		EF6A5A59219CC11900376078 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509191C38706D0027C24C /* QueueTests.swift */; };
+		EF6A5A5A219CC11900376078 /* Observable+ToArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9511EB4ECC000D431BC /* Observable+ToArrayTests.swift */; };
+		EF6A5A5B219CC11900376078 /* PublishSubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA11CED420A00C310FA /* PublishSubjectTest.swift */; };
+		EF6A5A5C219CC11900376078 /* Observable+GenerateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9751EB4F92100D431BC /* Observable+GenerateTests.swift */; };
+		EF6A5A5D219CC11900376078 /* AsyncSubjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA9496B1E224B9C0036DD06 /* AsyncSubjectTests.swift */; };
+		EF6A5A5E219CC11900376078 /* PrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FC1C38706D0027C24C /* PrimitiveHotObservable.swift */; };
+		EF6A5A5F219CC11900376078 /* NSObject+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E71C38706D0027C24C /* NSObject+RxTests.swift */; };
+		EF6A5A60219CC11900376078 /* Observable+DistinctUntilChangedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D51EB50C5C00D431BC /* Observable+DistinctUntilChangedTests.swift */; };
+		EF6A5A61219CC11900376078 /* Observable+MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B51EB5081400D431BC /* Observable+MapTests.swift */; };
+		EF6A5A62219CC11900376078 /* AssumptionsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509031C38706D0027C24C /* AssumptionsTest.swift */; };
+		EF6A5A63219CC11900376078 /* Observable+GroupByTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D11EB50B0900D431BC /* Observable+GroupByTests.swift */; };
+		EF6A5A64219CC11900376078 /* Observable+TimeoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA0D1EB5140100D431BC /* Observable+TimeoutTests.swift */; };
+		EF6A5A65219CC11900376078 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81B6AA81DB2C15C0047CF86 /* Platform.Darwin.swift */; };
+		EF6A5A66219CC11900376078 /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB01B8A72BE0088E94D /* RxMutableBox.swift */; };
+		EF6A5A67219CC11900376078 /* MainSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509091C38706D0027C24C /* MainSchedulerTests.swift */; };
+		EF6A5A68219CC11900376078 /* SharedSequence+OperatorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970E21F532FD30058F2FE /* SharedSequence+OperatorTest.swift */; };
+		EF6A5A69219CC11900376078 /* Observable+ScanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9ED1EB50EA100D431BC /* Observable+ScanTests.swift */; };
+		EF6A5A6A219CC11900376078 /* ControlEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DD1C38706D0027C24C /* ControlEventTests.swift */; };
+		EF6A5A6B219CC11900376078 /* KVOObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E41C38706D0027C24C /* KVOObservableTests.swift */; };
+		EF6A5A6C219CC11900376078 /* DelegateProxyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E11C38706D0027C24C /* DelegateProxyTest.swift */; };
+		EF6A5A6D219CC11900376078 /* Observable+CombineLatestTests+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835090F1C38706D0027C24C /* Observable+CombineLatestTests+arity.swift */; };
+		EF6A5A6E219CC11900376078 /* Event+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C822BAC51DB4048F00F98810 /* Event+Test.swift */; };
+		EF6A5A6F219CC11900376078 /* RecursiveLockTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BAA78C1E34F8D400EEC727 /* RecursiveLockTest.swift */; };
+		EF6A5A70219CC11900376078 /* Observable+MulticastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9551EB4ED7C00D431BC /* Observable+MulticastTests.swift */; };
+		EF6A5A71219CC11900376078 /* Reactive+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C822BACD1DB424EC00F98810 /* Reactive+Tests.swift */; };
+		EF6A5A72219CC11900376078 /* BackgroundThreadPrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F71C38706D0027C24C /* BackgroundThreadPrimitiveHotObservable.swift */; };
+		EF6A5A73219CC11900376078 /* ObservableConvertibleType+SharedSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8091C521FAA3588001DB32A /* ObservableConvertibleType+SharedSequence.swift */; };
+		EF6A5A74219CC11900376078 /* Observable+ZipTests+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509111C38706D0027C24C /* Observable+ZipTests+arity.swift */; };
+		EF6A5A75219CC11900376078 /* Observable+DematerializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9FD1EB5110E00D431BC /* Observable+DematerializeTests.swift */; };
+		EF6A5A76219CC11900376078 /* SharedSequence+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970E11F532FD20058F2FE /* SharedSequence+Extensions.swift */; };
+		EF6A5A77219CC11900376078 /* Observable+SwitchIfEmptyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9911EB4FD1400D431BC /* Observable+SwitchIfEmptyTests.swift */; };
+		EF6A5A78219CC11900376078 /* NSView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E81C38706D0027C24C /* NSView+RxTests.swift */; };
+		EF6A5A79219CC11900376078 /* Observable+ReduceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A94D1EB4EC3C00D431BC /* Observable+ReduceTests.swift */; };
+		EF6A5A7A219CC11900376078 /* Observable+UsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9811EB4FB0400D431BC /* Observable+UsingTests.swift */; };
+		EF6A5A7B219CC11900376078 /* Observable+DebugTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9851EB4FB5B00D431BC /* Observable+DebugTests.swift */; };
+		EF6A5A7C219CC11900376078 /* Observable+ThrottleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9DD1EB50CF800D431BC /* Observable+ThrottleTests.swift */; };
+		EF6A5A7D219CC11900376078 /* ObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509181C38706D0027C24C /* ObserverTests.swift */; };
+		EF6A5A7E219CC11900376078 /* Observable+SubscribeOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9651EB4F39500D431BC /* Observable+SubscribeOnTests.swift */; };
+		EF6A5A7F219CC11900376078 /* Observable+ConcatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9951EB4FF7000D431BC /* Observable+ConcatTests.swift */; };
+		EF6A5A80219CC11900376078 /* Observable+SwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A98D1EB4FCC400D431BC /* Observable+SwitchTests.swift */; };
+		EF6A5A81219CC11900376078 /* Observable+ShareReplayScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8845AD91EDB607800B36836 /* Observable+ShareReplayScopeTests.swift */; };
+		EF6A5A82219CC11900376078 /* NSControl+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C834F6C51DB3950600C29244 /* NSControl+RxTests.swift */; };
+		EF6A5A83219CC11900376078 /* SentMessageTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F01C38706D0027C24C /* SentMessageTest.swift */; };
+		EF6A5A84219CC11900376078 /* Observable+ZipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81A097C1E6C27A100900B3B /* Observable+ZipTests.swift */; };
+		EF6A5A85219CC11900376078 /* Observable+WindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA091EB513C800D431BC /* Observable+WindowTests.swift */; };
+		EF6A5A86219CC11900376078 /* BagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509041C38706D0027C24C /* BagTest.swift */; };
+		EF6A5A87219CC11900376078 /* SchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86B1E211D42BF5200130546 /* SchedulerTests.swift */; };
+		EF6A5A88219CC11900376078 /* PrimitiveSequenceTest+zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C898147D1E75AD380035949C /* PrimitiveSequenceTest+zip+arity.swift */; };
+		EF6A5A89219CC11900376078 /* Observable+MaterializeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9F91EB510D500D431BC /* Observable+MaterializeTests.swift */; };
+		EF6A5A8A219CC11900376078 /* PrimitiveMockObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FD1C38706D0027C24C /* PrimitiveMockObserver.swift */; };
+		EF6A5A8B219CC11900376078 /* DelegateProxyTest+Cocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DF1C38706D0027C24C /* DelegateProxyTest+Cocoa.swift */; };
+		EF6A5A8C219CC11900376078 /* Observable+DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9F11EB5109300D431BC /* Observable+DefaultIfEmpty.swift */; };
+		EF6A5A8D219CC11900376078 /* Observable+DelaySubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA011EB5134000D431BC /* Observable+DelaySubscriptionTests.swift */; };
+		EF6A5A8E219CC11900376078 /* Observable+EnumeratedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390671F379386004FC993 /* Observable+EnumeratedTests.swift */; };
+		EF6A5A8F219CC11900376078 /* TestErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE11DA19BC500BE3F5C /* TestErrors.swift */; };
+		EF6A5A90219CC11900376078 /* RxTest+Controls.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B290841C94D55600E923D0 /* RxTest+Controls.swift */; };
+		EF6A5A91219CC11900376078 /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
+		EF6A5A92219CC11900376078 /* NSSlider+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1741DE9D80A00003FA7 /* NSSlider+RxTests.swift */; };
+		EF6A5A93219CC11900376078 /* Observable+SampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E11EB50D6C00D431BC /* Observable+SampleTests.swift */; };
+		EF6A5A94219CC11900376078 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F03F4E1DBBAE9400AECC4C /* DispatchQueue+Extensions.swift */; };
+		EF6A5A95219CC11900376078 /* PerformanceTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E8BA701E2C18AE00A4AC2C /* PerformanceTools.swift */; };
+		EF6A5A96219CC11900376078 /* VirtualSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091C1C38706D0027C24C /* VirtualSchedulerTest.swift */; };
+		EF6A5A97219CC11900376078 /* MySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FA1C38706D0027C24C /* MySubject.swift */; };
+		EF6A5A98219CC11900376078 /* Observable+AmbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9491EB4E75E00D431BC /* Observable+AmbTests.swift */; };
+		EF6A5A99219CC11900376078 /* Observable+PrimitiveSequenceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE491F6EBB84008DB060 /* Observable+PrimitiveSequenceTest.swift */; };
+		EF6A5A9A219CC11900376078 /* ControlPropertyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508DE1C38706D0027C24C /* ControlPropertyTests.swift */; };
+		EF6A5A9B219CC11900376078 /* Observable+BufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA051EB5139C00D431BC /* Observable+BufferTests.swift */; };
+		EF6A5A9C219CC11900376078 /* Observable+SingleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9CD1EB50AD400D431BC /* Observable+SingleTests.swift */; };
+		EF6A5A9D219CC11900376078 /* Observable+SkipWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C51EB50A4200D431BC /* Observable+SkipWhileTests.swift */; };
+		EF6A5A9E219CC11900376078 /* Observable+RetryWhenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E91EB50E3400D431BC /* Observable+RetryWhenTests.swift */; };
+		EF6A5A9F219CC11900376078 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8323A8D1E33FD5200CC0C7F /* Resources.swift */; };
+		EF6A5AA0219CC11900376078 /* Observable+CatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9891EB4FBD600D431BC /* Observable+CatchTests.swift */; };
+		EF6A5AA1219CC11900376078 /* Observable+WithLatestFromTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A91EB505A800D431BC /* Observable+WithLatestFromTests.swift */; };
+		EF6A5AA2219CC11900376078 /* HistoricalSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509081C38706D0027C24C /* HistoricalSchedulerTest.swift */; };
+		EF6A5AA3219CC11900376078 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		EF6A5AA4219CC11900376078 /* Observable+TimerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9E51EB50DB900D431BC /* Observable+TimerTests.swift */; };
+		EF6A5AA5219CC11900376078 /* NSTextView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927A78C82117BCB400A45638 /* NSTextView+RxTests.swift */; };
+		EF6A5AA6219CC11900376078 /* Observable+ElementAtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C91EB50A7100D431BC /* Observable+ElementAtTests.swift */; };
+		EF6A5AA7219CC11900376078 /* RuntimeStateSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E91C38706D0027C24C /* RuntimeStateSnapshot.swift */; };
+		EF6A5AA8219CC11900376078 /* VariableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091B1C38706D0027C24C /* VariableTest.swift */; };
+		EF6A5AA9219CC11900376078 /* Completable+AndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A53AE41F09292A00490535 /* Completable+AndThen.swift */; };
+		EF6A5AAA219CC11900376078 /* RXObjCRuntime+Testing.m in Sources */ = {isa = PBXBuildFile; fileRef = C83508EB1C38706D0027C24C /* RXObjCRuntime+Testing.m */; };
+		EF6A5AAB219CC11900376078 /* MessageProcessingStage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CDB1DA19BA000BE3F5C /* MessageProcessingStage.swift */; };
+		EF6A5AAC219CC11900376078 /* Anomalies.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F03F401DBB98DB00AECC4C /* Anomalies.swift */; };
+		EF6A5AAD219CC11900376078 /* SharedSequence+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DD1F532FD10058F2FE /* SharedSequence+Test.swift */; };
+		EF6A5AAE219CC11900376078 /* NSLayoutConstraint+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E51C38706D0027C24C /* NSLayoutConstraint+RxTests.swift */; };
+		EF6A5AAF219CC11900376078 /* Observable+CombineLatestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C896A68A1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift */; };
+		EF6A5AB0219CC11900376078 /* Observable+TakeUntilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A11EB5011700D431BC /* Observable+TakeUntilTests.swift */; };
+		EF6A5AB1219CC11900376078 /* NSTextField+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1721DE9D7A300003FA7 /* NSTextField+RxTests.swift */; };
+		EF6A5AB2219CC11900376078 /* Observable+ObserveOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9611EB4EFD300D431BC /* Observable+ObserveOnTests.swift */; };
+		EF6A5AB3219CC11900376078 /* MockDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F91C38706D0027C24C /* MockDisposable.swift */; };
+		EF6A5AB4219CC11900376078 /* RxObjCRuntimeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508EC1C38706D0027C24C /* RxObjCRuntimeState.swift */; };
+		EF6A5AB5219CC11900376078 /* ReplaySubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */; };
+		EF6A5AB6219CC11900376078 /* Observable+RepeatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A97D1EB4FA5A00D431BC /* Observable+RepeatTests.swift */; };
+		EF6A5AB7219CC11900376078 /* Observable+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509021C38706D0027C24C /* Observable+Tests.swift */; };
+		EF6A5AB8219CC11900376078 /* TestConnectableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FE1C38706D0027C24C /* TestConnectableObservable.swift */; };
+		EF6A5AB9219CC11900376078 /* Observable+RangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9791EB4FA0800D431BC /* Observable+RangeTests.swift */; };
+		EF6A5ABA219CC11900376078 /* ObservableType+SubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C82FF0EE1F93DD2E00BDB34D /* ObservableType+SubscriptionTests.swift */; };
+		EF6A5ABB219CC11900376078 /* TestVirtualScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509001C38706D0027C24C /* TestVirtualScheduler.swift */; };
+		EF6A5ABC219CC11900376078 /* Observable+DoOnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9D91EB50CAA00D431BC /* Observable+DoOnTests.swift */; };
+		EF6A5ABD219CC11900376078 /* NotificationCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508E61C38706D0027C24C /* NotificationCenterTests.swift */; };
+		EF6A5ABE219CC11900376078 /* EquatableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F51C38706D0027C24C /* EquatableArray.swift */; };
+		EF6A5ABF219CC11900376078 /* Observable+TakeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B91EB5097700D431BC /* Observable+TakeTests.swift */; };
+		EF6A5AC0219CC11900376078 /* BehaviorSubjectTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509051C38706D0027C24C /* BehaviorSubjectTest.swift */; };
+		EF6A5AC1219CC11900376078 /* MainThreadPrimitiveHotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F81C38706D0027C24C /* MainThreadPrimitiveHotObservable.swift */; };
+		EF6A5AC2219CC11900376078 /* Observable+BlockingTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C834F6C11DB394E100C29244 /* Observable+BlockingTest.swift */; };
+		EF6A5AC3219CC11900376078 /* Observable+DelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820AA111EB5145200D431BC /* Observable+DelayTests.swift */; };
+		EF6A5AC4219CC11900376078 /* Observable+SubscriptionTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509161C38706D0027C24C /* Observable+SubscriptionTest.swift */; };
+		EF6A5AC5219CC11900376078 /* Binder+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A81CA51E05EAF70008DEF4 /* Binder+Tests.swift */; };
+		EF6A5AC6219CC11900376078 /* Observable+TakeLastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9BD1EB509B500D431BC /* Observable+TakeLastTests.swift */; };
+		EF6A5AC7219CC11900376078 /* Observable+TakeWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9B11EB507D300D431BC /* Observable+TakeWhileTests.swift */; };
+		EF6A5AC8219CC11900376078 /* Observable+FilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9AD1EB5073E00D431BC /* Observable+FilterTests.swift */; };
+		EF6A5AC9219CC11900376078 /* CurrentThreadSchedulerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509061C38706D0027C24C /* CurrentThreadSchedulerTest.swift */; };
+		EF6A5ACA219CC11900376078 /* Recorded+Timeless.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE01DA19BC500BE3F5C /* Recorded+Timeless.swift */; };
+		EF6A5ACB219CC11900376078 /* Observable+BindTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A9B6F31DAD752200C9B027 /* Observable+BindTests.swift */; };
+		EF6A5ACC219CC11900376078 /* Observable+MergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9991EB5001C00D431BC /* Observable+MergeTests.swift */; };
+		EF6A5ACD219CC11900376078 /* DisposableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83509071C38706D0027C24C /* DisposableTest.swift */; };
+		EF6A5ACE219CC11900376078 /* Observable+JustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9691EB4F64800D431BC /* Observable+JustTests.swift */; };
+		EF6A5ACF219CC11900376078 /* CompletableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */; };
+		EF6A5AD0219CC11900376078 /* Observable+OptionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9711EB4F84000D431BC /* Observable+OptionalTests.swift */; };
+		EF6A5AD1219CC11900376078 /* Observable+SkipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9C11EB509FC00D431BC /* Observable+SkipTests.swift */; };
+		EF6A5AD2219CC11900376078 /* Observable+SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A96D1EB4F7AC00D431BC /* Observable+SequenceTests.swift */; };
+		EF6A5AD3219CC11900376078 /* SharingSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B0F70C1F530A1700548EBE /* SharingSchedulerTests.swift */; };
+		EF6A5AD4219CC11900376078 /* SubjectConcurrencyTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C835091A1C38706D0027C24C /* SubjectConcurrencyTest.swift */; };
+		EF6A5AD5219CC11900376078 /* XCTest+AllTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8353CE21DA19BC500BE3F5C /* XCTest+AllTests.swift */; };
+		EF6A5AD6219CC11900376078 /* Signal+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DC1F532FD10058F2FE /* Signal+Test.swift */; };
+		EF6A5AD7219CC11900376078 /* AtomicInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8165AD421891DBE00494BEF /* AtomicInt.swift */; };
+		EF6A5AD8219CC11900376078 /* SingleTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE351F6EAD3C008DB060 /* SingleTest.swift */; };
+		EF6A5AD9219CC11900376078 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81B6AA91DB2C15C0047CF86 /* Platform.Linux.swift */; };
+		EF6A5ADA219CC11900376078 /* MaybeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE391F6EAD48008DB060 /* MaybeTest.swift */; };
+		EF6A5ADB219CC11900376078 /* NSButton+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C4F1761DE9D84900003FA7 /* NSButton+RxTests.swift */; };
+		EF6A5ADC219CC11900376078 /* Observable+SkipUntilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9A51EB5056C00D431BC /* Observable+SkipUntilTests.swift */; };
+		EF6A5ADD219CC11900376078 /* Observable.Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FB1C38706D0027C24C /* Observable.Extensions.swift */; };
+		EF6A5ADE219CC11900376078 /* Driver+Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970DE1F532FD20058F2FE /* Driver+Test.swift */; };
+		EF6A5ADF219CC11900376078 /* Observable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508FF1C38706D0027C24C /* Observable+Extensions.swift */; };
+		EF6A5AE0219CC11900376078 /* ElementIndexPair.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83508F41C38706D0027C24C /* ElementIndexPair.swift */; };
+		EF6A5AE1219CC11900376078 /* RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA0B1DAAB4670079D23B /* RxTest.swift */; };
+		EF6A5AE2219CC11900376078 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85218001E33FC160015DD38 /* RecursiveLock.swift */; };
 		F31F35B01BB4FED800961002 /* UIStepper+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */; };
 /* End PBXBuildFile section */
 
@@ -1235,6 +1700,90 @@
 			proxyType = 1;
 			remoteGlobalIDString = EF6A576F219CB6D200376078;
 			remoteInfo = "RxSwift-Static";
+		};
+		EF6A598B219CBA8600376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A576F219CB6D200376078;
+			remoteInfo = "RxSwift-Static";
+		};
+		EF6A598D219CBA8600376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A5814219CB72100376078;
+			remoteInfo = "RxCocoa-Static";
+		};
+		EF6A598F219CBA8600376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A5898219CB78300376078;
+			remoteInfo = "RxBlocking-Static";
+		};
+		EF6A5991219CBA8600376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A58B0219CB7BF00376078;
+			remoteInfo = "RxTest-Static";
+		};
+		EF6A5A47219CBF7200376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A576F219CB6D200376078;
+			remoteInfo = "RxSwift-Static";
+		};
+		EF6A5A49219CBF7200376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A5814219CB72100376078;
+			remoteInfo = "RxCocoa-Static";
+		};
+		EF6A5A4B219CBF7200376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A5898219CB78300376078;
+			remoteInfo = "RxBlocking-Static";
+		};
+		EF6A5A4D219CBF7200376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A58B0219CB7BF00376078;
+			remoteInfo = "RxTest-Static";
+		};
+		EF6A5AEB219CC13800376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A576F219CB6D200376078;
+			remoteInfo = "RxSwift-Static";
+		};
+		EF6A5AED219CC13800376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A5814219CB72100376078;
+			remoteInfo = "RxCocoa-Static";
+		};
+		EF6A5AEF219CC13800376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A5898219CB78300376078;
+			remoteInfo = "RxBlocking-Static";
+		};
+		EF6A5AF1219CC13800376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A58B0219CB7BF00376078;
+			remoteInfo = "RxTest-Static";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1750,6 +2299,9 @@
 		EF6A5894219CB72100376078 /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF6A58AE219CB78300376078 /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EF6A58CB219CB7BF00376078 /* RxTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF6A5989219CBA6500376078 /* AllTests-iOS-Static.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AllTests-iOS-Static.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF6A5A45219CBF5200376078 /* AllTests-tvOS-Static.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AllTests-tvOS-Static.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF6A5AE9219CC11900376078 /* AllTests-macOS-Static.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "AllTests-macOS-Static.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStepper+Rx.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1855,6 +2407,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		EF6A58C6219CB7BF00376078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5983219CBA6500376078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A5993219CBA9400376078 /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5A40219CBF5200376078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5AE4219CC11900376078 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2730,6 +3304,9 @@
 				EF6A5894219CB72100376078 /* RxCocoa.framework */,
 				EF6A58AE219CB78300376078 /* RxBlocking.framework */,
 				EF6A58CB219CB7BF00376078 /* RxTest.framework */,
+				EF6A5989219CBA6500376078 /* AllTests-iOS-Static.xctest */,
+				EF6A5A45219CBF5200376078 /* AllTests-tvOS-Static.xctest */,
+				EF6A5AE9219CC11900376078 /* AllTests-macOS-Static.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3167,6 +3744,69 @@
 			productReference = EF6A58CB219CB7BF00376078 /* RxTest.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		EF6A58D3219CBA6500376078 /* AllTests-iOS-Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF6A5985219CBA6500376078 /* Build configuration list for PBXNativeTarget "AllTests-iOS-Static" */;
+			buildPhases = (
+				EF6A58DC219CBA6500376078 /* Sources */,
+				EF6A5982219CBA6500376078 /* Resources */,
+				EF6A5983219CBA6500376078 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF6A598C219CBA8600376078 /* PBXTargetDependency */,
+				EF6A598E219CBA8600376078 /* PBXTargetDependency */,
+				EF6A5990219CBA8600376078 /* PBXTargetDependency */,
+				EF6A5992219CBA8600376078 /* PBXTargetDependency */,
+			);
+			name = "AllTests-iOS-Static";
+			productName = "AllTests-iOS";
+			productReference = EF6A5989219CBA6500376078 /* AllTests-iOS-Static.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		EF6A5994219CBF5200376078 /* AllTests-tvOS-Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF6A5A41219CBF5200376078 /* Build configuration list for PBXNativeTarget "AllTests-tvOS-Static" */;
+			buildPhases = (
+				EF6A599D219CBF5200376078 /* Sources */,
+				EF6A5A3F219CBF5200376078 /* Resources */,
+				EF6A5A40219CBF5200376078 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF6A5A48219CBF7200376078 /* PBXTargetDependency */,
+				EF6A5A4A219CBF7200376078 /* PBXTargetDependency */,
+				EF6A5A4C219CBF7200376078 /* PBXTargetDependency */,
+				EF6A5A4E219CBF7200376078 /* PBXTargetDependency */,
+			);
+			name = "AllTests-tvOS-Static";
+			productName = "AllTests-tvOS";
+			productReference = EF6A5A45219CBF5200376078 /* AllTests-tvOS-Static.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		EF6A5A4F219CC11900376078 /* AllTests-macOS-Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF6A5AE5219CC11900376078 /* Build configuration list for PBXNativeTarget "AllTests-macOS-Static" */;
+			buildPhases = (
+				EF6A5A58219CC11900376078 /* Sources */,
+				EF6A5AE3219CC11900376078 /* Resources */,
+				EF6A5AE4219CC11900376078 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF6A5AEC219CC13800376078 /* PBXTargetDependency */,
+				EF6A5AEE219CC13800376078 /* PBXTargetDependency */,
+				EF6A5AF0219CC13800376078 /* PBXTargetDependency */,
+				EF6A5AF2219CC13800376078 /* PBXTargetDependency */,
+			);
+			name = "AllTests-macOS-Static";
+			productName = "AllTests-OSX";
+			productReference = EF6A5AE9219CC11900376078 /* AllTests-macOS-Static.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -3239,8 +3879,11 @@
 				C88FA4FD1C25C44800CCFEA4 /* RxTest */,
 				EF6A58B0219CB7BF00376078 /* RxTest-Static */,
 				C83508C21C386F6F0027C24C /* AllTests-iOS */,
+				EF6A58D3219CBA6500376078 /* AllTests-iOS-Static */,
 				C83509831C38740E0027C24C /* AllTests-tvOS */,
+				EF6A5994219CBF5200376078 /* AllTests-tvOS-Static */,
 				C83509931C38742C0027C24C /* AllTests-macOS */,
+				EF6A5A4F219CC11900376078 /* AllTests-macOS-Static */,
 				C85BA04A1C3878740075D68E /* Microoptimizations */,
 				C8E8BA541E2C181A00A4AC2C /* Benchmarks */,
 			);
@@ -3347,6 +3990,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		EF6A58C5219CB7BF00376078 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5982219CBA6500376078 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5A3F219CBF5200376078 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5AE3219CC11900376078 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -4505,6 +5169,491 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EF6A58DC219CBA6500376078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A58DD219CBA6500376078 /* Observable+ConcatTests.swift in Sources */,
+				EF6A58DE219CBA6500376078 /* UIScrollView+RxTests.swift in Sources */,
+				EF6A58DF219CBA6500376078 /* Observable+DelayTests.swift in Sources */,
+				EF6A58E0219CBA6500376078 /* Observable+TakeUntilTests.swift in Sources */,
+				EF6A58E1219CBA6500376078 /* Observable+ShareReplayScopeTests.swift in Sources */,
+				EF6A58E2219CBA6500376078 /* ObserverTests.swift in Sources */,
+				EF6A58E3219CBA6500376078 /* PrimitiveMockObserver.swift in Sources */,
+				EF6A58E4219CBA6500376078 /* SharedSequence+Extensions.swift in Sources */,
+				EF6A58E5219CBA6500376078 /* DispatchQueue+Extensions.swift in Sources */,
+				EF6A58E6219CBA6500376078 /* Observable+Tests.swift in Sources */,
+				EF6A58E7219CBA6500376078 /* UITableView+RxTests.swift in Sources */,
+				EF6A58E8219CBA6500376078 /* UIControl+RxTests.swift in Sources */,
+				EF6A58E9219CBA6500376078 /* ControlEventTests.swift in Sources */,
+				EF6A58EA219CBA6500376078 /* UIPickerView+RxTests.swift in Sources */,
+				EF6A58EB219CBA6500376078 /* SingleTest.swift in Sources */,
+				EF6A58EC219CBA6500376078 /* Observable+CombineLatestTests.swift in Sources */,
+				EF6A58ED219CBA6500376078 /* DisposeBagTest.swift in Sources */,
+				EF6A58EE219CBA6500376078 /* Observable+WithLatestFromTests.swift in Sources */,
+				EF6A58EF219CBA6500376078 /* SharedSequence+Test.swift in Sources */,
+				EF6A58F0219CBA6500376078 /* Observable+ReduceTests.swift in Sources */,
+				EF6A58F1219CBA6500376078 /* Observable+RangeTests.swift in Sources */,
+				EF6A58F2219CBA6500376078 /* RxTest+Controls.swift in Sources */,
+				EF6A58F3219CBA6500376078 /* UILabel+RxTests.swift in Sources */,
+				EF6A58F4219CBA6500376078 /* Observable+GenerateTests.swift in Sources */,
+				EF6A58F5219CBA6500376078 /* MessageProcessingStage.swift in Sources */,
+				EF6A58F6219CBA6500376078 /* Observable+WindowTests.swift in Sources */,
+				EF6A58F7219CBA6500376078 /* MaybeTest.swift in Sources */,
+				EF6A58F8219CBA6500376078 /* UIAlertAction+RxTests.swift in Sources */,
+				EF6A58F9219CBA6500376078 /* ReplaySubjectTest.swift in Sources */,
+				EF6A58FA219CBA6500376078 /* Observable+ZipTests+arity.swift in Sources */,
+				EF6A58FB219CBA6500376078 /* QueueTests.swift in Sources */,
+				EF6A58FC219CBA6500376078 /* PerformanceTools.swift in Sources */,
+				EF6A58FD219CBA6500376078 /* UIPageControl+RxTest.swift in Sources */,
+				EF6A58FE219CBA6500376078 /* UIGestureRecognizer+RxTests.swift in Sources */,
+				EF6A58FF219CBA6500376078 /* KVOObservableTests.swift in Sources */,
+				EF6A5900219CBA6500376078 /* UISearchBar+RxTests.swift in Sources */,
+				EF6A5901219CBA6500376078 /* RecursiveLock.swift in Sources */,
+				EF6A5902219CBA6500376078 /* Event+Test.swift in Sources */,
+				EF6A5903219CBA6500376078 /* MainThreadPrimitiveHotObservable.swift in Sources */,
+				EF6A5904219CBA6500376078 /* Observable+PrimitiveSequenceTest.swift in Sources */,
+				EF6A5905219CBA6500376078 /* Observable+CatchTests.swift in Sources */,
+				EF6A5906219CBA6500376078 /* RuntimeStateSnapshot.swift in Sources */,
+				EF6A5907219CBA6500376078 /* ExampleTests.swift in Sources */,
+				EF6A5908219CBA6500376078 /* SchedulerTests.swift in Sources */,
+				EF6A5909219CBA6500376078 /* Observable+DistinctUntilChangedTests.swift in Sources */,
+				EF6A590A219CBA6500376078 /* Observable+DematerializeTests.swift in Sources */,
+				EF6A590B219CBA6500376078 /* UIStepper+RxTests.swift in Sources */,
+				EF6A590C219CBA6500376078 /* Observable+GroupByTests.swift in Sources */,
+				EF6A590D219CBA6500376078 /* MySubject.swift in Sources */,
+				EF6A590E219CBA6500376078 /* Observable+SubscriptionTest.swift in Sources */,
+				EF6A590F219CBA6500376078 /* UICollectionView+RxTests.swift in Sources */,
+				EF6A5910219CBA6500376078 /* Observable.Extensions.swift in Sources */,
+				EF6A5911219CBA6500376078 /* RXObjCRuntime+Testing.m in Sources */,
+				EF6A5912219CBA6500376078 /* VariableTest.swift in Sources */,
+				EF6A5913219CBA6500376078 /* PrimitiveHotObservable.swift in Sources */,
+				EF6A5914219CBA6500376078 /* Observable+DebugTests.swift in Sources */,
+				EF6A5915219CBA6500376078 /* Observable+DelaySubscriptionTests.swift in Sources */,
+				EF6A5916219CBA6500376078 /* RxMutableBox.swift in Sources */,
+				EF6A5917219CBA6500376078 /* Observable+SingleTests.swift in Sources */,
+				EF6A5918219CBA6500376078 /* UITextField+RxTests.swift in Sources */,
+				EF6A5919219CBA6500376078 /* DelegateProxyTest+UIKit.swift in Sources */,
+				EF6A591A219CBA6500376078 /* TestConnectableObservable.swift in Sources */,
+				EF6A591B219CBA6500376078 /* XCTest+AllTests.swift in Sources */,
+				EF6A591C219CBA6500376078 /* SharingSchedulerTests.swift in Sources */,
+				EF6A591D219CBA6500376078 /* UINavigationController+RxTests.swift in Sources */,
+				EF6A591E219CBA6500376078 /* Recorded+Timeless.swift in Sources */,
+				EF6A591F219CBA6500376078 /* NotificationCenterTests.swift in Sources */,
+				EF6A5920219CBA6500376078 /* Platform.Linux.swift in Sources */,
+				EF6A5921219CBA6500376078 /* Observable+SampleTests.swift in Sources */,
+				EF6A5922219CBA6500376078 /* UIActivityIndicatorView+RxTests.swift in Sources */,
+				EF6A5923219CBA6500376078 /* RxTest.swift in Sources */,
+				EF6A5924219CBA6500376078 /* CurrentThreadSchedulerTest.swift in Sources */,
+				EF6A5925219CBA6500376078 /* Observable+RepeatTests.swift in Sources */,
+				EF6A5926219CBA6500376078 /* Observable+AmbTests.swift in Sources */,
+				EF6A5927219CBA6500376078 /* PublishSubjectTest.swift in Sources */,
+				EF6A5928219CBA6500376078 /* Observable+SkipWhileTests.swift in Sources */,
+				EF6A5929219CBA6500376078 /* UIView+RxTests.swift in Sources */,
+				EF6A592A219CBA6500376078 /* UITabBarItem+RxTests.swift in Sources */,
+				EF6A592B219CBA6500376078 /* BackgroundThreadPrimitiveHotObservable.swift in Sources */,
+				EF6A592C219CBA6500376078 /* UIButton+RxTests.swift in Sources */,
+				EF6A592D219CBA6500376078 /* Observable+MapTests.swift in Sources */,
+				EF6A592E219CBA6500376078 /* UISlider+RxTests.swift in Sources */,
+				EF6A592F219CBA6500376078 /* Observable+UsingTests.swift in Sources */,
+				EF6A5930219CBA6500376078 /* Observable+DefaultIfEmpty.swift in Sources */,
+				EF6A5931219CBA6500376078 /* Observable+TimeoutTests.swift in Sources */,
+				EF6A5932219CBA6500376078 /* Anomalies.swift in Sources */,
+				EF6A5933219CBA6500376078 /* Observable+MulticastTests.swift in Sources */,
+				EF6A5934219CBA6500376078 /* Observable+TimerTests.swift in Sources */,
+				EF6A5935219CBA6500376078 /* TestErrors.swift in Sources */,
+				EF6A5936219CBA6500376078 /* Observable+ToArrayTests.swift in Sources */,
+				EF6A5937219CBA6500376078 /* CompletableTest.swift in Sources */,
+				EF6A5938219CBA6500376078 /* Observable+CombineLatestTests+arity.swift in Sources */,
+				EF6A5939219CBA6500376078 /* Completable+AndThen.swift in Sources */,
+				EF6A593A219CBA6500376078 /* Observable+MergeTests.swift in Sources */,
+				EF6A593B219CBA6500376078 /* VirtualSchedulerTest.swift in Sources */,
+				EF6A593C219CBA6500376078 /* UIBarButtonItem+RxTests.swift in Sources */,
+				EF6A593D219CBA6500376078 /* NSLayoutConstraint+RxTests.swift in Sources */,
+				EF6A593E219CBA6500376078 /* PrimitiveSequenceTest+zip+arity.swift in Sources */,
+				EF6A593F219CBA6500376078 /* UIProgressView+RxTests.swift in Sources */,
+				EF6A5940219CBA6500376078 /* Binder+Tests.swift in Sources */,
+				EF6A5941219CBA6500376078 /* UIWebView+RxTests.swift in Sources */,
+				EF6A5942219CBA6500376078 /* Observable+TakeTests.swift in Sources */,
+				EF6A5943219CBA6500376078 /* AssumptionsTest.swift in Sources */,
+				EF6A5944219CBA6500376078 /* KeyPathBinder+RxTests.swift in Sources */,
+				EF6A5945219CBA6500376078 /* SharedSequence+OperatorTest.swift in Sources */,
+				EF6A5946219CBA6500376078 /* Observable+BlockingTest.swift in Sources */,
+				EF6A5947219CBA6500376078 /* RecursiveLockTest.swift in Sources */,
+				EF6A5948219CBA6500376078 /* Observable+EnumeratedTests.swift in Sources */,
+				EF6A5949219CBA6500376078 /* ElementIndexPair.swift in Sources */,
+				EF6A594A219CBA6500376078 /* Observable+ElementAtTests.swift in Sources */,
+				EF6A594B219CBA6500376078 /* NSObject+RxTests.swift in Sources */,
+				EF6A594C219CBA6500376078 /* Observable+BufferTests.swift in Sources */,
+				EF6A594D219CBA6500376078 /* Observable+SequenceTests.swift in Sources */,
+				EF6A594E219CBA6500376078 /* Observable+BindTests.swift in Sources */,
+				EF6A594F219CBA6500376078 /* UIViewController+RxTests.swift in Sources */,
+				EF6A5950219CBA6500376078 /* SubjectConcurrencyTest.swift in Sources */,
+				EF6A5951219CBA6500376078 /* ObservableType+SubscriptionTests.swift in Sources */,
+				EF6A5952219CBA6500376078 /* Observable+OptionalTests.swift in Sources */,
+				EF6A5953219CBA6500376078 /* UISearchController+RxTests.swift in Sources */,
+				EF6A5954219CBA6500376078 /* UISwitch+RxTests.swift in Sources */,
+				EF6A5955219CBA6500376078 /* UITabBarController+RxTests.swift in Sources */,
+				EF6A5956219CBA6500376078 /* Observable+SkipUntilTests.swift in Sources */,
+				EF6A5957219CBA6500376078 /* UITabBar+RxTests.swift in Sources */,
+				EF6A5958219CBA6500376078 /* SectionedViewDataSourceMock.swift in Sources */,
+				EF6A5959219CBA6500376078 /* Reactive+Tests.swift in Sources */,
+				EF6A595A219CBA6500376078 /* Observable+TakeLastTests.swift in Sources */,
+				EF6A595B219CBA6500376078 /* AtomicInt.swift in Sources */,
+				EF6A595C219CBA6500376078 /* Observable+FilterTests.swift in Sources */,
+				EF6A595D219CBA6500376078 /* HistoricalSchedulerTest.swift in Sources */,
+				EF6A595E219CBA6500376078 /* MainSchedulerTests.swift in Sources */,
+				EF6A595F219CBA6500376078 /* BagTest.swift in Sources */,
+				EF6A5960219CBA6500376078 /* UINavigationItem+RxTests.swift.swift in Sources */,
+				EF6A5961219CBA6500376078 /* Observable+SkipTests.swift in Sources */,
+				EF6A5962219CBA6500376078 /* Observable+ThrottleTests.swift in Sources */,
+				EF6A5963219CBA6500376078 /* Observable+SwitchIfEmptyTests.swift in Sources */,
+				EF6A5964219CBA6500376078 /* SentMessageTest.swift in Sources */,
+				EF6A5965219CBA6500376078 /* EquatableArray.swift in Sources */,
+				EF6A5966219CBA6500376078 /* Observable+ObserveOnTests.swift in Sources */,
+				EF6A5967219CBA6500376078 /* Observable+DoOnTests.swift in Sources */,
+				EF6A5968219CBA6500376078 /* ControlPropertyTests.swift in Sources */,
+				EF6A5969219CBA6500376078 /* RxObjCRuntimeState.swift in Sources */,
+				EF6A596A219CBA6500376078 /* Observable+Extensions.swift in Sources */,
+				EF6A596B219CBA6500376078 /* UIRefreshControl+RxTests.swift in Sources */,
+				EF6A596C219CBA6500376078 /* TestVirtualScheduler.swift in Sources */,
+				EF6A596D219CBA6500376078 /* DisposableTest.swift in Sources */,
+				EF6A596E219CBA6500376078 /* BehaviorSubjectTest.swift in Sources */,
+				EF6A596F219CBA6500376078 /* UISegmentedControl+RxTests.swift in Sources */,
+				EF6A5970219CBA6500376078 /* Observable+SubscribeOnTests.swift in Sources */,
+				EF6A5971219CBA6500376078 /* Observable+ScanTests.swift in Sources */,
+				EF6A5972219CBA6500376078 /* Driver+Test.swift in Sources */,
+				EF6A5973219CBA6500376078 /* Observable+JustTests.swift in Sources */,
+				EF6A5974219CBA6500376078 /* Observable+SwitchTests.swift in Sources */,
+				EF6A5975219CBA6500376078 /* Platform.Darwin.swift in Sources */,
+				EF6A5976219CBA6500376078 /* Observable+ZipTests.swift in Sources */,
+				EF6A5977219CBA6500376078 /* DelegateProxyTest.swift in Sources */,
+				EF6A5978219CBA6500376078 /* ObservableConvertibleType+SharedSequence.swift in Sources */,
+				EF6A5979219CBA6500376078 /* AsyncSubjectTests.swift in Sources */,
+				EF6A597A219CBA6500376078 /* UITextView+RxTests.swift in Sources */,
+				EF6A597B219CBA6500376078 /* Observable+TakeWhileTests.swift in Sources */,
+				EF6A597C219CBA6500376078 /* Observable+MaterializeTests.swift in Sources */,
+				EF6A597D219CBA6500376078 /* Observable+RetryWhenTests.swift in Sources */,
+				EF6A597E219CBA6500376078 /* MockDisposable.swift in Sources */,
+				EF6A597F219CBA6500376078 /* Resources.swift in Sources */,
+				EF6A5980219CBA6500376078 /* UIDatePicker+RxTests.swift in Sources */,
+				EF6A5981219CBA6500376078 /* Signal+Test.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A599D219CBF5200376078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A599E219CBF5200376078 /* Observable+CombineLatestTests.swift in Sources */,
+				EF6A599F219CBF5200376078 /* AssumptionsTest.swift in Sources */,
+				EF6A59A0219CBF5200376078 /* MySubject.swift in Sources */,
+				EF6A59A1219CBF5200376078 /* NSObject+RxTests.swift in Sources */,
+				EF6A59A2219CBF5200376078 /* Observable+DebugTests.swift in Sources */,
+				EF6A59A3219CBF5200376078 /* UITableView+RxTests.swift in Sources */,
+				EF6A59A4219CBF5200376078 /* Observable+DematerializeTests.swift in Sources */,
+				EF6A59A5219CBF5200376078 /* Observable.Extensions.swift in Sources */,
+				EF6A59A6219CBF5200376078 /* ControlPropertyTests.swift in Sources */,
+				EF6A59A7219CBF5200376078 /* TestVirtualScheduler.swift in Sources */,
+				EF6A59A8219CBF5200376078 /* Observable+ReduceTests.swift in Sources */,
+				EF6A59A9219CBF5200376078 /* RxTest+Controls.swift in Sources */,
+				EF6A59AA219CBF5200376078 /* UIViewController+RxTests.swift in Sources */,
+				EF6A59AB219CBF5200376078 /* Observable+SubscribeOnTests.swift in Sources */,
+				EF6A59AC219CBF5200376078 /* VariableTest.swift in Sources */,
+				EF6A59AD219CBF5200376078 /* Observable+SkipWhileTests.swift in Sources */,
+				EF6A59AE219CBF5200376078 /* RecursiveLockTest.swift in Sources */,
+				EF6A59AF219CBF5200376078 /* PrimitiveHotObservable.swift in Sources */,
+				EF6A59B0219CBF5200376078 /* UIGestureRecognizer+RxTests.swift in Sources */,
+				EF6A59B1219CBF5200376078 /* UIScrollView+RxTests.swift in Sources */,
+				EF6A59B2219CBF5200376078 /* UINavigationItem+RxTests.swift.swift in Sources */,
+				EF6A59B3219CBF5200376078 /* SharedSequence+Test.swift in Sources */,
+				EF6A59B4219CBF5200376078 /* VirtualSchedulerTest.swift in Sources */,
+				EF6A59B5219CBF5200376078 /* Observable+TimerTests.swift in Sources */,
+				EF6A59B6219CBF5200376078 /* Observable+RepeatTests.swift in Sources */,
+				EF6A59B7219CBF5200376078 /* UIActivityIndicatorView+RxTests.swift in Sources */,
+				EF6A59B8219CBF5200376078 /* DelegateProxyTest+UIKit.swift in Sources */,
+				EF6A59B9219CBF5200376078 /* SharedSequence+OperatorTest.swift in Sources */,
+				EF6A59BA219CBF5200376078 /* Observable+AmbTests.swift in Sources */,
+				EF6A59BB219CBF5200376078 /* Observable+BlockingTest.swift in Sources */,
+				EF6A59BC219CBF5200376078 /* RxObjCRuntimeState.swift in Sources */,
+				EF6A59BD219CBF5200376078 /* Reactive+Tests.swift in Sources */,
+				EF6A59BE219CBF5200376078 /* UILabel+RxTests.swift in Sources */,
+				EF6A59BF219CBF5200376078 /* DelegateProxyTest.swift in Sources */,
+				EF6A59C0219CBF5200376078 /* Observable+DefaultIfEmpty.swift in Sources */,
+				EF6A59C1219CBF5200376078 /* SingleTest.swift in Sources */,
+				EF6A59C2219CBF5200376078 /* Observable+SubscriptionTest.swift in Sources */,
+				EF6A59C3219CBF5200376078 /* Observable+Extensions.swift in Sources */,
+				EF6A59C4219CBF5200376078 /* UIProgressView+RxTests.swift in Sources */,
+				EF6A59C5219CBF5200376078 /* PerformanceTools.swift in Sources */,
+				EF6A59C6219CBF5200376078 /* UIDatePicker+RxTests.swift in Sources */,
+				EF6A59C7219CBF5200376078 /* NSLayoutConstraint+RxTests.swift in Sources */,
+				EF6A59C8219CBF5200376078 /* Observable+OptionalTests.swift in Sources */,
+				EF6A59C9219CBF5200376078 /* Observable+SwitchIfEmptyTests.swift in Sources */,
+				EF6A59CA219CBF5200376078 /* UITabBar+RxTests.swift in Sources */,
+				EF6A59CB219CBF5200376078 /* ControlEventTests.swift in Sources */,
+				EF6A59CC219CBF5200376078 /* MockDisposable.swift in Sources */,
+				EF6A59CD219CBF5200376078 /* Observable+GroupByTests.swift in Sources */,
+				EF6A59CE219CBF5200376078 /* Observable+DelayTests.swift in Sources */,
+				EF6A59CF219CBF5200376078 /* Observable+WindowTests.swift in Sources */,
+				EF6A59D0219CBF5200376078 /* PublishSubjectTest.swift in Sources */,
+				EF6A59D1219CBF5200376078 /* Observable+ScanTests.swift in Sources */,
+				EF6A59D2219CBF5200376078 /* MessageProcessingStage.swift in Sources */,
+				EF6A59D3219CBF5200376078 /* Observable+UsingTests.swift in Sources */,
+				EF6A59D4219CBF5200376078 /* RxMutableBox.swift in Sources */,
+				EF6A59D5219CBF5200376078 /* Observable+MapTests.swift in Sources */,
+				EF6A59D6219CBF5200376078 /* UINavigationController+RxTests.swift in Sources */,
+				EF6A59D7219CBF5200376078 /* UIBarButtonItem+RxTests.swift in Sources */,
+				EF6A59D8219CBF5200376078 /* ObserverTests.swift in Sources */,
+				EF6A59D9219CBF5200376078 /* ReplaySubjectTest.swift in Sources */,
+				EF6A59DA219CBF5200376078 /* ObservableType+SubscriptionTests.swift in Sources */,
+				EF6A59DB219CBF5200376078 /* Observable+ToArrayTests.swift in Sources */,
+				EF6A59DC219CBF5200376078 /* Platform.Darwin.swift in Sources */,
+				EF6A59DD219CBF5200376078 /* MaybeTest.swift in Sources */,
+				EF6A59DE219CBF5200376078 /* Observable+CatchTests.swift in Sources */,
+				EF6A59DF219CBF5200376078 /* TestConnectableObservable.swift in Sources */,
+				EF6A59E0219CBF5200376078 /* BehaviorSubjectTest.swift in Sources */,
+				EF6A59E1219CBF5200376078 /* Observable+RangeTests.swift in Sources */,
+				EF6A59E2219CBF5200376078 /* UITabBarController+RxTests.swift in Sources */,
+				EF6A59E3219CBF5200376078 /* XCTest+AllTests.swift in Sources */,
+				EF6A59E4219CBF5200376078 /* RecursiveLock.swift in Sources */,
+				EF6A59E5219CBF5200376078 /* Signal+Test.swift in Sources */,
+				EF6A59E6219CBF5200376078 /* Observable+GenerateTests.swift in Sources */,
+				EF6A59E7219CBF5200376078 /* MainThreadPrimitiveHotObservable.swift in Sources */,
+				EF6A59E8219CBF5200376078 /* DispatchQueue+Extensions.swift in Sources */,
+				EF6A59E9219CBF5200376078 /* Observable+TakeLastTests.swift in Sources */,
+				EF6A59EA219CBF5200376078 /* Observable+ElementAtTests.swift in Sources */,
+				EF6A59EB219CBF5200376078 /* Event+Test.swift in Sources */,
+				EF6A59EC219CBF5200376078 /* Completable+AndThen.swift in Sources */,
+				EF6A59ED219CBF5200376078 /* Observable+MergeTests.swift in Sources */,
+				EF6A59EE219CBF5200376078 /* SharedSequence+Extensions.swift in Sources */,
+				EF6A59EF219CBF5200376078 /* Recorded+Timeless.swift in Sources */,
+				EF6A59F0219CBF5200376078 /* QueueTests.swift in Sources */,
+				EF6A59F1219CBF5200376078 /* Observable+DoOnTests.swift in Sources */,
+				EF6A59F2219CBF5200376078 /* Observable+ConcatTests.swift in Sources */,
+				EF6A59F3219CBF5200376078 /* KeyPathBinder+RxTests.swift in Sources */,
+				EF6A59F4219CBF5200376078 /* CompletableTest.swift in Sources */,
+				EF6A59F5219CBF5200376078 /* PrimitiveSequenceTest+zip+arity.swift in Sources */,
+				EF6A59F6219CBF5200376078 /* RxTest.swift in Sources */,
+				EF6A59F7219CBF5200376078 /* NotificationCenterTests.swift in Sources */,
+				EF6A59F8219CBF5200376078 /* Observable+SingleTests.swift in Sources */,
+				EF6A59F9219CBF5200376078 /* Observable+DistinctUntilChangedTests.swift in Sources */,
+				EF6A59FA219CBF5200376078 /* Observable+ObserveOnTests.swift in Sources */,
+				EF6A59FB219CBF5200376078 /* Observable+SwitchTests.swift in Sources */,
+				EF6A59FC219CBF5200376078 /* UITextField+RxTests.swift in Sources */,
+				EF6A59FD219CBF5200376078 /* Observable+CombineLatestTests+arity.swift in Sources */,
+				EF6A59FE219CBF5200376078 /* UISearchController+RxTests.swift in Sources */,
+				EF6A59FF219CBF5200376078 /* SentMessageTest.swift in Sources */,
+				EF6A5A00219CBF5200376078 /* UISlider+RxTests.swift in Sources */,
+				EF6A5A01219CBF5200376078 /* AsyncSubjectTests.swift in Sources */,
+				EF6A5A02219CBF5200376078 /* CurrentThreadSchedulerTest.swift in Sources */,
+				EF6A5A03219CBF5200376078 /* Observable+FilterTests.swift in Sources */,
+				EF6A5A04219CBF5200376078 /* Observable+ThrottleTests.swift in Sources */,
+				EF6A5A05219CBF5200376078 /* PrimitiveMockObserver.swift in Sources */,
+				EF6A5A06219CBF5200376078 /* Observable+SkipTests.swift in Sources */,
+				EF6A5A07219CBF5200376078 /* KVOObservableTests.swift in Sources */,
+				EF6A5A08219CBF5200376078 /* Observable+BindTests.swift in Sources */,
+				EF6A5A09219CBF5200376078 /* MainSchedulerTests.swift in Sources */,
+				EF6A5A0A219CBF5200376078 /* UISwitch+RxTests.swift in Sources */,
+				EF6A5A0B219CBF5200376078 /* Observable+DelaySubscriptionTests.swift in Sources */,
+				EF6A5A0C219CBF5200376078 /* UITabBarItem+RxTests.swift in Sources */,
+				EF6A5A0D219CBF5200376078 /* ObservableConvertibleType+SharedSequence.swift in Sources */,
+				EF6A5A0E219CBF5200376078 /* DisposeBagTest.swift in Sources */,
+				EF6A5A0F219CBF5200376078 /* UIPageControl+RxTest.swift in Sources */,
+				EF6A5A10219CBF5200376078 /* Binder+Tests.swift in Sources */,
+				EF6A5A11219CBF5200376078 /* EquatableArray.swift in Sources */,
+				EF6A5A12219CBF5200376078 /* DisposableTest.swift in Sources */,
+				EF6A5A13219CBF5200376078 /* UISearchBar+RxTests.swift in Sources */,
+				EF6A5A14219CBF5200376078 /* Resources.swift in Sources */,
+				EF6A5A15219CBF5200376078 /* Anomalies.swift in Sources */,
+				EF6A5A16219CBF5200376078 /* Observable+EnumeratedTests.swift in Sources */,
+				EF6A5A17219CBF5200376078 /* Observable+SkipUntilTests.swift in Sources */,
+				EF6A5A18219CBF5200376078 /* ElementIndexPair.swift in Sources */,
+				EF6A5A19219CBF5200376078 /* SharingSchedulerTests.swift in Sources */,
+				EF6A5A1A219CBF5200376078 /* Observable+ShareReplayScopeTests.swift in Sources */,
+				EF6A5A1B219CBF5200376078 /* SubjectConcurrencyTest.swift in Sources */,
+				EF6A5A1C219CBF5200376078 /* BackgroundThreadPrimitiveHotObservable.swift in Sources */,
+				EF6A5A1D219CBF5200376078 /* UIView+RxTests.swift in Sources */,
+				EF6A5A1E219CBF5200376078 /* TestErrors.swift in Sources */,
+				EF6A5A1F219CBF5200376078 /* Observable+TakeWhileTests.swift in Sources */,
+				EF6A5A20219CBF5200376078 /* Observable+WithLatestFromTests.swift in Sources */,
+				EF6A5A21219CBF5200376078 /* Observable+MulticastTests.swift in Sources */,
+				EF6A5A22219CBF5200376078 /* HistoricalSchedulerTest.swift in Sources */,
+				EF6A5A23219CBF5200376078 /* UIButton+RxTests.swift in Sources */,
+				EF6A5A24219CBF5200376078 /* Platform.Linux.swift in Sources */,
+				EF6A5A25219CBF5200376078 /* Observable+Tests.swift in Sources */,
+				EF6A5A26219CBF5200376078 /* Observable+SampleTests.swift in Sources */,
+				EF6A5A27219CBF5200376078 /* Driver+Test.swift in Sources */,
+				EF6A5A28219CBF5200376078 /* UIRefreshControl+RxTests.swift in Sources */,
+				EF6A5A29219CBF5200376078 /* Observable+MaterializeTests.swift in Sources */,
+				EF6A5A2A219CBF5200376078 /* Observable+PrimitiveSequenceTest.swift in Sources */,
+				EF6A5A2B219CBF5200376078 /* Observable+TimeoutTests.swift in Sources */,
+				EF6A5A2C219CBF5200376078 /* Observable+TakeTests.swift in Sources */,
+				EF6A5A2D219CBF5200376078 /* Observable+JustTests.swift in Sources */,
+				EF6A5A2E219CBF5200376078 /* UIAlertAction+RxTests.swift in Sources */,
+				EF6A5A2F219CBF5200376078 /* RXObjCRuntime+Testing.m in Sources */,
+				EF6A5A30219CBF5200376078 /* Observable+ZipTests.swift in Sources */,
+				EF6A5A31219CBF5200376078 /* UICollectionView+RxTests.swift in Sources */,
+				EF6A5A32219CBF5200376078 /* Observable+SequenceTests.swift in Sources */,
+				EF6A5A33219CBF5200376078 /* AtomicInt.swift in Sources */,
+				EF6A5A34219CBF5200376078 /* Observable+TakeUntilTests.swift in Sources */,
+				EF6A5A35219CBF5200376078 /* UISegmentedControl+RxTests.swift in Sources */,
+				EF6A5A36219CBF5200376078 /* Observable+RetryWhenTests.swift in Sources */,
+				EF6A5A37219CBF5200376078 /* RuntimeStateSnapshot.swift in Sources */,
+				EF6A5A38219CBF5200376078 /* UIStepper+RxTests.swift in Sources */,
+				EF6A5A39219CBF5200376078 /* BagTest.swift in Sources */,
+				EF6A5A3A219CBF5200376078 /* UITextView+RxTests.swift in Sources */,
+				EF6A5A3B219CBF5200376078 /* SchedulerTests.swift in Sources */,
+				EF6A5A3C219CBF5200376078 /* Observable+BufferTests.swift in Sources */,
+				EF6A5A3D219CBF5200376078 /* SectionedViewDataSourceMock.swift in Sources */,
+				EF6A5A3E219CBF5200376078 /* Observable+ZipTests+arity.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5A58219CC11900376078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A5A59219CC11900376078 /* QueueTests.swift in Sources */,
+				EF6A5A5A219CC11900376078 /* Observable+ToArrayTests.swift in Sources */,
+				EF6A5A5B219CC11900376078 /* PublishSubjectTest.swift in Sources */,
+				EF6A5A5C219CC11900376078 /* Observable+GenerateTests.swift in Sources */,
+				EF6A5A5D219CC11900376078 /* AsyncSubjectTests.swift in Sources */,
+				EF6A5A5E219CC11900376078 /* PrimitiveHotObservable.swift in Sources */,
+				EF6A5A5F219CC11900376078 /* NSObject+RxTests.swift in Sources */,
+				EF6A5A60219CC11900376078 /* Observable+DistinctUntilChangedTests.swift in Sources */,
+				EF6A5A61219CC11900376078 /* Observable+MapTests.swift in Sources */,
+				EF6A5A62219CC11900376078 /* AssumptionsTest.swift in Sources */,
+				EF6A5A63219CC11900376078 /* Observable+GroupByTests.swift in Sources */,
+				EF6A5A64219CC11900376078 /* Observable+TimeoutTests.swift in Sources */,
+				EF6A5A65219CC11900376078 /* Platform.Darwin.swift in Sources */,
+				EF6A5A66219CC11900376078 /* RxMutableBox.swift in Sources */,
+				EF6A5A67219CC11900376078 /* MainSchedulerTests.swift in Sources */,
+				EF6A5A68219CC11900376078 /* SharedSequence+OperatorTest.swift in Sources */,
+				EF6A5A69219CC11900376078 /* Observable+ScanTests.swift in Sources */,
+				EF6A5A6A219CC11900376078 /* ControlEventTests.swift in Sources */,
+				EF6A5A6B219CC11900376078 /* KVOObservableTests.swift in Sources */,
+				EF6A5A6C219CC11900376078 /* DelegateProxyTest.swift in Sources */,
+				EF6A5A6D219CC11900376078 /* Observable+CombineLatestTests+arity.swift in Sources */,
+				EF6A5A6E219CC11900376078 /* Event+Test.swift in Sources */,
+				EF6A5A6F219CC11900376078 /* RecursiveLockTest.swift in Sources */,
+				EF6A5A70219CC11900376078 /* Observable+MulticastTests.swift in Sources */,
+				EF6A5A71219CC11900376078 /* Reactive+Tests.swift in Sources */,
+				EF6A5A72219CC11900376078 /* BackgroundThreadPrimitiveHotObservable.swift in Sources */,
+				EF6A5A73219CC11900376078 /* ObservableConvertibleType+SharedSequence.swift in Sources */,
+				EF6A5A74219CC11900376078 /* Observable+ZipTests+arity.swift in Sources */,
+				EF6A5A75219CC11900376078 /* Observable+DematerializeTests.swift in Sources */,
+				EF6A5A76219CC11900376078 /* SharedSequence+Extensions.swift in Sources */,
+				EF6A5A77219CC11900376078 /* Observable+SwitchIfEmptyTests.swift in Sources */,
+				EF6A5A78219CC11900376078 /* NSView+RxTests.swift in Sources */,
+				EF6A5A79219CC11900376078 /* Observable+ReduceTests.swift in Sources */,
+				EF6A5A7A219CC11900376078 /* Observable+UsingTests.swift in Sources */,
+				EF6A5A7B219CC11900376078 /* Observable+DebugTests.swift in Sources */,
+				EF6A5A7C219CC11900376078 /* Observable+ThrottleTests.swift in Sources */,
+				EF6A5A7D219CC11900376078 /* ObserverTests.swift in Sources */,
+				EF6A5A7E219CC11900376078 /* Observable+SubscribeOnTests.swift in Sources */,
+				EF6A5A7F219CC11900376078 /* Observable+ConcatTests.swift in Sources */,
+				EF6A5A80219CC11900376078 /* Observable+SwitchTests.swift in Sources */,
+				EF6A5A81219CC11900376078 /* Observable+ShareReplayScopeTests.swift in Sources */,
+				EF6A5A82219CC11900376078 /* NSControl+RxTests.swift in Sources */,
+				EF6A5A83219CC11900376078 /* SentMessageTest.swift in Sources */,
+				EF6A5A84219CC11900376078 /* Observable+ZipTests.swift in Sources */,
+				EF6A5A85219CC11900376078 /* Observable+WindowTests.swift in Sources */,
+				EF6A5A86219CC11900376078 /* BagTest.swift in Sources */,
+				EF6A5A87219CC11900376078 /* SchedulerTests.swift in Sources */,
+				EF6A5A88219CC11900376078 /* PrimitiveSequenceTest+zip+arity.swift in Sources */,
+				EF6A5A89219CC11900376078 /* Observable+MaterializeTests.swift in Sources */,
+				EF6A5A8A219CC11900376078 /* PrimitiveMockObserver.swift in Sources */,
+				EF6A5A8B219CC11900376078 /* DelegateProxyTest+Cocoa.swift in Sources */,
+				EF6A5A8C219CC11900376078 /* Observable+DefaultIfEmpty.swift in Sources */,
+				EF6A5A8D219CC11900376078 /* Observable+DelaySubscriptionTests.swift in Sources */,
+				EF6A5A8E219CC11900376078 /* Observable+EnumeratedTests.swift in Sources */,
+				EF6A5A8F219CC11900376078 /* TestErrors.swift in Sources */,
+				EF6A5A90219CC11900376078 /* RxTest+Controls.swift in Sources */,
+				EF6A5A91219CC11900376078 /* DisposeBagTest.swift in Sources */,
+				EF6A5A92219CC11900376078 /* NSSlider+RxTests.swift in Sources */,
+				EF6A5A93219CC11900376078 /* Observable+SampleTests.swift in Sources */,
+				EF6A5A94219CC11900376078 /* DispatchQueue+Extensions.swift in Sources */,
+				EF6A5A95219CC11900376078 /* PerformanceTools.swift in Sources */,
+				EF6A5A96219CC11900376078 /* VirtualSchedulerTest.swift in Sources */,
+				EF6A5A97219CC11900376078 /* MySubject.swift in Sources */,
+				EF6A5A98219CC11900376078 /* Observable+AmbTests.swift in Sources */,
+				EF6A5A99219CC11900376078 /* Observable+PrimitiveSequenceTest.swift in Sources */,
+				EF6A5A9A219CC11900376078 /* ControlPropertyTests.swift in Sources */,
+				EF6A5A9B219CC11900376078 /* Observable+BufferTests.swift in Sources */,
+				EF6A5A9C219CC11900376078 /* Observable+SingleTests.swift in Sources */,
+				EF6A5A9D219CC11900376078 /* Observable+SkipWhileTests.swift in Sources */,
+				EF6A5A9E219CC11900376078 /* Observable+RetryWhenTests.swift in Sources */,
+				EF6A5A9F219CC11900376078 /* Resources.swift in Sources */,
+				EF6A5AA0219CC11900376078 /* Observable+CatchTests.swift in Sources */,
+				EF6A5AA1219CC11900376078 /* Observable+WithLatestFromTests.swift in Sources */,
+				EF6A5AA2219CC11900376078 /* HistoricalSchedulerTest.swift in Sources */,
+				EF6A5AA3219CC11900376078 /* KeyPathBinder+RxTests.swift in Sources */,
+				EF6A5AA4219CC11900376078 /* Observable+TimerTests.swift in Sources */,
+				EF6A5AA5219CC11900376078 /* NSTextView+RxTests.swift in Sources */,
+				EF6A5AA6219CC11900376078 /* Observable+ElementAtTests.swift in Sources */,
+				EF6A5AA7219CC11900376078 /* RuntimeStateSnapshot.swift in Sources */,
+				EF6A5AA8219CC11900376078 /* VariableTest.swift in Sources */,
+				EF6A5AA9219CC11900376078 /* Completable+AndThen.swift in Sources */,
+				EF6A5AAA219CC11900376078 /* RXObjCRuntime+Testing.m in Sources */,
+				EF6A5AAB219CC11900376078 /* MessageProcessingStage.swift in Sources */,
+				EF6A5AAC219CC11900376078 /* Anomalies.swift in Sources */,
+				EF6A5AAD219CC11900376078 /* SharedSequence+Test.swift in Sources */,
+				EF6A5AAE219CC11900376078 /* NSLayoutConstraint+RxTests.swift in Sources */,
+				EF6A5AAF219CC11900376078 /* Observable+CombineLatestTests.swift in Sources */,
+				EF6A5AB0219CC11900376078 /* Observable+TakeUntilTests.swift in Sources */,
+				EF6A5AB1219CC11900376078 /* NSTextField+RxTests.swift in Sources */,
+				EF6A5AB2219CC11900376078 /* Observable+ObserveOnTests.swift in Sources */,
+				EF6A5AB3219CC11900376078 /* MockDisposable.swift in Sources */,
+				EF6A5AB4219CC11900376078 /* RxObjCRuntimeState.swift in Sources */,
+				EF6A5AB5219CC11900376078 /* ReplaySubjectTest.swift in Sources */,
+				EF6A5AB6219CC11900376078 /* Observable+RepeatTests.swift in Sources */,
+				EF6A5AB7219CC11900376078 /* Observable+Tests.swift in Sources */,
+				EF6A5AB8219CC11900376078 /* TestConnectableObservable.swift in Sources */,
+				EF6A5AB9219CC11900376078 /* Observable+RangeTests.swift in Sources */,
+				EF6A5ABA219CC11900376078 /* ObservableType+SubscriptionTests.swift in Sources */,
+				EF6A5ABB219CC11900376078 /* TestVirtualScheduler.swift in Sources */,
+				EF6A5ABC219CC11900376078 /* Observable+DoOnTests.swift in Sources */,
+				EF6A5ABD219CC11900376078 /* NotificationCenterTests.swift in Sources */,
+				EF6A5ABE219CC11900376078 /* EquatableArray.swift in Sources */,
+				EF6A5ABF219CC11900376078 /* Observable+TakeTests.swift in Sources */,
+				EF6A5AC0219CC11900376078 /* BehaviorSubjectTest.swift in Sources */,
+				EF6A5AC1219CC11900376078 /* MainThreadPrimitiveHotObservable.swift in Sources */,
+				EF6A5AC2219CC11900376078 /* Observable+BlockingTest.swift in Sources */,
+				EF6A5AC3219CC11900376078 /* Observable+DelayTests.swift in Sources */,
+				EF6A5AC4219CC11900376078 /* Observable+SubscriptionTest.swift in Sources */,
+				EF6A5AC5219CC11900376078 /* Binder+Tests.swift in Sources */,
+				EF6A5AC6219CC11900376078 /* Observable+TakeLastTests.swift in Sources */,
+				EF6A5AC7219CC11900376078 /* Observable+TakeWhileTests.swift in Sources */,
+				EF6A5AC8219CC11900376078 /* Observable+FilterTests.swift in Sources */,
+				EF6A5AC9219CC11900376078 /* CurrentThreadSchedulerTest.swift in Sources */,
+				EF6A5ACA219CC11900376078 /* Recorded+Timeless.swift in Sources */,
+				EF6A5ACB219CC11900376078 /* Observable+BindTests.swift in Sources */,
+				EF6A5ACC219CC11900376078 /* Observable+MergeTests.swift in Sources */,
+				EF6A5ACD219CC11900376078 /* DisposableTest.swift in Sources */,
+				EF6A5ACE219CC11900376078 /* Observable+JustTests.swift in Sources */,
+				EF6A5ACF219CC11900376078 /* CompletableTest.swift in Sources */,
+				EF6A5AD0219CC11900376078 /* Observable+OptionalTests.swift in Sources */,
+				EF6A5AD1219CC11900376078 /* Observable+SkipTests.swift in Sources */,
+				EF6A5AD2219CC11900376078 /* Observable+SequenceTests.swift in Sources */,
+				EF6A5AD3219CC11900376078 /* SharingSchedulerTests.swift in Sources */,
+				EF6A5AD4219CC11900376078 /* SubjectConcurrencyTest.swift in Sources */,
+				EF6A5AD5219CC11900376078 /* XCTest+AllTests.swift in Sources */,
+				EF6A5AD6219CC11900376078 /* Signal+Test.swift in Sources */,
+				EF6A5AD7219CC11900376078 /* AtomicInt.swift in Sources */,
+				EF6A5AD8219CC11900376078 /* SingleTest.swift in Sources */,
+				EF6A5AD9219CC11900376078 /* Platform.Linux.swift in Sources */,
+				EF6A5ADA219CC11900376078 /* MaybeTest.swift in Sources */,
+				EF6A5ADB219CC11900376078 /* NSButton+RxTests.swift in Sources */,
+				EF6A5ADC219CC11900376078 /* Observable+SkipUntilTests.swift in Sources */,
+				EF6A5ADD219CC11900376078 /* Observable.Extensions.swift in Sources */,
+				EF6A5ADE219CC11900376078 /* Driver+Test.swift in Sources */,
+				EF6A5ADF219CC11900376078 /* Observable+Extensions.swift in Sources */,
+				EF6A5AE0219CC11900376078 /* ElementIndexPair.swift in Sources */,
+				EF6A5AE1219CC11900376078 /* RxTest.swift in Sources */,
+				EF6A5AE2219CC11900376078 /* RecursiveLock.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -4627,6 +5776,66 @@
 			isa = PBXTargetDependency;
 			target = EF6A576F219CB6D200376078 /* RxSwift-Static */;
 			targetProxy = EF6A58D1219CB81700376078 /* PBXContainerItemProxy */;
+		};
+		EF6A598C219CBA8600376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A576F219CB6D200376078 /* RxSwift-Static */;
+			targetProxy = EF6A598B219CBA8600376078 /* PBXContainerItemProxy */;
+		};
+		EF6A598E219CBA8600376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A5814219CB72100376078 /* RxCocoa-Static */;
+			targetProxy = EF6A598D219CBA8600376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5990219CBA8600376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A5898219CB78300376078 /* RxBlocking-Static */;
+			targetProxy = EF6A598F219CBA8600376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5992219CBA8600376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A58B0219CB7BF00376078 /* RxTest-Static */;
+			targetProxy = EF6A5991219CBA8600376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5A48219CBF7200376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A576F219CB6D200376078 /* RxSwift-Static */;
+			targetProxy = EF6A5A47219CBF7200376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5A4A219CBF7200376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A5814219CB72100376078 /* RxCocoa-Static */;
+			targetProxy = EF6A5A49219CBF7200376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5A4C219CBF7200376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A5898219CB78300376078 /* RxBlocking-Static */;
+			targetProxy = EF6A5A4B219CBF7200376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5A4E219CBF7200376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A58B0219CB7BF00376078 /* RxTest-Static */;
+			targetProxy = EF6A5A4D219CBF7200376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5AEC219CC13800376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A576F219CB6D200376078 /* RxSwift-Static */;
+			targetProxy = EF6A5AEB219CC13800376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5AEE219CC13800376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A5814219CB72100376078 /* RxCocoa-Static */;
+			targetProxy = EF6A5AED219CC13800376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5AF0219CC13800376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A5898219CB78300376078 /* RxBlocking-Static */;
+			targetProxy = EF6A5AEF219CC13800376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5AF2219CC13800376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A58B0219CB7BF00376078 /* RxTest-Static */;
+			targetProxy = EF6A5AF1219CC13800376078 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -5617,6 +6826,162 @@
 			};
 			name = "Release-Tests";
 		};
+		EF6A5986219CBA6500376078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-iOS-Bridging-Header.h";
+			};
+			name = Debug;
+		};
+		EF6A5987219CBA6500376078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-iOS-Bridging-Header.h";
+				SWIFT_REFLECTION_METADATA_LEVEL = none;
+			};
+			name = Release;
+		};
+		EF6A5988219CBA6500376078 /* Release-Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-iOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-iOS-Bridging-Header.h";
+				SWIFT_REFLECTION_METADATA_LEVEL = none;
+			};
+			name = "Release-Tests";
+		};
+		EF6A5A42219CBF5200376078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-tvOS-Bridging-Header.h";
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Debug;
+		};
+		EF6A5A43219CBF5200376078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-tvOS-Bridging-Header.h";
+				SWIFT_REFLECTION_METADATA_LEVEL = none;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = Release;
+		};
+		EF6A5A44219CBF5200376078 /* Release-Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-tvOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-tvOS-Bridging-Header.h";
+				SWIFT_REFLECTION_METADATA_LEVEL = none;
+				TVOS_DEPLOYMENT_TARGET = 9.1;
+			};
+			name = "Release-Tests";
+		};
+		EF6A5AE6219CC11900376078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-macOS-Bridging-Header.h";
+			};
+			name = Debug;
+		};
+		EF6A5AE7219CC11900376078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_BITCODE = NO;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-macOS-Bridging-Header.h";
+				SWIFT_REFLECTION_METADATA_LEVEL = none;
+			};
+			name = Release;
+		};
+		EF6A5AE8219CC11900376078 /* Release-Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				COMBINE_HIDPI_IMAGES = YES;
+				ENABLE_BITCODE = NO;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.AllTests-macOS";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SWIFT_OBJC_BRIDGING_HEADER = "Tests/RxCocoaTests/RxTest-macOS-Bridging-Header.h";
+				SWIFT_REFLECTION_METADATA_LEVEL = none;
+			};
+			name = "Release-Tests";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -5776,6 +7141,36 @@
 				EF6A58C8219CB7BF00376078 /* Debug */,
 				EF6A58C9219CB7BF00376078 /* Release */,
 				EF6A58CA219CB7BF00376078 /* Release-Tests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF6A5985219CBA6500376078 /* Build configuration list for PBXNativeTarget "AllTests-iOS-Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6A5986219CBA6500376078 /* Debug */,
+				EF6A5987219CBA6500376078 /* Release */,
+				EF6A5988219CBA6500376078 /* Release-Tests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF6A5A41219CBF5200376078 /* Build configuration list for PBXNativeTarget "AllTests-tvOS-Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6A5A42219CBF5200376078 /* Debug */,
+				EF6A5A43219CBF5200376078 /* Release */,
+				EF6A5A44219CBF5200376078 /* Release-Tests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF6A5AE5219CC11900376078 /* Build configuration list for PBXNativeTarget "AllTests-macOS-Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6A5AE6219CC11900376078 /* Debug */,
+				EF6A5AE7219CC11900376078 /* Release */,
+				EF6A5AE8219CC11900376078 /* Release-Tests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -770,6 +770,300 @@
 		ECBBA59E1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */; };
 		ECBBA5A11DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */; };
 		ECBBA5A21DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */; };
+		EF6A5764219CB68C00376078 /* RxAtomic.h in Headers */ = {isa = PBXBuildFile; fileRef = C8165AD121891D6700494BEF /* RxAtomic.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF6A5766219CB68C00376078 /* RxAtomic.c in Sources */ = {isa = PBXBuildFile; fileRef = C8165ACF21891D6700494BEF /* RxAtomic.c */; };
+		EF6A5774219CB6D200376078 /* SwitchIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A80A1EB4DA5900D431BC /* SwitchIfEmpty.swift */; };
+		EF6A5775219CB6D200376078 /* ConnectableObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C4D1B8A72BE0088E94D /* ConnectableObservableType.swift */; };
+		EF6A5776219CB6D200376078 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7FB1EB4DA5900D431BC /* Filter.swift */; };
+		EF6A5777219CB6D200376078 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F61EB4DA5900D431BC /* ElementAt.swift */; };
+		EF6A5778219CB6D200376078 /* Maybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F6ECBB1F48C366008552FA /* Maybe.swift */; };
+		EF6A5779219CB6D200376078 /* InvocableScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83D73B41C1DBAEE003DC470 /* InvocableScheduledItem.swift */; };
+		EF6A577A219CB6D200376078 /* NopDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C5C1B8A72BE0088E94D /* NopDisposable.swift */; };
+		EF6A577B219CB6D200376078 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C867816D1DB8129E00B2029A /* InfiniteSequence.swift */; };
+		EF6A577C219CB6D200376078 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C521B8A72BE0088E94D /* Disposable.swift */; };
+		EF6A577D219CB6D200376078 /* ObservableType+PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C801DE411F6EBB29008DB060 /* ObservableType+PrimitiveSequence.swift */; };
+		EF6A577E219CB6D200376078 /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8041EB4DA5900D431BC /* DistinctUntilChanged.swift */; };
+		EF6A577F219CB6D200376078 /* SingleAssignmentDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C601B8A72BE0088E94D /* SingleAssignmentDisposable.swift */; };
+		EF6A5780219CB6D200376078 /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7E81EB4DA5900D431BC /* Delay.swift */; };
+		EF6A5781219CB6D200376078 /* PrimitiveSequence+Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89814771E75A7D70035949C /* PrimitiveSequence+Zip+arity.swift */; };
+		EF6A5782219CB6D200376078 /* ObservableConvertibleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849BE2A1BAB5D070019AD27 /* ObservableConvertibleType.swift */; };
+		EF6A5783219CB6D200376078 /* SchedulerServices+Emulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CBB1B8A72BE0088E94D /* SchedulerServices+Emulation.swift */; };
+		EF6A5784219CB6D200376078 /* Concat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8091EB4DA5900D431BC /* Concat.swift */; };
+		EF6A5785219CB6D200376078 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7E71EB4DA5900D431BC /* Switch.swift */; };
+		EF6A5786219CB6D200376078 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
+		EF6A5787219CB6D200376078 /* First.swift in Sources */ = {isa = PBXBuildFile; fileRef = 819C2F081F2FBC7F009104B6 /* First.swift */; };
+		EF6A5788219CB6D200376078 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8081EB4DA5900D431BC /* TakeUntil.swift */; };
+		EF6A5789219CB6D200376078 /* DispatchQueueConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80EEC331D42D06E00131C39 /* DispatchQueueConfiguration.swift */; };
+		EF6A578A219CB6D200376078 /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7FC1EB4DA5900D431BC /* Dematerialize.swift */; };
+		EF6A578B219CB6D200376078 /* RetryWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8001EB4DA5900D431BC /* RetryWhen.swift */; };
+		EF6A578C219CB6D200376078 /* DelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7EC1EB4DA5900D431BC /* DelaySubscription.swift */; };
+		EF6A578D219CB6D200376078 /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8151EB4DA5900D431BC /* Just.swift */; };
+		EF6A578E219CB6D200376078 /* AnyObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CA01B8A72BE0088E94D /* AnyObserver.swift */; };
+		EF6A578F219CB6D200376078 /* ConcurrentMainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B144FA1BD2D44500267DCE /* ConcurrentMainScheduler.swift */; };
+		EF6A5790219CB6D200376078 /* AsMaybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8211EB4DA5900D431BC /* AsMaybe.swift */; };
+		EF6A5791219CB6D200376078 /* AsyncSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BA949661E224B7E0036DD06 /* AsyncSubject.swift */; };
+		EF6A5792219CB6D200376078 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E390621F379041004FC993 /* Enumerated.swift */; };
+		EF6A5793219CB6D200376078 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A80E1EB4DA5900D431BC /* Optional.swift */; };
+		EF6A5794219CB6D200376078 /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB01B8A72BE0088E94D /* RxMutableBox.swift */; };
+		EF6A5795219CB6D200376078 /* MainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB71B8A72BE0088E94D /* MainScheduler.swift */; };
+		EF6A5796219CB6D200376078 /* Skip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7ED1EB4DA5900D431BC /* Skip.swift */; };
+		EF6A5797219CB6D200376078 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8111EB4DA5900D431BC /* Using.swift */; };
+		EF6A5798219CB6D200376078 /* AtomicInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8165ACA21891BBF00494BEF /* AtomicInt.swift */; };
+		EF6A5799219CB6D200376078 /* Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8550B4A1D95A41400A6FCFE /* Reactive.swift */; };
+		EF6A579A219CB6D200376078 /* BooleanDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB883B441BE256D4000AC2EE /* BooleanDisposable.swift */; };
+		EF6A579B219CB6D200376078 /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8241EB4DA5900D431BC /* CombineLatest.swift */; };
+		EF6A579C219CB6D200376078 /* Bag+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86781871DB814AD00B2029A /* Bag+Rx.swift */; };
+		EF6A579D219CB6D200376078 /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7FD1EB4DA5900D431BC /* Materialize.swift */; };
+		EF6A579E219CB6D200376078 /* AddRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8231EB4DA5900D431BC /* AddRef.swift */; };
+		EF6A579F219CB6D200376078 /* Multicast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A81D1EB4DA5900D431BC /* Multicast.swift */; };
+		EF6A57A0219CB6D200376078 /* ReplaySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CC01B8A72BE0088E94D /* ReplaySubject.swift */; };
+		EF6A57A1219CB6D200376078 /* ObservableType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C671B8A72BE0088E94D /* ObservableType+Extensions.swift */; };
+		EF6A57A2219CB6D200376078 /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F91EB4DA5900D431BC /* TakeLast.swift */; };
+		EF6A57A3219CB6D200376078 /* InvocableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83D73B51C1DBAEE003DC470 /* InvocableType.swift */; };
+		EF6A57A4219CB6D200376078 /* ObserverBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CA61B8A72BE0088E94D /* ObserverBase.swift */; };
+		EF6A57A5219CB6D200376078 /* Never.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8161EB4DA5900D431BC /* Never.swift */; };
+		EF6A57A6219CB6D200376078 /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8011EB4DA5900D431BC /* Catch.swift */; };
+		EF6A57A7219CB6D200376078 /* String+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85106871C2D550E0075150C /* String+Rx.swift */; };
+		EF6A57A8219CB6D200376078 /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8201EB4DA5900D431BC /* ToArray.swift */; };
+		EF6A57A9219CB6D200376078 /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F81EB4DA5900D431BC /* SkipWhile.swift */; };
+		EF6A57AA219CB6D200376078 /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F6ECBD1F48C373008552FA /* Completable.swift */; };
+		EF6A57AB219CB6D200376078 /* AsSingle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8221EB4DA5900D431BC /* AsSingle.swift */; };
+		EF6A57AC219CB6D200376078 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BF34CA1C2E426800416CAE /* Platform.Linux.swift */; };
+		EF6A57AD219CB6D200376078 /* TailRecursiveSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CA91B8A72BE0088E94D /* TailRecursiveSink.swift */; };
+		EF6A57AE219CB6D200376078 /* AsyncLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C4B1B8A72BE0088E94D /* AsyncLock.swift */; };
+		EF6A57AF219CB6D200376078 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7EF1EB4DA5900D431BC /* Timer.swift */; };
+		EF6A57B0219CB6D200376078 /* Completable+AndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A53ADF1F09178700490535 /* Completable+AndThen.swift */; };
+		EF6A57B1219CB6D200376078 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8F03F491DBBAC0A00AECC4C /* DispatchQueue+Extensions.swift */; };
+		EF6A57B2219CB6D200376078 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8141EB4DA5900D431BC /* Error.swift */; };
+		EF6A57B3219CB6D200376078 /* BinaryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C551B8A72BE0088E94D /* BinaryDisposable.swift */; };
+		EF6A57B4219CB6D200376078 /* VirtualTimeConverterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FA89121C30405400CD3A17 /* VirtualTimeConverterType.swift */; };
+		EF6A57B5219CB6D200376078 /* SkipUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8071EB4DA5900D431BC /* SkipUntil.swift */; };
+		EF6A57B6219CB6D200376078 /* Create.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8181EB4DA5900D431BC /* Create.swift */; };
+		EF6A57B7219CB6D200376078 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7FF1EB4DA5900D431BC /* Scan.swift */; };
+		EF6A57B8219CB6D200376078 /* RefCountDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB883B3F1BE24C15000AC2EE /* RefCountDisposable.swift */; };
+		EF6A57B9219CB6D200376078 /* LockOwnerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC54D1BDCF48200E06A64 /* LockOwnerType.swift */; };
+		EF6A57BA219CB6D200376078 /* VirtualTimeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FA89131C30405400CD3A17 /* VirtualTimeScheduler.swift */; };
+		EF6A57BB219CB6D200376078 /* SynchronizedOnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC5521BDCF49300E06A64 /* SynchronizedOnType.swift */; };
+		EF6A57BC219CB6D200376078 /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F31EB4DA5900D431BC /* Generate.swift */; };
+		EF6A57BD219CB6D200376078 /* CurrentThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C3DA0E1B939767004D233E /* CurrentThreadScheduler.swift */; };
+		EF6A57BE219CB6D200376078 /* Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CAF1B8A72BE0088E94D /* Rx.swift */; };
+		EF6A57BF219CB6D200376078 /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7EE1EB4DA5900D431BC /* Take.swift */; };
+		EF6A57C0219CB6D200376078 /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8291EB4DA5900D431BC /* Zip.swift */; };
+		EF6A57C1219CB6D200376078 /* SubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CC11B8A72BE0088E94D /* SubjectType.swift */; };
+		EF6A57C2219CB6D200376078 /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8281EB4DA5900D431BC /* Sink.swift */; };
+		EF6A57C3219CB6D200376078 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EF320051B07006BAB40 /* DeprecationWarner.swift */; };
+		EF6A57C4219CB6D200376078 /* HistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FA89161C30409900CD3A17 /* HistoricalScheduler.swift */; };
+		EF6A57C5219CB6D200376078 /* TakeWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7FA1EB4DA5900D431BC /* TakeWhile.swift */; };
+		EF6A57C6219CB6D200376078 /* AnonymousObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CA21B8A72BE0088E94D /* AnonymousObserver.swift */; };
+		EF6A57C7219CB6D200376078 /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CBF1B8A72BE0088E94D /* PublishSubject.swift */; };
+		EF6A57C8219CB6D200376078 /* ScheduledItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83D73B71C1DBAEE003DC470 /* ScheduledItemType.swift */; };
+		EF6A57C9219CB6D200376078 /* CombineLatest+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A80C1EB4DA5900D431BC /* CombineLatest+Collection.swift */; };
+		EF6A57CA219CB6D200376078 /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8271EB4DA5900D431BC /* Producer.swift */; };
+		EF6A57CB219CB6D200376078 /* SchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB31B8A72BE0088E94D /* SchedulerType.swift */; };
+		EF6A57CC219CB6D200376078 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8101EB4DA5900D431BC /* Range.swift */; };
+		EF6A57CD219CB6D200376078 /* Zip+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A80B1EB4DA5900D431BC /* Zip+Collection.swift */; };
+		EF6A57CE219CB6D200376078 /* SynchronizedDisposeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC5611BDD037900E06A64 /* SynchronizedDisposeType.swift */; };
+		EF6A57CF219CB6D200376078 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7E91EB4DA5900D431BC /* Timeout.swift */; };
+		EF6A57D0219CB6D200376078 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F71EB4DA5900D431BC /* Merge.swift */; };
+		EF6A57D1219CB6D200376078 /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB81B8A72BE0088E94D /* OperationQueueScheduler.swift */; };
+		EF6A57D2219CB6D200376078 /* DisposeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C581B8A72BE0088E94D /* DisposeBag.swift */; };
+		EF6A57D3219CB6D200376078 /* GroupedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217E81E3374970015DD38 /* GroupedObservable.swift */; };
+		EF6A57D4219CB6D200376078 /* Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A82A1EB4DA5900D431BC /* Zip+arity.swift */; };
+		EF6A57D5219CB6D200376078 /* RecursiveScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB91B8A72BE0088E94D /* RecursiveScheduler.swift */; };
+		EF6A57D6219CB6D200376078 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81A09801E6C6B2400900B3B /* Deprecated.swift */; };
+		EF6A57D7219CB6D200376078 /* DisposeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C591B8A72BE0088E94D /* DisposeBase.swift */; };
+		EF6A57D8219CB6D200376078 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A80D1EB4DA5900D431BC /* Debug.swift */; };
+		EF6A57D9219CB6D200376078 /* SubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8191EB4DA5900D431BC /* SubscribeOn.swift */; };
+		EF6A57DA219CB6D200376078 /* AnonymousDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C541B8A72BE0088E94D /* AnonymousDisposable.swift */; };
+		EF6A57DB219CB6D200376078 /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8121EB4DA5900D431BC /* Repeat.swift */; };
+		EF6A57DC219CB6D200376078 /* SingleAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F51EB4DA5900D431BC /* SingleAsync.swift */; };
+		EF6A57DD219CB6D200376078 /* PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81A09861E6C702700900B3B /* PrimitiveSequence.swift */; };
+		EF6A57DE219CB6D200376078 /* ConcurrentDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CB51B8A72BE0088E94D /* ConcurrentDispatchQueueScheduler.swift */; };
+		EF6A57DF219CB6D200376078 /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25F6ECBF1F48C37C008552FA /* Single.swift */; };
+		EF6A57E0219CB6D200376078 /* Do.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8031EB4DA5900D431BC /* Do.swift */; };
+		EF6A57E1219CB6D200376078 /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CBE1B8A72BE0088E94D /* BehaviorSubject.swift */; };
+		EF6A57E2219CB6D200376078 /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7EA1EB4DA5900D431BC /* Window.swift */; };
+		EF6A57E3219CB6D200376078 /* ObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C9E1B8A72BE0088E94D /* ObservableType.swift */; };
+		EF6A57E4219CB6D200376078 /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8251EB4DA5900D431BC /* CombineLatest+arity.swift */; };
+		EF6A57E5219CB6D200376078 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F11EB4DA5900D431BC /* Debounce.swift */; };
+		EF6A57E6219CB6D200376078 /* SerialDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CBC1B8A72BE0088E94D /* SerialDispatchQueueScheduler.swift */; };
+		EF6A57E7219CB6D200376078 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDDEF1691D4FB40000CA8546 /* Disposables.swift */; };
+		EF6A57E8219CB6D200376078 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C4C1B8A72BE0088E94D /* Lock.swift */; };
+		EF6A57E9219CB6D200376078 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */; };
+		EF6A57EA219CB6D200376078 /* DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7FE1EB4DA5900D431BC /* DefaultIfEmpty.swift */; };
+		EF6A57EB219CB6D200376078 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7EB1EB4DA5900D431BC /* Buffer.swift */; };
+		EF6A57EC219CB6D200376078 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7E61EB4DA5900D431BC /* Map.swift */; };
+		EF6A57ED219CB6D200376078 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C631B8A72BE0088E94D /* Errors.swift */; };
+		EF6A57EE219CB6D200376078 /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C867816E1DB8129E00B2029A /* PriorityQueue.swift */; };
+		EF6A57EF219CB6D200376078 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A80F1EB4DA5900D431BC /* Sequence.swift */; };
+		EF6A57F0219CB6D200376078 /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8131EB4DA5900D431BC /* Deferred.swift */; };
+		EF6A57F1219CB6D200376078 /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8061EB4DA5900D431BC /* Amb.swift */; };
+		EF6A57F2219CB6D200376078 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F01EB4DA5900D431BC /* Sample.swift */; };
+		EF6A57F3219CB6D200376078 /* ShareReplayScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8845AD31EDB4C9900B36836 /* ShareReplayScope.swift */; };
+		EF6A57F4219CB6D200376078 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C867816C1DB8129E00B2029A /* Bag.swift */; };
+		EF6A57F5219CB6D200376078 /* ImmediateSchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C651B8A72BE0088E94D /* ImmediateSchedulerType.swift */; };
+		EF6A57F6219CB6D200376078 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BF34C91C2E426800416CAE /* Platform.Darwin.swift */; };
+		EF6A57F7219CB6D200376078 /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F21EB4DA5900D431BC /* Throttle.swift */; };
+		EF6A57F8219CB6D200376078 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C491B8A72BE0088E94D /* Cancelable.swift */; };
+		EF6A57F9219CB6D200376078 /* ScheduledDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C5D1B8A72BE0088E94D /* ScheduledDisposable.swift */; };
+		EF6A57FA219CB6D200376078 /* HistoricalSchedulerTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8FA891B1C30412A00CD3A17 /* HistoricalSchedulerTimeConverter.swift */; };
+		EF6A57FB219CB6D200376078 /* CompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C571B8A72BE0088E94D /* CompositeDisposable.swift */; };
+		EF6A57FC219CB6D200376078 /* ObserverType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093CAB1B8A72BE0088E94D /* ObserverType.swift */; };
+		EF6A57FD219CB6D200376078 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8171EB4DA5900D431BC /* Empty.swift */; };
+		EF6A57FE219CB6D200376078 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C681B8A72BE0088E94D /* Observable.swift */; };
+		EF6A57FF219CB6D200376078 /* SynchronizedUnsubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC55C1BDD010800E06A64 /* SynchronizedUnsubscribeType.swift */; };
+		EF6A5800219CB6D200376078 /* SerialDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C5F1B8A72BE0088E94D /* SerialDisposable.swift */; };
+		EF6A5801219CB6D200376078 /* Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A81F1EB4DA5900D431BC /* Reduce.swift */; };
+		EF6A5802219CB6D200376078 /* GroupBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A7F41EB4DA5900D431BC /* GroupBy.swift */; };
+		EF6A5803219CB6D200376078 /* SubscriptionDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84CC5661BDD08A500E06A64 /* SubscriptionDisposable.swift */; };
+		EF6A5804219CB6D200376078 /* StartWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8021EB4DA5900D431BC /* StartWith.swift */; };
+		EF6A5805219CB6D200376078 /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A81A1EB4DA5900D431BC /* ObserveOn.swift */; };
+		EF6A5806219CB6D200376078 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093C641B8A72BE0088E94D /* Event.swift */; };
+		EF6A5807219CB6D200376078 /* ScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83D73B61C1DBAEE003DC470 /* ScheduledItem.swift */; };
+		EF6A5808219CB6D200376078 /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A8051EB4DA5900D431BC /* WithLatestFrom.swift */; };
+		EF6A5809219CB6D200376078 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = C867816F1DB8129E00B2029A /* Queue.swift */; };
+		EF6A5818219CB72100376078 /* _RXDelegateProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = C89AB2561DAACC580065FBE6 /* _RXDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF6A5819219CB72100376078 /* _RXObjCRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = C89AB2581DAACC580065FBE6 /* _RXObjCRuntime.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF6A581A219CB72100376078 /* _RX.h in Headers */ = {isa = PBXBuildFile; fileRef = C89AB2551DAACC580065FBE6 /* _RX.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF6A581B219CB72100376078 /* RxCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = C89AB2781DAACE490065FBE6 /* RxCocoa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF6A581C219CB72100376078 /* _RXKVOObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = C89AB2571DAACC580065FBE6 /* _RXKVOObserver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EF6A581E219CB72100376078 /* UISlider+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254101B8A752B00B02D69 /* UISlider+Rx.swift */; };
+		EF6A581F219CB72100376078 /* UIScrollView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C882540D1B8A752B00B02D69 /* UIScrollView+Rx.swift */; };
+		EF6A5820219CB72100376078 /* NSSlider+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86781941DB823B500B2029A /* NSSlider+Rx.swift */; };
+		EF6A5821219CB72100376078 /* UIPickerView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844BC8B31CE4FD7500F5C7CB /* UIPickerView+Rx.swift */; };
+		EF6A5822219CB72100376078 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1C01DAAC3350065FBE6 /* Logging.swift */; };
+		EF6A5823219CB72100376078 /* UIWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */; };
+		EF6A5824219CB72100376078 /* NSControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86781921DB823B500B2029A /* NSControl+Rx.swift */; };
+		EF6A5825219CB72100376078 /* DelegateProxyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093E8C1B8A732E0088E94D /* DelegateProxyType.swift */; };
+		EF6A5826219CB72100376078 /* RxTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093E9C1B8A732E0088E94D /* RxTarget.swift */; };
+		EF6A5827219CB72100376078 /* BehaviorRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C8BCCE1F8944B800501D4D /* BehaviorRelay.swift */; };
+		EF6A5828219CB72100376078 /* UITextView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254141B8A752B00B02D69 /* UITextView+Rx.swift */; };
+		EF6A5829219CB72100376078 /* RxTableViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F21B8A752B00B02D69 /* RxTableViewReactiveArrayDataSource.swift */; };
+		EF6A582A219CB72100376078 /* PublishRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B0F7101F530CA700548EBE /* PublishRelay.swift */; };
+		EF6A582B219CB72100376078 /* BehaviorRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8C8BCD31F89459300501D4D /* BehaviorRelay+Driver.swift */; };
+		EF6A582C219CB72100376078 /* RxCollectionViewDataSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253FC1B8A752B00B02D69 /* RxCollectionViewDataSourceProxy.swift */; };
+		EF6A582D219CB72100376078 /* SchedulerType+SharedSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85E6FBD1F53025700C5681E /* SchedulerType+SharedSequence.swift */; };
+		EF6A582E219CB72100376078 /* RxTextStorageDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C225A21C33F00B008724EC /* RxTextStorageDelegateProxy.swift */; };
+		EF6A582F219CB72100376078 /* Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1B11DAAC3350065FBE6 /* Driver.swift */; };
+		EF6A5830219CB72100376078 /* RxTableViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254011B8A752B00B02D69 /* RxTableViewDelegateProxy.swift */; };
+		EF6A5831219CB72100376078 /* _RX.m in Sources */ = {isa = PBXBuildFile; fileRef = C89AB22D1DAAC3A60065FBE6 /* _RX.m */; };
+		EF6A5832219CB72100376078 /* NSTextView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927A78B621179FFD00A45638 /* NSTextView+Rx.swift */; };
+		EF6A5833219CB72100376078 /* UIRefreshControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */; };
+		EF6A5834219CB72100376078 /* UIStepper+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */; };
+		EF6A5835219CB72100376078 /* ObservableConvertibleType+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B0F7211F53135100548EBE /* ObservableConvertibleType+Signal.swift */; };
+		EF6A5836219CB72100376078 /* ControlEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1AB1DAAC3350065FBE6 /* ControlEvent.swift */; };
+		EF6A5837219CB72100376078 /* ControlEvent+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8091C561FAA39C1001DB32A /* ControlEvent+Signal.swift */; };
+		EF6A5838219CB72100376078 /* UIImageView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C882540B1B8A752B00B02D69 /* UIImageView+Rx.swift */; };
+		EF6A5839219CB72100376078 /* RxPickerViewDataSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */; };
+		EF6A583A219CB72100376078 /* UIControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254081B8A752B00B02D69 /* UIControl+Rx.swift */; };
+		EF6A583B219CB72100376078 /* Binder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8E65EFA1F6E91D1004478C3 /* Binder.swift */; };
+		EF6A583C219CB72100376078 /* SectionedViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D132431C42D15E00B59FFF /* SectionedViewDataSourceType.swift */; };
+		EF6A583D219CB72100376078 /* RxCollectionViewDataSourcePrefetchingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B562478D2035154900D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift */; };
+		EF6A583E219CB72100376078 /* UISearchController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84E4D3901C9AFCD500ADFDC9 /* UISearchController+Rx.swift */; };
+		EF6A583F219CB72100376078 /* NSImageView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86781931DB823B500B2029A /* NSImageView+Rx.swift */; };
+		EF6A5840219CB72100376078 /* UITableView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254121B8A752B00B02D69 /* UITableView+Rx.swift */; };
+		EF6A5841219CB72100376078 /* RxCocoaObjCRuntimeError+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1A51DAAC25A0065FBE6 /* RxCocoaObjCRuntimeError+Extensions.swift */; };
+		EF6A5842219CB72100376078 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F11B8A752B00B02D69 /* RxCollectionViewReactiveArrayDataSource.swift */; };
+		EF6A5843219CB72100376078 /* URLSession+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1C51DAAC3350065FBE6 /* URLSession+Rx.swift */; };
+		EF6A5844219CB72100376078 /* RxSearchControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846436E11C9AF64C0035B40D /* RxSearchControllerDelegateProxy.swift */; };
+		EF6A5845219CB72100376078 /* RxCollectionViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253FD1B8A752B00B02D69 /* RxCollectionViewDelegateProxy.swift */; };
+		EF6A5846219CB72100376078 /* UIAlertAction+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */; };
+		EF6A5847219CB72100376078 /* RxScrollViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253FE1B8A752B00B02D69 /* RxScrollViewDelegateProxy.swift */; };
+		EF6A5848219CB72100376078 /* KVORepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1BF1DAAC3350065FBE6 /* KVORepresentable.swift */; };
+		EF6A5849219CB72100376078 /* TextInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88F76801CE5341700D5A014 /* TextInput.swift */; };
+		EF6A584A219CB72100376078 /* PublishRelay+Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B0F7141F530F5900548EBE /* PublishRelay+Signal.swift */; };
+		EF6A584B219CB72100376078 /* UILabel+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C882540C1B8A752B00B02D69 /* UILabel+Rx.swift */; };
+		EF6A584C219CB72100376078 /* ControlEvent+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1AE1DAAC3350065FBE6 /* ControlEvent+Driver.swift */; };
+		EF6A584D219CB72100376078 /* Driver+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1B01DAAC3350065FBE6 /* Driver+Subscription.swift */; };
+		EF6A584E219CB72100376078 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
+		EF6A584F219CB72100376078 /* UIPageControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91BE429B1CBF7EC000F6B062 /* UIPageControl+Rx.swift */; };
+		EF6A5850219CB72100376078 /* RxSearchBarDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253FF1B8A752B00B02D69 /* RxSearchBarDelegateProxy.swift */; };
+		EF6A5851219CB72100376078 /* RxPickerViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A520FFF61F0D258E00573734 /* RxPickerViewDataSourceType.swift */; };
+		EF6A5852219CB72100376078 /* Signal+Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8D970CD1F5324D90058F2FE /* Signal+Subscription.swift */; };
+		EF6A5853219CB72100376078 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
+		EF6A5854219CB72100376078 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
+		EF6A5855219CB72100376078 /* UIApplication+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C839365E1C70E02200A9A09E /* UIApplication+Rx.swift */; };
+		EF6A5856219CB72100376078 /* RxPickerViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844BC8AA1CE4FA5600F5C7CB /* RxPickerViewDelegateProxy.swift */; };
+		EF6A5857219CB72100376078 /* RxCocoa.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB2261DAAC33F0065FBE6 /* RxCocoa.swift */; };
+		EF6A5858219CB72100376078 /* SharedSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1B91DAAC3350065FBE6 /* SharedSequence.swift */; };
+		EF6A5859219CB72100376078 /* SharedSequence+Operators+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1B61DAAC3350065FBE6 /* SharedSequence+Operators+arity.swift */; };
+		EF6A585A219CB72100376078 /* UITabBarController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */; };
+		EF6A585B219CB72100376078 /* NSObject+Rx+RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1C31DAAC3350065FBE6 /* NSObject+Rx+RawRepresentable.swift */; };
+		EF6A585C219CB72100376078 /* UIView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BCD3EC1C14B5FB005F1280 /* UIView+Rx.swift */; };
+		EF6A585D219CB72100376078 /* RxPickerViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */; };
+		EF6A585E219CB72100376078 /* KVORepresentable+CoreGraphics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1BD1DAAC3350065FBE6 /* KVORepresentable+CoreGraphics.swift */; };
+		EF6A585F219CB72100376078 /* Observable+Bind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80D338E1B91EF9E0014629D /* Observable+Bind.swift */; };
+		EF6A5860219CB72100376078 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81772971E7F408100EA679B /* Deprecated.swift */; };
+		EF6A5861219CB72100376078 /* UISegmentedControl+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C882540F1B8A752B00B02D69 /* UISegmentedControl+Rx.swift */; };
+		EF6A5862219CB72100376078 /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */; };
+		EF6A5863219CB72100376078 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
+		EF6A5864219CB72100376078 /* NSButton+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86781911DB823B500B2029A /* NSButton+Rx.swift */; };
+		EF6A5865219CB72100376078 /* NSTextField+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86781951DB823B500B2029A /* NSTextField+Rx.swift */; };
+		EF6A5866219CB72100376078 /* Signal.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85E6FBB1F52FF4F00C5681E /* Signal.swift */; };
+		EF6A5867219CB72100376078 /* NSView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86781961DB823B500B2029A /* NSView+Rx.swift */; };
+		EF6A5868219CB72100376078 /* _RXKVOObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = C89AB2311DAAC3A60065FBE6 /* _RXKVOObserver.m */; };
+		EF6A5869219CB72100376078 /* UIButton+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254061B8A752B00B02D69 /* UIButton+Rx.swift */; };
+		EF6A586A219CB72100376078 /* ObservableConvertibleType+SharedSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8091C4D1FAA345C001DB32A /* ObservableConvertibleType+SharedSequence.swift */; };
+		EF6A586B219CB72100376078 /* ControlProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1AC1DAAC3350065FBE6 /* ControlProperty.swift */; };
+		EF6A586C219CB72100376078 /* RxTabBarControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */; };
+		EF6A586D219CB72100376078 /* SharedSequence+Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1B81DAAC3350065FBE6 /* SharedSequence+Operators.swift */; };
+		EF6A586E219CB72100376078 /* UIActivityIndicatorView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BA1CBD11C0F7C0A0044B50A /* UIActivityIndicatorView+Rx.swift */; };
+		EF6A586F219CB72100376078 /* NSTextStorage+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 842A5A281C357F7D003568D5 /* NSTextStorage+Rx.swift */; };
+		EF6A5870219CB72100376078 /* RxTextViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254021B8A752B00B02D69 /* RxTextViewDelegateProxy.swift */; };
+		EF6A5871219CB72100376078 /* _RXDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = C89AB22F1DAAC3A60065FBE6 /* _RXDelegateProxy.m */; };
+		EF6A5872219CB72100376078 /* KVORepresentable+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1BE1DAAC3350065FBE6 /* KVORepresentable+Swift.swift */; };
+		EF6A5873219CB72100376078 /* ObservableConvertibleType+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1B21DAAC3350065FBE6 /* ObservableConvertibleType+Driver.swift */; };
+		EF6A5874219CB72100376078 /* RxNavigationControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */; };
+		EF6A5875219CB72100376078 /* UIBarButtonItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254051B8A752B00B02D69 /* UIBarButtonItem+Rx.swift */; };
+		EF6A5876219CB72100376078 /* NSObject+Rx+KVORepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1C21DAAC3350065FBE6 /* NSObject+Rx+KVORepresentable.swift */; };
+		EF6A5877219CB72100376078 /* UIDatePicker+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254091B8A752B00B02D69 /* UIDatePicker+Rx.swift */; };
+		EF6A5878219CB72100376078 /* RxTableViewDataSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254001B8A752B00B02D69 /* RxTableViewDataSourceProxy.swift */; };
+		EF6A5879219CB72100376078 /* NSLayoutConstraint+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BCD3F31C14B6D1005F1280 /* NSLayoutConstraint+Rx.swift */; };
+		EF6A587A219CB72100376078 /* UIGestureRecognizer+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C882540A1B8A752B00B02D69 /* UIGestureRecognizer+Rx.swift */; };
+		EF6A587B219CB72100376078 /* ControlProperty+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1AF1DAAC3350065FBE6 /* ControlProperty+Driver.swift */; };
+		EF6A587C219CB72100376078 /* DelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093E8B1B8A732E0088E94D /* DelegateProxy.swift */; };
+		EF6A587D219CB72100376078 /* _RXObjCRuntime.m in Sources */ = {isa = PBXBuildFile; fileRef = C89AB2331DAAC3A60065FBE6 /* _RXObjCRuntime.m */; };
+		EF6A587E219CB72100376078 /* NSObject+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1C41DAAC3350065FBE6 /* NSObject+Rx.swift */; };
+		EF6A587F219CB72100376078 /* UINavigationController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9080AD21EA05DDF002B433B /* UINavigationController+Rx.swift */; };
+		EF6A5880219CB72100376078 /* UITabBar+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88718CFD1CE5D80000D88D60 /* UITabBar+Rx.swift */; };
+		EF6A5881219CB72100376078 /* RxTabBarDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88D98F2D1CE7549A00D50457 /* RxTabBarDelegateProxy.swift */; };
+		EF6A5882219CB72100376078 /* UISwitch+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254111B8A752B00B02D69 /* UISwitch+Rx.swift */; };
+		EF6A5883219CB72100376078 /* UICollectionView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254071B8A752B00B02D69 /* UICollectionView+Rx.swift */; };
+		EF6A5884219CB72100376078 /* RxCollectionViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F71B8A752B00B02D69 /* RxCollectionViewDataSourceType.swift */; };
+		EF6A5885219CB72100376078 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A81C9F1E05E82C0008DEF4 /* DispatchQueue+Extensions.swift */; };
+		EF6A5886219CB72100376078 /* UITextField+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88254131B8A752B00B02D69 /* UITextField+Rx.swift */; };
+		EF6A5887219CB72100376078 /* RxWebViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */; };
+		EF6A5888219CB72100376078 /* UISearchBar+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C882540E1B8A752B00B02D69 /* UISearchBar+Rx.swift */; };
+		EF6A5889219CB72100376078 /* NotificationCenter+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1C11DAAC3350065FBE6 /* NotificationCenter+Rx.swift */; };
+		EF6A588A219CB72100376078 /* ItemEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F41B8A752B00B02D69 /* ItemEvents.swift */; };
+		EF6A588B219CB72100376078 /* ControlTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89AB1711DAAC1680065FBE6 /* ControlTarget.swift */; };
+		EF6A588C219CB72100376078 /* RxTableViewDataSourceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88253F81B8A752B00B02D69 /* RxTableViewDataSourceType.swift */; };
+		EF6A588D219CB72100376078 /* RxTableViewDataSourcePrefetchingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5624793203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift */; };
+		EF6A589F219CB78300376078 /* AtomicInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8165ACC21891BE400494BEF /* AtomicInt.swift */; };
+		EF6A58A0219CB78300376078 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85B01681DB2ACAF006043C3 /* Platform.Linux.swift */; };
+		EF6A58A1219CB78300376078 /* RunLoopLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88E296A1BEB712E001CCB92 /* RunLoopLock.swift */; };
+		EF6A58A2219CB78300376078 /* BlockingObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8941BDE1BD5695C00A0E874 /* BlockingObservable.swift */; };
+		EF6A58A3219CB78300376078 /* BlockingObservable+Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8941BE31BD56B0700A0E874 /* BlockingObservable+Operators.swift */; };
+		EF6A58A4219CB78300376078 /* ObservableConvertibleType+Blocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8093F581B8A73A20088E94D /* ObservableConvertibleType+Blocking.swift */; };
+		EF6A58A5219CB78300376078 /* Resources.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85218041E33FCA50015DD38 /* Resources.swift */; };
+		EF6A58A6219CB78300376078 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85B01671DB2ACAF006043C3 /* Platform.Darwin.swift */; };
+		EF6A58A7219CB78300376078 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C85217FB1E33FBFB0015DD38 /* RecursiveLock.swift */; };
+		EF6A58B5219CB7BF00376078 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C820A9441EB4E06800D431BC /* Deprecated.swift */; };
+		EF6A58B6219CB7BF00376078 /* DeprecationWarner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785D5EFC20051B1F006BAB40 /* DeprecationWarner.swift */; };
+		EF6A58B7219CB7BF00376078 /* Recorded.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA151DAABBE20079D23B /* Recorded.swift */; };
+		EF6A58B8219CB7BF00376078 /* TestableObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA1C1DAABBE20079D23B /* TestableObserver.swift */; };
+		EF6A58B9219CB7BF00376078 /* XCTest+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA1D1DAABBE20079D23B /* XCTest+Rx.swift */; };
+		EF6A58BA219CB7BF00376078 /* RxTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA161DAABBE20079D23B /* RxTest.swift */; };
+		EF6A58BB219CB7BF00376078 /* Event+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA121DAABBE20079D23B /* Event+Equatable.swift */; };
+		EF6A58BC219CB7BF00376078 /* ColdObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA111DAABBE20079D23B /* ColdObservable.swift */; };
+		EF6A58BD219CB7BF00376078 /* TestableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA1B1DAABBE20079D23B /* TestableObservable.swift */; };
+		EF6A58BE219CB7BF00376078 /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA181DAABBE20079D23B /* TestScheduler.swift */; };
+		EF6A58BF219CB7BF00376078 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C86781821DB8143A00B2029A /* Bag.swift */; };
+		EF6A58C0219CB7BF00376078 /* HotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA131DAABBE20079D23B /* HotObservable.swift */; };
+		EF6A58C1219CB7BF00376078 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
+		EF6A58C2219CB7BF00376078 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA1A1DAABBE20079D23B /* Subscription.swift */; };
+		EF6A58C3219CB7BF00376078 /* Any+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA101DAABBE20079D23B /* Any+Equatable.swift */; };
+		EF6A58C4219CB7BF00376078 /* TestSchedulerVirtualTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C89CFA191DAABBE20079D23B /* TestSchedulerVirtualTimeConverter.swift */; };
 		F31F35B01BB4FED800961002 /* UIStepper+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */; };
 /* End PBXBuildFile section */
 
@@ -906,6 +1200,41 @@
 			proxyType = 1;
 			remoteGlobalIDString = C80938F51B8A71760088E94D;
 			remoteInfo = "RxCocoa-iOS";
+		};
+		EF6A5812219CB70D00376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A5762219CB68C00376078;
+			remoteInfo = "RxAtomic-Static";
+		};
+		EF6A5896219CB75700376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A576F219CB6D200376078;
+			remoteInfo = "RxSwift-Static";
+		};
+		EF6A58CD219CB7D600376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A5762219CB68C00376078;
+			remoteInfo = "RxAtomic-Static";
+		};
+		EF6A58CF219CB7D600376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A576F219CB6D200376078;
+			remoteInfo = "RxSwift-Static";
+		};
+		EF6A58D1219CB81700376078 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C8A56ACE1AD7424700B4673B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EF6A576F219CB6D200376078;
+			remoteInfo = "RxSwift-Static";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -1416,6 +1745,11 @@
 		ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Rx.swift"; sourceTree = "<group>"; };
 		ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTabBarControllerDelegateProxy.swift; sourceTree = "<group>"; };
 		ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+RxTests.swift"; sourceTree = "<group>"; };
+		EF6A576D219CB68C00376078 /* RxAtomic.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxAtomic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF6A5810219CB6D200376078 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF6A5894219CB72100376078 /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF6A58AE219CB78300376078 /* RxBlocking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxBlocking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EF6A58CB219CB7BF00376078 /* RxTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F31F35AF1BB4FED800961002 /* UIStepper+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStepper+Rx.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1489,6 +1823,41 @@
 			buildActionMask = 2147483647;
 			files = (
 				C8E8BA5A1E2C181A00A4AC2C /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5767219CB68C00376078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A580B219CB6D200376078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A588F219CB72100376078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A58A9219CB78300376078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A58C6219CB7BF00376078 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2356,6 +2725,11 @@
 				C85BA04B1C3878740075D68E /* PerformanceTests.app */,
 				C8E8BA551E2C181A00A4AC2C /* Benchmarks.xctest */,
 				C8165ABC21891AFF00494BEF /* RxAtomic.framework */,
+				EF6A576D219CB68C00376078 /* RxAtomic.framework */,
+				EF6A5810219CB6D200376078 /* RxSwift.framework */,
+				EF6A5894219CB72100376078 /* RxCocoa.framework */,
+				EF6A58AE219CB78300376078 /* RxBlocking.framework */,
+				EF6A58CB219CB7BF00376078 /* RxTest.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2454,6 +2828,47 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C8A56AD41AD7424700B4673B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5763219CB68C00376078 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A5764219CB68C00376078 /* RxAtomic.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5772219CB6D200376078 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5817219CB72100376078 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A5818219CB72100376078 /* _RXDelegateProxy.h in Headers */,
+				EF6A5819219CB72100376078 /* _RXObjCRuntime.h in Headers */,
+				EF6A581A219CB72100376078 /* _RX.h in Headers */,
+				EF6A581B219CB72100376078 /* RxCocoa.h in Headers */,
+				EF6A581C219CB72100376078 /* _RXKVOObserver.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A589D219CB78300376078 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A58B3219CB7BF00376078 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -2657,6 +3072,101 @@
 			productReference = C8E8BA551E2C181A00A4AC2C /* Benchmarks.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		EF6A5762219CB68C00376078 /* RxAtomic-Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF6A5769219CB68C00376078 /* Build configuration list for PBXNativeTarget "RxAtomic-Static" */;
+			buildPhases = (
+				EF6A5763219CB68C00376078 /* Headers */,
+				EF6A5765219CB68C00376078 /* Sources */,
+				EF6A5767219CB68C00376078 /* Frameworks */,
+				EF6A5768219CB68C00376078 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "RxAtomic-Static";
+			productName = RxAtomic;
+			productReference = EF6A576D219CB68C00376078 /* RxAtomic.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		EF6A576F219CB6D200376078 /* RxSwift-Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF6A580C219CB6D200376078 /* Build configuration list for PBXNativeTarget "RxSwift-Static" */;
+			buildPhases = (
+				EF6A5772219CB6D200376078 /* Headers */,
+				EF6A5773219CB6D200376078 /* Sources */,
+				EF6A580A219CB6D200376078 /* Resources */,
+				EF6A580B219CB6D200376078 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF6A5813219CB70D00376078 /* PBXTargetDependency */,
+			);
+			name = "RxSwift-Static";
+			productName = RxSwift;
+			productReference = EF6A5810219CB6D200376078 /* RxSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		EF6A5814219CB72100376078 /* RxCocoa-Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF6A5890219CB72100376078 /* Build configuration list for PBXNativeTarget "RxCocoa-Static" */;
+			buildPhases = (
+				EF6A5817219CB72100376078 /* Headers */,
+				EF6A581D219CB72100376078 /* Sources */,
+				EF6A588E219CB72100376078 /* Resources */,
+				EF6A588F219CB72100376078 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF6A5897219CB75700376078 /* PBXTargetDependency */,
+			);
+			name = "RxCocoa-Static";
+			productName = RxSwift;
+			productReference = EF6A5894219CB72100376078 /* RxCocoa.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		EF6A5898219CB78300376078 /* RxBlocking-Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF6A58AA219CB78300376078 /* Build configuration list for PBXNativeTarget "RxBlocking-Static" */;
+			buildPhases = (
+				EF6A589D219CB78300376078 /* Headers */,
+				EF6A589E219CB78300376078 /* Sources */,
+				EF6A58A8219CB78300376078 /* Resources */,
+				EF6A58A9219CB78300376078 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF6A58CE219CB7D600376078 /* PBXTargetDependency */,
+				EF6A58D0219CB7D600376078 /* PBXTargetDependency */,
+			);
+			name = "RxBlocking-Static";
+			productName = RxSwift;
+			productReference = EF6A58AE219CB78300376078 /* RxBlocking.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		EF6A58B0219CB7BF00376078 /* RxTest-Static */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EF6A58C7219CB7BF00376078 /* Build configuration list for PBXNativeTarget "RxTest-Static" */;
+			buildPhases = (
+				EF6A58B3219CB7BF00376078 /* Headers */,
+				EF6A58B4219CB7BF00376078 /* Sources */,
+				EF6A58C5219CB7BF00376078 /* Resources */,
+				EF6A58C6219CB7BF00376078 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF6A58D2219CB81700376078 /* PBXTargetDependency */,
+			);
+			name = "RxTest-Static";
+			productName = RxSwift;
+			productReference = EF6A58CB219CB7BF00376078 /* RxTest.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -2719,10 +3229,15 @@
 			projectRoot = "";
 			targets = (
 				C8165ABB21891AFF00494BEF /* RxAtomic */,
+				EF6A5762219CB68C00376078 /* RxAtomic-Static */,
 				C8A56AD61AD7424700B4673B /* RxSwift */,
+				EF6A576F219CB6D200376078 /* RxSwift-Static */,
 				C80938F51B8A71760088E94D /* RxCocoa */,
+				EF6A5814219CB72100376078 /* RxCocoa-Static */,
 				C8093B4B1B8A71F00088E94D /* RxBlocking */,
+				EF6A5898219CB78300376078 /* RxBlocking-Static */,
 				C88FA4FD1C25C44800CCFEA4 /* RxTest */,
+				EF6A58B0219CB7BF00376078 /* RxTest-Static */,
 				C83508C21C386F6F0027C24C /* AllTests-iOS */,
 				C83509831C38740E0027C24C /* AllTests-tvOS */,
 				C83509931C38742C0027C24C /* AllTests-macOS */,
@@ -2797,6 +3312,41 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		C8E8BA531E2C181A00A4AC2C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5768219CB68C00376078 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A580A219CB6D200376078 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A588E219CB72100376078 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A58A8219CB78300376078 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A58C5219CB7BF00376078 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3632,6 +4182,329 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EF6A5765219CB68C00376078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A5766219CB68C00376078 /* RxAtomic.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A5773219CB6D200376078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A5774219CB6D200376078 /* SwitchIfEmpty.swift in Sources */,
+				EF6A5775219CB6D200376078 /* ConnectableObservableType.swift in Sources */,
+				EF6A5776219CB6D200376078 /* Filter.swift in Sources */,
+				EF6A5777219CB6D200376078 /* ElementAt.swift in Sources */,
+				EF6A5778219CB6D200376078 /* Maybe.swift in Sources */,
+				EF6A5779219CB6D200376078 /* InvocableScheduledItem.swift in Sources */,
+				EF6A577A219CB6D200376078 /* NopDisposable.swift in Sources */,
+				EF6A577B219CB6D200376078 /* InfiniteSequence.swift in Sources */,
+				EF6A577C219CB6D200376078 /* Disposable.swift in Sources */,
+				EF6A577D219CB6D200376078 /* ObservableType+PrimitiveSequence.swift in Sources */,
+				EF6A577E219CB6D200376078 /* DistinctUntilChanged.swift in Sources */,
+				EF6A577F219CB6D200376078 /* SingleAssignmentDisposable.swift in Sources */,
+				EF6A5780219CB6D200376078 /* Delay.swift in Sources */,
+				EF6A5781219CB6D200376078 /* PrimitiveSequence+Zip+arity.swift in Sources */,
+				EF6A5782219CB6D200376078 /* ObservableConvertibleType.swift in Sources */,
+				EF6A5783219CB6D200376078 /* SchedulerServices+Emulation.swift in Sources */,
+				EF6A5784219CB6D200376078 /* Concat.swift in Sources */,
+				EF6A5785219CB6D200376078 /* Switch.swift in Sources */,
+				EF6A5786219CB6D200376078 /* SwiftSupport.swift in Sources */,
+				EF6A5787219CB6D200376078 /* First.swift in Sources */,
+				EF6A5788219CB6D200376078 /* TakeUntil.swift in Sources */,
+				EF6A5789219CB6D200376078 /* DispatchQueueConfiguration.swift in Sources */,
+				EF6A578A219CB6D200376078 /* Dematerialize.swift in Sources */,
+				EF6A578B219CB6D200376078 /* RetryWhen.swift in Sources */,
+				EF6A578C219CB6D200376078 /* DelaySubscription.swift in Sources */,
+				EF6A578D219CB6D200376078 /* Just.swift in Sources */,
+				EF6A578E219CB6D200376078 /* AnyObserver.swift in Sources */,
+				EF6A578F219CB6D200376078 /* ConcurrentMainScheduler.swift in Sources */,
+				EF6A5790219CB6D200376078 /* AsMaybe.swift in Sources */,
+				EF6A5791219CB6D200376078 /* AsyncSubject.swift in Sources */,
+				EF6A5792219CB6D200376078 /* Enumerated.swift in Sources */,
+				EF6A5793219CB6D200376078 /* Optional.swift in Sources */,
+				EF6A5794219CB6D200376078 /* RxMutableBox.swift in Sources */,
+				EF6A5795219CB6D200376078 /* MainScheduler.swift in Sources */,
+				EF6A5796219CB6D200376078 /* Skip.swift in Sources */,
+				EF6A5797219CB6D200376078 /* Using.swift in Sources */,
+				EF6A5798219CB6D200376078 /* AtomicInt.swift in Sources */,
+				EF6A5799219CB6D200376078 /* Reactive.swift in Sources */,
+				EF6A579A219CB6D200376078 /* BooleanDisposable.swift in Sources */,
+				EF6A579B219CB6D200376078 /* CombineLatest.swift in Sources */,
+				EF6A579C219CB6D200376078 /* Bag+Rx.swift in Sources */,
+				EF6A579D219CB6D200376078 /* Materialize.swift in Sources */,
+				EF6A579E219CB6D200376078 /* AddRef.swift in Sources */,
+				EF6A579F219CB6D200376078 /* Multicast.swift in Sources */,
+				EF6A57A0219CB6D200376078 /* ReplaySubject.swift in Sources */,
+				EF6A57A1219CB6D200376078 /* ObservableType+Extensions.swift in Sources */,
+				EF6A57A2219CB6D200376078 /* TakeLast.swift in Sources */,
+				EF6A57A3219CB6D200376078 /* InvocableType.swift in Sources */,
+				EF6A57A4219CB6D200376078 /* ObserverBase.swift in Sources */,
+				EF6A57A5219CB6D200376078 /* Never.swift in Sources */,
+				EF6A57A6219CB6D200376078 /* Catch.swift in Sources */,
+				EF6A57A7219CB6D200376078 /* String+Rx.swift in Sources */,
+				EF6A57A8219CB6D200376078 /* ToArray.swift in Sources */,
+				EF6A57A9219CB6D200376078 /* SkipWhile.swift in Sources */,
+				EF6A57AA219CB6D200376078 /* Completable.swift in Sources */,
+				EF6A57AB219CB6D200376078 /* AsSingle.swift in Sources */,
+				EF6A57AC219CB6D200376078 /* Platform.Linux.swift in Sources */,
+				EF6A57AD219CB6D200376078 /* TailRecursiveSink.swift in Sources */,
+				EF6A57AE219CB6D200376078 /* AsyncLock.swift in Sources */,
+				EF6A57AF219CB6D200376078 /* Timer.swift in Sources */,
+				EF6A57B0219CB6D200376078 /* Completable+AndThen.swift in Sources */,
+				EF6A57B1219CB6D200376078 /* DispatchQueue+Extensions.swift in Sources */,
+				EF6A57B2219CB6D200376078 /* Error.swift in Sources */,
+				EF6A57B3219CB6D200376078 /* BinaryDisposable.swift in Sources */,
+				EF6A57B4219CB6D200376078 /* VirtualTimeConverterType.swift in Sources */,
+				EF6A57B5219CB6D200376078 /* SkipUntil.swift in Sources */,
+				EF6A57B6219CB6D200376078 /* Create.swift in Sources */,
+				EF6A57B7219CB6D200376078 /* Scan.swift in Sources */,
+				EF6A57B8219CB6D200376078 /* RefCountDisposable.swift in Sources */,
+				EF6A57B9219CB6D200376078 /* LockOwnerType.swift in Sources */,
+				EF6A57BA219CB6D200376078 /* VirtualTimeScheduler.swift in Sources */,
+				EF6A57BB219CB6D200376078 /* SynchronizedOnType.swift in Sources */,
+				EF6A57BC219CB6D200376078 /* Generate.swift in Sources */,
+				EF6A57BD219CB6D200376078 /* CurrentThreadScheduler.swift in Sources */,
+				EF6A57BE219CB6D200376078 /* Rx.swift in Sources */,
+				EF6A57BF219CB6D200376078 /* Take.swift in Sources */,
+				EF6A57C0219CB6D200376078 /* Zip.swift in Sources */,
+				EF6A57C1219CB6D200376078 /* SubjectType.swift in Sources */,
+				EF6A57C2219CB6D200376078 /* Sink.swift in Sources */,
+				EF6A57C3219CB6D200376078 /* DeprecationWarner.swift in Sources */,
+				EF6A57C4219CB6D200376078 /* HistoricalScheduler.swift in Sources */,
+				EF6A57C5219CB6D200376078 /* TakeWhile.swift in Sources */,
+				EF6A57C6219CB6D200376078 /* AnonymousObserver.swift in Sources */,
+				EF6A57C7219CB6D200376078 /* PublishSubject.swift in Sources */,
+				EF6A57C8219CB6D200376078 /* ScheduledItemType.swift in Sources */,
+				EF6A57C9219CB6D200376078 /* CombineLatest+Collection.swift in Sources */,
+				EF6A57CA219CB6D200376078 /* Producer.swift in Sources */,
+				EF6A57CB219CB6D200376078 /* SchedulerType.swift in Sources */,
+				EF6A57CC219CB6D200376078 /* Range.swift in Sources */,
+				EF6A57CD219CB6D200376078 /* Zip+Collection.swift in Sources */,
+				EF6A57CE219CB6D200376078 /* SynchronizedDisposeType.swift in Sources */,
+				EF6A57CF219CB6D200376078 /* Timeout.swift in Sources */,
+				EF6A57D0219CB6D200376078 /* Merge.swift in Sources */,
+				EF6A57D1219CB6D200376078 /* OperationQueueScheduler.swift in Sources */,
+				EF6A57D2219CB6D200376078 /* DisposeBag.swift in Sources */,
+				EF6A57D3219CB6D200376078 /* GroupedObservable.swift in Sources */,
+				EF6A57D4219CB6D200376078 /* Zip+arity.swift in Sources */,
+				EF6A57D5219CB6D200376078 /* RecursiveScheduler.swift in Sources */,
+				EF6A57D6219CB6D200376078 /* Deprecated.swift in Sources */,
+				EF6A57D7219CB6D200376078 /* DisposeBase.swift in Sources */,
+				EF6A57D8219CB6D200376078 /* Debug.swift in Sources */,
+				EF6A57D9219CB6D200376078 /* SubscribeOn.swift in Sources */,
+				EF6A57DA219CB6D200376078 /* AnonymousDisposable.swift in Sources */,
+				EF6A57DB219CB6D200376078 /* Repeat.swift in Sources */,
+				EF6A57DC219CB6D200376078 /* SingleAsync.swift in Sources */,
+				EF6A57DD219CB6D200376078 /* PrimitiveSequence.swift in Sources */,
+				EF6A57DE219CB6D200376078 /* ConcurrentDispatchQueueScheduler.swift in Sources */,
+				EF6A57DF219CB6D200376078 /* Single.swift in Sources */,
+				EF6A57E0219CB6D200376078 /* Do.swift in Sources */,
+				EF6A57E1219CB6D200376078 /* BehaviorSubject.swift in Sources */,
+				EF6A57E2219CB6D200376078 /* Window.swift in Sources */,
+				EF6A57E3219CB6D200376078 /* ObservableType.swift in Sources */,
+				EF6A57E4219CB6D200376078 /* CombineLatest+arity.swift in Sources */,
+				EF6A57E5219CB6D200376078 /* Debounce.swift in Sources */,
+				EF6A57E6219CB6D200376078 /* SerialDispatchQueueScheduler.swift in Sources */,
+				EF6A57E7219CB6D200376078 /* Disposables.swift in Sources */,
+				EF6A57E8219CB6D200376078 /* Lock.swift in Sources */,
+				EF6A57E9219CB6D200376078 /* RecursiveLock.swift in Sources */,
+				EF6A57EA219CB6D200376078 /* DefaultIfEmpty.swift in Sources */,
+				EF6A57EB219CB6D200376078 /* Buffer.swift in Sources */,
+				EF6A57EC219CB6D200376078 /* Map.swift in Sources */,
+				EF6A57ED219CB6D200376078 /* Errors.swift in Sources */,
+				EF6A57EE219CB6D200376078 /* PriorityQueue.swift in Sources */,
+				EF6A57EF219CB6D200376078 /* Sequence.swift in Sources */,
+				EF6A57F0219CB6D200376078 /* Deferred.swift in Sources */,
+				EF6A57F1219CB6D200376078 /* Amb.swift in Sources */,
+				EF6A57F2219CB6D200376078 /* Sample.swift in Sources */,
+				EF6A57F3219CB6D200376078 /* ShareReplayScope.swift in Sources */,
+				EF6A57F4219CB6D200376078 /* Bag.swift in Sources */,
+				EF6A57F5219CB6D200376078 /* ImmediateSchedulerType.swift in Sources */,
+				EF6A57F6219CB6D200376078 /* Platform.Darwin.swift in Sources */,
+				EF6A57F7219CB6D200376078 /* Throttle.swift in Sources */,
+				EF6A57F8219CB6D200376078 /* Cancelable.swift in Sources */,
+				EF6A57F9219CB6D200376078 /* ScheduledDisposable.swift in Sources */,
+				EF6A57FA219CB6D200376078 /* HistoricalSchedulerTimeConverter.swift in Sources */,
+				EF6A57FB219CB6D200376078 /* CompositeDisposable.swift in Sources */,
+				EF6A57FC219CB6D200376078 /* ObserverType.swift in Sources */,
+				EF6A57FD219CB6D200376078 /* Empty.swift in Sources */,
+				EF6A57FE219CB6D200376078 /* Observable.swift in Sources */,
+				EF6A57FF219CB6D200376078 /* SynchronizedUnsubscribeType.swift in Sources */,
+				EF6A5800219CB6D200376078 /* SerialDisposable.swift in Sources */,
+				EF6A5801219CB6D200376078 /* Reduce.swift in Sources */,
+				EF6A5802219CB6D200376078 /* GroupBy.swift in Sources */,
+				EF6A5803219CB6D200376078 /* SubscriptionDisposable.swift in Sources */,
+				EF6A5804219CB6D200376078 /* StartWith.swift in Sources */,
+				EF6A5805219CB6D200376078 /* ObserveOn.swift in Sources */,
+				EF6A5806219CB6D200376078 /* Event.swift in Sources */,
+				EF6A5807219CB6D200376078 /* ScheduledItem.swift in Sources */,
+				EF6A5808219CB6D200376078 /* WithLatestFrom.swift in Sources */,
+				EF6A5809219CB6D200376078 /* Queue.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A581D219CB72100376078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A581E219CB72100376078 /* UISlider+Rx.swift in Sources */,
+				EF6A581F219CB72100376078 /* UIScrollView+Rx.swift in Sources */,
+				EF6A5820219CB72100376078 /* NSSlider+Rx.swift in Sources */,
+				EF6A5821219CB72100376078 /* UIPickerView+Rx.swift in Sources */,
+				EF6A5822219CB72100376078 /* Logging.swift in Sources */,
+				EF6A5823219CB72100376078 /* UIWebView+Rx.swift in Sources */,
+				EF6A5824219CB72100376078 /* NSControl+Rx.swift in Sources */,
+				EF6A5825219CB72100376078 /* DelegateProxyType.swift in Sources */,
+				EF6A5826219CB72100376078 /* RxTarget.swift in Sources */,
+				EF6A5827219CB72100376078 /* BehaviorRelay.swift in Sources */,
+				EF6A5828219CB72100376078 /* UITextView+Rx.swift in Sources */,
+				EF6A5829219CB72100376078 /* RxTableViewReactiveArrayDataSource.swift in Sources */,
+				EF6A582A219CB72100376078 /* PublishRelay.swift in Sources */,
+				EF6A582B219CB72100376078 /* BehaviorRelay+Driver.swift in Sources */,
+				EF6A582C219CB72100376078 /* RxCollectionViewDataSourceProxy.swift in Sources */,
+				EF6A582D219CB72100376078 /* SchedulerType+SharedSequence.swift in Sources */,
+				EF6A582E219CB72100376078 /* RxTextStorageDelegateProxy.swift in Sources */,
+				EF6A582F219CB72100376078 /* Driver.swift in Sources */,
+				EF6A5830219CB72100376078 /* RxTableViewDelegateProxy.swift in Sources */,
+				EF6A5831219CB72100376078 /* _RX.m in Sources */,
+				EF6A5832219CB72100376078 /* NSTextView+Rx.swift in Sources */,
+				EF6A5833219CB72100376078 /* UIRefreshControl+Rx.swift in Sources */,
+				EF6A5834219CB72100376078 /* UIStepper+Rx.swift in Sources */,
+				EF6A5835219CB72100376078 /* ObservableConvertibleType+Signal.swift in Sources */,
+				EF6A5836219CB72100376078 /* ControlEvent.swift in Sources */,
+				EF6A5837219CB72100376078 /* ControlEvent+Signal.swift in Sources */,
+				EF6A5838219CB72100376078 /* UIImageView+Rx.swift in Sources */,
+				EF6A5839219CB72100376078 /* RxPickerViewDataSourceProxy.swift in Sources */,
+				EF6A583A219CB72100376078 /* UIControl+Rx.swift in Sources */,
+				EF6A583B219CB72100376078 /* Binder.swift in Sources */,
+				EF6A583C219CB72100376078 /* SectionedViewDataSourceType.swift in Sources */,
+				EF6A583D219CB72100376078 /* RxCollectionViewDataSourcePrefetchingProxy.swift in Sources */,
+				EF6A583E219CB72100376078 /* UISearchController+Rx.swift in Sources */,
+				EF6A583F219CB72100376078 /* NSImageView+Rx.swift in Sources */,
+				EF6A5840219CB72100376078 /* UITableView+Rx.swift in Sources */,
+				EF6A5841219CB72100376078 /* RxCocoaObjCRuntimeError+Extensions.swift in Sources */,
+				EF6A5842219CB72100376078 /* RxCollectionViewReactiveArrayDataSource.swift in Sources */,
+				EF6A5843219CB72100376078 /* URLSession+Rx.swift in Sources */,
+				EF6A5844219CB72100376078 /* RxSearchControllerDelegateProxy.swift in Sources */,
+				EF6A5845219CB72100376078 /* RxCollectionViewDelegateProxy.swift in Sources */,
+				EF6A5846219CB72100376078 /* UIAlertAction+Rx.swift in Sources */,
+				EF6A5847219CB72100376078 /* RxScrollViewDelegateProxy.swift in Sources */,
+				EF6A5848219CB72100376078 /* KVORepresentable.swift in Sources */,
+				EF6A5849219CB72100376078 /* TextInput.swift in Sources */,
+				EF6A584A219CB72100376078 /* PublishRelay+Signal.swift in Sources */,
+				EF6A584B219CB72100376078 /* UILabel+Rx.swift in Sources */,
+				EF6A584C219CB72100376078 /* ControlEvent+Driver.swift in Sources */,
+				EF6A584D219CB72100376078 /* Driver+Subscription.swift in Sources */,
+				EF6A584E219CB72100376078 /* UINavigationItem+Rx.swift in Sources */,
+				EF6A584F219CB72100376078 /* UIPageControl+Rx.swift in Sources */,
+				EF6A5850219CB72100376078 /* RxSearchBarDelegateProxy.swift in Sources */,
+				EF6A5851219CB72100376078 /* RxPickerViewDataSourceType.swift in Sources */,
+				EF6A5852219CB72100376078 /* Signal+Subscription.swift in Sources */,
+				EF6A5853219CB72100376078 /* KeyPathBinder.swift in Sources */,
+				EF6A5854219CB72100376078 /* UITabBarItem+Rx.swift in Sources */,
+				EF6A5855219CB72100376078 /* UIApplication+Rx.swift in Sources */,
+				EF6A5856219CB72100376078 /* RxPickerViewDelegateProxy.swift in Sources */,
+				EF6A5857219CB72100376078 /* RxCocoa.swift in Sources */,
+				EF6A5858219CB72100376078 /* SharedSequence.swift in Sources */,
+				EF6A5859219CB72100376078 /* SharedSequence+Operators+arity.swift in Sources */,
+				EF6A585A219CB72100376078 /* UITabBarController+Rx.swift in Sources */,
+				EF6A585B219CB72100376078 /* NSObject+Rx+RawRepresentable.swift in Sources */,
+				EF6A585C219CB72100376078 /* UIView+Rx.swift in Sources */,
+				EF6A585D219CB72100376078 /* RxPickerViewAdapter.swift in Sources */,
+				EF6A585E219CB72100376078 /* KVORepresentable+CoreGraphics.swift in Sources */,
+				EF6A585F219CB72100376078 /* Observable+Bind.swift in Sources */,
+				EF6A5860219CB72100376078 /* Deprecated.swift in Sources */,
+				EF6A5861219CB72100376078 /* UISegmentedControl+Rx.swift in Sources */,
+				EF6A5862219CB72100376078 /* UIProgressView+Rx.swift in Sources */,
+				EF6A5863219CB72100376078 /* UIViewController+Rx.swift in Sources */,
+				EF6A5864219CB72100376078 /* NSButton+Rx.swift in Sources */,
+				EF6A5865219CB72100376078 /* NSTextField+Rx.swift in Sources */,
+				EF6A5866219CB72100376078 /* Signal.swift in Sources */,
+				EF6A5867219CB72100376078 /* NSView+Rx.swift in Sources */,
+				EF6A5868219CB72100376078 /* _RXKVOObserver.m in Sources */,
+				EF6A5869219CB72100376078 /* UIButton+Rx.swift in Sources */,
+				EF6A586A219CB72100376078 /* ObservableConvertibleType+SharedSequence.swift in Sources */,
+				EF6A586B219CB72100376078 /* ControlProperty.swift in Sources */,
+				EF6A586C219CB72100376078 /* RxTabBarControllerDelegateProxy.swift in Sources */,
+				EF6A586D219CB72100376078 /* SharedSequence+Operators.swift in Sources */,
+				EF6A586E219CB72100376078 /* UIActivityIndicatorView+Rx.swift in Sources */,
+				EF6A586F219CB72100376078 /* NSTextStorage+Rx.swift in Sources */,
+				EF6A5870219CB72100376078 /* RxTextViewDelegateProxy.swift in Sources */,
+				EF6A5871219CB72100376078 /* _RXDelegateProxy.m in Sources */,
+				EF6A5872219CB72100376078 /* KVORepresentable+Swift.swift in Sources */,
+				EF6A5873219CB72100376078 /* ObservableConvertibleType+Driver.swift in Sources */,
+				EF6A5874219CB72100376078 /* RxNavigationControllerDelegateProxy.swift in Sources */,
+				EF6A5875219CB72100376078 /* UIBarButtonItem+Rx.swift in Sources */,
+				EF6A5876219CB72100376078 /* NSObject+Rx+KVORepresentable.swift in Sources */,
+				EF6A5877219CB72100376078 /* UIDatePicker+Rx.swift in Sources */,
+				EF6A5878219CB72100376078 /* RxTableViewDataSourceProxy.swift in Sources */,
+				EF6A5879219CB72100376078 /* NSLayoutConstraint+Rx.swift in Sources */,
+				EF6A587A219CB72100376078 /* UIGestureRecognizer+Rx.swift in Sources */,
+				EF6A587B219CB72100376078 /* ControlProperty+Driver.swift in Sources */,
+				EF6A587C219CB72100376078 /* DelegateProxy.swift in Sources */,
+				EF6A587D219CB72100376078 /* _RXObjCRuntime.m in Sources */,
+				EF6A587E219CB72100376078 /* NSObject+Rx.swift in Sources */,
+				EF6A587F219CB72100376078 /* UINavigationController+Rx.swift in Sources */,
+				EF6A5880219CB72100376078 /* UITabBar+Rx.swift in Sources */,
+				EF6A5881219CB72100376078 /* RxTabBarDelegateProxy.swift in Sources */,
+				EF6A5882219CB72100376078 /* UISwitch+Rx.swift in Sources */,
+				EF6A5883219CB72100376078 /* UICollectionView+Rx.swift in Sources */,
+				EF6A5884219CB72100376078 /* RxCollectionViewDataSourceType.swift in Sources */,
+				EF6A5885219CB72100376078 /* DispatchQueue+Extensions.swift in Sources */,
+				EF6A5886219CB72100376078 /* UITextField+Rx.swift in Sources */,
+				EF6A5887219CB72100376078 /* RxWebViewDelegateProxy.swift in Sources */,
+				EF6A5888219CB72100376078 /* UISearchBar+Rx.swift in Sources */,
+				EF6A5889219CB72100376078 /* NotificationCenter+Rx.swift in Sources */,
+				EF6A588A219CB72100376078 /* ItemEvents.swift in Sources */,
+				EF6A588B219CB72100376078 /* ControlTarget.swift in Sources */,
+				EF6A588C219CB72100376078 /* RxTableViewDataSourceType.swift in Sources */,
+				EF6A588D219CB72100376078 /* RxTableViewDataSourcePrefetchingProxy.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A589E219CB78300376078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A589F219CB78300376078 /* AtomicInt.swift in Sources */,
+				EF6A58A0219CB78300376078 /* Platform.Linux.swift in Sources */,
+				EF6A58A1219CB78300376078 /* RunLoopLock.swift in Sources */,
+				EF6A58A2219CB78300376078 /* BlockingObservable.swift in Sources */,
+				EF6A58A3219CB78300376078 /* BlockingObservable+Operators.swift in Sources */,
+				EF6A58A4219CB78300376078 /* ObservableConvertibleType+Blocking.swift in Sources */,
+				EF6A58A5219CB78300376078 /* Resources.swift in Sources */,
+				EF6A58A6219CB78300376078 /* Platform.Darwin.swift in Sources */,
+				EF6A58A7219CB78300376078 /* RecursiveLock.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EF6A58B4219CB7BF00376078 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EF6A58B5219CB7BF00376078 /* Deprecated.swift in Sources */,
+				EF6A58B6219CB7BF00376078 /* DeprecationWarner.swift in Sources */,
+				EF6A58B7219CB7BF00376078 /* Recorded.swift in Sources */,
+				EF6A58B8219CB7BF00376078 /* TestableObserver.swift in Sources */,
+				EF6A58B9219CB7BF00376078 /* XCTest+Rx.swift in Sources */,
+				EF6A58BA219CB7BF00376078 /* RxTest.swift in Sources */,
+				EF6A58BB219CB7BF00376078 /* Event+Equatable.swift in Sources */,
+				EF6A58BC219CB7BF00376078 /* ColdObservable.swift in Sources */,
+				EF6A58BD219CB7BF00376078 /* TestableObservable.swift in Sources */,
+				EF6A58BE219CB7BF00376078 /* TestScheduler.swift in Sources */,
+				EF6A58BF219CB7BF00376078 /* Bag.swift in Sources */,
+				EF6A58C0219CB7BF00376078 /* HotObservable.swift in Sources */,
+				EF6A58C1219CB7BF00376078 /* Recorded+Event.swift in Sources */,
+				EF6A58C2219CB7BF00376078 /* Subscription.swift in Sources */,
+				EF6A58C3219CB7BF00376078 /* Any+Equatable.swift in Sources */,
+				EF6A58C4219CB7BF00376078 /* TestSchedulerVirtualTimeConverter.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -3729,6 +4602,31 @@
 			isa = PBXTargetDependency;
 			target = C80938F51B8A71760088E94D /* RxCocoa */;
 			targetProxy = C8E8BA751E2C1BB200A4AC2C /* PBXContainerItemProxy */;
+		};
+		EF6A5813219CB70D00376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A5762219CB68C00376078 /* RxAtomic-Static */;
+			targetProxy = EF6A5812219CB70D00376078 /* PBXContainerItemProxy */;
+		};
+		EF6A5897219CB75700376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A576F219CB6D200376078 /* RxSwift-Static */;
+			targetProxy = EF6A5896219CB75700376078 /* PBXContainerItemProxy */;
+		};
+		EF6A58CE219CB7D600376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A5762219CB68C00376078 /* RxAtomic-Static */;
+			targetProxy = EF6A58CD219CB7D600376078 /* PBXContainerItemProxy */;
+		};
+		EF6A58D0219CB7D600376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A576F219CB6D200376078 /* RxSwift-Static */;
+			targetProxy = EF6A58CF219CB7D600376078 /* PBXContainerItemProxy */;
+		};
+		EF6A58D2219CB81700376078 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EF6A576F219CB6D200376078 /* RxSwift-Static */;
+			targetProxy = EF6A58D1219CB81700376078 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -4446,6 +5344,279 @@
 			};
 			name = "Release-Tests";
 		};
+		EF6A576A219CB68C00376078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = RxAtomic/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = io.rx.RxAtomic;
+				PRODUCT_NAME = RxAtomic;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		EF6A576B219CB68C00376078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = RxAtomic/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = io.rx.RxAtomic;
+				PRODUCT_NAME = RxAtomic;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		EF6A576C219CB68C00376078 /* Release-Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = RxAtomic/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = io.rx.RxAtomic;
+				PRODUCT_NAME = RxAtomic;
+				SKIP_INSTALL = YES;
+			};
+			name = "Release-Tests";
+		};
+		EF6A580D219CB6D200376078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxSwift;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		EF6A580E219CB6D200376078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxSwift;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		EF6A580F219CB6D200376078 /* Release-Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxSwift;
+				SKIP_INSTALL = YES;
+			};
+			name = "Release-Tests";
+		};
+		EF6A5891219CB72100376078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxCocoa;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		EF6A5892219CB72100376078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxCocoa;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		EF6A5893219CB72100376078 /* Release-Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxCocoa/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxCocoa;
+				SKIP_INSTALL = YES;
+			};
+			name = "Release-Tests";
+		};
+		EF6A58AB219CB78300376078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxBlocking;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		EF6A58AC219CB78300376078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxBlocking;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		EF6A58AD219CB78300376078 /* Release-Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/RxBlocking/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = "io.rx.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = RxBlocking;
+				SKIP_INSTALL = YES;
+			};
+			name = "Release-Tests";
+		};
+		EF6A58C8219CB7BF00376078 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INFOPLIST_FILE = RxTest/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				OTHER_LDFLAGS = "-weak-lswiftXCTest";
+				PRODUCT_BUNDLE_IDENTIFIER = io.rx.RxTest;
+				PRODUCT_NAME = RxTest;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+			};
+			name = Debug;
+		};
+		EF6A58C9219CB7BF00376078 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INFOPLIST_FILE = RxTest/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				OTHER_LDFLAGS = "-weak-lswiftXCTest";
+				PRODUCT_BUNDLE_IDENTIFIER = io.rx.RxTest;
+				PRODUCT_NAME = RxTest;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+			};
+			name = Release;
+		};
+		EF6A58CA219CB7BF00376078 /* Release-Tests */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				INFOPLIST_FILE = RxTest/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MACH_O_TYPE = staticlib;
+				OTHER_LDFLAGS = "-weak-lswiftXCTest";
+				PRODUCT_BUNDLE_IDENTIFIER = io.rx.RxTest;
+				PRODUCT_NAME = RxTest;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx appletvos appletvsimulator";
+				TARGETED_DEVICE_FAMILY = "1,2,3";
+			};
+			name = "Release-Tests";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -4555,6 +5726,56 @@
 				C8E8BA5E1E2C181A00A4AC2C /* Debug */,
 				C8E8BA5F1E2C181A00A4AC2C /* Release */,
 				C8E8BA601E2C181A00A4AC2C /* Release-Tests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF6A5769219CB68C00376078 /* Build configuration list for PBXNativeTarget "RxAtomic-Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6A576A219CB68C00376078 /* Debug */,
+				EF6A576B219CB68C00376078 /* Release */,
+				EF6A576C219CB68C00376078 /* Release-Tests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF6A580C219CB6D200376078 /* Build configuration list for PBXNativeTarget "RxSwift-Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6A580D219CB6D200376078 /* Debug */,
+				EF6A580E219CB6D200376078 /* Release */,
+				EF6A580F219CB6D200376078 /* Release-Tests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF6A5890219CB72100376078 /* Build configuration list for PBXNativeTarget "RxCocoa-Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6A5891219CB72100376078 /* Debug */,
+				EF6A5892219CB72100376078 /* Release */,
+				EF6A5893219CB72100376078 /* Release-Tests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF6A58AA219CB78300376078 /* Build configuration list for PBXNativeTarget "RxBlocking-Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6A58AB219CB78300376078 /* Debug */,
+				EF6A58AC219CB78300376078 /* Release */,
+				EF6A58AD219CB78300376078 /* Release-Tests */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		EF6A58C7219CB7BF00376078 /* Build configuration list for PBXNativeTarget "RxTest-Static" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6A58C8219CB7BF00376078 /* Debug */,
+				EF6A58C9219CB7BF00376078 /* Release */,
+				EF6A58CA219CB7BF00376078 /* Release-Tests */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-iOS-Static.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-iOS-Static.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-               BuildableName = "RxTest.framework"
-               BlueprintName = "RxTest-Static"
-               ReferencedContainer = "container:Rx.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -28,6 +12,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF6A58D3219CBA6500376078"
+               BuildableName = "AllTests-iOS-Static.xctest"
+               BlueprintName = "AllTests-iOS-Static"
+               ReferencedContainer = "container:Rx.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
@@ -42,15 +36,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-            BuildableName = "RxTest.framework"
-            BlueprintName = "RxTest-Static"
-            ReferencedContainer = "container:Rx.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -60,15 +45,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-            BuildableName = "RxTest.framework"
-            BlueprintName = "RxTest-Static"
-            ReferencedContainer = "container:Rx.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-macOS-Static.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-macOS-Static.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-               BuildableName = "RxTest.framework"
-               BlueprintName = "RxTest-Static"
-               ReferencedContainer = "container:Rx.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -28,6 +12,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF6A5A4F219CC11900376078"
+               BuildableName = "AllTests-macOS-Static.xctest"
+               BlueprintName = "AllTests-macOS-Static"
+               ReferencedContainer = "container:Rx.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
@@ -42,15 +36,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-            BuildableName = "RxTest.framework"
-            BlueprintName = "RxTest-Static"
-            ReferencedContainer = "container:Rx.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -60,15 +45,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-            BuildableName = "RxTest.framework"
-            BlueprintName = "RxTest-Static"
-            ReferencedContainer = "container:Rx.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-tvOS-Static.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-tvOS-Static.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-               BuildableName = "RxTest.framework"
-               BlueprintName = "RxTest-Static"
-               ReferencedContainer = "container:Rx.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
@@ -28,6 +12,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF6A5994219CBF5200376078"
+               BuildableName = "AllTests-tvOS-Static.xctest"
+               BlueprintName = "AllTests-tvOS-Static"
+               ReferencedContainer = "container:Rx.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <AdditionalOptions>
       </AdditionalOptions>
@@ -42,15 +36,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-            BuildableName = "RxTest.framework"
-            BlueprintName = "RxTest-Static"
-            ReferencedContainer = "container:Rx.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -60,15 +45,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
-            BuildableName = "RxTest.framework"
-            BlueprintName = "RxTest-Static"
-            ReferencedContainer = "container:Rx.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxAtomic-Static.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxAtomic-Static.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF6A5762219CB68C00376078"
+               BuildableName = "RxAtomic.framework"
+               BlueprintName = "RxAtomic-Static"
+               ReferencedContainer = "container:Rx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A5762219CB68C00376078"
+            BuildableName = "RxAtomic.framework"
+            BlueprintName = "RxAtomic-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A5762219CB68C00376078"
+            BuildableName = "RxAtomic.framework"
+            BlueprintName = "RxAtomic-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxBlocking-Static.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxBlocking-Static.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF6A5898219CB78300376078"
+               BuildableName = "RxBlocking.framework"
+               BlueprintName = "RxBlocking-Static"
+               ReferencedContainer = "container:Rx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A5898219CB78300376078"
+            BuildableName = "RxBlocking.framework"
+            BlueprintName = "RxBlocking-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A5898219CB78300376078"
+            BuildableName = "RxBlocking.framework"
+            BlueprintName = "RxBlocking-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxCocoa-Static.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxCocoa-Static.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF6A5814219CB72100376078"
+               BuildableName = "RxCocoa.framework"
+               BlueprintName = "RxCocoa-Static"
+               ReferencedContainer = "container:Rx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A5814219CB72100376078"
+            BuildableName = "RxCocoa.framework"
+            BlueprintName = "RxCocoa-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A5814219CB72100376078"
+            BuildableName = "RxCocoa.framework"
+            BlueprintName = "RxCocoa-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-Static.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxSwift-Static.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF6A576F219CB6D200376078"
+               BuildableName = "RxSwift.framework"
+               BlueprintName = "RxSwift-Static"
+               ReferencedContainer = "container:Rx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A576F219CB6D200376078"
+            BuildableName = "RxSwift.framework"
+            BlueprintName = "RxSwift-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A576F219CB6D200376078"
+            BuildableName = "RxSwift.framework"
+            BlueprintName = "RxSwift-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Rx.xcodeproj/xcshareddata/xcschemes/RxTest-Static.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/RxTest-Static.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
+               BuildableName = "RxTest-Static.framework"
+               BlueprintName = "RxTest-Static"
+               ReferencedContainer = "container:Rx.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
+            BuildableName = "RxTest-Static.framework"
+            BlueprintName = "RxTest-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "EF6A58B0219CB7BF00376078"
+            BuildableName = "RxTest-Static.framework"
+            BlueprintName = "RxTest-Static"
+            ReferencedContainer = "container:Rx.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
I created duplicate build targets for the RxSwift, RxCocoa, RxAtomic, RxBlocking, and RxTest framework targets. I customized the new targets to produce static frameworks instead of dynamic frameworks.

I created new build schemes (RxSwift-Static, RxCocoa-Static, RxAtomic-Static, RxBlocking-Static, and RxTest-Static) that Carthage will use to build the static frameworks using the support added to Carthage in version 0.30.0. 

I duplicated the unit test bundles for iOS, tvOS, and macOS and configured them to use the static frameworks.

Using these changes, Carthage users will have the option of linking to the static frameworks instead of the dynamic frameworks, potentially improving launch time by reducing the amount of dynamic linking that needs to occur. Carthage will store the static frameworks side-by-side with the dynamic frameworks in a `Static` subdirectory (ex. `Carthage/Build/iOS/Static`).

Resolves #1799 