### PR TITLE
Remove using "!" in Bag.swift

### DIFF
--- a/Platform/DataStructures/Bag.swift
+++ b/Platform/DataStructures/Bag.swift
@@ -74,8 +74,8 @@ struct Bag<T> : CustomDebugStringConvertible {
 
         _onlyFastPath = false
 
-        if _dictionary != nil {
-            _dictionary![key] = element
+        if var dict = _dictionary {
+            dict[key] = element
             return key
         }
 


### PR DESCRIPTION
It's not a good way to using "!" for optional Dictionary.