### PR TITLE
[Pitch] Creating type abstracting relay types common duplicated logic

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -33,6 +33,7 @@ custom_categories:
   - DispatchQueue+Extensions
 - name: RxCocoa/Traits
   children:
+  - ObservableRelayType
   - BehaviorRelay
   - ControlEvent
   - ControlProperty

--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -33,10 +33,10 @@ custom_categories:
   - DispatchQueue+Extensions
 - name: RxCocoa/Traits
   children:
-  - ObservableRelayType
   - BehaviorRelay
   - ControlEvent
   - ControlProperty
+  - ObservableRelayType
   - PublishRelay
 - name: RxCocoa/Traits/Driver
   children:

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		A520FFFC1F0D291500573734 /* RxPickerViewDataSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */; };
 		A5CD038A1F1660F40005A376 /* RxPickerViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */; };
 		AAE623761C82475700FC7801 /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */; };
+		B2A9B7E021AB7DFD002C892E /* ObservableRelayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A9B7DF21AB7DFD002C892E /* ObservableRelayType.swift */; };
 		B44D73EC1EE6D4A300EBFBE8 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
 		B562478F203515DD00D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B562478D2035154900D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift */; };
 		B5624794203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5624793203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift */; };
@@ -959,6 +960,7 @@
 		A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewDataSourceProxy.swift; sourceTree = "<group>"; };
 		A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewAdapter.swift; sourceTree = "<group>"; };
 		AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIProgressView+Rx.swift"; sourceTree = "<group>"; };
+		B2A9B7DF21AB7DFD002C892E /* ObservableRelayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableRelayType.swift; sourceTree = "<group>"; };
 		B562478D2035154900D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxCollectionViewDataSourcePrefetchingProxy.swift; sourceTree = "<group>"; };
 		B5624793203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTableViewDataSourcePrefetchingProxy.swift; sourceTree = "<group>"; };
 		C801DE351F6EAD3C008DB060 /* SingleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTest.swift; sourceTree = "<group>"; };
@@ -2219,6 +2221,7 @@
 		C89AB1AA1DAAC3350065FBE6 /* Traits */ = {
 			isa = PBXGroup;
 			children = (
+				B2A9B7DF21AB7DFD002C892E /* ObservableRelayType.swift */,
 				C8B0F7101F530CA700548EBE /* PublishRelay.swift */,
 				C8C8BCCE1F8944B800501D4D /* BehaviorRelay.swift */,
 				C89AB1AB1DAAC3350065FBE6 /* ControlEvent.swift */,
@@ -2829,6 +2832,7 @@
 				84C225A31C33F00B008724EC /* RxTextStorageDelegateProxy.swift in Sources */,
 				C89AB1DA1DAAC3350065FBE6 /* Driver.swift in Sources */,
 				C88254231B8A752B00B02D69 /* RxTableViewDelegateProxy.swift in Sources */,
+				B2A9B7E021AB7DFD002C892E /* ObservableRelayType.swift in Sources */,
 				C89AB2381DAAC3A60065FBE6 /* _RX.m in Sources */,
 				C83E39852189066F001F4F0E /* NSTextView+Rx.swift in Sources */,
 				7F600F411C5D0C6E00535B1D /* UIRefreshControl+Rx.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -69,7 +69,7 @@
 		A520FFFC1F0D291500573734 /* RxPickerViewDataSourceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */; };
 		A5CD038A1F1660F40005A376 /* RxPickerViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */; };
 		AAE623761C82475700FC7801 /* UIProgressView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */; };
-		B2A9B7E021AB7DFD002C892E /* ObservableRelayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A9B7DF21AB7DFD002C892E /* ObservableRelayType.swift */; };
+		B27D9A6421AE12D800912D98 /* ObservableRelayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B27D9A6321AE12D800912D98 /* ObservableRelayType.swift */; };
 		B44D73EC1EE6D4A300EBFBE8 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
 		B562478F203515DD00D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B562478D2035154900D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift */; };
 		B5624794203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5624793203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift */; };
