### PR TITLE
Add swift_version to podspecs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,35 +41,19 @@ matrix:
     include:
       - osx_image: xcode10
         os: osx
-        env: BUILD="pod lib lint --swift-version=4 RxSwift.podspec"
+        env: BUILD="pod lib lint RxSwift.podspec"
 
       - osx_image: xcode10
         os: osx
-        env: BUILD="pod lib lint --swift-version=4 RxCocoa.podspec"
+        env: BUILD="pod lib lint RxCocoa.podspec"
 
       - osx_image: xcode10
         os: osx
-        env: BUILD="pod lib lint --swift-version=4 RxBlocking.podspec"
+        env: BUILD="pod lib lint RxBlocking.podspec"
 
       - osx_image: xcode10
         os: osx
-        env: BUILD="pod lib lint --swift-version=4 RxTest.podspec"
-
-      - osx_image: xcode10
-        os: osx
-        env: BUILD="pod lib lint --swift-version=4.2 RxSwift.podspec"
-
-      - osx_image: xcode10
-        os: osx
-        env: BUILD="pod lib lint --swift-version=4.2 RxCocoa.podspec"
-
-      - osx_image: xcode10
-        os: osx
-        env: BUILD="pod lib lint --swift-version=4.2 RxBlocking.podspec"
-
-      - osx_image: xcode10
-        os: osx
-        env: BUILD="pod lib lint --swift-version=4.2 RxTest.podspec"
+        env: BUILD="pod lib lint RxTest.podspec"
 
 notifications:
   slack: rxswift:3ykt2Z61f8GkdvhCZTYPduOL

--- a/RxAtomic.podspec
+++ b/RxAtomic.podspec
@@ -12,6 +12,8 @@ Atomic primitives for RxSwift.
 
   s.requires_arc          = true
 
+  s.swift_version = '4.0'
+
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.ios.deployment_target = '8.0'

--- a/RxBlocking.podspec
+++ b/RxBlocking.podspec
@@ -17,6 +17,8 @@ Waiting for observable sequence to complete before exiting command line applicat
 
   s.requires_arc          = true
 
+  s.swift_version = '4.0'
+
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '3.0'

--- a/RxCocoa.podspec
+++ b/RxCocoa.podspec
@@ -14,6 +14,8 @@ Pod::Spec.new do |s|
 
   s.requires_arc          = true
 
+  s.swift_version = '4.0'
+
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '3.0'

--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -27,6 +27,8 @@ gitDiff().grep("bug").less          // sequences of swift objects
 
   s.requires_arc          = true
 
+  s.swift_version = '4.0'
+
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.watchos.deployment_target = '3.0'

--- a/RxTest.podspec
+++ b/RxTest.podspec
@@ -47,6 +47,8 @@ func testMap() {
 
   s.requires_arc          = true
 
+  s.swift_version = '4.0'
+
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.9'
   s.tvos.deployment_target = '9.0'


### PR DESCRIPTION
`swift_version` is supported as of [Cocoapods 1.4](https://blog.cocoapods.org/CocoaPods-1.4.0/#swift-version-dsl). Adding this removes the requirement that the pod be integrated into a target which uses the same Swift version.
