### PR TITLE
Update for Swift 5 compiler and Xcode 10.2

### DIFF
--- a/Platform/DataStructures/Bag.swift
+++ b/Platform/DataStructures/Bag.swift
@@ -171,9 +171,15 @@ extension Bag {
 }
 
 extension BagKey: Hashable {
+    #if !swift(>=4.2.2)
     var hashValue: Int {
         return rawValue.hashValue
     }
+    #else
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue)
+    }
+    #endif
 }
 
 func ==(lhs: BagKey, rhs: BagKey) -> Bool {

--- a/RxSwift/Observables/Zip+arity.swift
+++ b/RxSwift/Observables/Zip+arity.swift
@@ -71,7 +71,9 @@ final class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
+        #if !swift(>=4.2.2)
         return false
+        #endif
     }
 
     func run() -> Disposable {
@@ -183,7 +185,9 @@ final class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
+        #if !swift(>=4.2.2)
         return false
+        #endif
     }
 
     func run() -> Disposable {
@@ -303,7 +307,9 @@ final class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
+        #if !swift(>=4.2.2)
         return false
+        #endif
     }
 
     func run() -> Disposable {
@@ -431,7 +437,9 @@ final class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
+        #if !swift(>=4.2.2)
         return false
+        #endif
     }
 
     func run() -> Disposable {
@@ -567,7 +575,9 @@ final class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
+        #if !swift(>=4.2.2)
         return false
+        #endif
     }
 
     func run() -> Disposable {
@@ -711,7 +721,9 @@ final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> 
             rxFatalError("Unhandled case (Function)")
         }
 
+        #if !swift(>=4.2.2)
         return false
+        #endif
     }
 
     func run() -> Disposable {
@@ -863,7 +875,9 @@ final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink
             rxFatalError("Unhandled case (Function)")
         }
 
+        #if !swift(>=4.2.2)
         return false
+        #endif
     }
 
     func run() -> Disposable {

--- a/RxSwift/Observables/Zip+arity.tt
+++ b/RxSwift/Observables/Zip+arity.tt
@@ -71,7 +71,9 @@ final class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separato
             rxFatalError("Unhandled case \(index)")
         }
 
+        #if !swift(>=4.2.2)
         return false
+        #endif
     }
 
     func run() -> Disposable {

--- a/RxSwift/Rx.swift
+++ b/RxSwift/Rx.swift
@@ -38,7 +38,6 @@ func rxAbstractMethod(file: StaticString = #file, line: UInt = #line) -> Swift.N
 }
 
 func rxFatalError(_ lastMessage: @autoclosure () -> String, file: StaticString = #file, line: UInt = #line) -> Swift.Never  {
-    // The temptation to comment this line is great, but please don't, it's for your own good. The choice is yours.
     fatalError(lastMessage(), file: file, line: line)
 }
 

--- a/RxTest/Subscription.swift
+++ b/RxTest/Subscription.swift
@@ -38,9 +38,16 @@ extension Subscription
     : Hashable
     , Equatable {
     /// The hash value.
+    #if !swift(>=4.2.2)
     public var hashValue: Int {
         return self.subscribe.hashValue ^ self.unsubscribe.hashValue
     }
+    #else
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.subscribe)
+        hasher.combine(self.unsubscribe)
+    }
+    #endif
 }
 
 extension Subscription

--- a/Tests/RxSwiftTests/CompletableTest.swift
+++ b/Tests/RxSwiftTests/CompletableTest.swift
@@ -558,9 +558,11 @@ extension CompletableTest {
     }
 }
 
+#if !swift(>=4.2.2)
 extension Never: Equatable {
 
 }
+#endif
 
 public func == (lhs: Never, rhs: Never) -> Bool {
     fatalError()


### PR DESCRIPTION
The only part I'm not sure about is the `hasElements(_:)` functions in `Zip+arity.swift`. The Swift compiler is now smarter at knowing that `rxFatalError()` returns `Never` and now those `return false` statements are redundant as they are never called, _unless_ the user comments out the `fatalError()` inside `rxFatalError()`. 

I think that overall this pattern is odd, and these `hasElements(_:)` functions should just throw an error if they didn't work, leaving it up to the call site to decide how to handle the error, rather than using a `fatalError()` buried into the library.

Happy to make changes on how you think the above should be handled.

All these changes are likely required for the GM of 10.2.