### PR TITLE
Make class Sink implement Cancelable instead of Disposable

### DIFF
--- a/RxSwift/Observables/Debug.swift
+++ b/RxSwift/Observables/Debug.swift
@@ -65,7 +65,7 @@ final fileprivate class DebugSink<Source: ObservableType, O: ObserverType> : Sin
     }
     
     override func dispose() {
-        if !self.disposed {
+        if !self.isDisposed {
             logEvent(_parent._identifier, dateFormat: _timestampFormatter, content: "isDisposed")
         }
         super.dispose()

--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -84,6 +84,7 @@ final fileprivate class Map<SourceType, ResultType>: Producer<ResultType> {
 #if TRACE_RESOURCES
         let _ = _numberOfMapOperators.increment()
 #endif
+        super.init()
     }
 
     override func composeMap<R>(_ selector: @escaping (ResultType) throws -> R) -> Observable<R> {

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -265,7 +265,7 @@ final fileprivate class RefCountSink<CO: ConnectableObservableType, O: ObserverT
 
         _connectionIdSnapshot = _parent._connectionId
 
-        if self.disposed {
+        if self.isDisposed {
             return Disposables.create()
         }
 

--- a/RxSwift/Observables/Sink.swift
+++ b/RxSwift/Observables/Sink.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-class Sink<O : ObserverType> : Disposable {
+class Sink<O : ObserverType> : Cancelable {
     fileprivate let _observer: O
     fileprivate let _cancel: Cancelable
-    fileprivate var _disposed: Bool
+    fileprivate var _isDisposed: Bool
 
     #if DEBUG
         fileprivate let _synchronizationTracker = SynchronizationTracker()
@@ -21,7 +21,7 @@ class Sink<O : ObserverType> : Disposable {
 #endif
         _observer = observer
         _cancel = cancel
-        _disposed = false
+        _isDisposed = false
     }
     
     final func forwardOn(_ event: Event<O.E>) {
@@ -29,7 +29,7 @@ class Sink<O : ObserverType> : Disposable {
             _synchronizationTracker.register(synchronizationErrorMessage: .default)
             defer { _synchronizationTracker.unregister() }
         #endif
-        if _disposed {
+        if _isDisposed {
             return
         }
         _observer.on(event)
@@ -39,12 +39,12 @@ class Sink<O : ObserverType> : Disposable {
         return SinkForward(forward: self)
     }
 
-    final var disposed: Bool {
-        return _disposed
+    final var isDisposed: Bool {
+        return _isDisposed
     }
 
     func dispose() {
-        _disposed = true
+        _isDisposed = true
         _cancel.dispose()
     }
 


### PR DESCRIPTION
The Sink class had a compute property `disposed`, and it could be replaced by the `isDisposed` in the `Cancelable` protocol.