### PR TITLE
Fix Swift 5 compiler #ifdefs

### DIFF
--- a/Platform/DataStructures/Bag.swift
+++ b/Platform/DataStructures/Bag.swift
@@ -171,13 +171,13 @@ extension Bag {
 }
 
 extension BagKey: Hashable {
-    #if !swift(>=4.2.2)
-    var hashValue: Int {
-        return rawValue.hashValue
-    }
-    #else
+    #if swift(>=4.2)
     func hash(into hasher: inout Hasher) {
         hasher.combine(rawValue)
+    }
+    #else
+    var hashValue: Int {
+        return rawValue.hashValue
     }
     #endif
 }

--- a/RxSwift/Observables/Zip+arity.swift
+++ b/RxSwift/Observables/Zip+arity.swift
@@ -71,9 +71,13 @@ final class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
-        #if !swift(>=4.2.2)
+    #if swift(>=4.2)
+        #if !compiler(>=5.0)
         return false
         #endif
+    #else
+    return false
+    #endif
     }
 
     func run() -> Disposable {
@@ -185,9 +189,13 @@ final class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
-        #if !swift(>=4.2.2)
+    #if swift(>=4.2)
+        #if !compiler(>=5.0)
         return false
         #endif
+    #else
+    return false
+    #endif
     }
 
     func run() -> Disposable {
@@ -307,9 +315,13 @@ final class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
-        #if !swift(>=4.2.2)
+    #if swift(>=4.2)
+        #if !compiler(>=5.0)
         return false
         #endif
+    #else
+    return false
+    #endif
     }
 
     func run() -> Disposable {
@@ -437,9 +449,13 @@ final class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
-        #if !swift(>=4.2.2)
+    #if swift(>=4.2)
+        #if !compiler(>=5.0)
         return false
         #endif
+    #else
+    return false
+    #endif
     }
 
     func run() -> Disposable {
@@ -575,9 +591,13 @@ final class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
             rxFatalError("Unhandled case (Function)")
         }
 
-        #if !swift(>=4.2.2)
+    #if swift(>=4.2)
+        #if !compiler(>=5.0)
         return false
         #endif
+    #else
+    return false
+    #endif
     }
 
     func run() -> Disposable {
@@ -721,9 +741,13 @@ final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> 
             rxFatalError("Unhandled case (Function)")
         }
 
-        #if !swift(>=4.2.2)
+    #if swift(>=4.2)
+        #if !compiler(>=5.0)
         return false
         #endif
+    #else
+    return false
+    #endif
     }
 
     func run() -> Disposable {
@@ -875,9 +899,13 @@ final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink
             rxFatalError("Unhandled case (Function)")
         }
 
-        #if !swift(>=4.2.2)
+    #if swift(>=4.2)
+        #if !compiler(>=5.0)
         return false
         #endif
+    #else
+    return false
+    #endif
     }
 
     func run() -> Disposable {

--- a/RxSwift/Observables/Zip+arity.tt
+++ b/RxSwift/Observables/Zip+arity.tt
@@ -71,9 +71,13 @@ final class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separato
             rxFatalError("Unhandled case \(index)")
         }
 
-        #if !swift(>=4.2.2)
+    #if swift(>=4.2)
+        #if !compiler(>=5.0)
         return false
         #endif
+    #else
+    return false
+    #endif
     }
 
     func run() -> Disposable {

--- a/RxTest/Subscription.swift
+++ b/RxTest/Subscription.swift
@@ -38,14 +38,14 @@ extension Subscription
     : Hashable
     , Equatable {
     /// The hash value.
-    #if !swift(>=4.2.2)
-    public var hashValue: Int {
-        return self.subscribe.hashValue ^ self.unsubscribe.hashValue
-    }
-    #else
+    #if swift(>=4.2)
     public func hash(into hasher: inout Hasher) {
         hasher.combine(self.subscribe)
         hasher.combine(self.unsubscribe)
+    }
+    #else
+    public var hashValue: Int {
+        return self.subscribe.hashValue ^ self.unsubscribe.hashValue
     }
     #endif
 }

--- a/Tests/RxSwiftTests/CompletableTest.swift
+++ b/Tests/RxSwiftTests/CompletableTest.swift
@@ -558,7 +558,13 @@ extension CompletableTest {
     }
 }
 
-#if !swift(>=4.2.2)
+#if swift(>=4.2)
+    #if !compiler(>=5.0)
+    extension Never: Equatable {
+
+    }
+    #endif
+#else
 extension Never: Equatable {
 
 }


### PR DESCRIPTION
So in #1897 I used Xcode 10.1 to figure out what the version of Swift 4.2 that shipped with 10.1 (and conversely in 10.2) was. But later I found out that Apple has changed the Swift 4.2 'version' when in 4.2 mode in the 5.0 compiler to 4.2.0, whereas it was 4.2.1 in Xcode 10.1.

Because we are supporting older versions of Xcode, we gotta make sure that the compiler #ifdef is only checked when compiling for 4.2. Therefore we mix this using `#if swift(>=4.2) && compiler(>=5.0)`.

However in some places, we gotta do something funky like this:

```
    #if swift(>=4.2)
        #if !compiler(>=5.0)
        return false
        #endif
    #else
    return false
    #endif
```

This is because we can't do `#if !swift(>=4.2) && !compiler(>=5.0)`, because these changes are compatible with 4.2 on Xcode 10.0 and 10.1, but not needed with 4.2 on 10.2 — and the first #ifdef will pass, but the second one will fail on Xcode 9.3.