### PR TITLE
Remove unused code in AddRef.swift

### DIFF
--- a/RxSwift/Observables/AddRef.swift
+++ b/RxSwift/Observables/AddRef.swift
@@ -25,7 +25,6 @@ final class AddRefSink<O: ObserverType> : Sink<O>, ObserverType {
 }
 
 final class AddRef<Element> : Producer<Element> {
-    typealias EventHandler = (Event<Element>) throws -> Void
     
     private let _source: Observable<Element>
     private let _refCount: RefCountDisposable


### PR DESCRIPTION
The EventHandler is unused, so delete it.