### PR TITLE
Cast Thread as NSObject on Linux

### DIFF
--- a/Platform/Platform.Linux.swift
+++ b/Platform/Platform.Linux.swift
@@ -9,11 +9,12 @@
 #if os(Linux)
 
     import class Foundation.Thread
+    import class Foundation.NSObject
 
     extension Thread {
 
         static func setThreadLocalStorageValue<T: AnyObject>(_ value: T?, forKey key: String) {
-            if let newValue = value {
+            if let newValue = value as? NSObject {
                 Thread.current.threadDictionary[key] = newValue
             }
             else {


### PR DESCRIPTION
Without this change, this runtime error will occur when this logic is executed on Linux:

```
Could not cast value of type 'RxSwift.RxMutableBox<RxSwift.Queue<RxSwift.ScheduledItemType>>' (0x55f49961f930) to 'Foundation.NSObject' (0x7f8bcf936c48).
```