### PR TITLE
Fix multiple dispose() on SheduledDisposable causing crash (#1892)

### DIFF
--- a/RxSwift/Disposables/ScheduledDisposable.swift
+++ b/RxSwift/Disposables/ScheduledDisposable.swift
@@ -42,7 +42,7 @@ public final class ScheduledDisposable : Cancelable {
     }
 
     func disposeInner() {
-        if !isFlagSet(&self._isDisposed, 1) {
+        if fetchOr(&self._isDisposed, 1) == 0 {
             self._disposable!.dispose()
             self._disposable = nil
         }


### PR DESCRIPTION
Changed isFlagSet to fetchOr function call because of previously made typo in https://github.com/ReactiveX/RxSwift/commit/65efb404c80fe1b23108c8fbb57d05b615e21c93#diff-71e325b5b737d68192bbdea267e6d7e7