### PR TITLE
Update a deprecated example in GettingStarted.md

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -379,7 +379,7 @@ func myInterval(_ interval: TimeInterval) -> Observable<Int> {
     return Observable.create { observer in
         print("Subscribed")
         let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
-        timer.scheduleRepeating(deadline: DispatchTime.now() + interval, interval: interval)
+        timer.schedule(deadline: DispatchTime.now() + interval, repeating: interval)
 
         let cancel = Disposables.create {
             print("Disposed")


### PR DESCRIPTION
While reading through the documentation and trying things out in a sample project, I noticed that `timer.scheduleRepeating` is deprecated - the documentation now reflects the recommended usage of `timer.schedule`.

Thanks for the great docs!