### PR TITLE
CI: Drop support for Xcode 9. Test Swift 4, 4.2 and 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 language: generic
 sudo: required
 dist: xenial
-osx_image: xcode9.3
+osx_image: xcode10
 
 env:
   - DANGER=1
@@ -25,17 +25,13 @@ matrix:
         os: linux
         env: TEST=Unix swift=5.0
 
-      - osx_image:
-        os: linux
-        env: TEST=Unix swift=4.2
-        
-      - osx_image: xcode9.4
+      - osx_image: xcode10.2
         os: osx
-        env: TEST=iOS
+        env: TEST=iOS swift=4.2
 
       - osx_image: xcode10.2
         os: osx
-        env: TEST=iOS
+        env: TEST=iOS swift=5.0
 
       - osx_image: xcode10
         os: osx
@@ -68,6 +64,22 @@ matrix:
       - osx_image: xcode10
         os: osx
         env: BUILD="TARGET=RxTest SWIFT_VERSION=4.2 ./scripts/validate-podspec.sh"
+
+      - osx_image: xcode10.2
+        os: osx
+        env: BUILD="TARGET=RxSwift SWIFT_VERSION=5 ./scripts/validate-podspec.sh"
+
+      - osx_image: xcode10.2
+        os: osx
+        env: BUILD="TARGET=RxCocoa SWIFT_VERSION=5 ./scripts/validate-podspec.sh"
+
+      - osx_image: xcode10.2
+        os: osx
+        env: BUILD="TARGET=RxBlocking SWIFT_VERSION=5 ./scripts/validate-podspec.sh"
+
+      - osx_image: xcode10.2
+        os: osx
+        env: BUILD="TARGET=RxTest SWIFT_VERSION=5 ./scripts/validate-podspec.sh"
 
 
 notifications:

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 
 import PackageDescription
 
@@ -42,6 +42,9 @@ extension Target {
 
 let package = Package(
   name: "RxSwift",
+  platforms: [
+    .macOS(.v10_10), .iOS(.v9), .tvOS(.v9), .watchOS(.v3)
+  ],
   products: ([
     [
       .library(name: "RxAtomic", targets: ["RxAtomic"]),
@@ -64,5 +67,6 @@ let package = Package(
       .target(name: "RxTest", dependencies: ["RxSwift"]),
     ],
     Target.allTests()
-  ] as [[Target]]).flatMap { $0 }
+  ] as [[Target]]).flatMap { $0 },
+  swiftLanguageVersions: [.v4_2, .v5]
 )

--- a/scripts/validate-podspec.sh
+++ b/scripts/validate-podspec.sh
@@ -16,7 +16,7 @@ function cleanup {
 trap cleanup EXIT
 
 if [[ ! -z "${TRAVIS}" ]]; then
-    gem install cocoapods --pre --no-rdoc --no-ri --no-document --quiet;
+    gem install cocoapods --pre --no-document --quiet;
     pod repo update;
 fi;
 


### PR DESCRIPTION
This lets CocoaPods and Carthage builds still work for Swift 4/4.2 and 5.
The only downside is Swift 5 - there's no way to support `platforms` without only supporting Swift 5 in SPM. I think it's fine in general as SPM is in such an early stage.

If you'd want, we can bump a major version, as you originally suggested, but this way keeps 4.x and still supports all Swift versions, aside for in SPM. 

WDYT @kzaher ?