### PR TITLE
Stop assigning threadDictionary on Linux

### DIFF
--- a/Platform/Platform.Linux.swift
+++ b/Platform/Platform.Linux.swift
@@ -13,17 +13,12 @@
     extension Thread {
 
         static func setThreadLocalStorageValue<T: AnyObject>(_ value: T?, forKey key: String) {
-            let currentThread = Thread.current
-            var threadDictionary = currentThread.threadDictionary
-
             if let newValue = value {
-                threadDictionary[key] = newValue
+                Thread.current.threadDictionary[key] = newValue
             }
             else {
-                threadDictionary[key] = nil
+                Thread.current.threadDictionary[key] = nil
             }
-
-            currentThread.threadDictionary = threadDictionary
         }
 
         static func getThreadLocalStorageValueForKey<T: AnyObject>(_ key: String) -> T? {


### PR DESCRIPTION
As of this change https://github.com/apple/swift-corelibs-foundation/pull/1762/files which is part of Swift 5, you can no longer assign the entire threadDictionary, instead you need to mutate it

Fixes https://github.com/ReactiveX/RxSwift/issues/1911