### PR TITLE
Add `textColor` binder for iOS UILabel.

### DIFF
--- a/RxCocoa/iOS/UILabel+Rx.swift
+++ b/RxCocoa/iOS/UILabel+Rx.swift
@@ -26,6 +26,13 @@ extension Reactive where Base: UILabel {
             label.attributedText = text
         }
     }
+
+    /// Bindable sink for `textColor` property.
+    public var textColor: Binder<UIColor> {
+        return Binder(self.base) { label, textColor in
+            label.textColor = textColor
+        }
+    }
     
 }
 


### PR DESCRIPTION
This allows RxCocoa users to more easily bind textColors to UILabels. This is useful for MVVM applications on iOS.