### PR TITLE
Fix warnings from the Swift 5 compiler

### DIFF
--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -24,7 +24,7 @@
         private var _methodInvokedForSelector = [Selector: MessageDispatcher]()
 
         /// Parent object associated with delegate proxy.
-        private weak private(set) var _parentObject: ParentObject?
+        private weak var _parentObject: ParentObject?
 
         fileprivate let _currentDelegateFor: (ParentObject) -> AnyObject?
         fileprivate let _setCurrentDelegateTo: (AnyObject?, ParentObject) -> ()

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -398,7 +398,7 @@ fileprivate final class KVOObservable<Element>
 }
 
 fileprivate extension KeyValueObservingOptions {
-    fileprivate var nsOptions: NSKeyValueObservingOptions {
+    var nsOptions: NSKeyValueObservingOptions {
         var result: UInt = 0
         if self.contains(.new) {
             result |= NSKeyValueObservingOptions.new.rawValue

--- a/RxSwift/Observables/Zip+arity.swift
+++ b/RxSwift/Observables/Zip+arity.swift
@@ -70,8 +70,6 @@ final class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
         default:
             rxFatalError("Unhandled case (Function)")
         }
-
-        return false
     }
 
     func run() -> Disposable {
@@ -182,8 +180,6 @@ final class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
         default:
             rxFatalError("Unhandled case (Function)")
         }
-
-        return false
     }
 
     func run() -> Disposable {
@@ -302,8 +298,6 @@ final class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
         default:
             rxFatalError("Unhandled case (Function)")
         }
-
-        return false
     }
 
     func run() -> Disposable {
@@ -430,8 +424,6 @@ final class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
         default:
             rxFatalError("Unhandled case (Function)")
         }
-
-        return false
     }
 
     func run() -> Disposable {
@@ -566,8 +558,6 @@ final class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
         default:
             rxFatalError("Unhandled case (Function)")
         }
-
-        return false
     }
 
     func run() -> Disposable {
@@ -710,8 +700,6 @@ final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> 
         default:
             rxFatalError("Unhandled case (Function)")
         }
-
-        return false
     }
 
     func run() -> Disposable {
@@ -862,8 +850,6 @@ final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink
         default:
             rxFatalError("Unhandled case (Function)")
         }
-
-        return false
     }
 
     func run() -> Disposable {

--- a/RxSwift/Traits/Completable.swift
+++ b/RxSwift/Traits/Completable.swift
@@ -23,7 +23,7 @@ public enum CompletableEvent {
     case completed
 }
 
-public extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
+extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
     public typealias CompletableObserver = (CompletableEvent) -> ()
     
     /**
@@ -100,7 +100,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
     }
 }
 
-public extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
+extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
     /**
      Returns an observable sequence that terminates with an `error`.
 
@@ -136,7 +136,7 @@ public extension PrimitiveSequenceType where TraitType == CompletableTrait, Elem
 
 }
 
-public extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {    
+extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
     /**
      Invokes an action for each event in the observable sequence, and propagates all observer messages through the result sequence.
      

--- a/RxSwift/Traits/Maybe.swift
+++ b/RxSwift/Traits/Maybe.swift
@@ -26,7 +26,7 @@ public enum MaybeEvent<Element> {
     case completed
 }
 
-public extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where TraitType == MaybeTrait {
     public typealias MaybeObserver = (MaybeEvent<ElementType>) -> ()
     
     /**
@@ -111,7 +111,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-public extension PrimitiveSequenceType where TraitType == MaybeTrait {    
+extension PrimitiveSequenceType where TraitType == MaybeTrait {
     /**
      Returns an observable sequence that contains a single element.
      
@@ -171,7 +171,7 @@ public extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-public extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where TraitType == MaybeTrait {
     /**
      Invokes an action for each event in the observable sequence, and propagates all observer messages through the result sequence.
      


### PR DESCRIPTION
This makes some backwards compatible warnings fixes for the Swift 5
compiler in Swift 4.2 mode. There are 4 warnings being fixed here.

1. Functions inside public extensions don't need to be marked public.
For this case I opted to remove the public from the extension instead so
that no method that is meant to be internal in one of these extensions
accidentally becomes public API.
2. Members inside of a fileprivate extension don't need to be marked
fileprivate. Here I removed it from the member so that new members will
also be fileprivate unless decided otherwise.
3. private(set) is redundant on a private property. I assume this was
left over from some changes.
4. Removed unreachable return statements that now produce warnings