### PR TITLE
RunLoopMode to RunLoop.mode

### DIFF
--- a/RxBlocking/RunLoopLock.swift
+++ b/RxBlocking/RunLoopLock.swift
@@ -12,7 +12,12 @@ import RxSwift
 
 #if os(Linux)
     import Foundation
-    let runLoopMode: RunLoopMode = RunLoopMode.defaultRunLoopMode
+    #if swift(>=4.2)
+    let runLoopMode: RunLoop.Mode = .default
+    #else
+    let runLoopMode: RunLoopMode = .defaultRunLoopMode
+    #endif
+
     let runLoopModeRaw: CFString = unsafeBitCast(runLoopMode.rawValue._bridgeToObjectiveC(), to: CFString.self)
 #else
     let runLoopMode: CFRunLoopMode = CFRunLoopMode.defaultMode


### PR DESCRIPTION
Trying to build RxSwift on Ubuntu 18.04 fails due to this:

![image](https://user-images.githubusercontent.com/605076/55541145-1315f000-56cd-11e9-90ab-37914f666cdf.png)
