### PR TITLE
Add functions to Driver that sends elements to PublishRelay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Master
 
 * Adds `takeUntil(_ behavior:predicate:)`.
+* Adds functions to `Driver` that sends elements to `PublishRelay`
 
 ## [4.4.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.4.0)
 

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -69,6 +69,34 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     }
 
     /**
+     Creates new subscription and sends elements to `PublishRelay`.
+     This method can be only called from `MainThread`.
+
+     - parameter relay: Target relay for sequence elements.
+     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
+     */
+    public func drive(_ relay: PublishRelay<E>) -> Disposable {
+        MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
+        return drive(onNext: { e in
+            relay.accept(e)
+        })
+    }
+
+    /**
+     Creates new subscription and sends elements to `PublishRelay`.
+     This method can be only called from `MainThread`.
+
+     - parameter relay: Target relay for sequence elements.
+     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
+     */
+    public func drive(_ relay: PublishRelay<E?>) -> Disposable {
+        MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
+        return drive(onNext: { e in
+            relay.accept(e)
+        })
+    }
+
+    /**
     Subscribes to observable sequence using custom binder function.
     This method can be only called from `MainThread`.
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -249,6 +249,10 @@ final class DriverTest_ : DriverTest, RxTestCase {
     ("testDriveBehaviorRelay1", DriverTest.testDriveBehaviorRelay1),
     ("testDriveBehaviorRelay2", DriverTest.testDriveBehaviorRelay2),
     ("testDriveBehaviorRelay3", DriverTest.testDriveBehaviorRelay3),
+    ("testDrivePublishRelay", DriverTest.testDrivePublishRelay),
+    ("testDrivePublishRelay1", DriverTest.testDrivePublishRelay1),
+    ("testDrivePublishRelay2", DriverTest.testDrivePublishRelay2),
+    ("testDrivePublishRelay3", DriverTest.testDrivePublishRelay3),
     ] }
 }
 

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -435,3 +435,72 @@ extension DriverTest {
         subscription.dispose()
     }
 }
+
+// MARK: drive publish relay
+
+extension DriverTest {
+    func testDrivePublishRelay() {
+        let relay = PublishRelay<Int>()
+
+        var events: [Recorded<Int>] = []
+
+        let relaySubscription = relay.subscribe(onNext: { value in
+            events.append(Recorded(time: 0, value: value))
+        })
+
+        let subscription = (Driver.just(1) as Driver<Int>).drive(relay)
+
+        XCTAssertEqual(events.first?.value, 1)
+        subscription.dispose()
+        relaySubscription.dispose()
+    }
+
+    func testDrivePublishRelay1() {
+        let relay = PublishRelay<Int?>()
+
+        var events: [Recorded<Int?>] = []
+
+        let relaySubscription = relay.subscribe(onNext: { value in
+            events.append(Recorded(time: 0, value: value))
+        })
+
+        let subscription = (Driver.just(1) as Driver<Int>).drive(relay)
+
+        XCTAssertEqual(events.first?.value, 1)
+        subscription.dispose()
+        relaySubscription.dispose()
+    }
+
+    func testDrivePublishRelay2() {
+        let relay = PublishRelay<Int?>()
+
+        var events: [Recorded<Int?>] = []
+
+        let relaySubscription = relay.subscribe(onNext: { value in
+            events.append(Recorded(time: 0, value: value))
+        })
+
+        let subscription = (Driver.just(1) as Driver<Int?>).drive(relay)
+
+        XCTAssertEqual(events.first?.value, 1)
+        subscription.dispose()
+        relaySubscription.dispose()
+    }
+
+    func testDrivePublishRelay3() {
+        let relay = PublishRelay<Int?>()
+
+        var events: [Recorded<Int?>] = []
+
+        let relaySubscription = relay.subscribe(onNext: { value in
+            events.append(Recorded(time: 0, value: value))
+        })
+
+        // shouldn't cause compile time error
+        let subscription = Driver.just(1).drive(relay)
+
+        XCTAssertEqual(events.first?.value, 1)
+        subscription.dispose()
+        relaySubscription.dispose()
+    }
+}


### PR DESCRIPTION
There are already functions to `drive` to a `BehaviorRelay`. Sinds sending them to a `PublishRelay` is pretty much the same I think it's useful to have functions for that as well.