### PR TITLE
Replace instance of RxCocoa with RxRelay

### DIFF
--- a/Documentation/Subjects.md
+++ b/Documentation/Subjects.md
@@ -6,7 +6,7 @@ All of behave exactly the same like described [here](http://reactivex.io/documen
 Relays
 ======
 
-RxCocoa provides two kinds of Relays: `PublishRelay` and `BehaviorRelay`.
+RxRelay provides two kinds of Relays: `PublishRelay` and `BehaviorRelay`.
 They behave exactly like their parallel `Subject`s, with two changes:
 
 - Relays never complete.


### PR DESCRIPTION
Found this in some of the documentation.

As a side question: is a new release with RxRelay planned?