### PR TITLE
RxExample now uses DispatchTimeInterval

### DIFF
--- a/RxExample/RxDataSources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
+++ b/RxExample/RxDataSources/RxDataSources/RxCollectionViewSectionedAnimatedDataSource.swift
@@ -46,7 +46,7 @@ open class RxCollectionViewSectionedAnimatedDataSource<S: AnimatableSectionModel
             .observeOn(MainScheduler.asyncInstance)
             // Collection view has issues digesting fast updates, this should
             // help to alleviate the issues with them.
-            .throttle(0.5, scheduler: MainScheduler.instance)
+            .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
             .subscribe(onNext: { [weak self] event in
                 self?.collectionView(event.0, throttledObservedEvent: event.1)
             })

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesViewController.swift
@@ -54,7 +54,7 @@ class GitHubSearchRepositoriesViewController: ViewController, UITableViewDelegat
         let searchBar: UISearchBar = self.searchBar
 
         let state = githubSearchRepositories(
-            searchText: searchBar.rx.text.orEmpty.changed.asSignal().throttle(0.3),
+            searchText: searchBar.rx.text.orEmpty.changed.asSignal().throttle(.milliseconds(300)),
             loadNextPageTrigger: loadNextPageTrigger,
             performSearch: { URL in
                 GitHubSearchRepositoriesAPI.sharedAPI.loadSearchURL(URL)

--- a/RxExample/RxExample/Examples/GitHubSignup/DefaultImplementations.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/DefaultImplementations.swift
@@ -109,6 +109,6 @@ class GitHubDefaultAPI : GitHubAPI {
         let signupResult = arc4random() % 5 == 0 ? false : true
         
         return Observable.just(signupResult)
-            .delay(1.0, scheduler: MainScheduler.instance)
+            .delay(.seconds(1), scheduler: MainScheduler.instance)
     }
 }

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchViewController.swift
@@ -43,7 +43,7 @@ class WikipediaSearchViewController: ViewController {
 
         let results = searchBar.rx.text.orEmpty
             .asDriver()
-            .throttle(0.3)
+            .throttle(.milliseconds(300))
             .distinctUntilChanged()
             .flatMapLatest { query in
                 API.getSearchResults(query)

--- a/RxExample/RxExample/iOS/AppDelegate.swift
+++ b/RxExample/RxExample/iOS/AppDelegate.swift
@@ -22,7 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         RxImagePickerDelegateProxy.register { RxImagePickerDelegateProxy(imagePicker: $0) }
 
         #if DEBUG
-        _ = Observable<Int>.interval(1, scheduler: MainScheduler.instance)
+        _ = Observable<Int>.interval(.seconds(1), scheduler: MainScheduler.instance)
             .subscribe(onNext: { _ in
                 print("Resource count \(RxSwift.Resources.total)")
             })


### PR DESCRIPTION
RxExample was still using regular TimeInterval(s).

If we change the label as discussed in #1921, I'll change this from: 

```swift
 .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
```

to either
```swift
 .throttle(for: .milliseconds(500), scheduler: MainScheduler.instance)
```

or 
```swift
 .throttle(duration: .milliseconds(500), scheduler: MainScheduler.instance)
```