### PR TITLE
Add CompactMap to RxSwift

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -194,6 +194,7 @@ custom_categories:
   - CombineLatest+Collection
   - CombineLatest+arity
   - CombineLatest
+  - CompactMap
   - Concat
   - Create
   - Debounce

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		461345711D9A4543001ABAF2 /* UIWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */; };
 		4613457C1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */; };
 		46307D4E1CDE77D800E47A1C /* UIAlertAction+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */; };
+		4C5213AA225D41E60079FC77 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5213A9225D41E60079FC77 /* CompactMap.swift */; };
+		4C5213AE225E224F0079FC77 /* Observable+CompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */; };
+		4C5213AF225E22500079FC77 /* Observable+CompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */; };
+		4C5213B0225E22510079FC77 /* Observable+CompactMapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */; };
 		4C8DE0E220D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E320D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E420D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
@@ -915,6 +919,8 @@
 		461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+Rx.swift"; sourceTree = "<group>"; };
 		4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxWebViewDelegateProxy.swift; sourceTree = "<group>"; };
 		46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Rx.swift"; sourceTree = "<group>"; };
+		4C5213A9225D41E60079FC77 /* CompactMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompactMap.swift; sourceTree = "<group>"; };
+		4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+CompactMapTests.swift"; sourceTree = "<group>"; };
 		4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBagTest.swift; sourceTree = "<group>"; };
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
@@ -1562,6 +1568,7 @@
 				C820A8251EB4DA5900D431BC /* CombineLatest+arity.swift */,
 				C820A8261EB4DA5900D431BC /* CombineLatest+arity.tt */,
 				C820A80C1EB4DA5900D431BC /* CombineLatest+Collection.swift */,
+				4C5213A9225D41E60079FC77 /* CompactMap.swift */,
 				C820A8091EB4DA5900D431BC /* Concat.swift */,
 				C820A8181EB4DA5900D431BC /* Create.swift */,
 				C820A7F11EB4DA5900D431BC /* Debounce.swift */,
