### PR TITLE
Removing swift 3 compilation checks

### DIFF
--- a/Platform/DataStructures/PriorityQueue.swift
+++ b/Platform/DataStructures/PriorityQueue.swift
@@ -52,11 +52,7 @@ struct PriorityQueue<Element> {
     private mutating func removeAt(_ index: Int) {
         let removingLast = index == _elements.count - 1
         if !removingLast {
-            #if swift(>=3.2)
             _elements.swapAt(index, _elements.count - 1)
-            #else
-            swap(&_elements[index], &_elements[_elements.count - 1])
-            #endif
         }
 
         _ = _elements.popLast()
@@ -76,11 +72,7 @@ struct PriorityQueue<Element> {
         while unbalancedIndex > 0 {
             let parentIndex = (unbalancedIndex - 1) / 2
             guard _hasHigherPriority(_elements[unbalancedIndex], _elements[parentIndex]) else { break }
-            #if swift(>=3.2)
             _elements.swapAt(unbalancedIndex, parentIndex)
-            #else
-            swap(&_elements[unbalancedIndex], &_elements[parentIndex])
-            #endif
             unbalancedIndex = parentIndex
         }
     }
@@ -105,12 +97,8 @@ struct PriorityQueue<Element> {
             }
 
             guard highestPriorityIndex != unbalancedIndex else { break }
-
-            #if swift(>=3.2)
             _elements.swapAt(highestPriorityIndex, unbalancedIndex)
-            #else
-            swap(&_elements[highestPriorityIndex], &_elements[unbalancedIndex])
-            #endif
+
             unbalancedIndex = highestPriorityIndex
         }
     }

--- a/RxCocoa/Common/KeyPathBinder.swift
+++ b/RxCocoa/Common/KeyPathBinder.swift
@@ -6,31 +6,29 @@
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.
 //
 
