### PR TITLE
Remove warn_unused_result

### DIFF
--- a/Documentation/Tips.md
+++ b/Documentation/Tips.md
@@ -9,7 +9,6 @@ e.g.
 ```swift
 extension ObservableType where E: MaybeCool {
 
-    @warn_unused_result(message="http://git.io/rxs.uo")
     public func coolElements()
         -> Observable<E> {
           return filter { e -> Bool in


### PR DESCRIPTION
I believe it was removed in Swift 3, so this document is out of date. Not sure what to do about the link to http://git.io/rxs.uo, though. It's a shame to lose that extra bit of documentation.