### PR TITLE
Make bind debuggable

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -935,7 +935,7 @@ self.rx.observe(CGRect.self, "view.frame", retainSelf: false)
 
 ### `rx.observeWeakly`
 
-`rx.observeWeakly` has somewhat slower than `rx.observe` because it has to handle object deallocation in case of weak references.
+`rx.observeWeakly` is somewhat slower than `rx.observe` because it has to handle object deallocation in case of weak references.
 
 It can be used in all cases where `rx.observe` can be used and additionally
 

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -143,9 +143,9 @@ extension ObservableType {
     - parameter onNext: Action to invoke for each element in the observable sequence.
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
-    public func bind(onNext: @escaping (E) -> Void) -> Disposable {
+    public func bind(file: String = #file, line: UInt = #line, onNext: @escaping (E) -> Void) -> Disposable {
         return subscribe(onNext: onNext, onError: { error in
-            rxFatalErrorInDebug("Binding error: \(error)")
+          rxFatalErrorInDebug("\(file):\(line) Binding error: \(error)")
         })
     }
 }


### PR DESCRIPTION
In development, It occurs fatalError if `bind` receives.
But now, it's hard for us to find where the error occurred.
So, I would like to make it more debuggable.

This PR has my first idea.
Let me know what do you think about it.