### PR TITLE
Fix DISABLE_SWIZZLING compilation

### DIFF
--- a/RxCocoa/Runtime/_RXObjCRuntime.m
+++ b/RxCocoa/Runtime/_RXObjCRuntime.m
@@ -16,12 +16,12 @@
 #import "include/_RX.h"
 #import "include/_RXObjCRuntime.h"
 
+// self + cmd
+#define HIDDEN_ARGUMENT_COUNT   2
+
 #if !DISABLE_SWIZZLING
 
 #define NSErrorParam NSError *__autoreleasing __nullable * __nullable
-
-// self + cmd
-#define HIDDEN_ARGUMENT_COUNT   2
 
 @class RXObjCRuntime;
 
@@ -130,6 +130,8 @@ SEL __nonnull RX_selector(SEL __nonnull selector) {
     return NSSelectorFromString([RX_PREFIX stringByAppendingString:selectorString]);
 }
 
+#endif
+
 BOOL RX_is_method_signature_void(NSMethodSignature * __nonnull methodSignature) {
     const char *methodReturnType = methodSignature.methodReturnType;
     return strcmp(methodReturnType, @encode(void)) == 0;
@@ -201,6 +203,12 @@ NSArray *RX_extract_arguments(NSInvocation *invocation) {
     
     return arguments;
 }
+
+IMP __nonnull RX_default_target_implementation(void) {
+    return _objc_msgForward;
+}
+
+#if !DISABLE_SWIZZLING
 
 void * __nonnull RX_reference_from_selector(SEL __nonnull selector) {
     return selector;
@@ -314,10 +322,6 @@ IMP __nullable RX_ensure_observing(id __nonnull target, SEL __nonnull selector, 
     }
 
     return targetImplementation;
-}
-
-IMP __nonnull RX_default_target_implementation(void) {
-    return _objc_msgForward;
 }
 
 // bodies

--- a/RxCocoa/Runtime/include/_RXObjCRuntime.h
+++ b/RxCocoa/Runtime/include/_RXObjCRuntime.h
@@ -87,6 +87,8 @@ void * __nonnull RX_reference_from_selector(SEL __nonnull selector);
 /// Ensures interceptor is installed on target object.
 IMP __nullable RX_ensure_observing(id __nonnull target, SEL __nonnull selector, NSError *__autoreleasing __nullable * __nullable error);
 
+#endif
+
 /// Extracts arguments for `invocation`.
 NSArray * __nonnull RX_extract_arguments(NSInvocation * __nonnull invocation);
 
@@ -98,5 +100,3 @@ BOOL RX_is_method_signature_void(NSMethodSignature * __nonnull methodSignature);
 
 /// Default value for `RXInterceptionObserver.targetImplementation`.
 IMP __nonnull RX_default_target_implementation(void);
-
-#endif

--- a/Sources/RxCocoaRuntime/include/_RXObjCRuntime.h
+++ b/Sources/RxCocoaRuntime/include/_RXObjCRuntime.h
@@ -87,6 +87,8 @@ void * __nonnull RX_reference_from_selector(SEL __nonnull selector);
 /// Ensures interceptor is installed on target object.
 IMP __nullable RX_ensure_observing(id __nonnull target, SEL __nonnull selector, NSError *__autoreleasing __nullable * __nullable error);
 
+#endif
+
 /// Extracts arguments for `invocation`.
 NSArray * __nonnull RX_extract_arguments(NSInvocation * __nonnull invocation);
 
@@ -98,5 +100,3 @@ BOOL RX_is_method_signature_void(NSMethodSignature * __nonnull methodSignature);
 
 /// Default value for `RXInterceptionObserver.targetImplementation`.
 IMP __nonnull RX_default_target_implementation(void);
-
-#endif


### PR DESCRIPTION
Some methods under the compiler flag are being used by RxCocoa's proxy delegate. So this commit is moving these outside the conditional.

Fixes #1804 