### PR TITLE
[source-breaking] Fix label mistake for RxSwift 5.0

### DIFF
--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -380,9 +380,9 @@ extension SharedSequence {
      - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func zip<C: Collection, R>(_ collection: C, _ resultSelector: @escaping ([Element]) throws -> R) -> SharedSequence<SharingStrategy, R>
+    public static func zip<C: Collection, R>(_ collection: C, resultSelector: @escaping ([Element]) throws -> R) -> SharedSequence<SharingStrategy, R>
         where C.Iterator.Element == SharedSequence<SharingStrategy, Element> {
-        let source = Observable.zip(collection.map { $0.asSharedSequence().asObservable() }, resultSelector)
+        let source = Observable.zip(collection.map { $0.asSharedSequence().asObservable() }, resultSelector: resultSelector)
         return SharedSequence<SharingStrategy, R>(source)
     }
 
@@ -407,9 +407,9 @@ extension SharedSequence {
      - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func combineLatest<C: Collection, R>(_ collection: C, _ resultSelector: @escaping ([Element]) throws -> R) -> SharedSequence<SharingStrategy, R>
+    public static func combineLatest<C: Collection, R>(_ collection: C, resultSelector: @escaping ([Element]) throws -> R) -> SharedSequence<SharingStrategy, R>
         where C.Iterator.Element == SharedSequence<SharingStrategy, Element> {
-        let source = Observable.combineLatest(collection.map { $0.asObservable() }, resultSelector)
+        let source = Observable.combineLatest(collection.map { $0.asObservable() }, resultSelector: resultSelector)
         return SharedSequence<SharingStrategy, R>(source)
     }
 

--- a/RxSwift/Observables/CombineLatest+Collection.swift
+++ b/RxSwift/Observables/CombineLatest+Collection.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func combineLatest<C: Collection>(_ collection: C, _ resultSelector: @escaping ([C.Iterator.Element.E]) throws -> E) -> Observable<E>
+    public static func combineLatest<C: Collection>(_ collection: C, resultSelector: @escaping ([C.Iterator.Element.E]) throws -> E) -> Observable<E>
         where C.Iterator.Element: ObservableType {
         return CombineLatestCollectionType(sources: collection, resultSelector: resultSelector)
     }

--- a/RxSwift/Observables/Zip+Collection.swift
+++ b/RxSwift/Observables/Zip+Collection.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func zip<C: Collection>(_ collection: C, _ resultSelector: @escaping ([C.Iterator.Element.E]) throws -> E) -> Observable<E>
+    public static func zip<C: Collection>(_ collection: C, resultSelector: @escaping ([C.Iterator.Element.E]) throws -> E) -> Observable<E>
         where C.Iterator.Element: ObservableType {
         return ZipCollectionType(sources: collection, resultSelector: resultSelector)
     }

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -258,7 +258,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func zip<C: Collection, R>(_ collection: C, _ resultSelector: @escaping ([ElementType]) throws -> R) -> PrimitiveSequence<TraitType, R> where C.Iterator.Element == PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<C: Collection, R>(_ collection: C, resultSelector: @escaping ([ElementType]) throws -> R) -> PrimitiveSequence<TraitType, R> where C.Iterator.Element == PrimitiveSequence<TraitType, ElementType> {
         
         if collection.isEmpty {
             return PrimitiveSequence<TraitType, R>.deferred {
@@ -266,7 +266,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
             }
         }
         
-        let raw = Observable.zip(collection.map { $0.asObservable() }, resultSelector)
+        let raw = Observable.zip(collection.map { $0.asObservable() }, resultSelector: resultSelector)
         return PrimitiveSequence<TraitType, R>(raw: raw)
     }
     


### PR DESCRIPTION
This PR contains a source breaking change. It aligns some methods to require `resultSelector` label to be consistent with the other overloads of the same operators.

This change was discussed on Slack with @freak4pc but has no explicit issue that is tracked.