### PR TITLE
Add Completable.zip (alias for Completable.merge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * Xcode 10.2 is the minimum supported version (or Swift 5 on Linux).
 * Changes the return type of `ObservableType.toArray` to `Single`. 
 * Adds `compactMap`.
+* Adds `Completable.zip` (alias of `Completable.merge`).
 
 If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.com/ReactiveX/RxSwift/releases/tag/4.5.0).
 

--- a/RxSwift/Traits/Completable.swift
+++ b/RxSwift/Traits/Completable.swift
@@ -224,26 +224,26 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
     }
     
     /**
-     Merges elements from all observable sequences from collection into a single observable sequence.
+     Merges the completion of all Completables from a collection into a single Completable.
      
      - seealso: [merge operator on reactivex.io](http://reactivex.io/documentation/operators/merge.html)
      
-     - parameter sources: Collection of observable sequences to merge.
-     - returns: The observable sequence that merges the elements of the observable sequences.
+     - parameter sources: Collection of Completables to merge.
+     - returns: A Completable that merges the completion of all Completables.
      */
     public static func merge<C: Collection>(_ sources: C) -> Completable
-        where C.Iterator.Element == Completable {
+        where C.Element == Completable {
             let source = Observable.merge(sources.map { $0.asObservable() })
             return Completable(raw: source)
     }
     
     /**
-     Merges elements from all observable sequences from array into a single observable sequence.
-     
+     Merges the completion of all Completables from an array into a single Completable.
+
      - seealso: [merge operator on reactivex.io](http://reactivex.io/documentation/operators/merge.html)
      
      - parameter sources: Array of observable sequences to merge.
-     - returns: The observable sequence that merges the elements of the observable sequences.
+     - returns: A Completable that merges the completion of all Completables.
      */
     public static func merge(_ sources: [Completable]) -> Completable {
         let source = Observable.merge(sources.map { $0.asObservable() })
@@ -251,7 +251,7 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
     }
     
     /**
-     Merges elements from all observable sequences into a single observable sequence.
+     Merges the completion of all Completables into a single Completable.
      
      - seealso: [merge operator on reactivex.io](http://reactivex.io/documentation/operators/merge.html)
      
@@ -261,5 +261,45 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
     public static func merge(_ sources: Completable...) -> Completable {
         let source = Observable.merge(sources.map { $0.asObservable() })
         return Completable(raw: source)
+    }
+
+    /**
+     Merges the completion of all Completables from a collection into a single Completable.
+
+     - seealso: [merge operator on reactivex.io](http://reactivex.io/documentation/operators/merge.html)
+     - note: For `Completable`, `zip` is an alias for `merge`.
+
+     - parameter sources: Collection of Completables to merge.
+     - returns: A Completable that merges the completion of all Completables.
+     */
+    public static func zip<C: Collection>(_ sources: C) -> Completable
+           where C.Element == Completable {
+        return merge(sources)
+    }
+
+    /**
+     Merges the completion of all Completables from an array into a single Completable.
+
+     - seealso: [merge operator on reactivex.io](http://reactivex.io/documentation/operators/merge.html)
+     - note: For `Completable`, `zip` is an alias for `merge`.
+
+     - parameter sources: Array of observable sequences to merge.
+     - returns: A Completable that merges the completion of all Completables.
+     */
+    public static func zip(_ sources: [Completable]) -> Completable {
+        return merge(sources)
+    }
+
+    /**
+     Merges the completion of all Completables into a single Completable.
+
+     - seealso: [merge operator on reactivex.io](http://reactivex.io/documentation/operators/merge.html)
+     - note: For `Completable`, `zip` is an alias for `merge`.
+
+     - parameter sources: Collection of observable sequences to merge.
+     - returns: The observable sequence that merges the elements of the observable sequences.
+     */
+    public static func zip(_ sources: Completable...) -> Completable {
+        return merge(sources)
     }
 }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -147,6 +147,9 @@ final class CompletableTest_ : CompletableTest, RxTestCase {
     ("test_merge_collection", CompletableTest.test_merge_collection),
     ("test_merge_array", CompletableTest.test_merge_array),
     ("test_merge_variadic", CompletableTest.test_merge_variadic),
+    ("test_zip_collection", CompletableTest.test_zip_collection),
+    ("test_zip_array", CompletableTest.test_zip_array),
+    ("test_zip_variadic", CompletableTest.test_zip_variadic),
     ("testDefaultErrorHandler", CompletableTest.testDefaultErrorHandler),
     ] }
 }

--- a/Tests/RxSwiftTests/CompletableTest.swift
+++ b/Tests/RxSwiftTests/CompletableTest.swift
@@ -533,6 +533,42 @@ extension CompletableTest {
             .completed(200)
             ])
     }
+
+    func test_zip_collection() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let res = scheduler.start {
+            (Completable.zip(AnyCollection([Completable.empty(), Completable.empty()])) as Completable).asObservable()
+        }
+
+        XCTAssertEqual(res.events, [
+            .completed(200)
+            ])
+    }
+
+    func test_zip_array() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let res = scheduler.start {
+            (Completable.zip([Completable.empty(), Completable.empty()]) as Completable).asObservable()
+        }
+
+        XCTAssertEqual(res.events, [
+            .completed(200)
+            ])
+    }
+
+    func test_zip_variadic() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let res = scheduler.start {
+            (Completable.zip(Completable.empty(), Completable.empty()) as Completable).asObservable()
+        }
+
+        XCTAssertEqual(res.events, [
+            .completed(200)
+            ])
+    }
 }
 
 extension CompletableTest {


### PR DESCRIPTION
@kzaher We've discussed this before in a different thread and I bumped into this as well, when someone asked how to do this in a Slack group.

I was actually wondering if we should just entirely remove `merge` (or deprecate it) and leave only `zip`, as long as we're doing breaking changes. Since `zip` better describes the behavior, and `merge` is about merging of elements, which are not in the context of Completable.

WDYT ? 