@@ -1849,26 +1856,29 @@
 		C83508F21C38706D0027C24C /* RxSwiftTests */ = {
 			isa = PBXGroup;
 			children = (
-				C83508F31C38706D0027C24C /* TestImplementations */,
-				1E3079AB21FB52330072A7E6 /* AtomicTests.swift */,
 				C8F03F401DBB98DB00AECC4C /* Anomalies.swift */,
 				C83509031C38706D0027C24C /* AssumptionsTest.swift */,
 				0BA9496B1E224B9C0036DD06 /* AsyncSubjectTests.swift */,
+				C8ADC18D2200F9B000B611D4 /* Atomic+Overrides.swift */,
+				1E3079AB21FB52330072A7E6 /* AtomicTests.swift */,
 				C83509041C38706D0027C24C /* BagTest.swift */,
 				C83509051C38706D0027C24C /* BehaviorSubjectTest.swift */,
 				C8A53AE41F09292A00490535 /* Completable+AndThen.swift */,
+				C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */,
 				C83509061C38706D0027C24C /* CurrentThreadSchedulerTest.swift */,
 				C83509071C38706D0027C24C /* DisposableTest.swift */,
 				4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */,
 				C822BAC51DB4048F00F98810 /* Event+Test.swift */,
 				C83509081C38706D0027C24C /* HistoricalSchedulerTest.swift */,
 				C83509091C38706D0027C24C /* MainSchedulerTests.swift */,
+				C801DE391F6EAD48008DB060 /* MaybeTest.swift */,
 				C820A9491EB4E75E00D431BC /* Observable+AmbTests.swift */,
 				C820AA051EB5139C00D431BC /* Observable+BufferTests.swift */,
 				C820A9891EB4FBD600D431BC /* Observable+CatchTests.swift */,
 				C896A68A1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift */,
 				C835090F1C38706D0027C24C /* Observable+CombineLatestTests+arity.swift */,
 				C83509101C38706D0027C24C /* Observable+CombineLatestTests+arity.tt */,
+				4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */,
 				C820A9951EB4FF7000D431BC /* Observable+ConcatTests.swift */,
 				C820A9851EB4FB5B00D431BC /* Observable+DebugTests.swift */,
 				C820A9F11EB5109300D431BC /* Observable+DefaultIfEmpty.swift */,
@@ -1889,6 +1899,7 @@
 				C820A9551EB4ED7C00D431BC /* Observable+MulticastTests.swift */,
 				C820A9611EB4EFD300D431BC /* Observable+ObserveOnTests.swift */,
 				C820A9711EB4F84000D431BC /* Observable+OptionalTests.swift */,
+				C801DE491F6EBB84008DB060 /* Observable+PrimitiveSequenceTest.swift */,
 				C820A9791EB4FA0800D431BC /* Observable+RangeTests.swift */,
 				C820A94D1EB4EC3C00D431BC /* Observable+ReduceTests.swift */,
 				C820A97D1EB4FA5A00D431BC /* Observable+RepeatTests.swift */,
@@ -1920,6 +1931,7 @@
 				C81A097C1E6C27A100900B3B /* Observable+ZipTests.swift */,
 				C83509111C38706D0027C24C /* Observable+ZipTests+arity.swift */,
 				C83509121C38706D0027C24C /* Observable+ZipTests+arity.tt */,
+				C82FF0EE1F93DD2E00BDB34D /* ObservableType+SubscriptionTests.swift */,
 				C83509181C38706D0027C24C /* ObserverTests.swift */,
 				C898147D1E75AD380035949C /* PrimitiveSequenceTest+zip+arity.swift */,
 				C898147C1E75A98A0035949C /* PrimitiveSequenceTest+zip+arity.tt */,
@@ -1929,16 +1941,12 @@
 				C8BAA78C1E34F8D400EEC727 /* RecursiveLockTest.swift */,
 				1AF67DA51CED430100C310FA /* ReplaySubjectTest.swift */,
 				C86B1E211D42BF5200130546 /* SchedulerTests.swift */,
-				C835091A1C38706D0027C24C /* SubjectConcurrencyTest.swift */,
-				C835091C1C38706D0027C24C /* VirtualSchedulerTest.swift */,
 				C8B0F70C1F530A1700548EBE /* SharingSchedulerTests.swift */,
 				C801DE351F6EAD3C008DB060 /* SingleTest.swift */,
-				C801DE391F6EAD48008DB060 /* MaybeTest.swift */,
-				C801DE3D1F6EAD57008DB060 /* CompletableTest.swift */,
-				C801DE491F6EBB84008DB060 /* Observable+PrimitiveSequenceTest.swift */,
-				C82FF0EE1F93DD2E00BDB34D /* ObservableType+SubscriptionTests.swift */,
+				C835091A1C38706D0027C24C /* SubjectConcurrencyTest.swift */,
 				1E9DA0C422006858000EB80A /* Synchronized.swift */,
-				C8ADC18D2200F9B000B611D4 /* Atomic+Overrides.swift */,
+				C83508F31C38706D0027C24C /* TestImplementations */,
+				C835091C1C38706D0027C24C /* VirtualSchedulerTest.swift */,
 			);
 			path = RxSwiftTests;
 			sourceTree = "<group>";
@@ -2964,6 +2972,7 @@
 				C820A94E1EB4EC3C00D431BC /* Observable+ReduceTests.swift in Sources */,
 				C820A97A1EB4FA0800D431BC /* Observable+RangeTests.swift in Sources */,
 				C8B290891C94D64600E923D0 /* RxTest+Controls.swift in Sources */,
+				4C5213AE225E224F0079FC77 /* Observable+CompactMapTests.swift in Sources */,
 				C8C4F1611DE9CD1600003FA7 /* UILabel+RxTests.swift in Sources */,
 				C820A9761EB4F92100D431BC /* Observable+GenerateTests.swift in Sources */,
 				C8353CDC1DA19BA000BE3F5C /* MessageProcessingStage.swift in Sources */,
@@ -3126,6 +3135,7 @@
 				1E9DA0C622006858000EB80A /* Synchronized.swift in Sources */,
 				C83509EE1C3875580027C24C /* Observable.Extensions.swift in Sources */,
 				C83509BD1C38750D0027C24C /* ControlPropertyTests.swift in Sources */,
+				4C5213AF225E22500079FC77 /* Observable+CompactMapTests.swift in Sources */,
 				C83509E11C3875500027C24C /* TestVirtualScheduler.swift in Sources */,
 				C820A94F1EB4EC3C00D431BC /* Observable+ReduceTests.swift in Sources */,
 				C8B2908A1C94D64700E923D0 /* RxTest+Controls.swift in Sources */,
@@ -3302,6 +3312,7 @@
 				C8350A2B1C3875B60027C24C /* RxMutableBox.swift in Sources */,
 				C8350A071C38755E0027C24C /* MainSchedulerTests.swift in Sources */,
 				C8D970F41F532FD30058F2FE /* SharedSequence+OperatorTest.swift in Sources */,
+				4C5213B0225E22510079FC77 /* Observable+CompactMapTests.swift in Sources */,
 				C820A9F01EB50EA100D431BC /* Observable+ScanTests.swift in Sources */,
 				C8ADC1902200F9B000B611D4 /* Atomic+Overrides.swift in Sources */,
 				C83509B81C38750D0027C24C /* ControlEventTests.swift in Sources */,
@@ -3511,6 +3522,7 @@
 				C820A9081EB4DA5A00D431BC /* Multicast.swift in Sources */,
 				C8093DA31B8A72BE0088E94D /* ReplaySubject.swift in Sources */,
 				C8093CFB1B8A72BE0088E94D /* ObservableType+Extensions.swift in Sources */,
+				4C5213AA225D41E60079FC77 /* CompactMap.swift in Sources */,
 				C820A8781EB4DA5A00D431BC /* TakeLast.swift in Sources */,
 				C83D73C01C1DBAEE003DC470 /* InvocableType.swift in Sources */,
 				C8093D731B8A72BE0088E94D /* ObserverBase.swift in Sources */,

--- a/RxSwift/Observables/CompactMap.swift
+++ b/RxSwift/Observables/CompactMap.swift
@@ -3,7 +3,7 @@
 //  RxSwift
 //
 //  Created by Michael Long on 04/09/2019.
-//
+//  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
 extension ObservableType {

--- a/RxSwift/Observables/CompactMap.swift
+++ b/RxSwift/Observables/CompactMap.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Michael Long on 04/09/2019.
 //
+//
 
 extension ObservableType {
 

--- a/RxSwift/Observables/CompactMap.swift
+++ b/RxSwift/Observables/CompactMap.swift
@@ -1,0 +1,81 @@
+//
+//  CompactMap.swift
+//  RxSwift
+//
+//  Created by Michael Long on 04/09/2019.
+//
+
+extension ObservableType {
+
+    /**
+     Projects each element of an observable sequence into an optional form and filters all optional results.
+
+     Equivalent to:
+
+     func compactMap<R>(_ transform: @escaping (Self.E) throws -> R?) -> RxSwift.Observable<R> {
+        return self.map { try? transform($0) }.filter { $0 != nil }.map { $0! }
+     }
+
+     - parameter transform: A transform function to apply to each source element and which returns an element or nil.
+     - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
+
+     */
+    public func compactMap<R>(_ transform: @escaping (E) throws -> R?)
+        -> Observable<R> {
+            return CompactMap(source: self.asObservable(), transform: transform)
+    }
+}
+
+final private class CompactMapSink<SourceType, O: ObserverType>: Sink<O>, ObserverType {
+    typealias Transform = (SourceType) throws -> ResultType?
+
+    typealias ResultType = O.E
+    typealias Element = SourceType
+
+    private let _transform: Transform
+
+    init(transform: @escaping Transform, observer: O, cancel: Cancelable) {
+        self._transform = transform
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ event: Event<SourceType>) {
+        switch event {
+        case .next(let element):
+            do {
+                if let mappedElement = try self._transform(element) {
+                    self.forwardOn(.next(mappedElement))
+                }
+            }
+            catch let e {
+                self.forwardOn(.error(e))
+                self.dispose()
+            }
+        case .error(let error):
+            self.forwardOn(.error(error))
+            self.dispose()
+        case .completed:
+            self.forwardOn(.completed)
+            self.dispose()
+        }
+    }
+}
+
+final private class CompactMap<SourceType, ResultType>: Producer<ResultType> {
+    typealias Transform = (SourceType) throws -> ResultType?
+
+    private let _source: Observable<SourceType>
+
+    private let _transform: Transform
+
+    init(source: Observable<SourceType>, transform: @escaping Transform) {
+        self._source = source
+        self._transform = transform
+    }
+
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == ResultType {
+        let sink = CompactMapSink(transform: self._transform, observer: observer, cancel: cancel)
+        let subscription = self._source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+}

--- a/Sources/AllTestz/Observable+CompactMapTests.swift
+++ b/Sources/AllTestz/Observable+CompactMapTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Observable+CompactMapTests.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -585,6 +585,21 @@ final class ObservableCombineLatestTest_ : ObservableCombineLatestTest, RxTestCa
     ] }
 }
 
+final class ObservableCompactMapTest_ : ObservableCompactMapTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableCompactMapTest_) -> () -> Void)] { return [
+    ("test_compactMapComplete", ObservableCompactMapTest.test_compactMapComplete),
+    ("test_compactMapValues", ObservableCompactMapTest.test_compactMapValues),
+    ("test_compactMapNil", ObservableCompactMapTest.test_compactMapNil),
+    ("test_compactMapDisposed", ObservableCompactMapTest.test_compactMapDisposed),
+    ] }
+}
+
 final class ObservableConcatTest_ : ObservableConcatTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -2031,6 +2046,7 @@ func XCTMain(_ tests: [() -> Void]) {
         testCase(ObservableBufferTest_.allTests),
         testCase(ObservableCatchTest_.allTests),
         testCase(ObservableCombineLatestTest_.allTests),
+        testCase(ObservableCompactMapTest_.allTests),
         testCase(ObservableConcatTest_.allTests),
         testCase(ObservableDebugTest_.allTests),
         testCase(ObservableDefaultIfEmptyTest_.allTests),

--- a/Sources/RxSwift/CompactMap.swift
+++ b/Sources/RxSwift/CompactMap.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/CompactMap.swift

--- a/Tests/RxSwiftTests/Observable+CompactMapTests.swift
+++ b/Tests/RxSwiftTests/Observable+CompactMapTests.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Michael Long on 05/10/19.
 //
+//
 
 import XCTest
 import RxSwift

--- a/Tests/RxSwiftTests/Observable+CompactMapTests.swift
+++ b/Tests/RxSwiftTests/Observable+CompactMapTests.swift
@@ -18,7 +18,8 @@ class ObservableCompactMapTest : RxTest {
 }
 
 extension ObservableCompactMapTest {
-    func test_compactMapComplete() {
+
+    func test_compactMapNilFromClosure() {
         let scheduler = TestScheduler(initialClock: 0)
         
         var invoked = 0
@@ -63,91 +64,43 @@ extension ObservableCompactMapTest {
         XCTAssertEqual(9, invoked)
     }
     
-    func test_compactMapValues() {
+    func test_compactMapNilFromElement() {
         let scheduler = TestScheduler(initialClock: 0)
-        
+
         var invoked = 0
-        
-        let xs = scheduler.createHotObservable([
+
+        let xs: TestableObservable<Int?> = scheduler.createHotObservable([
             .next(110, 1),
             .next(180, 2),
             .next(230, 3),
-            .next(270, 4),
+            .next(270, nil),
             .next(340, 5),
-            .next(380, 6),
-            .next(390, 7),
-            .next(450, 8),
-            .next(470, 9),
-            .next(560, 10),
-            .next(580, 11),
-            .completed(600)
+            .completed(400),
+            .next(410, 7),
+            .error(420, testError),
+            .completed(430)
             ])
-        
+
         let res = scheduler.start { () -> Observable<Int> in
             return xs.compactMap { num in
                 invoked += 1
                 return num
             }
         }
-        
+
         XCTAssertEqual(res.events, [
             .next(230, 3),
-            .next(270, 4),
             .next(340, 5),
-            .next(380, 6),
-            .next(390, 7),
-            .next(450, 8),
-            .next(470, 9),
-            .next(560, 10),
-            .next(580, 11),
-            .completed(600)
+            .completed(400),
             ])
-        
+
         XCTAssertEqual(xs.subscriptions, [
-            Subscription(200, 600)
+            Subscription(200, 400)
             ])
-        
-        XCTAssertEqual(9, invoked)
+
+        XCTAssertEqual(3, invoked)
     }
-   
-    func test_compactMapNil() {
-        let scheduler = TestScheduler(initialClock: 0)
-        
-        var invoked = 0
-        
-        let xs = scheduler.createHotObservable([
-            .next(110, 1),
-            .next(180, 2),
-            .next(230, 3),
-            .next(270, 4),
-            .next(340, 5),
-            .next(380, 6),
-            .next(390, 7),
-            .next(450, 8),
-            .next(470, 9),
-            .next(560, 10),
-            .next(580, 11),
-            .completed(600)
-            ])
-        
-        let res = scheduler.start { () -> Observable<Int> in
-            return xs.compactMap { _ in
-                invoked += 1
-                return nil
-            }
-        }
-        
-        XCTAssertEqual(res.events, [
-            .completed(600)
-            ])
-        
-        XCTAssertEqual(xs.subscriptions, [
-            Subscription(200, 600)
-            ])
-        
-        XCTAssertEqual(9, invoked)
-    }
-    
+
     func test_compactMapDisposed() {
         let scheduler = TestScheduler(initialClock: 0)
         

--- a/Tests/RxSwiftTests/Observable+CompactMapTests.swift
+++ b/Tests/RxSwiftTests/Observable+CompactMapTests.swift
@@ -3,7 +3,7 @@
 //  Tests
 //
 //  Created by Michael Long on 05/10/19.
-//
+//  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
 import XCTest

--- a/Tests/RxSwiftTests/Observable+CompactMapTests.swift
+++ b/Tests/RxSwiftTests/Observable+CompactMapTests.swift
@@ -1,0 +1,190 @@
+//
+//  Observable+CompactMapTests.swift
+//  Tests
+//
+//  Created by Michael Long on 05/10/19.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+#if os(Linux)
+    import Glibc
+#endif
+
+class ObservableCompactMapTest : RxTest {
+}
+
+extension ObservableCompactMapTest {
+    func test_compactMapComplete() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        var invoked = 0
+        
+        let xs = scheduler.createHotObservable([
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600),
+            .next(610, 12),
+            .error(620, testError),
+            .completed(630)
+        ])
+        
+        let res = scheduler.start { () -> Observable<Int> in
+            return xs.compactMap { num in
+                invoked += 1
+                return isPrime(num) ? num : nil
+            }
+        }
+        
+        XCTAssertEqual(res.events, [
+            .next(230, 3),
+            .next(340, 5),
+            .next(390, 7),
+            .next(580, 11),
+            .completed(600)
+        ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 600)
+        ])
+        
+        XCTAssertEqual(9, invoked)
+    }
+    
+    func test_compactMapValues() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        var invoked = 0
+        
+        let xs = scheduler.createHotObservable([
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
+            ])
+        
+        let res = scheduler.start { () -> Observable<Int> in
+            return xs.compactMap { num in
+                invoked += 1
+                return num
+            }
+        }
+        
+        XCTAssertEqual(res.events, [
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 600)
+            ])
+        
+        XCTAssertEqual(9, invoked)
+    }
+   
+    func test_compactMapNil() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        var invoked = 0
+        
+        let xs = scheduler.createHotObservable([
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
+            ])
+        
+        let res = scheduler.start { () -> Observable<Int> in
+            return xs.compactMap { _ in
+                invoked += 1
+                return nil
+            }
+        }
+        
+        XCTAssertEqual(res.events, [
+            .completed(600)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 600)
+            ])
+        
+        XCTAssertEqual(9, invoked)
+    }
+    
+    func test_compactMapDisposed() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        var invoked = 0
+        
+        let xs = scheduler.createHotObservable([
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
+            ])
+        
+        let res = scheduler.start(disposed: 400) { () -> Observable<Int> in
+            return xs.compactMap { num in
+                invoked += 1
+                return isPrime(num) ? num : nil
+            }
+        }
+        
+        XCTAssertEqual(res.events, [
+            .next(230, 3),
+            .next(340, 5),
+            .next(390, 7)
+            ])
+        
+        XCTAssertEqual(xs.subscriptions, [
+            Subscription(200, 400)
+            ])
+        
+        XCTAssertEqual(5, invoked)
+    }
+
+}


