### PR TITLE
Using Cancelable instead of Disposable for BehaviorSubject

### DIFF
--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -14,7 +14,7 @@ public final class BehaviorSubject<Element>
     , SubjectType
     , ObserverType
     , SynchronizedUnsubscribeType
-    , Disposable {
+    , Cancelable {
     public typealias SubjectObserverType = BehaviorSubject<Element>
 
     typealias Observers = AnyObserver<Element>.s


### PR DESCRIPTION
BehaviorSubject has implemented `var isDisposed: Bool`, so it would be better for using Cancelable.