### PR TITLE
Add `firstOrError` operator to ObservableType

### DIFF
--- a/RxSwift/Observables/First.swift
+++ b/RxSwift/Observables/First.swift
@@ -10,6 +10,13 @@ fileprivate final class FirstSink<Element, O: ObserverType> : Sink<O>, ObserverT
     typealias E = Element
     typealias Parent = First<E>
 
+    private let _parent: Parent
+
+    init(parent: Parent, observer: O, cancel: Cancelable) {
+        _parent = parent
+        super.init(observer: observer, cancel: cancel)
+    }
+
     func on(_ event: Event<E>) {
         switch event {
         case .next(let value):
@@ -20,8 +27,12 @@ fileprivate final class FirstSink<Element, O: ObserverType> : Sink<O>, ObserverT
             self.forwardOn(.error(error))
             self.dispose()
         case .completed:
-            self.forwardOn(.next(nil))
-            self.forwardOn(.completed)
+            if(_parent._isFirstOrError){
+                self.forwardOn(.error(RxError.noElements))
+            } else {
+                self.forwardOn(.next(nil))
+                self.forwardOn(.completed)
+            }
             self.dispose()
         }
     }
@@ -29,13 +40,15 @@ fileprivate final class FirstSink<Element, O: ObserverType> : Sink<O>, ObserverT
 
 final class First<Element>: Producer<Element?> {
     fileprivate let _source: Observable<Element>
+    fileprivate let _isFirstOrError: Bool
 
-    init(source: Observable<Element>) {
+    init(source: Observable<Element>, isFirstOrError: Bool = false) {
         self._source = source
+        self._isFirstOrError = isFirstOrError
     }
 
     override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element? {
-        let sink = FirstSink(observer: observer, cancel: cancel)
+        let sink = FirstSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Traits/ObservableType+PrimitiveSequence.swift
+++ b/RxSwift/Traits/ObservableType+PrimitiveSequence.swift
@@ -32,6 +32,18 @@ extension ObservableType {
     }
 
     /**
+     The `firstOrError` operator emits only the very first item emitted by this Observable or
+     throws a `RxError.noElements` if this Observable is empty.
+     
+     - seealso: [single operator on reactivex.io](http://reactivex.io/documentation/operators/first.html)
+     
+     - returns: An observable sequence that emits a single element or throws `RxError.noElements` if the source Publisher completes without emitting any items.
+     */
+    public func firstOrError() -> Single<E?> {
+        return PrimitiveSequence(raw: First(source: self.asObservable(), isFirstOrError: true))
+    }
+
+    /**
      The `asMaybe` operator throws a `RxError.moreThanOneElement`
      if the source Observable does not emit at most one element before successfully completing.
 

--- a/Tests/RxSwiftTests/Observable+PrimitiveSequenceTest.swift
+++ b/Tests/RxSwiftTests/Observable+PrimitiveSequenceTest.swift
@@ -308,6 +308,140 @@ extension ObservablePrimitiveSequenceTest {
 }
 
 extension ObservablePrimitiveSequenceTest {
+    func testFirstOrError_Empty() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .completed(250),
+            .error(260, testError)
+            ])
+        
+        let res: TestableObserver<Int?> = scheduler.start { () -> Observable<Int?> in
+            let single: Single<Int?> = xs.firstOrError()
+            return single.asObservable()
+        }
+        
+        XCTAssertEqual(res.events, [
+            error(250, RxError.noElements)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+            ])
+    }
+
+    func testFirstOrError_One() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .completed(250),
+            .error(260, testError)
+            ])
+        
+        let res: TestableObserver<Int?> = scheduler.start { () -> Observable<Int?> in
+            let single: Single<Int?> = xs.firstOrError()
+            return single.asObservable()
+        }
+        
+        XCTAssertEqual(res.events, [
+            .next(210, 2),
+            .completed(210)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 210)
+            ])
+    }
+
+    func testFirstOrError_Many() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .completed(250),
+            .error(260, testError)
+            ])
+        
+        let res: TestableObserver<Int?> = scheduler.start { () -> Observable<Int?> in
+            let single: Single<Int?> = xs.firstOrError()
+            return single.asObservable()
+        }
+        
+        XCTAssertEqual(res.events, [
+            .next(210, 2),
+            .completed(210)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 210)
+            ])
+    }
+
+    func testFirstOrError_ManyWithoutCompletion() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(160, 2),
+            .next(280, 3),
+            .next(250, 4),
+            .next(300, 5)
+            ])
+        
+        let res: TestableObserver<Int?> = scheduler.start { () -> Observable<Int?> in
+            let single: Single<Int?> = xs.firstOrError()
+            return single.asObservable()
+        }
+        
+        XCTAssertEqual(res.events, [
+            .next(250, 4),
+            .completed(250)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 250)
+            ])
+    }
+
+    func testFirstOrError_Error() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .error(210, testError)
+            ])
+        
+        let res: TestableObserver<Int?> = scheduler.start { () -> Observable<Int?> in
+            let single: Single<Int?> = xs.firstOrError()
+            return single.asObservable()
+        }
+        
+        XCTAssertEqual(res.events, [
+            .error(210, testError)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 210)
+            ])
+    }
+    
+    #if TRACE_RESOURCES
+    func testFirstOrErrorReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).firstOrError().subscribe({ _ in })
+    }
+    
+    func testFirstOrErrorReleasesResourcesOnError1() {
+        _ = Observable<Int>.error(testError).firstOrError().subscribe({ _ in })
+    }
+    #endif
+}
+
+extension ObservablePrimitiveSequenceTest {
     func testAsMaybe_Empty() {
         let scheduler = TestScheduler(initialClock: 0)
 


### PR DESCRIPTION
The `firstOrError` operator emits only the very first item emitted by a specific Observable or throws a `RxError.noElements` if the Observable is empty.

http://reactivex.io/RxJava/2.x/javadoc/io/reactivex/Observable.html#firstOrError--