### PR TITLE
Add Linux-supported RxMutableBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 ---
 ## Master
 
+### Anomalies
+
+* Make `RxMutableBox` supported on Linux in Swift 5. #1917
+* Fix incorrect assignment to `Thread.threadDictionary` on Linux. #1912
+
 ## [4.5.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.5.0)
 
 * Compatibility with Xcode 10.2.

--- a/RxSwift/RxMutableBox.swift
+++ b/RxSwift/RxMutableBox.swift
@@ -6,10 +6,35 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+#if os(Linux)
+/// As Swift 5 was released, A patch to `Thread` for Linux
+/// changed `threadDictionary` to a `NSMutableDictionary` instead of
+/// a `Dictionary<String, Any>`: https://github.com/apple/swift-corelibs-foundation/pull/1762/files
+///
+/// This means that on Linux specifically, `RxMutableBox` must be a `NSObject`
+/// or it won't be possible to store it in `Thread.threadDictionary`.
+///
+/// For more information, read the discussion at:
+/// https://github.com/ReactiveX/RxSwift/issues/1911#issuecomment-479723298
+import class Foundation.NSObject
+
 /// Creates mutable reference wrapper for any type.
-final class RxMutableBox<T> : CustomDebugStringConvertible {
+final class RxMutableBox<T>: NSObject {
     /// Wrapped value
-    var value : T
+    var value: T
+
+    /// Creates reference wrapper for `value`.
+    ///
+    /// - parameter value: Value to wrap.
+    init (_ value: T) {
+        self.value = value
+    }
+}
+#else
+/// Creates mutable reference wrapper for any type.
+final class RxMutableBox<T>: CustomDebugStringConvertible {
+    /// Wrapped value
+    var value: T
     
     /// Creates reference wrapper for `value`.
     ///
@@ -25,3 +50,4 @@ extension RxMutableBox {
         return "MutatingBox(\(self.value))"
     }
 }
+#endif


### PR DESCRIPTION
Make RxMutableBox inherit from NSObject on Linux. 

Fixes #1911. 