### PR TITLE
Fix RxBlocking Swift 5 warning

### DIFF
--- a/RxBlocking/RunLoopLock.swift
+++ b/RxBlocking/RunLoopLock.swift
@@ -84,6 +84,8 @@ final class RunLoopLock {
                     return
                 case .timedOut:
                     throw RxError.timeout
+                default:
+                    return
                 }
             #endif
         }


### PR DESCRIPTION
This is required for Swift 5, in this case we can't really assume what
the new case will be, but for this use case it seems logic to return
instead of crashing.