### PR TITLE
Update Package.swift to support Swift 5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 
@@ -42,6 +42,9 @@ extension Target {
 
 let package = Package(
   name: "RxSwift",
+  platforms: [
+    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
+  ],
   products: ([
     [
       .library(name: "RxAtomic", targets: ["RxAtomic"]),
@@ -64,5 +67,6 @@ let package = Package(
       .target(name: "RxTest", dependencies: ["RxSwift"]),
     ],
     Target.allTests()
-  ] as [[Target]]).flatMap { $0 }
+  ] as [[Target]]).flatMap { $0 },
+  swiftLanguageVersions: [.v4_2, .v5]
 )


### PR DESCRIPTION
As upgrading to Swift 5, without having `platforms` the default deployment target is set to the latest version of each OS. It causes a compile-time minimum deployment target error.

* Add `platforms`([SE-0236](https://github.com/apple/swift-evolution/blob/master/proposals/0236-package-manager-platform-deployment-settings.md))
* Add `.v5` to `swiftLanguageVersions`