### PR DESCRIPTION
Adds compactMap operator to RxSwift ObservableType.

CompactMap allows you to map an event stream and automatically filters any optional results that may be nil.
```
class AccountInfoViewModel {
    
    var accountInformation: Observable<AccountInformation>!
    var processing: Observable<Bool>!
    var error: Observable<String>!

    init(load: Observable<Void>) {
        let loading = load
            .flatMapLatest { 
                AccountInformation.load()
                    .materialize()
            }
            .share()

        accountInformation = loading
            .compactMap { $0.element }
            .share()

        error = loading
            .compactMap { $0.error?.localizedDescription }

        processing = Observable
            .merge(load.map{_ in true}, loading.map{_ in false})
    }

}
```
In the above example, the accountInformation assignment is functionally equivalent to:
```
        accountInformation = loading
            .map { $0.element }  // element may be nil
            .filter { $0 != nil }
            .map { $0! }
            .share()
```
Or creating your own extension:
```
extension ObservableType {
    func compactMap<R>(_ transform: @escaping (Self.E) throws -> R?) -> RxSwift.Observable<R> {
        return self.map { try? transform($0) }.filter { $0 != nil }.map { $0! }
    }
}
```
CompactMap also provides builtin functionality similar to the unwrap extension.
```
optionalStringObservable
    .compactMap { $0 }
    .bind(to: requiredStringObserver)
```
Optionals are a major part of the Swift language, and compactMap makes manipulating optional streams of data much, much easier.