### PR TITLE
Update Geolocation.swift

### DIFF
--- a/RxExample/RxExample/Services/GeolocationService.swift
+++ b/RxExample/RxExample/Services/GeolocationService.swift
@@ -37,6 +37,8 @@ class GeolocationService {
                 switch $0 {
                 case .authorizedAlways:
                     return true
+                case .authorizedWhenInUse:
+                    return true    
                 default:
                     return false
                 }


### PR DESCRIPTION
dd case for whenInUse, as we required the only whenInUse  location in our app to its better that our demo for geolocation subscription should work when user give the whenInUse permission. Currently its is showing error in case user given the whenInUse permission.
Thanks