-#if swift(>=3.2)
-    import RxSwift
+import RxSwift
+
+extension Reactive where Base: AnyObject {
     
-    extension Reactive where Base: AnyObject {
-        
-        /// Bindable sink for arbitrary property using the given key path.
-        /// Binding runs on the MainScheduler.
-        ///
-        /// - parameter keyPath: Key path to write to the property.
-        public subscript<Value>(keyPath: ReferenceWritableKeyPath<Base, Value>) -> Binder<Value> {
-            return Binder(self.base) { base, value in
-                base[keyPath: keyPath] = value
-            }
+    /// Bindable sink for arbitrary property using the given key path.
+    /// Binding runs on the MainScheduler.
+    ///
+    /// - parameter keyPath: Key path to write to the property.
+    public subscript<Value>(keyPath: ReferenceWritableKeyPath<Base, Value>) -> Binder<Value> {
+        return Binder(self.base) { base, value in
+            base[keyPath: keyPath] = value
         }
-        
-        /// Bindable sink for arbitrary property using the given key path.
-        /// Binding runs on the specified scheduler.
-        ///
-        /// - parameter keyPath: Key path to write to the property.
-        /// - parameter scheduler: Scheduler to run bindings on.
-        public subscript<Value>(keyPath: ReferenceWritableKeyPath<Base, Value>, on scheduler: ImmediateSchedulerType) -> Binder<Value> {
-            return Binder(self.base, scheduler: scheduler) { base, value in
-                base[keyPath: keyPath] = value
-            }
-        }
-        
     }
-#endif
+    
+    /// Bindable sink for arbitrary property using the given key path.
+    /// Binding runs on the specified scheduler.
+    ///
+    /// - parameter keyPath: Key path to write to the property.
+    /// - parameter scheduler: Scheduler to run bindings on.
+    public subscript<Value>(keyPath: ReferenceWritableKeyPath<Base, Value>, on scheduler: ImmediateSchedulerType) -> Binder<Value> {
+        return Binder(self.base, scheduler: scheduler) { base, value in
+            base[keyPath: keyPath] = value
+        }
+    }
+    
+}

--- a/RxExample/RxExample/Services/ReachabilityService.swift
+++ b/RxExample/RxExample/Services/ReachabilityService.swift
@@ -8,11 +8,7 @@
 
 import RxSwift
 
-#if swift(>=3.2)
-    import class Dispatch.DispatchQueue
-#else
-    import class Dispatch.queue.DispatchQueue
-#endif
+import class Dispatch.DispatchQueue
 
 public enum ReachabilityStatus {
     case reachable(viaWiFi: Bool)

--- a/Tests/RxCocoaTests/KeyPathBinder+RxTests.swift
+++ b/Tests/RxCocoaTests/KeyPathBinder+RxTests.swift
@@ -6,66 +6,61 @@
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.
 //
 
-#if swift(>=3.2)
-    
-    import RxCocoa
-    import RxSwift
-    import XCTest
-    
-    final class KeyPathBinderTests: RxTest {}
-    
-    private final class Object: ReactiveCompatible {
-        var value: Int = 0 {
-            didSet { valueDidSet() }
-        }
-        
-        private let valueDidSet: () -> Void
-        
-        init(valueDidSet: @escaping () -> Void) {
-            self.valueDidSet = valueDidSet
-        }
-    }
-    
-    extension KeyPathBinderTests {
-        
-        func testBindingOnNonMainQueueDispatchesToMainQueue() {
-            let waitForElement = self.expectation(description: "wait until element arrives")
-            
-            let object = Object {
-                MainScheduler.ensureExecutingOnScheduler()
-                waitForElement.fulfill()
-            }
-            
-            let bindingObserver = object.rx[\.value]
-            
-            DispatchQueue.global(qos: .default).async {
-                bindingObserver.on(.next(1))
-            }
-            
-            self.waitForExpectations(timeout: 1.0) { (e) in
-                XCTAssertNil(e)
-            }
-        }
-        
-        func testBindingOnMainQueueDispatchesToNonMainQueue() {
-            let waitForElement = self.expectation(description: "wait until element arrives")
-            
-            let object = Object {
-                XCTAssert(!DispatchQueue.isMain)
-                waitForElement.fulfill()
-            }
-            
-            let scheduler = ConcurrentDispatchQueueScheduler(qos: .default)
-            let bindingObserver = object.rx[\.value, on: scheduler]
-            
-            bindingObserver.on(.next(1))
-            
-            self.waitForExpectations(timeout: 1.0) { (e) in
-                XCTAssertNil(e)
-            }
-        }
-        
-    }
-    
-#endif
+import RxCocoa
+import RxSwift
+import XCTest
 
+final class KeyPathBinderTests: RxTest {}
+
+private final class Object: ReactiveCompatible {
+    var value: Int = 0 {
+        didSet { valueDidSet() }
+    }
+    
+    private let valueDidSet: () -> Void
+    
+    init(valueDidSet: @escaping () -> Void) {
+        self.valueDidSet = valueDidSet
+    }
+}
+
+extension KeyPathBinderTests {
+    
+    func testBindingOnNonMainQueueDispatchesToMainQueue() {
+        let waitForElement = self.expectation(description: "wait until element arrives")
+        
+        let object = Object {
+            MainScheduler.ensureExecutingOnScheduler()
+            waitForElement.fulfill()
+        }
+        
+        let bindingObserver = object.rx[\.value]
+        
+        DispatchQueue.global(qos: .default).async {
+            bindingObserver.on(.next(1))
+        }
+        
+        self.waitForExpectations(timeout: 1.0) { (e) in
+            XCTAssertNil(e)
+        }
+    }
+    
+    func testBindingOnMainQueueDispatchesToNonMainQueue() {
+        let waitForElement = self.expectation(description: "wait until element arrives")
+        
+        let object = Object {
+            XCTAssert(!DispatchQueue.isMain)
+            waitForElement.fulfill()
+        }
+        
+        let scheduler = ConcurrentDispatchQueueScheduler(qos: .default)
+        let bindingObserver = object.rx[\.value, on: scheduler]
+        
+        bindingObserver.on(.next(1))
+        
+        self.waitForExpectations(timeout: 1.0) { (e) in
+            XCTAssertNil(e)
+        }
+    }
+    
+}


### PR DESCRIPTION
Hey guys :))
Since swift 3.x support is tagged on  rxswift-3.0 branch and the minimum requirement for this master/develop branching is 4.0, maybe is a good clean up to remove that swift 3 compile checks.
@kzaher @freak4pc 