### PR TITLE
Change type returned by didFinishPickingMediaWithInfo

### DIFF
--- a/RxExample/Extensions/UIImagePickerController+Rx.swift
+++ b/RxExample/Extensions/UIImagePickerController+Rx.swift
@@ -18,11 +18,11 @@
         /**
          Reactive wrapper for `delegate` message.
          */
-        public var didFinishPickingMediaWithInfo: Observable<[String : AnyObject]> {
+        public var didFinishPickingMediaWithInfo: Observable<[UIImagePickerController.InfoKey : Any]> {
             return delegate
                 .methodInvoked(#selector(UIImagePickerControllerDelegate.imagePickerController(_:didFinishPickingMediaWithInfo:)))
                 .map({ (a) in
-                    return try castOrThrow(Dictionary<String, AnyObject>.self, a[1])
+                    return try castOrThrow([UIImagePickerController.InfoKey : Any].self, a[1])
                 })
         }
 


### PR DESCRIPTION
The returnType of the method didFinishPickingMediaWithInfo has changed in Swift 4.2, so I modified this method to adapt the new one