### PR TITLE
remove RxExample Dependencies singleton keeping simplicity

### DIFF
--- a/RxExample/RxExample/Examples/Dependencies.swift
+++ b/RxExample/RxExample/Examples/Dependencies.swift
@@ -13,29 +13,22 @@ import class Foundation.OperationQueue
 import enum Foundation.QualityOfService
 
 class Dependencies {
-
-    // *****************************************************************************************
-    // !!! This is defined for simplicity sake, using singletons isn't advised               !!!
-    // !!! This is just a simple way to move services to one location so you can see Rx code !!!
-    // *****************************************************************************************
-    static let sharedDependencies = Dependencies() // Singleton
     
-    let URLSession = Foundation.URLSession.shared
-    let backgroundWorkScheduler: ImmediateSchedulerType
-    let mainScheduler: SerialDispatchQueueScheduler
-    let wireframe: Wireframe
-    let reachabilityService: ReachabilityService
-    
-    private init() {
-        wireframe = DefaultWireframe()
-        
+    private static let _URLSession = Foundation.URLSession.shared
+    private static let _backgroundWorkScheduler: ImmediateSchedulerType = {
         let operationQueue = OperationQueue()
         operationQueue.maxConcurrentOperationCount = 2
         operationQueue.qualityOfService = QualityOfService.userInitiated
-        backgroundWorkScheduler = OperationQueueScheduler(operationQueue: operationQueue)
-        
-        mainScheduler = MainScheduler.instance
-        reachabilityService = try! DefaultReachabilityService() // try! is only for simplicity sake
-    }
+        return OperationQueueScheduler(operationQueue: operationQueue)
+    }()
+    private static let _mainScheduler: SerialDispatchQueueScheduler = MainScheduler.instance
+    private static let _wireframe: Wireframe = DefaultWireframe()
+    private static let _reachabilityService: ReachabilityService = try! DefaultReachabilityService() // try! is only for simplicity sake
+    
+    let URLSession: URLSession = Dependencies._URLSession
+    let backgroundWorkScheduler: ImmediateSchedulerType = Dependencies._backgroundWorkScheduler
+    let mainScheduler: SerialDispatchQueueScheduler = Dependencies._mainScheduler
+    let wireframe: Wireframe = Dependencies._wireframe
+    let reachabilityService: ReachabilityService = Dependencies._reachabilityService
     
 }

--- a/RxExample/RxExample/Examples/Dependencies.swift
+++ b/RxExample/RxExample/Examples/Dependencies.swift
@@ -12,7 +12,15 @@ import class Foundation.URLSession
 import class Foundation.OperationQueue
 import enum Foundation.QualityOfService
 