@@ -960,7 +960,7 @@
 		A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewDataSourceProxy.swift; sourceTree = "<group>"; };
 		A5CD03891F1660F40005A376 /* RxPickerViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxPickerViewAdapter.swift; sourceTree = "<group>"; };
 		AAE623751C82475700FC7801 /* UIProgressView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIProgressView+Rx.swift"; sourceTree = "<group>"; };
-		B2A9B7DF21AB7DFD002C892E /* ObservableRelayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableRelayType.swift; sourceTree = "<group>"; };
+		B27D9A6321AE12D800912D98 /* ObservableRelayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservableRelayType.swift; sourceTree = "<group>"; };
 		B562478D2035154900D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxCollectionViewDataSourcePrefetchingProxy.swift; sourceTree = "<group>"; };
 		B5624793203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTableViewDataSourcePrefetchingProxy.swift; sourceTree = "<group>"; };
 		C801DE351F6EAD3C008DB060 /* SingleTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTest.swift; sourceTree = "<group>"; };
@@ -1383,7 +1383,7 @@
 		C8C8BCD31F89459300501D4D /* BehaviorRelay+Driver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BehaviorRelay+Driver.swift"; sourceTree = "<group>"; };
 		C8D132431C42D15E00B59FFF /* SectionedViewDataSourceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SectionedViewDataSourceType.swift; sourceTree = "<group>"; };
 		C8D2C1501D4F3CD6006E2431 /* Rx.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = Rx.playground; sourceTree = "<group>"; };
-		C8D970CD1F5324D90058F2FE /* Signal+Subscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Signal+Subscription.swift"; sourceTree = "<group>"; };
+		C8D970CD1F5324D90058F2FE /* Signal+Subscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Signal+Subscription.swift"; sourceTree = "<group>"; };
 		C8D970DC1F532FD10058F2FE /* Signal+Test.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Signal+Test.swift"; sourceTree = "<group>"; };
 		C8D970DD1F532FD10058F2FE /* SharedSequence+Test.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SharedSequence+Test.swift"; sourceTree = "<group>"; };
 		C8D970DE1F532FD20058F2FE /* Driver+Test.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Driver+Test.swift"; sourceTree = "<group>"; };
@@ -2221,7 +2221,7 @@
 		C89AB1AA1DAAC3350065FBE6 /* Traits */ = {
 			isa = PBXGroup;
 			children = (
-				B2A9B7DF21AB7DFD002C892E /* ObservableRelayType.swift */,
+				B27D9A6321AE12D800912D98 /* ObservableRelayType.swift */,
 				C8B0F7101F530CA700548EBE /* PublishRelay.swift */,
 				C8C8BCCE1F8944B800501D4D /* BehaviorRelay.swift */,
 				C89AB1AB1DAAC3350065FBE6 /* ControlEvent.swift */,
@@ -2832,7 +2832,6 @@
 				84C225A31C33F00B008724EC /* RxTextStorageDelegateProxy.swift in Sources */,
 				C89AB1DA1DAAC3350065FBE6 /* Driver.swift in Sources */,
 				C88254231B8A752B00B02D69 /* RxTableViewDelegateProxy.swift in Sources */,
-				B2A9B7E021AB7DFD002C892E /* ObservableRelayType.swift in Sources */,
 				C89AB2381DAAC3A60065FBE6 /* _RX.m in Sources */,
 				C83E39852189066F001F4F0E /* NSTextView+Rx.swift in Sources */,
 				7F600F411C5D0C6E00535B1D /* UIRefreshControl+Rx.swift in Sources */,
@@ -2907,6 +2906,7 @@
 				C88254221B8A752B00B02D69 /* RxTableViewDataSourceProxy.swift in Sources */,
 				C8BCD3F41C14B6D1005F1280 /* NSLayoutConstraint+Rx.swift in Sources */,
 				C882542C1B8A752B00B02D69 /* UIGestureRecognizer+Rx.swift in Sources */,
+				B27D9A6421AE12D800912D98 /* ObservableRelayType.swift in Sources */,
 				C89AB1D21DAAC3350065FBE6 /* ControlProperty+Driver.swift in Sources */,
 				C8093EE11B8A732E0088E94D /* DelegateProxy.swift in Sources */,
 				C89AB2501DAAC3A60065FBE6 /* _RXObjCRuntime.m in Sources */,

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -38,7 +38,7 @@ extension ObservableType {
     }
 
     /**
-     Creates new subscription and sends elements to publish relay.
+     Creates new subscription and sends elements to relay.
      
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
@@ -46,13 +46,13 @@ extension ObservableType {
      - parameter to: Target publish relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relay: PublishRelay<E>) -> Disposable {
+    public func bind<O: ObservableRelayType>(to relay: O) -> Disposable where O.E == E {
         return subscribe { e in
             switch e {
             case let .next(element):
                 relay.accept(element)
             case let .error(error):
-                rxFatalErrorInDebug("Binding error to publish relay: \(error)")
+                rxFatalErrorInDebug("Binding error to relay type: \(error)")
             case .completed:
                 break
             }
@@ -60,7 +60,7 @@ extension ObservableType {
     }
     
     /**
-     Creates new subscription and sends elements to publish relay.
+     Creates new subscription and sends elements to relay.
      
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
@@ -68,42 +68,7 @@ extension ObservableType {
      - parameter to: Target publish relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relay: PublishRelay<E?>) -> Disposable {
-        return self.map { $0 as E? }.bind(to: relay)
-    }
-    
-    /**
-     Creates new subscription and sends elements to behavior relay.
-     
-     In case error occurs in debug mode, `fatalError` will be raised.
-     In case error occurs in release mode, `error` will be logged.
-     
-     - parameter to: Target behavior relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    public func bind(to relay: BehaviorRelay<E>) -> Disposable {
-        return subscribe { e in
-            switch e {
-            case let .next(element):
-                relay.accept(element)
-            case let .error(error):
-                rxFatalErrorInDebug("Binding error to behavior relay: \(error)")
-            case .completed:
-                break
-            }
-        }
-    }
-    
-    /**
-     Creates new subscription and sends elements to behavior relay.
-     
-     In case error occurs in debug mode, `fatalError` will be raised.
-     In case error occurs in release mode, `error` will be logged.
-     
-     - parameter to: Target behavior relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    public func bind(to relay: BehaviorRelay<E?>) -> Disposable {
+    public func bind<O: ObservableRelayType>(to relay: O) -> Disposable where O.E == E? {
         return self.map { $0 as E? }.bind(to: relay)
     }
     

--- a/RxCocoa/Traits/BehaviorRelay.swift
+++ b/RxCocoa/Traits/BehaviorRelay.swift
@@ -11,7 +11,7 @@ import RxSwift
 /// BehaviorRelay is a wrapper for `BehaviorSubject`.
 ///
 /// Unlike `BehaviorSubject` it can't terminate with error or completed.
-public final class BehaviorRelay<Element>: ObservableType {
+public final class BehaviorRelay<Element>: ObservableRelayType {
     public typealias E = Element
 
     private let _subject: BehaviorSubject<Element>

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -41,13 +41,13 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     }
 
     /**
-    Creates new subscription and sends elements to `BehaviorRelay`.
+    Creates new subscription and sends elements to relay.
     This method can be only called from `MainThread`.
 
     - parameter relay: Target relay for sequence elements.
     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
     */
-    public func drive(_ relay: BehaviorRelay<E>) -> Disposable {
+    public func drive<O: ObservableRelayType>(_ relay: O) -> Disposable where O.E == E {
         MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
         return drive(onNext: { e in
             relay.accept(e)
@@ -55,13 +55,13 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     }
 
     /**
-     Creates new subscription and sends elements to `BehaviorRelay`.
+     Creates new subscription and sends elements to relay.
      This method can be only called from `MainThread`.
 
      - parameter relay: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
-    public func drive(_ relay: BehaviorRelay<E?>) -> Disposable {
+    public func drive<O: ObservableRelayType>(_ relay: O) -> Disposable where O.E == E? {
         MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
         return drive(onNext: { e in
             relay.accept(e)

--- a/RxCocoa/Traits/ObservableRelayType.swift
+++ b/RxCocoa/Traits/ObservableRelayType.swift
@@ -2,14 +2,15 @@
 //  ObservableRelayType.swift
 //  RxCocoa
 //
-//  Created by Luciano Almeida on 25/11/18.
+//  Created by Luciano Almeida on 27/11/18.
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.
 //
 
 import RxSwift
 
-/// `ObservableRelayType` is an ObservableType that accepts events and emits it to subscribers.
-///  See `PublishRelay` and `BehaviorRelay`.
+/// `ObservableRelayType` is an ObservableType that accepts events and emits them to its subscribers.
+///
+/// See `BehaviorRelay` and `PublishRelay`.
 public protocol ObservableRelayType: ObservableType {
     func accept(_ event: E)
 }

--- a/RxCocoa/Traits/ObservableRelayType.swift
+++ b/RxCocoa/Traits/ObservableRelayType.swift
@@ -1,0 +1,15 @@
+//
+//  ObservableRelayType.swift
+//  RxCocoa
+//
+//  Created by Luciano Almeida on 25/11/18.
+//  Copyright © 2018 Krunoslav Zaher. All rights reserved.
+//
+
+import RxSwift
+
+/// `ObservableRelayType` is an ObservableType that accepts events and emits it to subscribers.
+///  See `PublishRelay` and `BehaviorRelay`.
+public protocol ObservableRelayType: ObservableType {
+    func accept(_ event: E)
+}

--- a/RxCocoa/Traits/PublishRelay.swift
+++ b/RxCocoa/Traits/PublishRelay.swift
@@ -11,7 +11,7 @@ import RxSwift
 /// PublishRelay is a wrapper for `PublishSubject`.
 ///
 /// Unlike `PublishSubject` it can't terminate with error or completed.
-public final class PublishRelay<Element>: ObservableType {
+public final class PublishRelay<Element>: ObservableRelayType {
     public typealias E = Element
 
     private let _subject: PublishSubject<Element>

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -34,22 +34,11 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     }
 
     /**
-     Creates new subscription and sends elements to `BehaviorRelay`.
+     Creates new subscription and sends elements to relay.
      - parameter relay: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
-    public func emit(to relay: BehaviorRelay<E>) -> Disposable {
-        return emit(onNext: { e in
-            relay.accept(e)
-        })
-    }
-    
-    /**
-     Creates new subscription and sends elements to `BehaviorRelay`.
-     - parameter relay: Target relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
-     */
-    public func emit(to relay: BehaviorRelay<E?>) -> Disposable {
+    public func emit<O: ObservableRelayType>(to relay: O) -> Disposable where O.E == E {
         return emit(onNext: { e in
             relay.accept(e)
         })
@@ -57,28 +46,15 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     
     /**
      Creates new subscription and sends elements to relay.
-
      - parameter relay: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
-    public func emit(to relay: PublishRelay<E>) -> Disposable {
+    public func emit<O: ObservableRelayType>(to relay: O) -> Disposable where O.E == E? {
         return emit(onNext: { e in
             relay.accept(e)
         })
     }
-
-    /**
-     Creates new subscription and sends elements to relay.
-
-     - parameter to: Target relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
-     */
-    public func emit(to relay: PublishRelay<E?>) -> Disposable {
-        return emit(onNext: { e in
-            relay.accept(e)
-        })
-    }
-
+    
     /**
      Subscribes an element handler, a completion handler and disposed handler to an observable sequence.
 

--- a/Sources/RxCocoa/ObservableRelayType.swift
+++ b/Sources/RxCocoa/ObservableRelayType.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/Traits/ObservableRelayType.swift


### PR DESCRIPTION
On Signal+Subscriptions there were two methods with the same implementation for two different types of Relays (`Publish` and `Behavior`). So maybe it's worth creating a protocol level of abstraction over relay and remove this duplication using the generic type. It's a very little duplication and maybe doesn't worth the abstraction. 
@kzaher and @freak4pc let me know your thoughts on this one :)