-class Dependencies {
+protocol CommonDependencies {
+    var URLSession: URLSession { get }
+    var backgroundWorkScheduler: ImmediateSchedulerType { get }
+    var mainScheduler: SerialDispatchQueueScheduler { get }
+    var wireframe: Wireframe { get }
+    var reachabilityService: ReachabilityService { get }
+}
+
+class Dependencies: CommonDependencies {
     
     private static let _URLSession = Foundation.URLSession.shared
     private static let _backgroundWorkScheduler: ImmediateSchedulerType = {

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesAPI.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesAPI.swift
@@ -65,7 +65,7 @@ extension GitHubSearchRepositoriesAPI {
         return URLSession.shared
             .rx.response(request: URLRequest(url: searchURL))
             .retry(3)
-            .observeOn(Dependencies.sharedDependencies.backgroundWorkScheduler)
+            .observeOn(Dependencies().backgroundWorkScheduler)
             .map { pair -> SearchRepositoriesResponse in
                 if pair.0.statusCode == 403 {
                     return .failure(.githubLimitReached)

--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/DetailViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/DetailViewController.swift
@@ -13,7 +13,7 @@ class DetailViewController: ViewController {
     
     var user: User!
     
-    var `$` = Dependencies()
+    var `$`: CommonDependencies = Dependencies()
     
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var label: UILabel!

--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/DetailViewController.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/DetailViewController.swift
@@ -13,7 +13,7 @@ class DetailViewController: ViewController {
     
     var user: User!
     
-    let `$` = Dependencies.sharedDependencies
+    var `$` = Dependencies()
     
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var label: UILabel!

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/ViewModels/SearchResultViewModel.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/ViewModels/SearchResultViewModel.swift
@@ -16,7 +16,7 @@ class SearchResultViewModel {
     var imageURLs: Driver<[URL]>
 
     let API = DefaultWikipediaAPI.sharedAPI
-    var `$`: Dependencies = Dependencies()
+    var `$`: CommonDependencies = Dependencies()
 
     init(searchResult: WikipediaSearchResult) {
         self.searchResult = searchResult

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/ViewModels/SearchResultViewModel.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/ViewModels/SearchResultViewModel.swift
@@ -16,7 +16,7 @@ class SearchResultViewModel {
     var imageURLs: Driver<[URL]>
 
     let API = DefaultWikipediaAPI.sharedAPI
-    let `$`: Dependencies = Dependencies.sharedDependencies
+    var `$`: Dependencies = Dependencies()
 
     init(searchResult: WikipediaSearchResult) {
         self.searchResult = searchResult

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchCell.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchCell.swift
@@ -41,7 +41,7 @@ public class WikipediaSearchCell: UITableViewCell {
 
             self.URLOutlet.text = viewModel.searchResult.URL.absoluteString
 
-            let reachabilityService = Dependencies.sharedDependencies.reachabilityService
+            let reachabilityService = Dependencies().reachabilityService
             viewModel.imageURLs
                 .drive(self.imagesOutlet.rx.items(cellIdentifier: "ImageCell", cellType: CollectionViewImageCell.self)) { [weak self] (_, url, cell) in
                     cell.downloadableImage = self?.imageService.imageFromURL(url, reachabilityService: reachabilityService) ?? Observable.empty()

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
@@ -48,7 +48,7 @@ class WikipediaSearchViewController: ViewController {
             .flatMapLatest { query in
                 API.getSearchResults(query)
                     .retry(3)
-                    .retryOnBecomesReachable([], reachabilityService: Dependencies.sharedDependencies.reachabilityService)
+                    .retryOnBecomesReachable([], reachabilityService: Dependencies().reachabilityService)
                     .startWith([]) // clears results on new search term
                     .asDriver(onErrorJustReturn: [])
             }

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaAPI.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaAPI.swift
@@ -24,7 +24,7 @@ class DefaultWikipediaAPI: WikipediaAPI {
     
     static let sharedAPI = DefaultWikipediaAPI() // Singleton
     
-    var `$`: Dependencies = Dependencies()
+    var `$`: CommonDependencies = Dependencies()
 
     let loadingWikipediaData = ActivityIndicator()
 

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaAPI.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaAPI.swift
@@ -24,7 +24,7 @@ class DefaultWikipediaAPI: WikipediaAPI {
     
     static let sharedAPI = DefaultWikipediaAPI() // Singleton
     
-    let `$`: Dependencies = Dependencies.sharedDependencies
+    var `$`: Dependencies = Dependencies()
 
     let loadingWikipediaData = ActivityIndicator()
 

--- a/RxExample/RxExample/Services/ImageService.swift
+++ b/RxExample/RxExample/Services/ImageService.swift
@@ -23,7 +23,7 @@ class DefaultImageService: ImageService {
 
     static let sharedImageService = DefaultImageService() // Singleton
 
-    var `$`: Dependencies = Dependencies()
+    var `$`: CommonDependencies = Dependencies()
 
     // 1st level cache
     private let _imageCache = NSCache<AnyObject, AnyObject>()

--- a/RxExample/RxExample/Services/ImageService.swift
+++ b/RxExample/RxExample/Services/ImageService.swift
@@ -23,7 +23,7 @@ class DefaultImageService: ImageService {
 
     static let sharedImageService = DefaultImageService() // Singleton
 
-    let `$`: Dependencies = Dependencies.sharedDependencies
+    var `$`: Dependencies = Dependencies()
 
     // 1st level cache
     private let _imageCache = NSCache<AnyObject, AnyObject>()

--- a/RxExample/RxExample/iOS/RootViewController.swift
+++ b/RxExample/RxExample/iOS/RootViewController.swift
@@ -19,7 +19,7 @@ public class RootViewController : UITableViewController {
         _ = DefaultImageService.sharedImageService
         _ = DefaultWireframe.shared
         _ = MainScheduler.instance
-        _ = Dependencies.sharedDependencies.reachabilityService
+        _ = Dependencies().reachabilityService
         
         let geoService = GeolocationService.instance
         geoService.authorized.drive(onNext: { _ in


### PR DESCRIPTION
I remember that a long time ago we opted to use a singleton to facilitate the understanding that the dependencies (especially those of the Schedulers) could be shared. I think that this new approach does away with the singleton, making an injection of dependencies more correct, and at the same time maintain the understanding that instances are shared.