### PR TITLE
Align associated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
 
 ### Anomalies
 
+* The `E` associated type on `ObservableConvertibleType` and `ObserverType` have been renamed to `Element`. #1945
+* Renamed `ElementType` associatedtype to `Element`. #1945
+* Renamed `TraitType` associatedtype to `Trait`. #1945
 * Make `RxMutableBox` supported on Linux in Swift 5. #1917
 * Fix incorrect assignment to `Thread.threadDictionary` on Linux. #1912
 * `combineLatest` of an empty array now completes immediately. #1879

--- a/Platform/DataStructures/InfiniteSequence.swift
+++ b/Platform/DataStructures/InfiniteSequence.swift
@@ -7,13 +7,12 @@
 //
 
 /// Sequence that repeats `repeatedValue` infinite number of times.
-struct InfiniteSequence<E> : Sequence {
-    typealias Element = E
-    typealias Iterator = AnyIterator<E>
+struct InfiniteSequence<Element> : Sequence {
+    typealias Iterator = AnyIterator<Element>
     
-    private let _repeatedValue: E
+    private let _repeatedValue: Element
     
-    init(repeatedValue: E) {
+    init(repeatedValue: Element) {
         _repeatedValue = repeatedValue
     }
     

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -27,7 +27,7 @@ extension BlockingObservable {
     /// If sequence terminates with error, terminating error will be thrown.
     ///
     /// - returns: All elements of sequence.
-    public func toArray() throws -> [E] {
+    public func toArray() throws -> [Element] {
         let results = self.materializeResult()
         return try self.elementsOrThrow(results)
     }
@@ -39,7 +39,7 @@ extension BlockingObservable {
     /// If sequence terminates with error before producing first element, terminating error will be thrown.
     ///
     /// - returns: First element of sequence. If sequence is empty `nil` is returned.
-    public func first() throws -> E? {
+    public func first() throws -> Element? {
         let results = self.materializeResult(max: 1)
         return try self.elementsOrThrow(results).first
     }
@@ -51,7 +51,7 @@ extension BlockingObservable {
     /// If sequence terminates with error, terminating error will be thrown.
     ///
     /// - returns: Last element in the sequence. If sequence is empty `nil` is returned.
-    public func last() throws -> E? {
+    public func last() throws -> Element? {
         let results = self.materializeResult()
         return try self.elementsOrThrow(results).last
     }
@@ -63,7 +63,7 @@ extension BlockingObservable {
     /// If sequence terminates with error before producing first element, terminating error will be thrown.
     ///
     /// - returns: Returns the only element of an sequence, and reports an error if there is not exactly one element in the observable sequence.
-    public func single() throws -> E {
+    public func single() throws -> Element {
         return try self.single { _ in true }
     }
 
@@ -73,7 +73,7 @@ extension BlockingObservable {
     ///
     /// - parameter predicate: A function to test each source element for a condition.
     /// - returns: Returns the only element of an sequence that satisfies the condition in the predicate, and reports an error if there is not exactly one element in the sequence.
-    public func single(_ predicate: @escaping (E) throws -> Bool) throws -> E {
+    public func single(_ predicate: @escaping (Element) throws -> Bool) throws -> Element {
         let results = self.materializeResult(max: 2, predicate: predicate)
         let elements = try self.elementsOrThrow(results)
 
@@ -95,14 +95,14 @@ extension BlockingObservable {
     /// The sequence is materialized as a result type capturing how the sequence terminated (completed or error), along with any elements up to that point.
     ///
     /// - returns: On completion, returns the list of elements in the sequence. On error, returns the list of elements up to that point, along with the error itself.
-    public func materialize() -> MaterializedSequenceResult<E> {
+    public func materialize() -> MaterializedSequenceResult<Element> {
         return self.materializeResult()
     }
 }
 
 extension BlockingObservable {
-    fileprivate func materializeResult(max: Int? = nil, predicate: @escaping (E) throws -> Bool = { _ in true }) -> MaterializedSequenceResult<E> {
-        var elements = [E]()
+    fileprivate func materializeResult(max: Int? = nil, predicate: @escaping (Element) throws -> Bool = { _ in true }) -> MaterializedSequenceResult<Element> {
+        var elements = [Element]()
         var error: Swift.Error?
         
         let lock = RunLoopLock(timeout: self.timeout)
@@ -159,7 +159,7 @@ extension BlockingObservable {
         return MaterializedSequenceResult.completed(elements: elements)
     }
     
-    fileprivate func elementsOrThrow(_ results: MaterializedSequenceResult<E>) throws -> [E] {
+    fileprivate func elementsOrThrow(_ results: MaterializedSequenceResult<Element>) throws -> [Element] {
         switch results {
         case .failed(_, let error):
             throw error

--- a/RxBlocking/BlockingObservable.swift
+++ b/RxBlocking/BlockingObservable.swift
@@ -17,7 +17,7 @@ It can be useful for testing and demo purposes, but is generally inappropriate f
 If you think you need to use a `BlockingObservable` this is usually a sign that you should rethink your
 design.
 */
-public struct BlockingObservable<E> {
+public struct BlockingObservable<Element> {
     let timeout: TimeInterval?
-    let source: Observable<E>
+    let source: Observable<Element>
 }

--- a/RxBlocking/ObservableConvertibleType+Blocking.swift
+++ b/RxBlocking/ObservableConvertibleType+Blocking.swift
@@ -14,7 +14,7 @@ extension ObservableConvertibleType {
     ///
     /// - parameter timeout: Maximal time interval BlockingObservable can block without throwing `RxError.timeout`.
     /// - returns: `BlockingObservable` version of `self`
-    public func toBlocking(timeout: TimeInterval? = nil) -> BlockingObservable<E> {
+    public func toBlocking(timeout: TimeInterval? = nil) -> BlockingObservable<Element> {
         return BlockingObservable(timeout: timeout, source: self.asObservable())
     }
 }

--- a/RxBlocking/README.md
+++ b/RxBlocking/README.md
@@ -12,20 +12,20 @@ extension BlockingObservable {
 }
 
 extension BlockingObservable {
-    public func first() throws -> E? {}
+    public func first() throws -> Element? {}
 }
 
 extension BlockingObservable {
-    public func last() throws -> E? {}
+    public func last() throws -> Element? {}
 }
 
 extension BlockingObservable {
-    public func single() throws -> E? {}
-    public func single(_ predicate: @escaping (E) throws -> Bool) throws -> E? {}
+    public func single() throws -> Element? {}
+    public func single(_ predicate: @escaping (E) throws -> Bool) throws -> Element? {}
 }
 
 extension BlockingObservable {
-    public func materialize() -> MaterializedSequenceResult<E>
+    public func materialize() -> MaterializedSequenceResult<Element>
 }
 ```
 

--- a/RxCocoa/Common/Binder.swift
+++ b/RxCocoa/Common/Binder.swift
@@ -18,7 +18,7 @@ import RxSwift
  By default it binds elements on main scheduler.
  */
 public struct Binder<Value>: ObserverType {
-    public typealias E = Value
+    public typealias Element = Value
     
     private let _binding: (Event<Value>) -> Void
 

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -319,7 +319,7 @@ extension DelegateProxyType where ParentObject: HasPrefetchDataSource, Self.Dele
         import UIKit
 
         extension ObservableType {
-            func subscribeProxyDataSource<DelegateProxy: DelegateProxyType>(ofObject object: DelegateProxy.ParentObject, dataSource: DelegateProxy.Delegate, retainDataSource: Bool, binding: @escaping (DelegateProxy, Event<E>) -> Void)
+            func subscribeProxyDataSource<DelegateProxy: DelegateProxyType>(ofObject object: DelegateProxy.ParentObject, dataSource: DelegateProxy.Delegate, retainDataSource: Bool, binding: @escaping (DelegateProxy, Event<Element>) -> Void)
                 -> Disposable
                 where DelegateProxy.ParentObject: UIView
                 , DelegateProxy.Delegate: AnyObject {
@@ -337,7 +337,7 @@ extension DelegateProxyType where ParentObject: HasPrefetchDataSource, Self.Dele
                     // source can never end, otherwise it would release the subscriber, and deallocate the data source
                     .concat(Observable.never())
                     .takeUntil(object.rx.deallocated)
-                    .subscribe { [weak object] (event: Event<E>) in
+                    .subscribe { [weak object] (event: Event<Element>) in
 
                         if let object = object {
                             assert(proxy === DelegateProxy.currentDelegate(for: object), "Proxy changed from the time it was first set.\nOriginal: \(proxy)\nExisting: \(String(describing: DelegateProxy.currentDelegate(for: object)))")

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter to: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
-    public func bind<O: ObserverType>(to observers: O...) -> Disposable where O.E == E {
+    public func bind<O: ObserverType>(to observers: O...) -> Disposable where O.Element == Element {
         return self.bind(to: observers)
     }
 
@@ -27,8 +27,8 @@ extension ObservableType {
      - parameter to: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
-    public func bind<O: ObserverType>(to observers: O...) -> Disposable where O.E == E? {
-        return self.map { $0 as E? }.bind(to: observers)
+    public func bind<O: ObserverType>(to observers: O...) -> Disposable where O.Element == Element? {
+        return self.map { $0 as Element? }.bind(to: observers)
     }
 
     /**
@@ -38,7 +38,7 @@ extension ObservableType {
      - parameter to: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
-    private func bind<O: ObserverType>(to observers: [O]) -> Disposable where O.E == E {
+    private func bind<O: ObserverType>(to observers: [O]) -> Disposable where O.Element == Element {
         return self.subscribe { event in
             observers.forEach { $0.on(event) }
         }
@@ -79,7 +79,7 @@ extension ObservableType {
     - parameter onNext: Action to invoke for each element in the observable sequence.
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
-    public func bind(onNext: @escaping (E) -> Void) -> Disposable {
+    public func bind(onNext: @escaping (Element) -> Void) -> Disposable {
         return self.subscribe(onNext: onNext, onError: { error in
             rxFatalErrorInDebug("Binding error: \(error)")
         })

--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -22,7 +22,7 @@ extension ObservableType {
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     @available(*, deprecated, renamed: "bind(to:)")
-    public func bindTo<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func bindTo<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         return self.subscribe(observer)
     }
 
@@ -36,7 +36,7 @@ extension ObservableType {
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     @available(*, deprecated, renamed: "bind(to:)")
-    public func bindTo<O: ObserverType>(_ observer: O) -> Disposable where O.E == E? {
+    public func bindTo<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element? {
         return self.map { $0 }.subscribe(observer)
     }
 
@@ -50,7 +50,7 @@ extension ObservableType {
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     @available(*, deprecated, renamed: "bind(to:)")
-    public func bindTo(_ variable: Variable<E>) -> Disposable {
+    public func bindTo(_ variable: Variable<Element>) -> Disposable {
         return self.subscribe { e in
             switch e {
             case let .next(element):
@@ -78,8 +78,8 @@ extension ObservableType {
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     @available(*, deprecated, renamed: "bind(to:)")
-    public func bindTo(_ variable: Variable<E?>) -> Disposable {
-        return self.map { $0 as E? }.bindTo(variable)
+    public func bindTo(_ variable: Variable<Element?>) -> Disposable {
+        return self.map { $0 as Element? }.bindTo(variable)
     }
 
     /**
@@ -121,7 +121,7 @@ extension ObservableType {
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
     @available(*, deprecated, renamed: "bind(onNext:)")
-    public func bindNext(_ onNext: @escaping (E) -> Void) -> Disposable {
+    public func bindNext(_ onNext: @escaping (Element) -> Void) -> Disposable {
         return self.subscribe(onNext: onNext, onError: { error in
             let error = "Binding error: \(error)"
             #if DEBUG
@@ -256,7 +256,7 @@ extension Variable {
     ///
     /// - returns: Observable sequence.
     @available(*, deprecated, renamed: "asDriver()")
-    public func asSharedSequence<SharingStrategy: SharingStrategyProtocol>(strategy: SharingStrategy.Type = SharingStrategy.self) -> SharedSequence<SharingStrategy, E> {
+    public func asSharedSequence<SharingStrategy: SharingStrategyProtocol>(strategy: SharingStrategy.Type = SharingStrategy.self) -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .observeOn(SharingStrategy.scheduler)
         return SharedSequence(source)
@@ -291,7 +291,7 @@ Observer that enforces interface binding rules:
 */
 @available(*, deprecated, renamed: "Binder")
 public final class UIBindingObserver<UIElementType, Value> : ObserverType where UIElementType: AnyObject {
-    public typealias E = Value
+    public typealias Element = Value
 
     weak var UIElement: UIElementType?
 
@@ -414,7 +414,7 @@ extension Variable {
     /// Converts `Variable` to `Driver` trait.
     ///
     /// - returns: Driving observable sequence.
-    public func asDriver() -> Driver<E> {
+    public func asDriver() -> Driver<Element> {
         let source = self.asObservable()
             .observeOn(DriverSharingStrategy.scheduler)
         return Driver(source)
@@ -434,7 +434,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
      - returns: Disposable object that can be used to unsubscribe the observer from the variable.
      */
     @available(*, deprecated, message: "Variable is deprecated. Please use `BehaviorRelay` as a replacement.")
-    public func drive(_ variable: Variable<E>) -> Disposable {
+    public func drive(_ variable: Variable<Element>) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.drive(onNext: { e in
             variable.value = e
@@ -449,7 +449,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
      - returns: Disposable object that can be used to unsubscribe the observer from the variable.
      */
     @available(*, deprecated, message: "Variable is deprecated. Please use `BehaviorRelay` as a replacement.")
-    public func drive(_ variable: Variable<E?>) -> Disposable {
+    public func drive(_ variable: Variable<Element?>) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.drive(onNext: { e in
             variable.value = e
@@ -468,7 +468,7 @@ extension ObservableType {
      - parameter to: Target variable for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to variable: Variable<E>) -> Disposable {
+    public func bind(to variable: Variable<Element>) -> Disposable {
         return self.subscribe { e in
             switch e {
             case let .next(element):
@@ -495,8 +495,8 @@ extension ObservableType {
      - parameter to: Target variable for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to variable: Variable<E?>) -> Disposable {
-        return self.map { $0 as E? }.bind(to: variable)
+    public func bind(to variable: Variable<Element?>) -> Disposable {
+        return self.map { $0 as Element? }.bind(to: variable)
     }
 }
 
@@ -515,7 +515,7 @@ extension SharedSequenceConvertibleType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "timeout(_:latest:)")
     public func throttle(_ dueTime: Foundation.TimeInterval, latest: Bool = true)
-        -> SharedSequence<SharingStrategy, E> {
+        -> SharedSequence<SharingStrategy, Element> {
         return throttle(.milliseconds(Int(dueTime * 1000.0)), latest: latest)
     }
 
@@ -527,7 +527,7 @@ extension SharedSequenceConvertibleType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "debounce(_:)")
     public func debounce(_ dueTime: Foundation.TimeInterval)
-        -> SharedSequence<SharingStrategy, E> {
+        -> SharedSequence<SharingStrategy, Element> {
         return debounce(.milliseconds(Int(dueTime * 1000.0)))
     }
 }
@@ -546,7 +546,7 @@ extension SharedSequenceConvertibleType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "delay(_:)")
     public func delay(_ dueTime: Foundation.TimeInterval)
-        -> SharedSequence<SharingStrategy, E> {
+        -> SharedSequence<SharingStrategy, Element> {
         return delay(.milliseconds(Int(dueTime * 1000.0)))
     }
 }
@@ -562,7 +562,7 @@ extension SharedSequence where Element : RxAbstractInteger {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "interval(_:)")
     public static func interval(_ period: Foundation.TimeInterval)
-        -> SharedSequence<S, E> {
+        -> SharedSequence<S, Element> {
         return interval(.milliseconds(Int(period * 1000.0)))
     }
 }
@@ -581,7 +581,7 @@ extension SharedSequence where Element: RxAbstractInteger {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "timer(_:)")
     public static func timer(_ dueTime: Foundation.TimeInterval, period: Foundation.TimeInterval)
-        -> SharedSequence<S, E> {
+        -> SharedSequence<S, Element> {
         return timer(.milliseconds(Int(dueTime * 1000.0)), period: .milliseconds(Int(period * 1000.0)))
     }
 }

--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -290,16 +290,16 @@ Observer that enforces interface binding rules:
  queue.
 */
 @available(*, deprecated, renamed: "Binder")
-public final class UIBindingObserver<UIElementType, Value> : ObserverType where UIElementType: AnyObject {
+public final class UIBindingObserver<UIElement, Value> : ObserverType where UIElement: AnyObject {
     public typealias Element = Value
 
-    weak var UIElement: UIElementType?
+    weak var UIElement: UIElement?
 
-    let binding: (UIElementType, Value) -> Void
+    let binding: (UIElement, Value) -> Void
 
     /// Initializes `ViewBindingObserver` using
     @available(*, deprecated, renamed: "UIBinder.init(_:scheduler:binding:)")
-    public init(UIElement: UIElementType, binding: @escaping (UIElementType, Value) -> Void) {
+    public init(UIElement: UIElement, binding: @escaping (UIElement, Value) -> Void) {
         self.UIElement = UIElement
         self.binding = binding
     }

--- a/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
@@ -36,9 +36,9 @@ extension Reactive where Base: NSObject {
 
      For more information take a look at `observe` method.
      */
-    public func observe<E: KVORepresentable>(_ type: E.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> {
-        return self.observe(E.KVOType.self, keyPath, options: options, retainSelf: retainSelf)
-            .map(E.init)
+    public func observe<Element: KVORepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Element?> {
+        return self.observe(Element.KVOType.self, keyPath, options: options, retainSelf: retainSelf)
+            .map(Element.init)
     }
 }
 
@@ -50,9 +50,9 @@ extension Reactive where Base: NSObject {
 
         For more information take a look at `observeWeakly` method.
         */
-        public func observeWeakly<E: KVORepresentable>(_ type: E.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> {
-            return self.observeWeakly(E.KVOType.self, keyPath, options: options)
-                .map(E.init)
+        public func observeWeakly<Element: KVORepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Element?> {
+            return self.observeWeakly(Element.KVOType.self, keyPath, options: options)
+                .map(Element.init)
         }
     }
 #endif

--- a/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
@@ -22,9 +22,9 @@ extension Reactive where Base: NSObject {
 
      For more information take a look at `observe` method.
      */
-    public func observe<E: RawRepresentable>(_ type: E.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> where E.RawValue: KVORepresentable {
-        return self.observe(E.RawValue.KVOType.self, keyPath, options: options, retainSelf: retainSelf)
-            .map(E.init)
+    public func observe<Element: RawRepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Element?> where Element.RawValue: KVORepresentable {
+        return self.observe(Element.RawValue.KVOType.self, keyPath, options: options, retainSelf: retainSelf)
+            .map(Element.init)
     }
 }
 
@@ -42,9 +42,9 @@ extension Reactive where Base: NSObject {
 
          For more information take a look at `observeWeakly` method.
          */
-        public func observeWeakly<E: RawRepresentable>(_ type: E.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> where E.RawValue: KVORepresentable {
-            return self.observeWeakly(E.RawValue.KVOType.self, keyPath, options: options)
-                .map(E.init)
+        public func observeWeakly<Element: RawRepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Element?> where Element.RawValue: KVORepresentable {
+            return self.observeWeakly(Element.RawValue.KVOType.self, keyPath, options: options)
+                .map(Element.init)
         }
     }
 #endif

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -63,7 +63,7 @@ extension Reactive where Base: NSObject {
      - parameter retainSelf: Retains self during observation if set `true`.
      - returns: Observable sequence of objects on `keyPath`.
      */
-    public func observe<E>(_ type: E.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<E?> {
+    public func observe<Element>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Element?> {
         return KVOObservable(object: self.base, keyPath: keyPath, options: options, retainTarget: retainSelf).asObservable()
     }
 }
@@ -87,10 +87,10 @@ extension Reactive where Base: NSObject {
      - parameter options: KVO mechanism notification options.
      - returns: Observable sequence of objects on `keyPath`.
      */
-    public func observeWeakly<E>(_ type: E.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<E?> {
+    public func observeWeakly<Element>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Element?> {
         return observeWeaklyKeyPathFor(self.base, keyPath: keyPath, options: options)
             .map { n in
-                return n as? E
+                return n as? Element
             }
     }
 }
@@ -254,7 +254,7 @@ extension Reactive where Base: AnyObject {
     fileprivate final class DeallocatingProxy
         : MessageInterceptorSubject
         , RXDeallocatingObserver {
-        typealias E = ()
+        typealias Element = ()
 
         let messageSent = ReplaySubject<()>.create(bufferSize: 1)
 
@@ -279,7 +279,7 @@ extension Reactive where Base: AnyObject {
     fileprivate final class MessageSentProxy
         : MessageInterceptorSubject
         , RXMessageSentObserver {
-        typealias E = [AnyObject]
+        typealias Element = [AnyObject]
 
         let messageSent = PublishSubject<[Any]>()
         let methodInvoked = PublishSubject<[Any]>()
@@ -364,7 +364,7 @@ fileprivate final class KVOObserver
 fileprivate final class KVOObservable<Element>
     : ObservableType
     , KVOObservableProtocol {
-    typealias E = Element?
+    typealias Element = Element?
 
     unowned var target: AnyObject
     var strongTarget: AnyObject?
@@ -383,7 +383,7 @@ fileprivate final class KVOObservable<Element>
         }
     }
 
-    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element? {
+    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element? {
         let observer = KVOObserver(parent: self) { value in
             if value as? NSNull != nil {
                 observer.on(.next(nil))
@@ -438,7 +438,7 @@ fileprivate extension KeyValueObservingOptions {
         return properyRuntimeInfo.range(of: ",W,") != nil
     }
 
-    fileprivate extension ObservableType where E == AnyObject? {
+    fileprivate extension ObservableType where Element == AnyObject? {
         func finishWithNilWhenDealloc(_ target: NSObject)
             -> Observable<AnyObject?> {
                 let deallocating = target.rx.deallocating

--- a/RxCocoa/Traits/ControlEvent.swift
+++ b/RxCocoa/Traits/ControlEvent.swift
@@ -12,7 +12,7 @@ import RxSwift
 public protocol ControlEventType : ObservableType {
 
     /// - returns: `ControlEvent` interface
-    func asControlEvent() -> ControlEvent<E>
+    func asControlEvent() -> ControlEvent<Element>
 }
 
 /**
@@ -37,7 +37,7 @@ public protocol ControlEventType : ObservableType {
      properties, don’t use this trait.**
 */
 public struct ControlEvent<PropertyType> : ControlEventType {
-    public typealias E = PropertyType
+    public typealias Element = PropertyType
 
     let _events: Observable<PropertyType>
 
@@ -45,7 +45,7 @@ public struct ControlEvent<PropertyType> : ControlEventType {
     ///
     /// - parameter events: Observable sequence that represents events.
     /// - returns: Control event created with a observable sequence of events.
-    public init<Ev: ObservableType>(events: Ev) where Ev.E == E {
+    public init<Ev: ObservableType>(events: Ev) where Ev.Element == Element {
         self._events = events.subscribeOn(ConcurrentMainScheduler.instance)
     }
 
@@ -53,17 +53,17 @@ public struct ControlEvent<PropertyType> : ControlEventType {
     ///
     /// - parameter observer: Observer to subscribe to events.
     /// - returns: Disposable object that can be used to unsubscribe the observer from receiving control events.
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         return self._events.subscribe(observer)
     }
 
     /// - returns: `Observable` interface.
-    public func asObservable() -> Observable<E> {
+    public func asObservable() -> Observable<Element> {
         return self._events
     }
 
     /// - returns: `ControlEvent` interface.
-    public func asControlEvent() -> ControlEvent<E> {
+    public func asControlEvent() -> ControlEvent<Element> {
         return self
     }
 }

--- a/RxCocoa/Traits/ControlProperty.swift
+++ b/RxCocoa/Traits/ControlProperty.swift
@@ -12,7 +12,7 @@ import RxSwift
 public protocol ControlPropertyType : ObservableType, ObserverType {
 
     /// - returns: `ControlProperty` interface
-    func asControlProperty() -> ControlProperty<E>
+    func asControlProperty() -> ControlProperty<Element>
 }
 
 /**
@@ -41,7 +41,7 @@ public protocol ControlPropertyType : ObservableType, ObserverType {
     properties, please don't use this trait.**
 */
 public struct ControlProperty<PropertyType> : ControlPropertyType {
-    public typealias E = PropertyType
+    public typealias Element = PropertyType
 
     let _values: Observable<PropertyType>
     let _valueSink: AnyObserver<PropertyType>
@@ -53,7 +53,7 @@ public struct ControlProperty<PropertyType> : ControlPropertyType {
     /// - parameter valueSink: Observer that enables binding values to control property.
     /// - returns: Control property created with a observable sequence of values and an observer that enables binding values
     /// to property.
-    public init<V: ObservableType, S: ObserverType>(values: V, valueSink: S) where E == V.E, E == S.E {
+    public init<V: ObservableType, S: ObserverType>(values: V, valueSink: S) where Element == V.Element, Element == S.Element {
         self._values = values.subscribeOn(ConcurrentMainScheduler.instance)
         self._valueSink = valueSink.asObserver()
     }
@@ -62,7 +62,7 @@ public struct ControlProperty<PropertyType> : ControlPropertyType {
     ///
     /// - parameter observer: Observer to subscribe to property values.
     /// - returns: Disposable object that can be used to unsubscribe the observer from receiving control property values.
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         return self._values.subscribe(observer)
     }
 
@@ -81,12 +81,12 @@ public struct ControlProperty<PropertyType> : ControlPropertyType {
     }
 
     /// - returns: `Observable` interface.
-    public func asObservable() -> Observable<E> {
+    public func asObservable() -> Observable<Element> {
         return self._values
     }
 
     /// - returns: `ControlProperty` interface.
-    public func asControlProperty() -> ControlProperty<E> {
+    public func asControlProperty() -> ControlProperty<Element> {
         return self
     }
 
@@ -95,7 +95,7 @@ public struct ControlProperty<PropertyType> : ControlPropertyType {
     /// - In case next element is received, it is being set to control value.
     /// - In case error is received, DEBUG buids raise fatal error, RELEASE builds log event to standard output.
     /// - In case sequence completes, nothing happens.
-    public func on(_ event: Event<E>) {
+    public func on(_ event: Event<Element>) {
         switch event {
         case .error(let error):
             bindingError(error)
@@ -107,7 +107,7 @@ public struct ControlProperty<PropertyType> : ControlPropertyType {
     }
 }
 
-extension ControlPropertyType where E == String? {
+extension ControlPropertyType where Element == String? {
     /// Transforms control property of type `String?` into control property of type `String`.
     public var orEmpty: ControlProperty<String> {
         let original: ControlProperty<String?> = self.asControlProperty()

--- a/RxCocoa/Traits/Driver/ControlEvent+Driver.swift
+++ b/RxCocoa/Traits/Driver/ControlEvent+Driver.swift
@@ -12,8 +12,8 @@ extension ControlEvent {
     /// Converts `ControlEvent` to `Driver` trait.
     ///
     /// `ControlEvent` already can't fail, so no special case needs to be handled.
-    public func asDriver() -> Driver<E> {
-        return self.asDriver { _ -> Driver<E> in
+    public func asDriver() -> Driver<Element> {
+        return self.asDriver { _ -> Driver<Element> in
             #if DEBUG
                 rxFatalError("Somehow driver received error from a source that shouldn't fail.")
             #else

--- a/RxCocoa/Traits/Driver/ControlProperty+Driver.swift
+++ b/RxCocoa/Traits/Driver/ControlProperty+Driver.swift
@@ -12,8 +12,8 @@ extension ControlProperty {
     /// Converts `ControlProperty` to `Driver` trait.
     ///
     /// `ControlProperty` already can't fail, so no special case needs to be handled.
-    public func asDriver() -> Driver<E> {
-        return self.asDriver { _ -> Driver<E> in
+    public func asDriver() -> Driver<Element> {
+        return self.asDriver { _ -> Driver<Element> in
             #if DEBUG
                 rxFatalError("Somehow driver received error from a source that shouldn't fail.")
             #else

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -22,7 +22,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     - parameter observer: Observer that receives events.
     - returns: Disposable object that can be used to unsubscribe the observer from the subject.
     */
-    public func drive<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func drive<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.asSharedSequence().asObservable().subscribe(observer)
     }
@@ -36,9 +36,9 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
      - parameter observer: Observer that receives events.
      - returns: Disposable object that can be used to unsubscribe the observer from the subject.
      */
-    public func drive<O: ObserverType>(_ observer: O) -> Disposable where O.E == E? {
+    public func drive<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element? {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
-        return self.asSharedSequence().asObservable().map { $0 as E? }.subscribe(observer)
+        return self.asSharedSequence().asObservable().map { $0 as Element? }.subscribe(observer)
     }
 
     /**
@@ -48,7 +48,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     - parameter relay: Target relay for sequence elements.
     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
     */
-    public func drive(_ relay: BehaviorRelay<E>) -> Disposable {
+    public func drive(_ relay: BehaviorRelay<Element>) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.drive(onNext: { e in
             relay.accept(e)
@@ -62,7 +62,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
      - parameter relay: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
-    public func drive(_ relay: BehaviorRelay<E?>) -> Disposable {
+    public func drive(_ relay: BehaviorRelay<Element?>) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.drive(onNext: { e in
             relay.accept(e)
@@ -76,7 +76,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     - parameter with: Function used to bind elements from `self`.
     - returns: Object representing subscription.
     */
-    public func drive<R>(_ transformation: (Observable<E>) -> R) -> R {
+    public func drive<R>(_ transformation: (Observable<Element>) -> R) -> R {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return transformation(self.asObservable())
     }
@@ -95,7 +95,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     - parameter curriedArgument: Final argument passed to `binder` to finish binding process.
     - returns: Object representing subscription.
     */
-    public func drive<R1, R2>(_ with: (Observable<E>) -> (R1) -> R2, curriedArgument: R1) -> R2 {
+    public func drive<R1, R2>(_ with: (Observable<Element>) -> (R1) -> R2, curriedArgument: R1) -> R2 {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return with(self.asObservable())(curriedArgument)
     }
@@ -113,7 +113,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     gracefully completed, errored, or if the generation is canceled by disposing subscription)
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
-    public func drive(onNext: ((E) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil) -> Disposable {
+    public func drive(onNext: ((Element) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
     }

--- a/RxCocoa/Traits/Driver/Driver.swift
+++ b/RxCocoa/Traits/Driver/Driver.swift
@@ -35,18 +35,18 @@ import RxSwift
 
  To find out more about traits and how to use them, please visit `Documentation/Traits.md`.
  */
-public typealias Driver<E> = SharedSequence<DriverSharingStrategy, E>
+public typealias Driver<Element> = SharedSequence<DriverSharingStrategy, Element>
 
 public struct DriverSharingStrategy: SharingStrategyProtocol {
     public static var scheduler: SchedulerType { return SharingScheduler.make() }
-    public static func share<E>(_ source: Observable<E>) -> Observable<E> {
+    public static func share<Element>(_ source: Observable<Element>) -> Observable<Element> {
         return source.share(replay: 1, scope: .whileConnected)
     }
 }
 
 extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingStrategy {
     /// Adds `asDriver` to `SharingSequence` with `DriverSharingStrategy`.
-    public func asDriver() -> Driver<E> {
+    public func asDriver() -> Driver<Element> {
         return self.asSharedSequence()
     }
 }

--- a/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
+++ b/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
@@ -15,7 +15,7 @@ extension ObservableConvertibleType {
     - parameter onErrorJustReturn: Element to return in case of error and after that complete the sequence.
     - returns: Driver trait.
     */
-    public func asDriver(onErrorJustReturn: E) -> Driver<E> {
+    public func asDriver(onErrorJustReturn: Element) -> Driver<Element> {
         let source = self
             .asObservable()
             .observeOn(DriverSharingStrategy.scheduler)
@@ -29,7 +29,7 @@ extension ObservableConvertibleType {
     - parameter onErrorDriveWith: Driver that continues to drive the sequence in case of error.
     - returns: Driver trait.
     */
-    public func asDriver(onErrorDriveWith: Driver<E>) -> Driver<E> {
+    public func asDriver(onErrorDriveWith: Driver<Element>) -> Driver<Element> {
         let source = self
             .asObservable()
             .observeOn(DriverSharingStrategy.scheduler)
@@ -45,7 +45,7 @@ extension ObservableConvertibleType {
     - parameter onErrorRecover: Calculates driver that continues to drive the sequence in case of error.
     - returns: Driver trait.
     */
-    public func asDriver(onErrorRecover: @escaping (_ error: Swift.Error) -> Driver<E>) -> Driver<E> {
+    public func asDriver(onErrorRecover: @escaping (_ error: Swift.Error) -> Driver<Element>) -> Driver<Element> {
         let source = self
             .asObservable()
             .observeOn(DriverSharingStrategy.scheduler)

--- a/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
@@ -15,7 +15,7 @@ extension ObservableConvertibleType {
      - parameter onErrorJustReturn: Element to return in case of error and after that complete the sequence.
      - returns: Driving observable sequence.
      */
-    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorJustReturn: E) -> SharedSequence<S, E> {
+    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorJustReturn: Element) -> SharedSequence<S, Element> {
         let source = self
             .asObservable()
             .observeOn(S.scheduler)
@@ -29,7 +29,7 @@ extension ObservableConvertibleType {
      - parameter onErrorDriveWith: SharedSequence that provides elements of the sequence in case of error.
      - returns: Driving observable sequence.
      */
-    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorDriveWith: SharedSequence<S, E>) -> SharedSequence<S, E> {
+    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorDriveWith: SharedSequence<S, Element>) -> SharedSequence<S, Element> {
         let source = self
             .asObservable()
             .observeOn(S.scheduler)
@@ -45,7 +45,7 @@ extension ObservableConvertibleType {
      - parameter onErrorRecover: Calculates driver that continues to drive the sequence in case of error.
      - returns: Driving observable sequence.
      */
-    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorRecover: @escaping (_ error: Swift.Error) -> SharedSequence<S, E>) -> SharedSequence<S, E> {
+    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorRecover: @escaping (_ error: Swift.Error) -> SharedSequence<S, Element>) -> SharedSequence<S, Element> {
         let source = self
             .asObservable()
             .observeOn(S.scheduler)

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
@@ -21,19 +21,19 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.E, O2.E) throws -> E)
-        -> SharedSequence<O1.SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.Element, O2.Element) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy {
         let source = Observable.zip(
             source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(),
             resultSelector: resultSelector
         )
 
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -41,13 +41,13 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2)
-        -> SharedSequence<O1.SharingStrategy, (O1.E, O2.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy {
         let source = Observable.zip(
             source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable()
         )
 
-        return SharedSequence<SharingStrategy, (O1.E, O2.E)>(source)
+        return SharedSequence<SharingStrategy, (O1.Element, O2.Element)>(source)
     }
 }
 
@@ -59,19 +59,19 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.E, O2.E) throws -> E)
-        -> SharedSequence<SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.Element, O2.Element) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy {
         let source = Observable.combineLatest(
                 source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(),
                 resultSelector: resultSelector
             )
 
-        return SharedSequence<O1.SharingStrategy, E>(source)
+        return SharedSequence<O1.SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
 
@@ -79,13 +79,13 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2)
-        -> SharedSequence<SharingStrategy, (O1.E, O2.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<SharingStrategy, (O1.Element, O2.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy {
         let source = Observable.combineLatest(
                 source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable()
             )
 
-        return SharedSequence<O1.SharingStrategy, (O1.E, O2.E)>(source)
+        return SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element)>(source)
     }
 }
 
@@ -101,8 +101,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.E, O2.E, O3.E) throws -> E)
-        -> SharedSequence<O1.SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.Element, O2.Element, O3.Element) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy {
         let source = Observable.zip(
@@ -110,11 +110,11 @@ extension SharedSequence {
             resultSelector: resultSelector
         )
 
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -122,14 +122,14 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3)
-        -> SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy {
         let source = Observable.zip(
             source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable()
         )
 
-        return SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E)>(source)
+        return SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element)>(source)
     }
 }
 
@@ -141,8 +141,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.E, O2.E, O3.E) throws -> E)
-        -> SharedSequence<SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.Element, O2.Element, O3.Element) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy {
         let source = Observable.combineLatest(
@@ -150,11 +150,11 @@ extension SharedSequence {
                 resultSelector: resultSelector
             )
 
-        return SharedSequence<O1.SharingStrategy, E>(source)
+        return SharedSequence<O1.SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
 
@@ -162,14 +162,14 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3)
-        -> SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy {
         let source = Observable.combineLatest(
                 source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable()
             )
 
-        return SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E)>(source)
+        return SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element)>(source)
     }
 }
 
@@ -185,8 +185,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E) throws -> E)
-        -> SharedSequence<O1.SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy {
@@ -195,11 +195,11 @@ extension SharedSequence {
             resultSelector: resultSelector
         )
 
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -207,7 +207,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4)
-        -> SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy {
@@ -215,7 +215,7 @@ extension SharedSequenceConvertibleType where E == Any {
             source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable()
         )
 
-        return SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E)>(source)
+        return SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element)>(source)
     }
 }
 
@@ -227,8 +227,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E) throws -> E)
-        -> SharedSequence<SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy {
@@ -237,11 +237,11 @@ extension SharedSequence {
                 resultSelector: resultSelector
             )
 
-        return SharedSequence<O1.SharingStrategy, E>(source)
+        return SharedSequence<O1.SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
 
@@ -249,7 +249,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4)
-        -> SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy {
@@ -257,7 +257,7 @@ extension SharedSequenceConvertibleType where E == Any {
                 source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable()
             )
 
-        return SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E)>(source)
+        return SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element)>(source)
     }
 }
 
@@ -273,8 +273,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E) throws -> E)
-        -> SharedSequence<O1.SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -284,11 +284,11 @@ extension SharedSequence {
             resultSelector: resultSelector
         )
 
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -296,7 +296,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5)
-        -> SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -305,7 +305,7 @@ extension SharedSequenceConvertibleType where E == Any {
             source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable()
         )
 
-        return SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E)>(source)
+        return SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element)>(source)
     }
 }
 
@@ -317,8 +317,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E) throws -> E)
-        -> SharedSequence<SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -328,11 +328,11 @@ extension SharedSequence {
                 resultSelector: resultSelector
             )
 
-        return SharedSequence<O1.SharingStrategy, E>(source)
+        return SharedSequence<O1.SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
 
@@ -340,7 +340,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5)
-        -> SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -349,7 +349,7 @@ extension SharedSequenceConvertibleType where E == Any {
                 source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable()
             )
 
-        return SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E)>(source)
+        return SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element)>(source)
     }
 }
 
@@ -365,8 +365,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E) throws -> E)
-        -> SharedSequence<O1.SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -377,11 +377,11 @@ extension SharedSequence {
             resultSelector: resultSelector
         )
 
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -389,7 +389,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6)
-        -> SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -399,7 +399,7 @@ extension SharedSequenceConvertibleType where E == Any {
             source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable()
         )
 
-        return SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E)>(source)
+        return SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element)>(source)
     }
 }
 
@@ -411,8 +411,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E) throws -> E)
-        -> SharedSequence<SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -423,11 +423,11 @@ extension SharedSequence {
                 resultSelector: resultSelector
             )
 
-        return SharedSequence<O1.SharingStrategy, E>(source)
+        return SharedSequence<O1.SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
 
@@ -435,7 +435,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6)
-        -> SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -445,7 +445,7 @@ extension SharedSequenceConvertibleType where E == Any {
                 source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable()
             )
 
-        return SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E)>(source)
+        return SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element)>(source)
     }
 }
 
@@ -461,8 +461,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E) throws -> E)
-        -> SharedSequence<O1.SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -474,11 +474,11 @@ extension SharedSequence {
             resultSelector: resultSelector
         )
 
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -486,7 +486,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7)
-        -> SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -497,7 +497,7 @@ extension SharedSequenceConvertibleType where E == Any {
             source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable(), source7.asSharedSequence().asObservable()
         )
 
-        return SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E)>(source)
+        return SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element)>(source)
     }
 }
 
@@ -509,8 +509,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E) throws -> E)
-        -> SharedSequence<SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -522,11 +522,11 @@ extension SharedSequence {
                 resultSelector: resultSelector
             )
 
-        return SharedSequence<O1.SharingStrategy, E>(source)
+        return SharedSequence<O1.SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
 
@@ -534,7 +534,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7)
-        -> SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -545,7 +545,7 @@ extension SharedSequenceConvertibleType where E == Any {
                 source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable(), source7.asSharedSequence().asObservable()
             )
 
-        return SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E)>(source)
+        return SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element)>(source)
     }
 }
 
@@ -561,8 +561,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E) throws -> E)
-        -> SharedSequence<O1.SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -575,11 +575,11 @@ extension SharedSequence {
             resultSelector: resultSelector
         )
 
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -587,7 +587,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8)
-        -> SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -599,7 +599,7 @@ extension SharedSequenceConvertibleType where E == Any {
             source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable(), source7.asSharedSequence().asObservable(), source8.asSharedSequence().asObservable()
         )
 
-        return SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E)>(source)
+        return SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element)>(source)
     }
 }
 
@@ -611,8 +611,8 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E) throws -> E)
-        -> SharedSequence<SharingStrategy, E> where SharingStrategy == O1.SharingStrategy,
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -625,11 +625,11 @@ extension SharedSequence {
                 resultSelector: resultSelector
             )
 
-        return SharedSequence<O1.SharingStrategy, E>(source)
+        return SharedSequence<O1.SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
 
@@ -637,7 +637,7 @@ extension SharedSequenceConvertibleType where E == Any {
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8)
-        -> SharedSequence<SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E)> where SharingStrategy == O1.SharingStrategy,
+        -> SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element)> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
             SharingStrategy == O4.SharingStrategy,
@@ -649,7 +649,7 @@ extension SharedSequenceConvertibleType where E == Any {
                 source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable(), source7.asSharedSequence().asObservable(), source8.asSharedSequence().asObservable()
             )
 
-        return SharedSequence<O1.SharingStrategy, (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E)>(source)
+        return SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element)>(source)
     }
 }
 

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.tt
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.tt
@@ -20,18 +20,18 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<<%= (Array(1...i).map { "O\($0): SharedSequenceConvertibleType" }).joined(separator: ", ") %>>
-        (<%= (Array(1...i).map { "_ source\($0): O\($0)" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "O\($0).E" }).joined(separator: ", ") %>) throws -> E)
-        -> SharedSequence<O1.SharingStrategy, E> where <%= (Array(1...i).map { "SharingStrategy == O\($0).SharingStrategy" }).joined(separator: ",\n            ") %> {
+        (<%= (Array(1...i).map { "_ source\($0): O\($0)" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "O\($0).E" }).joined(separator: ", ") %>) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where <%= (Array(1...i).map { "SharingStrategy == O\($0).SharingStrategy" }).joined(separator: ",\n            ") %> {
         let source = Observable.zip(
             <%= (Array(1...i).map { "source\($0).asSharedSequence().asObservable()" }).joined(separator: ", ") %>,
             resultSelector: resultSelector
         )
 
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -56,18 +56,18 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<<%= (Array(1...i).map { "O\($0): SharedSequenceConvertibleType" }).joined(separator: ", ") %>>
-        (<%= (Array(1...i).map { "_ source\($0): O\($0)" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "O\($0).E" }).joined(separator: ", ") %>) throws -> E)
-        -> SharedSequence<SharingStrategy, E> where <%= (Array(1...i).map { "SharingStrategy == O\($0).SharingStrategy" }).joined(separator: ",\n            ") %> {
+        (<%= (Array(1...i).map { "_ source\($0): O\($0)" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "O\($0).E" }).joined(separator: ", ") %>) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where <%= (Array(1...i).map { "SharingStrategy == O\($0).SharingStrategy" }).joined(separator: ",\n            ") %> {
         let source = Observable.combineLatest(
                 <%= (Array(1...i).map { "source\($0).asSharedSequence().asObservable()" }).joined(separator: ", ") %>,
                 resultSelector: resultSelector
             )
 
-        return SharedSequence<O1.SharingStrategy, E>(source)
+        return SharedSequence<O1.SharingStrategy, Element>(source)
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any {
+extension SharedSequenceConvertibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
 

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -17,7 +17,7 @@ extension SharedSequenceConvertibleType {
     - parameter selector: A transform function to apply to each source element.
     - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
     */
-    public func map<R>(_ selector: @escaping (E) -> R) -> SharedSequence<SharingStrategy, R> {
+    public func map<R>(_ selector: @escaping (Element) -> R) -> SharedSequence<SharingStrategy, R> {
         let source = self
             .asObservable()
             .map(selector)
@@ -33,7 +33,7 @@ extension SharedSequenceConvertibleType {
     - parameter predicate: A function to test each source element for a condition.
     - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
     */
-    public func filter(_ predicate: @escaping (E) -> Bool) -> SharedSequence<SharingStrategy, E> {
+    public func filter(_ predicate: @escaping (Element) -> Bool) -> SharedSequence<SharingStrategy, Element> {
         let source = self
             .asObservable()
             .filter(predicate)
@@ -42,7 +42,7 @@ extension SharedSequenceConvertibleType {
 }
 
 // MARK: switchLatest
-extension SharedSequenceConvertibleType where E : SharedSequenceConvertibleType {
+extension SharedSequenceConvertibleType where Element : SharedSequenceConvertibleType {
     
     /**
     Transforms an observable sequence of observable sequences into an observable sequence
@@ -53,12 +53,12 @@ extension SharedSequenceConvertibleType where E : SharedSequenceConvertibleType 
     
     - returns: The observable sequence that at any point in time produces the elements of the most recent inner observable sequence that has been received.
     */
-    public func switchLatest() -> SharedSequence<E.SharingStrategy, E.E> {
-        let source: Observable<E.E> = self
+    public func switchLatest() -> SharedSequence<Element.SharingStrategy, Element.Element> {
+        let source: Observable<Element.Element> = self
             .asObservable()
             .map { $0.asSharedSequence() }
             .switchLatest()
-        return SharedSequence<E.SharingStrategy, E.E>(source)
+        return SharedSequence<Element.SharingStrategy, Element.Element>(source)
     }
 }
 
@@ -74,7 +74,7 @@ extension SharedSequenceConvertibleType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source producing an
      Observable of Observable sequences and that at any point in time produces the elements of the most recent inner observable sequence that has been received.
      */
-    public func flatMapLatest<Sharing, R>(_ selector: @escaping (E) -> SharedSequence<Sharing, R>)
+    public func flatMapLatest<Sharing, R>(_ selector: @escaping (Element) -> SharedSequence<Sharing, R>)
         -> SharedSequence<Sharing, R> {
         let source: Observable<R> = self
             .asObservable()
@@ -93,7 +93,7 @@ extension SharedSequenceConvertibleType {
      - parameter selector: A transform function to apply to element that was observed while no observable is executing in parallel.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence that was received while no other sequence was being calculated.
      */
-    public func flatMapFirst<Sharing, R>(_ selector: @escaping (E) -> SharedSequence<Sharing, R>)
+    public func flatMapFirst<Sharing, R>(_ selector: @escaping (Element) -> SharedSequence<Sharing, R>)
         -> SharedSequence<Sharing, R> {
         let source: Observable<R> = self
             .asObservable()
@@ -116,8 +116,8 @@ extension SharedSequenceConvertibleType {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onNext: ((E) -> Void)? = nil, afterNext: ((E) -> Void)? = nil, onCompleted: (() -> Void)? = nil, afterCompleted: (() -> Void)? = nil, onSubscribe: (() -> Void)? = nil, onSubscribed: (() -> Void)? = nil, onDispose: (() -> Void)? = nil)
-        -> SharedSequence<SharingStrategy, E> {
+    public func `do`(onNext: ((Element) -> Void)? = nil, afterNext: ((Element) -> Void)? = nil, onCompleted: (() -> Void)? = nil, afterCompleted: (() -> Void)? = nil, onSubscribe: (() -> Void)? = nil, onSubscribed: (() -> Void)? = nil, onDispose: (() -> Void)? = nil)
+        -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .do(onNext: onNext, afterNext: afterNext, onCompleted: onCompleted, afterCompleted: afterCompleted, onSubscribe: onSubscribe, onSubscribed: onSubscribed, onDispose: onDispose)
 
@@ -134,7 +134,7 @@ extension SharedSequenceConvertibleType {
     - parameter identifier: Identifier that is printed together with event description to standard output.
     - returns: An observable sequence whose events are printed to standard output.
     */
-    public func debug(_ identifier: String? = nil, trimOutput: Bool = false, file: String = #file, line: UInt = #line, function: String = #function) -> SharedSequence<SharingStrategy, E> {
+    public func debug(_ identifier: String? = nil, trimOutput: Bool = false, file: String = #file, line: UInt = #line, function: String = #function) -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .debug(identifier, trimOutput: trimOutput, file: file, line: line, function: function)
         return SharedSequence(source)
@@ -142,7 +142,7 @@ extension SharedSequenceConvertibleType {
 }
 
 // MARK: distinctUntilChanged
-extension SharedSequenceConvertibleType where E: Equatable {
+extension SharedSequenceConvertibleType where Element: Equatable {
     
     /**
     Returns an observable sequence that contains only distinct contiguous elements according to equality operator.
@@ -150,7 +150,7 @@ extension SharedSequenceConvertibleType where E: Equatable {
     - returns: An observable sequence only containing the distinct contiguous elements, based on equality operator, from the source sequence.
     */
     public func distinctUntilChanged()
-        -> SharedSequence<SharingStrategy, E> {
+        -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .distinctUntilChanged({ $0 }, comparer: { ($0 == $1) })
             
@@ -166,7 +166,7 @@ extension SharedSequenceConvertibleType {
     - parameter keySelector: A function to compute the comparison key for each element.
     - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value, from the source sequence.
     */
-    public func distinctUntilChanged<K: Equatable>(_ keySelector: @escaping (E) -> K) -> SharedSequence<SharingStrategy, E> {
+    public func distinctUntilChanged<K: Equatable>(_ keySelector: @escaping (Element) -> K) -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .distinctUntilChanged(keySelector, comparer: { $0 == $1 })
         return SharedSequence(source)
@@ -178,10 +178,10 @@ extension SharedSequenceConvertibleType {
     - parameter comparer: Equality comparer for computed key values.
     - returns: An observable sequence only containing the distinct contiguous elements, based on `comparer`, from the source sequence.
     */
-    public func distinctUntilChanged(_ comparer: @escaping (E, E) -> Bool) -> SharedSequence<SharingStrategy, E> {
+    public func distinctUntilChanged(_ comparer: @escaping (Element, Element) -> Bool) -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .distinctUntilChanged({ $0 }, comparer: comparer)
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
     
     /**
@@ -191,10 +191,10 @@ extension SharedSequenceConvertibleType {
     - parameter comparer: Equality comparer for computed key values.
     - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value and the comparer, from the source sequence.
     */
-    public func distinctUntilChanged<K>(_ keySelector: @escaping (E) -> K, comparer: @escaping (K, K) -> Bool) -> SharedSequence<SharingStrategy, E> {
+    public func distinctUntilChanged<K>(_ keySelector: @escaping (Element) -> K, comparer: @escaping (K, K) -> Bool) -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .distinctUntilChanged(keySelector, comparer: comparer)
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 }
 
@@ -208,7 +208,7 @@ extension SharedSequenceConvertibleType {
     - parameter selector: A transform function to apply to each element.
     - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
     */
-    public func flatMap<Sharing, R>(_ selector: @escaping (E) -> SharedSequence<Sharing, R>) -> SharedSequence<Sharing, R> {
+    public func flatMap<Sharing, R>(_ selector: @escaping (Element) -> SharedSequence<Sharing, R>) -> SharedSequence<Sharing, R> {
         let source = self.asObservable()
             .flatMap(selector)
         
@@ -226,10 +226,10 @@ extension SharedSequenceConvertibleType {
      - parameter sources: Collection of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge<C: Collection>(_ sources: C) -> SharedSequence<SharingStrategy, E>
-        where C.Iterator.Element == SharedSequence<SharingStrategy, E> {
+    public static func merge<C: Collection>(_ sources: C) -> SharedSequence<SharingStrategy, Element>
+        where C.Iterator.Element == SharedSequence<SharingStrategy, Element> {
         let source = Observable.merge(sources.map { $0.asObservable() })
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 
     /**
@@ -240,9 +240,9 @@ extension SharedSequenceConvertibleType {
      - parameter sources: Array of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge(_ sources: [SharedSequence<SharingStrategy, E>]) -> SharedSequence<SharingStrategy, E> {
+    public static func merge(_ sources: [SharedSequence<SharingStrategy, Element>]) -> SharedSequence<SharingStrategy, Element> {
         let source = Observable.merge(sources.map { $0.asObservable() })
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
 
     /**
@@ -253,25 +253,25 @@ extension SharedSequenceConvertibleType {
      - parameter sources: Collection of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge(_ sources: SharedSequence<SharingStrategy, E>...) -> SharedSequence<SharingStrategy, E> {
+    public static func merge(_ sources: SharedSequence<SharingStrategy, Element>...) -> SharedSequence<SharingStrategy, Element> {
         let source = Observable.merge(sources.map { $0.asObservable() })
-        return SharedSequence<SharingStrategy, E>(source)
+        return SharedSequence<SharingStrategy, Element>(source)
     }
     
 }
 
 // MARK: merge
-extension SharedSequenceConvertibleType where E : SharedSequenceConvertibleType {
+extension SharedSequenceConvertibleType where Element : SharedSequenceConvertibleType {
     /**
     Merges elements from all observable sequences in the given enumerable sequence into a single observable sequence.
     
     - returns: The observable sequence that merges the elements of the observable sequences.
     */
-    public func merge() -> SharedSequence<E.SharingStrategy, E.E> {
+    public func merge() -> SharedSequence<Element.SharingStrategy, Element.Element> {
         let source = self.asObservable()
             .map { $0.asSharedSequence() }
             .merge()
-        return SharedSequence<E.SharingStrategy, E.E>(source)
+        return SharedSequence<Element.SharingStrategy, Element.Element>(source)
     }
     
     /**
@@ -281,11 +281,11 @@ extension SharedSequenceConvertibleType where E : SharedSequenceConvertibleType 
     - returns: The observable sequence that merges the elements of the inner sequences.
     */
     public func merge(maxConcurrent: Int)
-        -> SharedSequence<E.SharingStrategy, E.E> {
+        -> SharedSequence<Element.SharingStrategy, Element.Element> {
         let source = self.asObservable()
             .map { $0.asSharedSequence() }
             .merge(maxConcurrent: maxConcurrent)
-        return SharedSequence<E.SharingStrategy, E.E>(source)
+        return SharedSequence<Element.SharingStrategy, Element.Element>(source)
     }
 }
 
@@ -304,7 +304,7 @@ extension SharedSequenceConvertibleType {
      - returns: The throttled sequence.
     */
     public func throttle(_ dueTime: RxTimeInterval, latest: Bool = true)
-        -> SharedSequence<SharingStrategy, E> {
+        -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .throttle(dueTime, latest: latest, scheduler: SharingStrategy.scheduler)
 
@@ -318,7 +318,7 @@ extension SharedSequenceConvertibleType {
     - returns: The throttled sequence.
     */
     public func debounce(_ dueTime: RxTimeInterval)
-        -> SharedSequence<SharingStrategy, E> {
+        -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .debounce(dueTime, scheduler: SharingStrategy.scheduler)
 
@@ -337,7 +337,7 @@ extension SharedSequenceConvertibleType {
     - parameter accumulator: An accumulator function to be invoked on each element.
     - returns: An observable sequence containing the accumulated values.
     */
-    public func scan<A>(_ seed: A, accumulator: @escaping (A, E) -> A)
+    public func scan<A>(_ seed: A, accumulator: @escaping (A, Element) -> A)
         -> SharedSequence<SharingStrategy, A> {
         let source = self.asObservable()
             .scan(seed, accumulator: accumulator)
@@ -435,7 +435,7 @@ extension SharedSequenceConvertibleType {
     - parameter resultSelector: Function to invoke for each element from the self combined with the latest element from the second source, if any.
     - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
     */
-    public func withLatestFrom<SecondO: SharedSequenceConvertibleType, ResultType>(_ second: SecondO, resultSelector: @escaping (E, SecondO.E) -> ResultType) -> SharedSequence<SharingStrategy, ResultType> where SecondO.SharingStrategy == SharingStrategy {
+    public func withLatestFrom<SecondO: SharedSequenceConvertibleType, ResultType>(_ second: SecondO, resultSelector: @escaping (Element, SecondO.Element) -> ResultType) -> SharedSequence<SharingStrategy, ResultType> where SecondO.SharingStrategy == SharingStrategy {
         let source = self.asObservable()
             .withLatestFrom(second.asSharedSequence(), resultSelector: resultSelector)
 
@@ -448,11 +448,11 @@ extension SharedSequenceConvertibleType {
     - parameter second: Second observable source.
     - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
     */
-    public func withLatestFrom<SecondO: SharedSequenceConvertibleType>(_ second: SecondO) -> SharedSequence<SharingStrategy, SecondO.E> {
+    public func withLatestFrom<SecondO: SharedSequenceConvertibleType>(_ second: SecondO) -> SharedSequence<SharingStrategy, SecondO.Element> {
         let source = self.asObservable()
             .withLatestFrom(second.asSharedSequence())
 
-        return SharedSequence<SharingStrategy, SecondO.E>(source)
+        return SharedSequence<SharingStrategy, SecondO.Element>(source)
     }
 }
 
@@ -468,7 +468,7 @@ extension SharedSequenceConvertibleType {
      - returns: An observable sequence that contains the elements that occur after the specified index in the input sequence.
      */
     public func skip(_ count: Int)
-        -> SharedSequence<SharingStrategy, E> {
+        -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .skip(count)
         return SharedSequence(source)
@@ -486,8 +486,8 @@ extension SharedSequenceConvertibleType {
     - parameter element: Element to prepend to the specified sequence.
     - returns: The source sequence prepended with the specified values.
     */
-    public func startWith(_ element: E)
-        -> SharedSequence<SharingStrategy, E> {
+    public func startWith(_ element: Element)
+        -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
                 .startWith(element)
 
@@ -508,7 +508,7 @@ extension SharedSequenceConvertibleType {
      - returns: the source Observable shifted in time by the specified delay.
      */
     public func delay(_ dueTime: RxTimeInterval)
-        -> SharedSequence<SharingStrategy, E> {
+        -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .delay(dueTime, scheduler: SharingStrategy.scheduler)
 

--- a/RxCocoa/Traits/SharedSequence/SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence.swift
@@ -20,7 +20,6 @@ import RxSwift
     To find out more about units and how to use them, please visit `Documentation/Traits.md`.
 */
 public struct SharedSequence<S: SharingStrategyProtocol, Element> : SharedSequenceConvertibleType {
-    public typealias Element = Element
     public typealias SharingStrategy = S
 
     let _source: Observable<Element>

--- a/RxCocoa/Traits/SharedSequence/SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence.swift
@@ -20,42 +20,42 @@ import RxSwift
     To find out more about units and how to use them, please visit `Documentation/Traits.md`.
 */
 public struct SharedSequence<S: SharingStrategyProtocol, Element> : SharedSequenceConvertibleType {
-    public typealias E = Element
+    public typealias Element = Element
     public typealias SharingStrategy = S
 
-    let _source: Observable<E>
+    let _source: Observable<Element>
 
-    init(_ source: Observable<E>) {
+    init(_ source: Observable<Element>) {
         self._source = S.share(source)
     }
 
-    init(raw: Observable<E>) {
+    init(raw: Observable<Element>) {
         self._source = raw
     }
 
-    #if EXPANDABLE_SHARED_SEQUENCE
+    #if EXPANDABLE_SHARED_SEQUENC
     /**
      This method is extension hook in case this unit needs to extended from outside the library.
      
      By defining `EXPANDABLE_SHARED_SEQUENCE` one agrees that it's up to him to ensure shared sequence
      properties are preserved after extension.
     */
-    public static func createUnsafe<O: ObservableType>(source: O) -> SharedSequence<S, O.E> {
-        return SharedSequence<S, O.E>(raw: source.asObservable())
+    public static func createUnsafe<O: ObservableType>(source: O) -> SharedSequence<S, O.Element> {
+        return SharedSequence<S, O.Element>(raw: source.asObservable())
     }
     #endif
 
     /**
     - returns: Built observable sequence.
     */
-    public func asObservable() -> Observable<E> {
+    public func asObservable() -> Observable<Element> {
         return self._source
     }
 
     /**
     - returns: `self`
     */
-    public func asSharedSequence() -> SharedSequence<SharingStrategy, E> {
+    public func asSharedSequence() -> SharedSequence<SharingStrategy, Element> {
         return self
     }
 }
@@ -76,7 +76,7 @@ public protocol SharingStrategyProtocol {
      as sequence event sharing strategies, but also do something more exotic, like
      implementing promises or lazy loading chains.
     */
-    static func share<E>(_ source: Observable<E>) -> Observable<E>
+    static func share<Element>(_ source: Observable<Element>) -> Observable<Element>
 }
 
 /**
@@ -88,11 +88,11 @@ public protocol SharedSequenceConvertibleType : ObservableConvertibleType {
     /**
     Converts self to `SharedSequence`.
     */
-    func asSharedSequence() -> SharedSequence<SharingStrategy, E>
+    func asSharedSequence() -> SharedSequence<SharingStrategy, Element>
 }
 
 extension SharedSequenceConvertibleType {
-    public func asObservable() -> Observable<E> {
+    public func asObservable() -> Observable<Element> {
         return self.asSharedSequence().asObservable()
     }
 }
@@ -105,7 +105,7 @@ extension SharedSequence {
 
     - returns: An observable sequence with no elements.
     */
-    public static func empty() -> SharedSequence<S, E> {
+    public static func empty() -> SharedSequence<S, Element> {
         return SharedSequence(raw: Observable.empty().subscribeOn(S.scheduler))
     }
 
@@ -114,7 +114,7 @@ extension SharedSequence {
 
     - returns: An observable sequence whose observers will never get called.
     */
-    public static func never() -> SharedSequence<S, E> {
+    public static func never() -> SharedSequence<S, Element> {
         return SharedSequence(raw: Observable.never())
     }
 
@@ -124,7 +124,7 @@ extension SharedSequence {
     - parameter element: Single element in the resulting observable sequence.
     - returns: An observable sequence containing the single specified element.
     */
-    public static func just(_ element: E) -> SharedSequence<S, E> {
+    public static func just(_ element: Element) -> SharedSequence<S, Element> {
         return SharedSequence(raw: Observable.just(element).subscribeOn(S.scheduler))
     }
 
@@ -134,8 +134,8 @@ extension SharedSequence {
      - parameter observableFactory: Observable factory function to invoke for each observer that subscribes to the resulting sequence.
      - returns: An observable sequence whose observers trigger an invocation of the given observable factory function.
      */
-    public static func deferred(_ observableFactory: @escaping () -> SharedSequence<S, E>)
-        -> SharedSequence<S, E> {
+    public static func deferred(_ observableFactory: @escaping () -> SharedSequence<S, Element>)
+        -> SharedSequence<S, Element> {
         return SharedSequence(Observable.deferred { observableFactory().asObservable() })
     }
 
@@ -147,7 +147,7 @@ extension SharedSequence {
     - parameter elements: Elements to generate.
     - returns: The observable sequence whose elements are pulled from the given arguments.
     */
-    public static func of(_ elements: E ...) -> SharedSequence<S, E> {
+    public static func of(_ elements: Element ...) -> SharedSequence<S, Element> {
         let source = Observable.from(elements, scheduler: S.scheduler)
         return SharedSequence(raw: source)
     }
@@ -162,7 +162,7 @@ extension SharedSequence {
      
     - returns: The observable sequence whose elements are pulled from the given enumerable sequence.
      */
-    public static func from(_ array: [E]) -> SharedSequence<S, E> {
+    public static func from(_ array: [Element]) -> SharedSequence<S, Element> {
         let source = Observable.from(array, scheduler: S.scheduler)
         return SharedSequence(raw: source)
     }
@@ -174,7 +174,7 @@ extension SharedSequence {
      
      - returns: The observable sequence whose elements are pulled from the given enumerable sequence.
     */
-    public static func from<S: Sequence>(_ sequence: S) -> SharedSequence<SharingStrategy, E> where S.Iterator.Element == E {
+    public static func from<S: Sequence>(_ sequence: S) -> SharedSequence<SharingStrategy, Element> where S.Iterator.Element == Element {
         let source = Observable.from(sequence, scheduler: SharingStrategy.scheduler)
         return SharedSequence(raw: source)
     }
@@ -188,7 +188,7 @@ extension SharedSequence {
      
      - returns: An observable sequence containing the wrapped value or not from given optional.
      */
-    public static func from(optional: E?) -> SharedSequence<S, E> {
+    public static func from(optional: Element?) -> SharedSequence<S, Element> {
         let source = Observable.from(optional: optional, scheduler: S.scheduler)
         return SharedSequence(raw: source)
     }
@@ -204,7 +204,7 @@ extension SharedSequence where Element : RxAbstractInteger {
      - returns: An observable sequence that produces a value after each period.
      */
     public static func interval(_ period: RxTimeInterval)
-        -> SharedSequence<S, E> {
+        -> SharedSequence<S, Element> {
         return SharedSequence(Observable.interval(period, scheduler: S.scheduler))
     }
 }
@@ -222,7 +222,7 @@ extension SharedSequence where Element: RxAbstractInteger {
      - returns: An observable sequence that produces a value after due time has elapsed and then each period.
      */
     public static func timer(_ dueTime: RxTimeInterval, period: RxTimeInterval)
-        -> SharedSequence<S, E> {
+        -> SharedSequence<S, Element> {
         return SharedSequence(Observable.timer(dueTime, period: period, scheduler: S.scheduler))
     }
 }

--- a/RxCocoa/Traits/Signal/ControlEvent+Signal.swift
+++ b/RxCocoa/Traits/Signal/ControlEvent+Signal.swift
@@ -12,8 +12,8 @@ extension ControlEvent {
     /// Converts `ControlEvent` to `Signal` trait.
     ///
     /// `ControlEvent` already can't fail, so no special case needs to be handled.
-    public func asSignal() -> Signal<E> {
-        return self.asSignal { _ -> Signal<E> in
+    public func asSignal() -> Signal<Element> {
+        return self.asSignal { _ -> Signal<Element> in
             #if DEBUG
                 rxFatalError("Somehow signal received error from a source that shouldn't fail.")
             #else

--- a/RxCocoa/Traits/Signal/ObservableConvertibleType+Signal.swift
+++ b/RxCocoa/Traits/Signal/ObservableConvertibleType+Signal.swift
@@ -15,7 +15,7 @@ extension ObservableConvertibleType {
      - parameter onErrorJustReturn: Element to return in case of error and after that complete the sequence.
      - returns: Signal trait.
      */
-    public func asSignal(onErrorJustReturn: E) -> Signal<E> {
+    public func asSignal(onErrorJustReturn: Element) -> Signal<Element> {
         let source = self
             .asObservable()
             .observeOn(SignalSharingStrategy.scheduler)
@@ -29,7 +29,7 @@ extension ObservableConvertibleType {
      - parameter onErrorDriveWith: Driver that continues to drive the sequence in case of error.
      - returns: Signal trait.
      */
-    public func asSignal(onErrorSignalWith: Signal<E>) -> Signal<E> {
+    public func asSignal(onErrorSignalWith: Signal<Element>) -> Signal<Element> {
         let source = self
             .asObservable()
             .observeOn(SignalSharingStrategy.scheduler)
@@ -45,7 +45,7 @@ extension ObservableConvertibleType {
      - parameter onErrorRecover: Calculates driver that continues to drive the sequence in case of error.
      - returns: Signal trait.
      */
-    public func asSignal(onErrorRecover: @escaping (_ error: Swift.Error) -> Signal<E>) -> Signal<E> {
+    public func asSignal(onErrorRecover: @escaping (_ error: Swift.Error) -> Signal<Element>) -> Signal<Element> {
         let source = self
             .asObservable()
             .observeOn(SignalSharingStrategy.scheduler)

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -18,7 +18,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - parameter to: Observer that receives events.
      - returns: Disposable object that can be used to unsubscribe the observer from the subject.
      */
-    public func emit<O: ObserverType>(to observer: O) -> Disposable where O.E == E {
+    public func emit<O: ObserverType>(to observer: O) -> Disposable where O.Element == Element {
         return self.asSharedSequence().asObservable().subscribe(observer)
     }
 
@@ -30,8 +30,8 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - parameter to: Observer that receives events.
      - returns: Disposable object that can be used to unsubscribe the observer from the subject.
      */
-    public func emit<O: ObserverType>(to observer: O) -> Disposable where O.E == E? {
-        return self.asSharedSequence().asObservable().map { $0 as E? }.subscribe(observer)
+    public func emit<O: ObserverType>(to observer: O) -> Disposable where O.Element == Element? {
+        return self.asSharedSequence().asObservable().map { $0 as Element? }.subscribe(observer)
     }
 
     /**
@@ -39,7 +39,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - parameter relay: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
-    public func emit(to relay: BehaviorRelay<E>) -> Disposable {
+    public func emit(to relay: BehaviorRelay<Element>) -> Disposable {
         return self.emit(onNext: { e in
             relay.accept(e)
         })
@@ -50,7 +50,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - parameter relay: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
-    public func emit(to relay: BehaviorRelay<E?>) -> Disposable {
+    public func emit(to relay: BehaviorRelay<Element?>) -> Disposable {
         return self.emit(onNext: { e in
             relay.accept(e)
         })
@@ -62,7 +62,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - parameter relay: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
-    public func emit(to relay: PublishRelay<E>) -> Disposable {
+    public func emit(to relay: PublishRelay<Element>) -> Disposable {
         return self.emit(onNext: { e in
             relay.accept(e)
         })
@@ -74,7 +74,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - parameter to: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
-    public func emit(to relay: PublishRelay<E?>) -> Disposable {
+    public func emit(to relay: PublishRelay<Element?>) -> Disposable {
         return self.emit(onNext: { e in
             relay.accept(e)
         })
@@ -92,7 +92,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      gracefully completed, errored, or if the generation is canceled by disposing subscription)
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func emit(onNext: ((E) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil) -> Disposable {
+    public func emit(onNext: ((Element) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil) -> Disposable {
         return self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
     }
 }

--- a/RxCocoa/Traits/Signal/Signal.swift
+++ b/RxCocoa/Traits/Signal/Signal.swift
@@ -27,19 +27,19 @@ import RxSwift
  
  To find out more about units and how to use them, please visit `Documentation/Traits.md`.
  */
-public typealias Signal<E> = SharedSequence<SignalSharingStrategy, E>
+public typealias Signal<Element> = SharedSequence<SignalSharingStrategy, Element>
 
 public struct SignalSharingStrategy : SharingStrategyProtocol {
     public static var scheduler: SchedulerType { return SharingScheduler.make() }
     
-    public static func share<E>(_ source: Observable<E>) -> Observable<E> {
+    public static func share<Element>(_ source: Observable<Element>) -> Observable<Element> {
         return source.share(scope: .whileConnected)
     }
 }
 
 extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingStrategy {
     /// Adds `asPublisher` to `SharingSequence` with `PublishSharingStrategy`.
-    public func asSignal() -> Signal<E> {
+    public func asSignal() -> Signal<Element> {
         return self.asSharedSequence()
     }
 }

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -42,7 +42,7 @@ extension Reactive where Base: UICollectionView {
     public func items<S: Sequence, O: ObservableType>
         (_ source: O)
         -> (_ cellFactory: @escaping (UICollectionView, Int, S.Iterator.Element) -> UICollectionViewCell)
-        -> Disposable where O.E == S {
+        -> Disposable where O.Element == S {
         return { cellFactory in
             let dataSource = RxCollectionViewReactiveArrayDataSourceSequenceWrapper<S>(cellFactory: cellFactory)
             return self.items(dataSource: dataSource)(source)
@@ -77,7 +77,7 @@ extension Reactive where Base: UICollectionView {
         (cellIdentifier: String, cellType: Cell.Type = Cell.self)
         -> (_ source: O)
         -> (_ configureCell: @escaping (Int, S.Iterator.Element, Cell) -> Void)
-        -> Disposable where O.E == S {
+        -> Disposable where O.Element == S {
         return { source in
             return { configureCell in
                 let dataSource = RxCollectionViewReactiveArrayDataSourceSequenceWrapper<S> { cv, i, item in
@@ -137,7 +137,7 @@ extension Reactive where Base: UICollectionView {
             O: ObservableType>
         (dataSource: DataSource)
         -> (_ source: O)
-        -> Disposable where DataSource.Element == O.E
+        -> Disposable where DataSource.Element == O.Element
           {
         return { source in
             // This is called for sideeffects only, and to make sure delegate proxy is in place when

--- a/RxCocoa/iOS/UIPickerView+Rx.swift
+++ b/RxCocoa/iOS/UIPickerView+Rx.swift
@@ -107,7 +107,7 @@
         public func itemTitles<S: Sequence, O: ObservableType>
             (_ source: O)
             -> (_ titleForRow: @escaping (Int, S.Iterator.Element) -> String?)
-            -> Disposable where O.E == S  {
+            -> Disposable where O.Element == S  {
                 return { titleForRow in
                     let adapter = RxStringPickerViewAdapter<S>(titleForRow: titleForRow)
                     return self.items(adapter: adapter)(source)
@@ -140,7 +140,7 @@
         public func itemAttributedTitles<S: Sequence, O: ObservableType>
             (_ source: O)
             -> (_ attributedTitleForRow: @escaping (Int, S.Iterator.Element) -> NSAttributedString?)
-            -> Disposable where O.E == S  {
+            -> Disposable where O.Element == S  {
                 return { attributedTitleForRow in
                     let adapter = RxAttributedStringPickerViewAdapter<S>(attributedTitleForRow: attributedTitleForRow)
                     return self.items(adapter: adapter)(source)
@@ -179,7 +179,7 @@
         public func items<S: Sequence, O: ObservableType>
             (_ source: O)
             -> (_ viewForRow: @escaping (Int, S.Iterator.Element, UIView?) -> UIView)
-            -> Disposable where O.E == S  {
+            -> Disposable where O.Element == S  {
                 return { viewForRow in
                     let adapter = RxPickerViewAdapter<S>(viewForRow: viewForRow)
                     return self.items(adapter: adapter)(source)
@@ -200,7 +200,7 @@
         public func items<O: ObservableType,
                           Adapter: RxPickerViewDataSourceType & UIPickerViewDataSource & UIPickerViewDelegate>(adapter: Adapter)
             -> (_ source: O)
-            -> Disposable where O.E == Adapter.Element {
+            -> Disposable where O.Element == Adapter.Element {
                 return { source in
                     let delegateSubscription = self.setDelegate(adapter)
                     let dataSourceSubscription = source.subscribeProxyDataSource(ofObject: self.base, dataSource: adapter, retainDataSource: true, binding: { [weak pickerView = self.base] (_: RxPickerViewDataSourceProxy, event) in

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -43,7 +43,7 @@ extension Reactive where Base: UITableView {
         (_ source: O)
         -> (_ cellFactory: @escaping (UITableView, Int, S.Iterator.Element) -> UITableViewCell)
         -> Disposable
-        where O.E == S {
+        where O.Element == S {
             return { cellFactory in
                 let dataSource = RxTableViewReactiveArrayDataSourceSequenceWrapper<S>(cellFactory: cellFactory)
                 return self.items(dataSource: dataSource)(source)
@@ -78,7 +78,7 @@ extension Reactive where Base: UITableView {
         -> (_ source: O)
         -> (_ configureCell: @escaping (Int, S.Iterator.Element, Cell) -> Void)
         -> Disposable
-        where O.E == S {
+        where O.Element == S {
         return { source in
             return { configureCell in
                 let dataSource = RxTableViewReactiveArrayDataSourceSequenceWrapper<S> { tv, i, item in
@@ -110,7 +110,7 @@ extension Reactive where Base: UITableView {
         (dataSource: DataSource)
         -> (_ source: O)
         -> Disposable
-        where DataSource.Element == O.E {
+        where DataSource.Element == O.Element {
         return { source in
             // This is called for sideeffects only, and to make sure delegate proxy is in place when
             // data source is being bound.

--- a/RxExample/RxExample/Feedbacks.swift
+++ b/RxExample/RxExample/Feedbacks.swift
@@ -222,9 +222,9 @@ public func react<State, Query, Event>(
 
 extension ObservableType {
     // This is important to avoid reentrancy issues. Completed event is only used for cleanup
-    fileprivate func takeUntilWithCompletedAsync<O>(_ other: Observable<O>, scheduler: ImmediateSchedulerType) -> Observable<E> {
+    fileprivate func takeUntilWithCompletedAsync<O>(_ other: Observable<O>, scheduler: ImmediateSchedulerType) -> Observable<Element> {
         // this little piggy will delay completed event
-        let completeAsSoonAsPossible = Observable<E>.empty().observeOn(scheduler)
+        let completeAsSoonAsPossible = Observable<Element>.empty().observeOn(scheduler)
         return other
             .take(1)
             .map { _ in completeAsSoonAsPossible }

--- a/RxExample/RxExample/Observable+Extensions.swift
+++ b/RxExample/RxExample/Observable+Extensions.swift
@@ -11,7 +11,7 @@ import RxCocoa
 
 // taken from RxFeedback repo
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /// Feedback loop
     public typealias Feedback<State, Event> = (ObservableSchedulerContext<State>) -> Observable<Event>
     public typealias FeedbackLoop = Feedback
@@ -68,7 +68,7 @@ extension ObservableType where E == Any {
     }
 }
 
-extension SharedSequenceConvertibleType where E == Any, SharingStrategy == DriverSharingStrategy {
+extension SharedSequenceConvertibleType where Element == Any, SharingStrategy == DriverSharingStrategy {
     /// Feedback loop
     public typealias Feedback<State, Event> = (Driver<State>) -> Signal<Event>
 
@@ -126,7 +126,7 @@ extension ImmediateSchedulerType {
 /// Tuple of observable sequence and corresponding scheduler context on which that observable
 /// sequence receives elements.
 public struct ObservableSchedulerContext<Element>: ObservableType {
-    public typealias E = Element
+    public typealias Element = Element
 
     /// Source observable sequence
     public let source: Observable<Element>
@@ -143,7 +143,7 @@ public struct ObservableSchedulerContext<Element>: ObservableType {
         self.scheduler = scheduler
     }
 
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
         return self.source.subscribe(observer)
     }
 }

--- a/RxExample/RxExample/Services/ActivityIndicator.swift
+++ b/RxExample/RxExample/Services/ActivityIndicator.swift
@@ -34,7 +34,7 @@ If there is at least one sequence computation in progress, `true` will be sent.
 When all activities complete `false` will be sent.
 */
 public class ActivityIndicator : SharedSequenceConvertibleType {
-    public typealias E = Bool
+    public typealias Element = Bool
     public typealias SharingStrategy = DriverSharingStrategy
 
     private let _lock = NSRecursiveLock()
@@ -47,8 +47,8 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
             .distinctUntilChanged()
     }
 
-    fileprivate func trackActivityOfObservable<O: ObservableConvertibleType>(_ source: O) -> Observable<O.E> {
-        return Observable.using({ () -> ActivityToken<O.E> in
+    fileprivate func trackActivityOfObservable<O: ObservableConvertibleType>(_ source: O) -> Observable<O.Element> {
+        return Observable.using({ () -> ActivityToken<O.Element> in
             self.increment()
             return ActivityToken(source: source.asObservable(), disposeAction: self.decrement)
         }) { t in
@@ -68,13 +68,13 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
         _lock.unlock()
     }
 
-    public func asSharedSequence() -> SharedSequence<SharingStrategy, E> {
+    public func asSharedSequence() -> SharedSequence<SharingStrategy, Element> {
         return _loading
     }
 }
 
 extension ObservableConvertibleType {
-    public func trackActivity(_ activityIndicator: ActivityIndicator) -> Observable<E> {
+    public func trackActivity(_ activityIndicator: ActivityIndicator) -> Observable<Element> {
         return activityIndicator.trackActivityOfObservable(self)
     }
 }

--- a/RxExample/RxExample/Services/ReachabilityService.swift
+++ b/RxExample/RxExample/Services/ReachabilityService.swift
@@ -75,9 +75,9 @@ class DefaultReachabilityService
 }
 
 extension ObservableConvertibleType {
-    func retryOnBecomesReachable(_ valueOnFailure:E, reachabilityService: ReachabilityService) -> Observable<E> {
+    func retryOnBecomesReachable(_ valueOnFailure:Element, reachabilityService: ReachabilityService) -> Observable<Element> {
         return self.asObservable()
-            .catchError { (e) -> Observable<E> in
+            .catchError { (e) -> Observable<Element> in
                 reachabilityService.reachability
                     .skip(1)
                     .filter { $0.reachable }

--- a/RxRelay/BehaviorRelay.swift
+++ b/RxRelay/BehaviorRelay.swift
@@ -12,8 +12,6 @@ import RxSwift
 ///
 /// Unlike `BehaviorSubject` it can't terminate with error or completed.
 public final class BehaviorRelay<Element>: ObservableType {
-    public typealias Element = Element
-
     private let _subject: BehaviorSubject<Element>
 
     /// Accepts `event` and emits it to subscribers

--- a/RxRelay/BehaviorRelay.swift
+++ b/RxRelay/BehaviorRelay.swift
@@ -12,7 +12,7 @@ import RxSwift
 ///
 /// Unlike `BehaviorSubject` it can't terminate with error or completed.
 public final class BehaviorRelay<Element>: ObservableType {
-    public typealias E = Element
+    public typealias Element = Element
 
     private let _subject: BehaviorSubject<Element>
 
@@ -33,7 +33,7 @@ public final class BehaviorRelay<Element>: ObservableType {
     }
 
     /// Subscribes observer
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         return self._subject.subscribe(observer)
     }
 

--- a/RxRelay/Observable+Bind.swift
+++ b/RxRelay/Observable+Bind.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter to: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: PublishRelay<E>...) -> Disposable {
+    public func bind(to relays: PublishRelay<Element>...) -> Disposable {
         return bind(to: relays)
     }
 
@@ -29,8 +29,8 @@ extension ObservableType {
      - parameter to: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: PublishRelay<E?>...) -> Disposable {
-        return self.map { $0 as E? }.bind(to: relays)
+    public func bind(to relays: PublishRelay<Element?>...) -> Disposable {
+        return self.map { $0 as Element? }.bind(to: relays)
     }
 
     /**
@@ -40,7 +40,7 @@ extension ObservableType {
      - parameter to: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    private func bind(to relays: [PublishRelay<E>]) -> Disposable {
+    private func bind(to relays: [PublishRelay<Element>]) -> Disposable {
         return subscribe { e in
             switch e {
             case let .next(element):
@@ -62,7 +62,7 @@ extension ObservableType {
      - parameter to: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: BehaviorRelay<E>...) -> Disposable {
+    public func bind(to relays: BehaviorRelay<Element>...) -> Disposable {
         return self.bind(to: relays)
     }
 
@@ -75,8 +75,8 @@ extension ObservableType {
      - parameter to: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: BehaviorRelay<E?>...) -> Disposable {
-        return self.map { $0 as E? }.bind(to: relays)
+    public func bind(to relays: BehaviorRelay<Element?>...) -> Disposable {
+        return self.map { $0 as Element? }.bind(to: relays)
     }
 
     /**
@@ -86,7 +86,7 @@ extension ObservableType {
      - parameter to: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    private func bind(to relays: [BehaviorRelay<E>]) -> Disposable {
+    private func bind(to relays: [BehaviorRelay<Element>]) -> Disposable {
         return subscribe { e in
             switch e {
             case let .next(element):

--- a/RxRelay/PublishRelay.swift
+++ b/RxRelay/PublishRelay.swift
@@ -12,8 +12,6 @@ import RxSwift
 ///
 /// Unlike `PublishSubject` it can't terminate with error or completed.
 public final class PublishRelay<Element>: ObservableType {
-    public typealias Element = Element
-
     private let _subject: PublishSubject<Element>
     
     // Accepts `event` and emits it to subscribers

--- a/RxRelay/PublishRelay.swift
+++ b/RxRelay/PublishRelay.swift
@@ -12,7 +12,7 @@ import RxSwift
 ///
 /// Unlike `PublishSubject` it can't terminate with error or completed.
 public final class PublishRelay<Element>: ObservableType {
-    public typealias E = Element
+    public typealias Element = Element
 
     private let _subject: PublishSubject<Element>
     
@@ -27,7 +27,7 @@ public final class PublishRelay<Element>: ObservableType {
     }
 
     /// Subscribes observer
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         return self._subject.subscribe(observer)
     }
     

--- a/RxSwift/AnyObserver.swift
+++ b/RxSwift/AnyObserver.swift
@@ -11,7 +11,7 @@
 /// Forwards operations to an arbitrary underlying observer with the same `Element` type, hiding the specifics of the underlying observer type.
 public struct AnyObserver<Element> : ObserverType {
     /// The type of elements in sequence that observer can observe.
-    public typealias E = Element
+    public typealias Element = Element
     
     /// Anonymous event handler type.
     public typealias EventHandler = (Event<Element>) -> Void
@@ -28,7 +28,7 @@ public struct AnyObserver<Element> : ObserverType {
     /// Construct an instance whose `on(event)` calls `observer.on(event)`
     ///
     /// - parameter observer: Observer that receives sequence events.
-    public init<O : ObserverType>(_ observer: O) where O.E == Element {
+    public init<O : ObserverType>(_ observer: O) where O.Element == Element {
         self.observer = observer.on
     }
     
@@ -42,7 +42,7 @@ public struct AnyObserver<Element> : ObserverType {
     /// Erases type of observer and returns canonical observer.
     ///
     /// - returns: type erased observer.
-    public func asObserver() -> AnyObserver<E> {
+    public func asObserver() -> AnyObserver<Element> {
         return self
     }
 }
@@ -56,7 +56,7 @@ extension ObserverType {
     /// Erases type of observer and returns canonical observer.
     ///
     /// - returns: type erased observer.
-    public func asObserver() -> AnyObserver<E> {
+    public func asObserver() -> AnyObserver<Element> {
         return AnyObserver(self)
     }
 
@@ -64,7 +64,7 @@ extension ObserverType {
     /// Each event sent to result observer is transformed and sent to `self`.
     ///
     /// - returns: observer that transforms events.
-    public func mapObserver<R>(_ transform: @escaping (R) throws -> E) -> AnyObserver<R> {
+    public func mapObserver<R>(_ transform: @escaping (R) throws -> Element) -> AnyObserver<R> {
         return AnyObserver { e in
             self.on(e.map(transform))
         }

--- a/RxSwift/AnyObserver.swift
+++ b/RxSwift/AnyObserver.swift
@@ -10,9 +10,6 @@
 ///
 /// Forwards operations to an arbitrary underlying observer with the same `Element` type, hiding the specifics of the underlying observer type.
 public struct AnyObserver<Element> : ObserverType {
-    /// The type of elements in sequence that observer can observe.
-    public typealias Element = Element
-    
     /// Anonymous event handler type.
     public typealias EventHandler = (Event<Element>) -> Void
 

--- a/RxSwift/Concurrency/SynchronizedOnType.swift
+++ b/RxSwift/Concurrency/SynchronizedOnType.swift
@@ -7,11 +7,11 @@
 //
 
 protocol SynchronizedOnType : class, ObserverType, Lock {
-    func _synchronized_on(_ event: Event<E>)
+    func _synchronized_on(_ event: Event<Element>)
 }
 
 extension SynchronizedOnType {
-    func synchronizedOn(_ event: Event<E>) {
+    func synchronizedOn(_ event: Event<Element>) {
         self.lock(); defer { self.unlock() }
         self._synchronized_on(event)
     }

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -469,7 +469,7 @@ extension PrimitiveSequence {
     }
 }
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
 
     /**
      Invokes an action for each event in the observable sequence, and propagates all observer messages through the result sequence.
@@ -484,12 +484,12 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - returns: The source sequence with the side-effecting behavior applied.
      */
     @available(*, deprecated, renamed: "do(onSuccess:onError:onSubscribe:onSubscribed:onDispose:)")
-    public func `do`(onNext: ((ElementType) throws -> Void)?,
+    public func `do`(onNext: ((Element) throws -> Void)?,
                      onError: ((Swift.Error) throws -> Void)? = nil,
                      onSubscribe: (() -> Void)? = nil,
                      onSubscribed: (() -> Void)? = nil,
                      onDispose: (() -> Void)? = nil)
-        -> Single<ElementType> {
+        -> Single<Element> {
         return self.`do`(
             onSuccess: onNext,
             onError: onError,
@@ -520,7 +520,7 @@ extension ObservableType {
     }
 }
 
-extension PrimitiveSequenceType where ElementType: RxAbstractInteger
+extension PrimitiveSequenceType where Element: RxAbstractInteger
 {
     /**
      Returns an observable sequence that periodically produces a value after the specified initial relative due time has elapsed, using the specified scheduler to run timers.
@@ -533,7 +533,7 @@ extension PrimitiveSequenceType where ElementType: RxAbstractInteger
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "timer(_:scheduler:)")
     public static func timer(_ dueTime: Foundation.TimeInterval, scheduler: SchedulerType)
-        -> PrimitiveSequence<TraitType, ElementType>  {
+        -> PrimitiveSequence<Trait, Element>  {
         return timer(.milliseconds(Int(dueTime * 1000.0)), scheduler: scheduler)
     }
 }

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -171,9 +171,6 @@ extension ObservableType {
 /// Once plans are finalized, official availability attribute will be added in one of upcoming versions.
 @available(*, deprecated, message: "Variable is deprecated. Please use `BehaviorRelay` as a replacement.")
 public final class Variable<Element> {
-
-    public typealias Element = Element
-
     private let _subject: BehaviorSubject<Element>
 
     private var _lock = SpinLock()

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -18,7 +18,7 @@ extension Observable {
      - returns: An observable sequence containing the wrapped value or not from given optional.
      */
     @available(*, deprecated, message: "Implicit conversions from any type to optional type are allowed and that is causing issues with `from` operator overloading.", renamed: "from(optional:)")
-    public static func from(_ optional: E?) -> Observable<E> {
+    public static func from(_ optional: Element?) -> Observable<Element> {
         return Observable.from(optional: optional)
     }
 
@@ -32,7 +32,7 @@ extension Observable {
      - returns: An observable sequence containing the wrapped value or not from given optional.
      */
     @available(*, deprecated, message: "Implicit conversions from any type to optional type are allowed and that is causing issues with `from` operator overloading.", renamed: "from(optional:scheduler:)")
-    public static func from(_ optional: E?, scheduler: ImmediateSchedulerType) -> Observable<E> {
+    public static func from(_ optional: Element?, scheduler: ImmediateSchedulerType) -> Observable<Element> {
         return Observable.from(optional: optional, scheduler: scheduler)
     }
 }
@@ -48,7 +48,7 @@ extension ObservableType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
      */
     @available(*, deprecated, message: "Please use enumerated().map()")
-    public func mapWithIndex<R>(_ selector: @escaping (E, Int) throws -> R)
+    public func mapWithIndex<R>(_ selector: @escaping (Element, Int) throws -> R)
         -> Observable<R> {
         return self.enumerated().map { try selector($0.element, $0.index) }
     }
@@ -64,8 +64,8 @@ extension ObservableType {
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
     @available(*, deprecated, message: "Please use enumerated().flatMap()")
-    public func flatMapWithIndex<O: ObservableConvertibleType>(_ selector: @escaping (E, Int) throws -> O)
-        -> Observable<O.E> {
+    public func flatMapWithIndex<O: ObservableConvertibleType>(_ selector: @escaping (Element, Int) throws -> O)
+        -> Observable<O.Element> {
         return self.enumerated().flatMap { try selector($0.element, $0.index) }
     }
 
@@ -80,7 +80,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
      */
     @available(*, deprecated, message: "Please use enumerated().skipWhile().map()")
-    public func skipWhileWithIndex(_ predicate: @escaping (E, Int) throws -> Bool) -> Observable<E> {
+    public func skipWhileWithIndex(_ predicate: @escaping (Element, Int) throws -> Bool) -> Observable<Element> {
         return self.enumerated().skipWhile { try predicate($0.element, $0.index) }.map { $0.element }
     }
 
@@ -97,7 +97,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test no longer passes.
      */
     @available(*, deprecated, message: "Please use enumerated().takeWhile().map()")
-    public func takeWhileWithIndex(_ predicate: @escaping (E, Int) throws -> Bool) -> Observable<E> {
+    public func takeWhileWithIndex(_ predicate: @escaping (Element, Int) throws -> Bool) -> Observable<Element> {
         return self.enumerated().takeWhile { try predicate($0.element, $0.index) }.map { $0.element }
     }
 }
@@ -129,7 +129,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "use share(replay: 1) instead", renamed: "share(replay:)")
     public func shareReplayLatestWhileConnected()
-        -> Observable<E> {
+        -> Observable<Element> {
         return self.share(replay: 1, scope: .whileConnected)
     }
 }
@@ -149,7 +149,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Suggested replacement is `share(replay: 1)`. In case old 3.x behavior of `shareReplay` is required please use `share(replay: 1, scope: .forever)` instead.", renamed: "share(replay:)")
     public func shareReplay(_ bufferSize: Int)
-        -> Observable<E> {
+        -> Observable<Element> {
         return self.share(replay: bufferSize, scope: .forever)
     }
 }
@@ -172,14 +172,14 @@ extension ObservableType {
 @available(*, deprecated, message: "Variable is deprecated. Please use `BehaviorRelay` as a replacement.")
 public final class Variable<Element> {
 
-    public typealias E = Element
+    public typealias Element = Element
 
     private let _subject: BehaviorSubject<Element>
 
     private var _lock = SpinLock()
 
     // state
-    private var _value: E
+    private var _value: Element
 
     #if DEBUG
     fileprivate let _synchronizationTracker = SynchronizationTracker()
@@ -190,7 +190,7 @@ public final class Variable<Element> {
     /// Whenever a new value is set, all the observers are notified of the change.
     ///
     /// Even if the newly set value is same as the old value, observers are still notified for change.
-    public var value: E {
+    public var value: Element {
         get {
             self._lock.lock(); defer { self._lock.unlock() }
             return self._value
@@ -217,7 +217,7 @@ public final class Variable<Element> {
     }
 
     /// - returns: Canonical interface for push style sequence
-    public func asObservable() -> Observable<E> {
+    public func asObservable() -> Observable<Element> {
         return self._subject
     }
 
@@ -238,7 +238,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "delay(_:scheduler:)")
     public func delay(_ dueTime: Foundation.TimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return self.delay(.milliseconds(Int(dueTime * 1000.0)), scheduler: scheduler)
     }
 }
@@ -256,7 +256,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "timeout(_:scheduler:)")
     public func timeout(_ dueTime: Foundation.TimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return timeout(.milliseconds(Int(dueTime * 1000.0)), scheduler: scheduler)
     }
     
@@ -272,7 +272,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "timeout(_:other:scheduler:)")
     public func timeout<O: ObservableConvertibleType>(_ dueTime: Foundation.TimeInterval, other: O, scheduler: SchedulerType)
-        -> Observable<E> where E == O.E {
+        -> Observable<Element> where Element == O.Element {
         return timeout(.milliseconds(Int(dueTime * 1000.0)), other: other, scheduler: scheduler)
     }
 }
@@ -290,12 +290,12 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "skip(_:scheduler:)")
     public func skip(_ duration: Foundation.TimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return skip(.milliseconds(Int(duration * 1000.0)), scheduler: scheduler)
     }
 }
 
-extension ObservableType where E : RxAbstractInteger {
+extension ObservableType where Element : RxAbstractInteger {
     /**
      Returns an observable sequence that produces a value after each period, using the specified scheduler to run timers and to send out observer messages.
      
@@ -307,12 +307,12 @@ extension ObservableType where E : RxAbstractInteger {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "interval(_:scheduler:)")
     public static func interval(_ period: Foundation.TimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return interval(.milliseconds(Int(period * 1000.0)), scheduler: scheduler)
     }
 }
 
-extension ObservableType where E: RxAbstractInteger {
+extension ObservableType where Element: RxAbstractInteger {
     /**
      Returns an observable sequence that periodically produces a value after the specified initial relative due time has elapsed, using the specified scheduler to run timers.
      
@@ -325,7 +325,7 @@ extension ObservableType where E: RxAbstractInteger {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "timer(_:period:scheduler:)")
     public static func timer(_ dueTime: Foundation.TimeInterval, period: Foundation.TimeInterval? = nil, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return timer(.milliseconds(Int(dueTime * 1000.0)), period: period.map { .milliseconds(Int($0 * 1000.0)) }, scheduler: scheduler)
     }
 }
@@ -346,7 +346,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "throttle(_:latest:scheduler:)")
     public func throttle(_ dueTime: Foundation.TimeInterval, latest: Bool = true, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return throttle(.milliseconds(Int(dueTime * 1000.0)), latest: latest, scheduler: scheduler)
     }
 }
@@ -364,7 +364,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "take(_:scheduler:)")
     public func take(_ duration: Foundation.TimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return take(.milliseconds(Int(duration * 1000.0)), scheduler: scheduler)
     }
 }
@@ -383,7 +383,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "delaySubscription(_:scheduler:)")
     public func delaySubscription(_ dueTime: Foundation.TimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return delaySubscription(.milliseconds(Int(dueTime * 1000.0)), scheduler: scheduler)
     }
 }
@@ -402,7 +402,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "window(_:)")
     public func window(timeSpan: Foundation.TimeInterval, count: Int, scheduler: SchedulerType)
-        -> Observable<Observable<E>> {
+        -> Observable<Observable<Element>> {
             return window(timeSpan: .milliseconds(Int(timeSpan * 1000.0)), count: count, scheduler: scheduler)
     }
 }
@@ -518,7 +518,7 @@ extension ObservableType {
      */
     @available(*, deprecated, message: "Use DispatchTimeInterval overload instead.", renamed: "buffer(timeSpan:count:scheduler:)")
     public func buffer(timeSpan: Foundation.TimeInterval, count: Int, scheduler: SchedulerType)
-        -> Observable<[E]> {
+        -> Observable<[Element]> {
         return buffer(timeSpan: .milliseconds(Int(timeSpan * 1000.0)), count: count, scheduler: scheduler)
     }
 }

--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -21,7 +21,7 @@ public enum Event<Element> {
     case completed
 }
 
-extension Event : CustomDebugStringConvertible {
+extension Event: CustomDebugStringConvertible {
     /// Description of event.
     public var debugDescription: String {
         switch self {
@@ -98,7 +98,7 @@ public protocol EventConvertible {
     var event: Event<ElementType> { get }
 }
 
-extension Event : EventConvertible {
+extension Event: EventConvertible {
     /// Event representation of this instance
     public var event: Event<Element> {
         return self

--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -92,10 +92,13 @@ extension Event {
 /// A type that can be converted to `Event<Element>`.
 public protocol EventConvertible {
     /// Type of element in event
-    associatedtype ElementType
+    associatedtype Element
+
+    @available(*, deprecated, message: "Use `Element` instead.")
+    typealias ElementType = Element
 
     /// Event representation of this instance
-    var event: Event<ElementType> { get }
+    var event: Event<Element> { get }
 }
 
 extension Event: EventConvertible {

--- a/RxSwift/Extensions/Bag+Rx.swift
+++ b/RxSwift/Extensions/Bag+Rx.swift
@@ -10,7 +10,7 @@
 // MARK: forEach
 
 @inline(__always)
-func dispatch<E>(_ bag: Bag<(Event<E>) -> Void>, _ event: Event<E>) {
+func dispatch<Element>(_ bag: Bag<(Event<Element>) -> Void>, _ event: Event<Element>) {
     bag._value0?(event)
 
     if bag._onlyFastPath {

--- a/RxSwift/GroupedObservable.swift
+++ b/RxSwift/GroupedObservable.swift
@@ -8,7 +8,7 @@
 
 /// Represents an observable sequence of elements that have a common key.
 public struct GroupedObservable<Key, Element> : ObservableType {
-    public typealias E = Element
+    public typealias Element = Element
 
     /// Gets the common key.
     public let key: Key
@@ -26,7 +26,7 @@ public struct GroupedObservable<Key, Element> : ObservableType {
     }
 
     /// Subscribes `observer` to receive events for this sequence.
-    public func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         return self.source.subscribe(observer)
     }
 

--- a/RxSwift/GroupedObservable.swift
+++ b/RxSwift/GroupedObservable.swift
@@ -8,8 +8,6 @@
 
 /// Represents an observable sequence of elements that have a common key.
 public struct GroupedObservable<Key, Element> : ObservableType {
-    public typealias Element = Element
-
     /// Gets the common key.
     public let key: Key
 

--- a/RxSwift/Observable.swift
+++ b/RxSwift/Observable.swift
@@ -10,20 +10,17 @@
 ///
 /// It represents a push style sequence.
 public class Observable<Element> : ObservableType {
-    /// Type of elements in sequence.
-    public typealias E = Element
-    
     init() {
 #if TRACE_RESOURCES
         _ = Resources.incrementTotal()
 #endif
     }
     
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         rxAbstractMethod()
     }
     
-    public func asObservable() -> Observable<E> {
+    public func asObservable() -> Observable<Element> {
         return self
     }
     

--- a/RxSwift/ObservableConvertibleType.swift
+++ b/RxSwift/ObservableConvertibleType.swift
@@ -6,13 +6,16 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-/// Type that can be converted to observable sequence (`Observable<E>`).
+/// Type that can be converted to observable sequence (`Observable<Element>`).
 public protocol ObservableConvertibleType {
     /// Type of elements in sequence.
-    associatedtype E
+    associatedtype Element
+
+    @available(*, deprecated, message: "Use `Element` instead.")
+    typealias E = Element
 
     /// Converts `self` to `Observable` sequence.
     ///
     /// - returns: Observable sequence that represents `self`.
-    func asObservable() -> Observable<E>
+    func asObservable() -> Observable<Element>
 }

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - parameter on: Action to invoke for each event in the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(_ on: @escaping (Event<E>) -> Void)
+    public func subscribe(_ on: @escaping (Event<Element>) -> Void)
         -> Disposable {
             let observer = AnonymousObserver { e in
                 on(e)
@@ -36,7 +36,7 @@ extension ObservableType {
      gracefully completed, errored, or if the generation is canceled by disposing subscription).
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(onNext: ((E) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
+    public func subscribe(onNext: ((Element) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
         -> Disposable {
             let disposable: Disposable
             
@@ -53,7 +53,7 @@ extension ObservableType {
             
             let callStack = Hooks.recordCallStackOnError ? Hooks.customCaptureSubscriptionCallstack() : []
             
-            let observer = AnonymousObserver<E> { event in
+            let observer = AnonymousObserver<Element> { event in
                 
                 #if DEBUG
                     synchronizationTracker.register(synchronizationErrorMessage: .default)

--- a/RxSwift/ObservableType.swift
+++ b/RxSwift/ObservableType.swift
@@ -31,13 +31,13 @@ public protocol ObservableType : ObservableConvertibleType {
     
     - returns: Subscription for `observer` that can be used to cancel production of sequence elements and free resources.
     */
-    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E
+    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element
 }
 
 extension ObservableType {
     
     /// Default implementation of converting `ObservableType` to `Observable`.
-    public func asObservable() -> Observable<E> {
+    public func asObservable() -> Observable<Element> {
         // temporary workaround
         //return Observable.create(subscribe: self.subscribe)
         return Observable.create { o in

--- a/RxSwift/Observables/AddRef.swift
+++ b/RxSwift/Observables/AddRef.swift
@@ -7,7 +7,7 @@
 //
 
 final class AddRefSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     
     override init(observer: O, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
@@ -34,7 +34,7 @@ final class AddRef<Element> : Producer<Element> {
         self._refCount = refCount
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let releaseDisposable = self._refCount.retain()
         let sink = AddRefSink(observer: observer, cancel: cancel)
         let subscription = Disposables.create(releaseDisposable, self._source.subscribe(sink))

--- a/RxSwift/Observables/Amb.swift
+++ b/RxSwift/Observables/Amb.swift
@@ -14,9 +14,9 @@ extension ObservableType {
 
      - returns: An observable sequence that surfaces any of the given sequences, whichever reacted first.
      */
-    public static func amb<S: Sequence>(_ sequence: S) -> Observable<E>
-        where S.Iterator.Element == Observable<E> {
-            return sequence.reduce(Observable<S.Iterator.Element.E>.never()) { a, o in
+    public static func amb<S: Sequence>(_ sequence: S) -> Observable<Element>
+        where S.Iterator.Element == Observable<Element> {
+            return sequence.reduce(Observable<S.Iterator.Element.Element>.never()) { a, o in
                 return a.amb(o.asObservable())
             }
     }
@@ -34,7 +34,7 @@ extension ObservableType {
      */
     public func amb<O2: ObservableType>
         (_ right: O2)
-        -> Observable<E> where O2.E == E {
+        -> Observable<Element> where O2.Element == Element {
         return Amb(left: self.asObservable(), right: right.asObservable())
     }
 }
@@ -46,7 +46,7 @@ fileprivate enum AmbState {
 }
 
 final private class AmbObserver<O: ObserverType>: ObserverType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias Parent = AmbSink<O>
     typealias This = AmbObserver<O>
     typealias Sink = (This, Event<Element>) -> Void
@@ -80,7 +80,7 @@ final private class AmbObserver<O: ObserverType>: ObserverType {
 }
 
 final private class AmbSink<O: ObserverType>: Sink<O> {
-    typealias ElementType = O.E
+    typealias ElementType = O.Element 
     typealias Parent = Amb<ElementType>
     typealias AmbObserverType = AmbObserver<O>
 
@@ -149,7 +149,7 @@ final private class Amb<Element>: Producer<Element> {
         self._right = right
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = AmbSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Amb.swift
+++ b/RxSwift/Observables/Amb.swift
@@ -80,8 +80,8 @@ final private class AmbObserver<O: ObserverType>: ObserverType {
 }
 
 final private class AmbSink<O: ObserverType>: Sink<O> {
-    typealias ElementType = O.Element 
-    typealias Parent = Amb<ElementType>
+    typealias Element = O.Element
+    typealias Parent = Amb<Element>
     typealias AmbObserverType = AmbObserver<O>
 
     private let _parent: Parent
@@ -100,14 +100,14 @@ final private class AmbSink<O: ObserverType>: Sink<O> {
         let subscription2 = SingleAssignmentDisposable()
         let disposeAll = Disposables.create(subscription1, subscription2)
         
-        let forwardEvent = { (o: AmbObserverType, event: Event<ElementType>) -> Void in
+        let forwardEvent = { (o: AmbObserverType, event: Event<Element>) -> Void in
             self.forwardOn(event)
             if event.isStopEvent {
                 self.dispose()
             }
         }
 
-        let decide = { (o: AmbObserverType, event: Event<ElementType>, me: AmbState, otherSubscription: Disposable) in
+        let decide = { (o: AmbObserverType, event: Event<Element>, me: AmbState, otherSubscription: Disposable) in
             self._lock.performLocked {
                 if self._choice == .neither {
                     self._choice = me

--- a/RxSwift/Observables/AsMaybe.swift
+++ b/RxSwift/Observables/AsMaybe.swift
@@ -7,8 +7,7 @@
 //
 
 fileprivate final class AsMaybeSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias ElementType = O.Element 
-    typealias Element = ElementType
+    typealias Element = O.Element
 
     private var _element: Event<Element>?
 

--- a/RxSwift/Observables/AsMaybe.swift
+++ b/RxSwift/Observables/AsMaybe.swift
@@ -7,12 +7,12 @@
 //
 
 fileprivate final class AsMaybeSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias ElementType = O.E
-    typealias E = ElementType
+    typealias ElementType = O.Element 
+    typealias Element = ElementType
 
-    private var _element: Event<E>?
+    private var _element: Event<Element>?
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next:
             if self._element != nil {
@@ -41,7 +41,7 @@ final class AsMaybe<Element>: Producer<Element> {
         self._source = source
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = AsMaybeSink(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/AsSingle.swift
+++ b/RxSwift/Observables/AsSingle.swift
@@ -7,12 +7,12 @@
 //
 
 fileprivate final class AsSingleSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias ElementType = O.E
-    typealias E = ElementType
+    typealias ElementType = O.Element 
+    typealias Element = ElementType
 
-    private var _element: Event<E>?
+    private var _element: Event<Element>?
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next:
             if self._element != nil {
@@ -44,7 +44,7 @@ final class AsSingle<Element>: Producer<Element> {
         self._source = source
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = AsSingleSink(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/AsSingle.swift
+++ b/RxSwift/Observables/AsSingle.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-fileprivate final class AsSingleSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias ElementType = O.Element 
-    typealias Element = ElementType
+fileprivate final class AsSingleSink<O: ObserverType> : Sink<O>, ObserverType { 
+    typealias Element = O.Element
 
     private var _element: Event<Element>?
 

--- a/RxSwift/Observables/Buffer.swift
+++ b/RxSwift/Observables/Buffer.swift
@@ -21,7 +21,7 @@ extension ObservableType {
      - returns: An observable sequence of buffers.
      */
     public func buffer(timeSpan: RxTimeInterval, count: Int, scheduler: SchedulerType)
-        -> Observable<[E]> {
+        -> Observable<[Element]> {
         return BufferTimeCount(source: self.asObservable(), timeSpan: timeSpan, count: count, scheduler: scheduler)
     }
 }
@@ -40,7 +40,7 @@ final private class BufferTimeCount<Element>: Producer<[Element]> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == [Element] {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == [Element] {
         let sink = BufferTimeCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -51,9 +51,9 @@ final private class BufferTimeCountSink<Element, O: ObserverType>
     : Sink<O>
     , LockOwnerType
     , ObserverType
-    , SynchronizedOnType where O.E == [Element] {
+    , SynchronizedOnType where O.Element == [Element] {
     typealias Parent = BufferTimeCount<Element>
-    typealias E = Element
+    typealias Element = Element
     
     private let _parent: Parent
     
@@ -85,11 +85,11 @@ final private class BufferTimeCountSink<Element, O: ObserverType>
         self.createTimer(windowID)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next(let element):
             self._buffer.append(element)

--- a/RxSwift/Observables/Buffer.swift
+++ b/RxSwift/Observables/Buffer.swift
@@ -53,7 +53,6 @@ final private class BufferTimeCountSink<Element, O: ObserverType>
     , ObserverType
     , SynchronizedOnType where O.Element == [Element] {
     typealias Parent = BufferTimeCount<Element>
-    typealias Element = Element
     
     private let _parent: Parent
     

--- a/RxSwift/Observables/CombineLatest+Collection.swift
+++ b/RxSwift/Observables/CombineLatest+Collection.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func combineLatest<C: Collection>(_ collection: C, resultSelector: @escaping ([C.Iterator.Element.E]) throws -> E) -> Observable<E>
+    public static func combineLatest<C: Collection>(_ collection: C, resultSelector: @escaping ([C.Iterator.Element.Element]) throws -> Element) -> Observable<Element>
         where C.Iterator.Element: ObservableType {
         return CombineLatestCollectionType(sources: collection, resultSelector: resultSelector)
     }
@@ -27,17 +27,17 @@ extension ObservableType {
 
      - returns: An observable sequence containing the result of combining elements of the sources.
      */
-    public static func combineLatest<C: Collection>(_ collection: C) -> Observable<[E]>
-        where C.Iterator.Element: ObservableType, C.Iterator.Element.E == E {
+    public static func combineLatest<C: Collection>(_ collection: C) -> Observable<[Element]>
+        where C.Iterator.Element: ObservableType, C.Iterator.Element.Element == Element {
         return CombineLatestCollectionType(sources: collection, resultSelector: { $0 })
     }
 }
 
 final private class CombineLatestCollectionTypeSink<C: Collection, O: ObserverType>
     : Sink<O> where C.Iterator.Element: ObservableConvertibleType {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatestCollectionType<C, R>
-    typealias SourceElement = C.Iterator.Element.E
+    typealias SourceElement = C.Iterator.Element.Element
     
     let _parent: Parent
     
@@ -146,7 +146,7 @@ final private class CombineLatestCollectionTypeSink<C: Collection, O: ObserverTy
 }
 
 final private class CombineLatestCollectionType<C: Collection, R>: Producer<R> where C.Iterator.Element: ObservableConvertibleType {
-    typealias ResultSelector = ([C.Iterator.Element.E]) throws -> R
+    typealias ResultSelector = ([C.Iterator.Element.Element]) throws -> R
     
     let _sources: C
     let _resultSelector: ResultSelector
@@ -158,7 +158,7 @@ final private class CombineLatestCollectionType<C: Collection, R>: Producer<R> w
         self._count = Int(Int64(self._sources.count))
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestCollectionTypeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/CombineLatest+arity.swift
+++ b/RxSwift/Observables/CombineLatest+arity.swift
@@ -21,8 +21,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType>
-        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.E, O2.E) throws -> E)
-            -> Observable<E> {
+        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.Element, O2.Element) throws -> Element)
+            -> Observable<Element> {
         return CombineLatest2(
             source1: source1.asObservable(), source2: source2.asObservable(),
             resultSelector: resultSelector
@@ -30,7 +30,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -40,7 +40,7 @@ extension ObservableType where E == Any {
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType>
         (_ source1: O1, _ source2: O2)
-            -> Observable<(O1.E, O2.E)> {
+            -> Observable<(O1.Element, O2.Element)> {
         return CombineLatest2(
             source1: source1.asObservable(), source2: source2.asObservable(),
             resultSelector: { ($0, $1) }
@@ -49,7 +49,7 @@ extension ObservableType where E == Any {
 }
 
 final class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatest2<E1, E2, R>
 
     let _parent: Parent
@@ -98,7 +98,7 @@ final class CombineLatest2<E1, E2, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestSink2_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -119,8 +119,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.E, O2.E, O3.E) throws -> E)
-            -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.Element, O2.Element, O3.Element) throws -> Element)
+            -> Observable<Element> {
         return CombineLatest3(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(),
             resultSelector: resultSelector
@@ -128,7 +128,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -138,7 +138,7 @@ extension ObservableType where E == Any {
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3)
-            -> Observable<(O1.E, O2.E, O3.E)> {
+            -> Observable<(O1.Element, O2.Element, O3.Element)> {
         return CombineLatest3(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(),
             resultSelector: { ($0, $1, $2) }
@@ -147,7 +147,7 @@ extension ObservableType where E == Any {
 }
 
 final class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatest3<E1, E2, E3, R>
 
     let _parent: Parent
@@ -203,7 +203,7 @@ final class CombineLatest3<E1, E2, E3, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestSink3_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -224,8 +224,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E) throws -> E)
-            -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
+            -> Observable<Element> {
         return CombineLatest4(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(),
             resultSelector: resultSelector
@@ -233,7 +233,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -243,7 +243,7 @@ extension ObservableType where E == Any {
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4)
-            -> Observable<(O1.E, O2.E, O3.E, O4.E)> {
+            -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element)> {
         return CombineLatest4(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(),
             resultSelector: { ($0, $1, $2, $3) }
@@ -252,7 +252,7 @@ extension ObservableType where E == Any {
 }
 
 final class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatestSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatest4<E1, E2, E3, E4, R>
 
     let _parent: Parent
@@ -315,7 +315,7 @@ final class CombineLatest4<E1, E2, E3, E4, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestSink4_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -336,8 +336,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E) throws -> E)
-            -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
+            -> Observable<Element> {
         return CombineLatest5(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(),
             resultSelector: resultSelector
@@ -345,7 +345,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -355,7 +355,7 @@ extension ObservableType where E == Any {
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5)
-            -> Observable<(O1.E, O2.E, O3.E, O4.E, O5.E)> {
+            -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element)> {
         return CombineLatest5(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(),
             resultSelector: { ($0, $1, $2, $3, $4) }
@@ -364,7 +364,7 @@ extension ObservableType where E == Any {
 }
 
 final class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLatestSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatest5<E1, E2, E3, E4, E5, R>
 
     let _parent: Parent
@@ -434,7 +434,7 @@ final class CombineLatest5<E1, E2, E3, E4, E5, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestSink5_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -455,8 +455,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E) throws -> E)
-            -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
+            -> Observable<Element> {
         return CombineLatest6(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(),
             resultSelector: resultSelector
@@ -464,7 +464,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -474,7 +474,7 @@ extension ObservableType where E == Any {
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6)
-            -> Observable<(O1.E, O2.E, O3.E, O4.E, O5.E, O6.E)> {
+            -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element)> {
         return CombineLatest6(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(),
             resultSelector: { ($0, $1, $2, $3, $4, $5) }
@@ -483,7 +483,7 @@ extension ObservableType where E == Any {
 }
 
 final class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : CombineLatestSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatest6<E1, E2, E3, E4, E5, E6, R>
 
     let _parent: Parent
@@ -560,7 +560,7 @@ final class CombineLatest6<E1, E2, E3, E4, E5, E6, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestSink6_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -581,8 +581,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E) throws -> E)
-            -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
+            -> Observable<Element> {
         return CombineLatest7(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(),
             resultSelector: resultSelector
@@ -590,7 +590,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -600,7 +600,7 @@ extension ObservableType where E == Any {
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7)
-            -> Observable<(O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E)> {
+            -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element)> {
         return CombineLatest7(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(),
             resultSelector: { ($0, $1, $2, $3, $4, $5, $6) }
@@ -609,7 +609,7 @@ extension ObservableType where E == Any {
 }
 
 final class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : CombineLatestSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatest7<E1, E2, E3, E4, E5, E6, E7, R>
 
     let _parent: Parent
@@ -693,7 +693,7 @@ final class CombineLatest7<E1, E2, E3, E4, E5, E6, E7, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestSink7_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -714,8 +714,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E) throws -> E)
-            -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
+            -> Observable<Element> {
         return CombineLatest8(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(),
             resultSelector: resultSelector
@@ -723,7 +723,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -733,7 +733,7 @@ extension ObservableType where E == Any {
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8)
-            -> Observable<(O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E)> {
+            -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element)> {
         return CombineLatest8(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(),
             resultSelector: { ($0, $1, $2, $3, $4, $5, $6, $7) }
@@ -742,7 +742,7 @@ extension ObservableType where E == Any {
 }
 
 final class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : CombineLatestSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, R>
 
     let _parent: Parent
@@ -833,7 +833,7 @@ final class CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestSink8_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/CombineLatest+arity.tt
+++ b/RxSwift/Observables/CombineLatest+arity.tt
@@ -20,8 +20,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<<%= (Array(1...i).map { "O\($0): ObservableType" }).joined(separator: ", ") %>>
-        (<%= (Array(1...i).map { "_ source\($0): O\($0)" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "O\($0).E" }).joined(separator: ", ") %>) throws -> E)
-            -> Observable<E> {
+        (<%= (Array(1...i).map { "_ source\($0): O\($0)" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "O\($0).E" }).joined(separator: ", ") %>) throws -> Element)
+            -> Observable<Element> {
         return CombineLatest<%= i %>(
             <%= (Array(1...i).map { "source\($0): source\($0).asObservable()" }).joined(separator: ", ") %>,
             resultSelector: resultSelector
@@ -29,7 +29,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -48,7 +48,7 @@ extension ObservableType where E == Any {
 }
 
 final class CombineLatestSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, O: ObserverType> : CombineLatestSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = CombineLatest<%= i %><<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, R>
 
     let _parent: Parent
@@ -102,7 +102,7 @@ final class CombineLatest<%= i %><<%= (Array(1...i).map { "E\($0)" }).joined(sep
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = CombineLatestSink<%= i %>_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/CombineLatest.swift
+++ b/RxSwift/Observables/CombineLatest.swift
@@ -90,11 +90,10 @@ class CombineLatestSink<O: ObserverType>
     }
 }
 
-final class CombineLatestObserver<ElementType>
+final class CombineLatestObserver<Element>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = ElementType
     typealias ValueSetter = (Element) -> Void
     
     private let _parent: CombineLatestProtocol

--- a/RxSwift/Observables/CombineLatest.swift
+++ b/RxSwift/Observables/CombineLatest.swift
@@ -15,7 +15,7 @@ protocol CombineLatestProtocol : class {
 class CombineLatestSink<O: ObserverType>
     : Sink<O>
     , CombineLatestProtocol {
-    typealias Element = O.E
+    typealias Element = O.Element 
    
     let _lock = RecursiveLock()
 

--- a/RxSwift/Observables/CompactMap.swift
+++ b/RxSwift/Observables/CompactMap.swift
@@ -21,7 +21,7 @@ extension ObservableType {
      - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
 
      */
-    public func compactMap<R>(_ transform: @escaping (E) throws -> R?)
+    public func compactMap<R>(_ transform: @escaping (Element) throws -> R?)
         -> Observable<R> {
             return CompactMap(source: self.asObservable(), transform: transform)
     }
@@ -30,7 +30,7 @@ extension ObservableType {
 final private class CompactMapSink<SourceType, O: ObserverType>: Sink<O>, ObserverType {
     typealias Transform = (SourceType) throws -> ResultType?
 
-    typealias ResultType = O.E
+    typealias ResultType = O.Element 
     typealias Element = SourceType
 
     private let _transform: Transform
@@ -74,7 +74,7 @@ final private class CompactMap<SourceType, ResultType>: Producer<ResultType> {
         self._transform = transform
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == ResultType {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == ResultType {
         let sink = CompactMapSink(transform: self._transform, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Concat.swift
+++ b/RxSwift/Observables/Concat.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter second: Second observable sequence.
      - returns: An observable sequence that contains the elements of `self`, followed by those of the second sequence.
      */
-    public func concat<O: ObservableConvertibleType>(_ second: O) -> Observable<E> where O.E == E {
+    public func concat<O: ObservableConvertibleType>(_ second: O) -> Observable<Element> where O.Element == Element {
         return Observable.concat([self.asObservable(), second.asObservable()])
     }
 }
@@ -35,8 +35,8 @@ extension ObservableType {
 
      - returns: An observable sequence that contains the elements of each given sequence, in sequential order.
      */
-    public static func concat<S: Sequence >(_ sequence: S) -> Observable<E>
-        where S.Iterator.Element == Observable<E> {
+    public static func concat<S: Sequence >(_ sequence: S) -> Observable<Element>
+        where S.Iterator.Element == Observable<Element> {
             return Concat(sources: sequence, count: nil)
     }
 
@@ -53,8 +53,8 @@ extension ObservableType {
 
      - returns: An observable sequence that contains the elements of each given sequence, in sequential order.
      */
-    public static func concat<S: Collection >(_ collection: S) -> Observable<E>
-        where S.Iterator.Element == Observable<E> {
+    public static func concat<S: Collection >(_ collection: S) -> Observable<Element>
+        where S.Iterator.Element == Observable<Element> {
             return Concat(sources: collection, count: Int64(collection.count))
     }
 
@@ -71,15 +71,15 @@ extension ObservableType {
 
      - returns: An observable sequence that contains the elements of each given sequence, in sequential order.
      */
-    public static func concat(_ sources: Observable<E> ...) -> Observable<E> {
+    public static func concat(_ sources: Observable<Element> ...) -> Observable<Element> {
         return Concat(sources: sources, count: Int64(sources.count))
     }
 }
 
 final private class ConcatSink<S: Sequence, O: ObserverType>
     : TailRecursiveSink<S, O>
-    , ObserverType where S.Iterator.Element: ObservableConvertibleType, S.Iterator.Element.E == O.E {
-    typealias Element = O.E
+    , ObserverType where S.Iterator.Element: ObservableConvertibleType, S.Iterator.Element.Element == O.Element {
+    typealias Element = O.Element 
     
     override init(observer: O, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
@@ -97,11 +97,11 @@ final private class ConcatSink<S: Sequence, O: ObserverType>
         }
     }
 
-    override func subscribeToNext(_ source: Observable<E>) -> Disposable {
+    override func subscribeToNext(_ source: Observable<Element>) -> Disposable {
         return source.subscribe(self)
     }
     
-    override func extract(_ observable: Observable<E>) -> SequenceGenerator? {
+    override func extract(_ observable: Observable<Element>) -> SequenceGenerator? {
         if let source = observable as? Concat<S> {
             return (source._sources.makeIterator(), source._count)
         }
@@ -111,8 +111,8 @@ final private class ConcatSink<S: Sequence, O: ObserverType>
     }
 }
 
-final private class Concat<S: Sequence>: Producer<S.Iterator.Element.E> where S.Iterator.Element: ObservableConvertibleType {
-    typealias Element = S.Iterator.Element.E
+final private class Concat<S: Sequence>: Producer<S.Iterator.Element.Element> where S.Iterator.Element: ObservableConvertibleType {
+    typealias Element = S.Iterator.Element.Element
     
     fileprivate let _sources: S
     fileprivate let _count: IntMax?
@@ -122,7 +122,7 @@ final private class Concat<S: Sequence>: Producer<S.Iterator.Element.E> where S.
         self._count = count
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = ConcatSink<S, O>(observer: observer, cancel: cancel)
         let subscription = sink.run((self._sources.makeIterator(), self._count))
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Create.swift
+++ b/RxSwift/Observables/Create.swift
@@ -17,14 +17,14 @@ extension ObservableType {
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(_ subscribe: @escaping (AnyObserver<E>) -> Disposable) -> Observable<E> {
+    public static func create(_ subscribe: @escaping (AnyObserver<Element>) -> Disposable) -> Observable<Element> {
         return AnonymousObservable(subscribe)
     }
 }
 
 final private class AnonymousObservableSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias E = O.E
-    typealias Parent = AnonymousObservable<E>
+    typealias Element = O.Element 
+    typealias Parent = AnonymousObservable<Element>
 
     // state
     private let _isStopped = AtomicInt(0)
@@ -37,7 +37,7 @@ final private class AnonymousObservableSink<O: ObserverType>: Sink<O>, ObserverT
         super.init(observer: observer, cancel: cancel)
     }
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         #if DEBUG
             self._synchronizationTracker.register(synchronizationErrorMessage: .default)
             defer { self._synchronizationTracker.unregister() }
@@ -70,7 +70,7 @@ final private class AnonymousObservable<Element>: Producer<Element> {
         self._subscribeHandler = subscribeHandler
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = AnonymousObservableSink(observer: observer, cancel: cancel)
         let subscription = sink.run(self)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Debounce.swift
+++ b/RxSwift/Observables/Debounce.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      - returns: The throttled sequence.
      */
     public func debounce(_ dueTime: RxTimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
             return Debounce(source: self.asObservable(), dueTime: dueTime, scheduler: scheduler)
     }
 }
@@ -28,7 +28,7 @@ final private class DebounceSink<O: ObserverType>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias ParentType = Debounce<Element>
 
     private let _parent: ParentType
@@ -109,7 +109,7 @@ final private class Debounce<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = DebounceSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Debug.swift
+++ b/RxSwift/Observables/Debug.swift
@@ -21,7 +21,7 @@ extension ObservableType {
      - returns: An observable sequence whose events are printed to standard output.
      */
     public func debug(_ identifier: String? = nil, trimOutput: Bool = false, file: String = #file, line: UInt = #line, function: String = #function)
-        -> Observable<E> {
+        -> Observable<Element> {
             return Debug(source: self, identifier: identifier, trimOutput: trimOutput, file: file, line: line, function: function)
     }
 }
@@ -32,8 +32,8 @@ fileprivate func logEvent(_ identifier: String, dateFormat: DateFormatter, conte
     print("\(dateFormat.string(from: Date())): \(identifier) -> \(content)")
 }
 
-final private class DebugSink<Source: ObservableType, O: ObserverType>: Sink<O>, ObserverType where O.E == Source.E {
-    typealias Element = O.E
+final private class DebugSink<Source: ObservableType, O: ObserverType>: Sink<O>, ObserverType where O.Element == Source.Element {
+    typealias Element = O.Element 
     typealias Parent = Debug<Source>
     
     private let _parent: Parent
@@ -72,7 +72,7 @@ final private class DebugSink<Source: ObservableType, O: ObserverType>: Sink<O>,
     }
 }
 
-final private class Debug<Source: ObservableType>: Producer<Source.E> {
+final private class Debug<Source: ObservableType>: Producer<Source.Element> {
     fileprivate let _identifier: String
     fileprivate let _trimOutput: Bool
     fileprivate let _source: Source
@@ -95,7 +95,7 @@ final private class Debug<Source: ObservableType>: Producer<Source.E> {
         self._source = source
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Source.E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Source.Element {
         let sink = DebugSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/DefaultIfEmpty.swift
+++ b/RxSwift/Observables/DefaultIfEmpty.swift
@@ -16,22 +16,22 @@ extension ObservableType {
      - parameter default: Default element to be sent if the source does not emit any elements
      - returns: An observable sequence which emits default element end completes in case the original sequence is empty
      */
-    public func ifEmpty(default: E) -> Observable<E> {
+    public func ifEmpty(default: Element) -> Observable<Element> {
         return DefaultIfEmpty(source: self.asObservable(), default: `default`)
     }
 }
 
 final private class DefaultIfEmptySink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias E = O.E
-    private let _default: E
+    typealias Element = O.Element 
+    private let _default: Element
     private var _isEmpty = true
     
-    init(default: E, observer: O, cancel: Cancelable) {
+    init(default: Element, observer: O, cancel: Cancelable) {
         self._default = `default`
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next:
             self._isEmpty = false
@@ -58,7 +58,7 @@ final private class DefaultIfEmpty<SourceType>: Producer<SourceType> {
         self._default = `default`
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == SourceType {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceType {
         let sink = DefaultIfEmptySink(default: self._default, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Deferred.swift
+++ b/RxSwift/Observables/Deferred.swift
@@ -15,14 +15,14 @@ extension ObservableType {
      - parameter observableFactory: Observable factory function to invoke for each observer that subscribes to the resulting sequence.
      - returns: An observable sequence whose observers trigger an invocation of the given observable factory function.
      */
-    public static func deferred(_ observableFactory: @escaping () throws -> Observable<E>)
-        -> Observable<E> {
+    public static func deferred(_ observableFactory: @escaping () throws -> Observable<Element>)
+        -> Observable<Element> {
         return Deferred(observableFactory: observableFactory)
     }
 }
 
-final private class DeferredSink<S: ObservableType, O: ObserverType>: Sink<O>, ObserverType where S.E == O.E {
-    typealias E = O.E
+final private class DeferredSink<S: ObservableType, O: ObserverType>: Sink<O>, ObserverType where S.Element == O.Element {
+    typealias Element = O.Element 
 
     private let _observableFactory: () throws -> S
 
@@ -43,7 +43,7 @@ final private class DeferredSink<S: ObservableType, O: ObserverType>: Sink<O>, O
         }
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.forwardOn(event)
         
         switch event {
@@ -57,7 +57,7 @@ final private class DeferredSink<S: ObservableType, O: ObserverType>: Sink<O>, O
     }
 }
 
-final private class Deferred<S: ObservableType>: Producer<S.E> {
+final private class Deferred<S: ObservableType>: Producer<S.Element> {
     typealias Factory = () throws -> S
     
     private let _observableFactory : Factory
@@ -66,7 +66,7 @@ final private class Deferred<S: ObservableType>: Producer<S.E> {
         self._observableFactory = observableFactory
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == S.E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == S.Element {
         let sink = DeferredSink(observableFactory: self._observableFactory, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Delay.swift
+++ b/RxSwift/Observables/Delay.swift
@@ -20,7 +20,7 @@ extension ObservableType {
      - returns: the source Observable shifted in time by the specified delay.
      */
     public func delay(_ dueTime: RxTimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
             return Delay(source: self.asObservable(), dueTime: dueTime, scheduler: scheduler)
     }
 }
@@ -28,8 +28,8 @@ extension ObservableType {
 final private class DelaySink<O: ObserverType>
     : Sink<O>
     , ObserverType {
-    typealias E = O.E
-    typealias Source = Observable<E>
+    typealias Element = O.Element 
+    typealias Source = Observable<Element>
     typealias DisposeKey = Bag<Disposable>.KeyType
     
     private let _lock = RecursiveLock()
@@ -44,10 +44,10 @@ final private class DelaySink<O: ObserverType>
     private var _active = false
     // is "run loop" on different scheduler running
     private var _running = false
-    private var _errorEvent: Event<E>?
+    private var _errorEvent: Event<Element>?
 
     // state
-    private var _queue = Queue<(eventTime: RxTime, event: Event<E>)>(capacity: 0)
+    private var _queue = Queue<(eventTime: RxTime, event: Event<Element>)>(capacity: 0)
     private var _disposed = false
     
     init(observer: O, dueTime: RxTimeInterval, scheduler: SchedulerType, cancel: Cancelable) {
@@ -121,7 +121,7 @@ final private class DelaySink<O: ObserverType>
         }
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         if event.isStopEvent {
             self._sourceSubscription.dispose()
         }
@@ -151,7 +151,7 @@ final private class DelaySink<O: ObserverType>
         }
     }
     
-    func run(source: Observable<E>) -> Disposable {
+    func run(source: Observable<Element>) -> Disposable {
         self._sourceSubscription.setDisposable(source.subscribe(self))
         return Disposables.create(_sourceSubscription, _cancelable)
     }
@@ -168,7 +168,7 @@ final private class Delay<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = DelaySink(observer: observer, dueTime: self._dueTime, scheduler: self._scheduler, cancel: cancel)
         let subscription = sink.run(source: self._source)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/DelaySubscription.swift
+++ b/RxSwift/Observables/DelaySubscription.swift
@@ -18,16 +18,16 @@ extension ObservableType {
      - returns: Time-shifted sequence.
      */
     public func delaySubscription(_ dueTime: RxTimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return DelaySubscription(source: self.asObservable(), dueTime: dueTime, scheduler: scheduler)
     }
 }
 
 final private class DelaySubscriptionSink<O: ObserverType>
     : Sink<O>, ObserverType {
-    typealias E = O.E
+    typealias Element = O.Element 
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.forwardOn(event)
         if event.isStopEvent {
             self.dispose()
@@ -47,7 +47,7 @@ final private class DelaySubscription<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = DelaySubscriptionSink(observer: observer, cancel: cancel)
         let subscription = self._scheduler.scheduleRelative((), dueTime: self._dueTime) { _ in
             return self._source.subscribe(sink)

--- a/RxSwift/Observables/Dematerialize.swift
+++ b/RxSwift/Observables/Dematerialize.swift
@@ -12,13 +12,13 @@ extension ObservableType where Element: EventConvertible {
      - seealso: [materialize operator on reactivex.io](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
      - returns: The dematerialized observable sequence.
      */
-    public func dematerialize() -> Observable<Element.ElementType> {
+    public func dematerialize() -> Observable<Element.Element> {
         return Dematerialize(source: self.asObservable())
     }
 
 }
 
-fileprivate final class DematerializeSink<T: EventConvertible, O: ObserverType>: Sink<O>, ObserverType where O.Element == T.ElementType {
+fileprivate final class DematerializeSink<T: EventConvertible, O: ObserverType>: Sink<O>, ObserverType where O.Element == T.Element {
     fileprivate func on(_ event: Event<T>) {
         switch event {
         case .next(let element):
@@ -36,14 +36,14 @@ fileprivate final class DematerializeSink<T: EventConvertible, O: ObserverType>:
     }
 }
 
-final private class Dematerialize<T: EventConvertible>: Producer<T.ElementType> {
+final private class Dematerialize<T: EventConvertible>: Producer<T.Element> {
     private let _source: Observable<T>
 
     init(source: Observable<T>) {
         self._source = source
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == T.ElementType {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == T.Element {
         let sink = DematerializeSink<T, O>(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Dematerialize.swift
+++ b/RxSwift/Observables/Dematerialize.swift
@@ -6,20 +6,20 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-extension ObservableType where E: EventConvertible {
+extension ObservableType where Element: EventConvertible {
     /**
      Convert any previously materialized Observable into it's original form.
      - seealso: [materialize operator on reactivex.io](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
      - returns: The dematerialized observable sequence.
      */
-    public func dematerialize() -> Observable<E.ElementType> {
+    public func dematerialize() -> Observable<Element.ElementType> {
         return Dematerialize(source: self.asObservable())
     }
 
 }
 
-fileprivate final class DematerializeSink<Element: EventConvertible, O: ObserverType>: Sink<O>, ObserverType where O.E == Element.ElementType {
-    fileprivate func on(_ event: Event<Element>) {
+fileprivate final class DematerializeSink<T: EventConvertible, O: ObserverType>: Sink<O>, ObserverType where O.Element == T.ElementType {
+    fileprivate func on(_ event: Event<T>) {
         switch event {
         case .next(let element):
             self.forwardOn(element.event)
@@ -36,15 +36,15 @@ fileprivate final class DematerializeSink<Element: EventConvertible, O: Observer
     }
 }
 
-final private class Dematerialize<Element: EventConvertible>: Producer<Element.ElementType> {
-    private let _source: Observable<Element>
-    
-    init(source: Observable<Element>) {
+final private class Dematerialize<T: EventConvertible>: Producer<T.ElementType> {
+    private let _source: Observable<T>
+
+    init(source: Observable<T>) {
         self._source = source
     }
-    
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element.ElementType {
-        let sink = DematerializeSink<Element, O>(observer: observer, cancel: cancel)
+
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == T.ElementType {
+        let sink = DematerializeSink<T, O>(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Observables/DistinctUntilChanged.swift
+++ b/RxSwift/Observables/DistinctUntilChanged.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-extension ObservableType where E: Equatable {
+extension ObservableType where Element: Equatable {
 
     /**
      Returns an observable sequence that contains only distinct contiguous elements according to equality operator.
@@ -16,7 +16,7 @@ extension ObservableType where E: Equatable {
      - returns: An observable sequence only containing the distinct contiguous elements, based on equality operator, from the source sequence.
      */
     public func distinctUntilChanged()
-        -> Observable<E> {
+        -> Observable<Element> {
             return self.distinctUntilChanged({ $0 }, comparer: { ($0 == $1) })
     }
 }
@@ -30,8 +30,8 @@ extension ObservableType {
      - parameter keySelector: A function to compute the comparison key for each element.
      - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value, from the source sequence.
      */
-    public func distinctUntilChanged<K: Equatable>(_ keySelector: @escaping (E) throws -> K)
-        -> Observable<E> {
+    public func distinctUntilChanged<K: Equatable>(_ keySelector: @escaping (Element) throws -> K)
+        -> Observable<Element> {
             return self.distinctUntilChanged(keySelector, comparer: { $0 == $1 })
     }
 
@@ -43,8 +43,8 @@ extension ObservableType {
      - parameter comparer: Equality comparer for computed key values.
      - returns: An observable sequence only containing the distinct contiguous elements, based on `comparer`, from the source sequence.
      */
-    public func distinctUntilChanged(_ comparer: @escaping (E, E) throws -> Bool)
-        -> Observable<E> {
+    public func distinctUntilChanged(_ comparer: @escaping (Element, Element) throws -> Bool)
+        -> Observable<Element> {
             return self.distinctUntilChanged({ $0 }, comparer: comparer)
     }
 
@@ -57,24 +57,24 @@ extension ObservableType {
      - parameter comparer: Equality comparer for computed key values.
      - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value and the comparer, from the source sequence.
      */
-    public func distinctUntilChanged<K>(_ keySelector: @escaping (E) throws -> K, comparer: @escaping (K, K) throws -> Bool)
-        -> Observable<E> {
+    public func distinctUntilChanged<K>(_ keySelector: @escaping (Element) throws -> K, comparer: @escaping (K, K) throws -> Bool)
+        -> Observable<Element> {
             return DistinctUntilChanged(source: self.asObservable(), selector: keySelector, comparer: comparer)
     }
 }
 
 final private class DistinctUntilChangedSink<O: ObserverType, Key>: Sink<O>, ObserverType {
-    typealias E = O.E
+    typealias Element = O.Element 
     
-    private let _parent: DistinctUntilChanged<E, Key>
+    private let _parent: DistinctUntilChanged<Element, Key>
     private var _currentKey: Key?
     
-    init(parent: DistinctUntilChanged<E, Key>, observer: O, cancel: Cancelable) {
+    init(parent: DistinctUntilChanged<Element, Key>, observer: O, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next(let value):
             do {
@@ -117,7 +117,7 @@ final private class DistinctUntilChanged<Element, Key>: Producer<Element> {
         self._comparer = comparer
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = DistinctUntilChangedSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Do.swift
+++ b/RxSwift/Observables/Do.swift
@@ -23,8 +23,8 @@ extension ObservableType {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onNext: ((E) throws -> Void)? = nil, afterNext: ((E) throws -> Void)? = nil, onError: ((Swift.Error) throws -> Void)? = nil, afterError: ((Swift.Error) throws -> Void)? = nil, onCompleted: (() throws -> Void)? = nil, afterCompleted: (() throws -> Void)? = nil, onSubscribe: (() -> Void)? = nil, onSubscribed: (() -> Void)? = nil, onDispose: (() -> Void)? = nil)
-        -> Observable<E> {
+    public func `do`(onNext: ((Element) throws -> Void)? = nil, afterNext: ((Element) throws -> Void)? = nil, onError: ((Swift.Error) throws -> Void)? = nil, afterError: ((Swift.Error) throws -> Void)? = nil, onCompleted: (() throws -> Void)? = nil, afterCompleted: (() throws -> Void)? = nil, onSubscribe: (() -> Void)? = nil, onSubscribed: (() -> Void)? = nil, onDispose: (() -> Void)? = nil)
+        -> Observable<Element> {
             return Do(source: self.asObservable(), eventHandler: { e in
                 switch e {
                 case .next(let element):
@@ -48,7 +48,7 @@ extension ObservableType {
 }
 
 final private class DoSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias EventHandler = (Event<Element>) throws -> Void
     typealias AfterEventHandler = (Event<Element>) throws -> Void
     
@@ -97,7 +97,7 @@ final private class Do<Element>: Producer<Element> {
         self._onDispose = onDispose
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         self._onSubscribe?()
         let sink = DoSink(eventHandler: self._eventHandler, afterEventHandler: self._afterEventHandler, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)

--- a/RxSwift/Observables/ElementAt.swift
+++ b/RxSwift/Observables/ElementAt.swift
@@ -17,13 +17,13 @@ extension ObservableType {
      - returns: An observable sequence that emits the desired element as its own sole emission.
      */
     public func elementAt(_ index: Int)
-        -> Observable<E> {
+        -> Observable<Element> {
         return ElementAt(source: self.asObservable(), index: index, throwOnEmpty: true)
     }
 }
 
 final private class ElementAtSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias SourceType = O.E
+    typealias SourceType = O.Element 
     typealias Parent = ElementAt<SourceType>
     
     let _parent: Parent
@@ -84,7 +84,7 @@ final private class ElementAt<SourceType>: Producer<SourceType> {
         self._throwOnEmpty = throwOnEmpty
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == SourceType {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceType {
         let sink = ElementAtSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Empty.swift
+++ b/RxSwift/Observables/Empty.swift
@@ -14,13 +14,13 @@ extension ObservableType {
 
      - returns: An observable sequence with no elements.
      */
-    public static func empty() -> Observable<E> {
-        return EmptyProducer<E>()
+    public static func empty() -> Observable<Element> {
+        return EmptyProducer<Element>()
     }
 }
 
 final private class EmptyProducer<Element>: Producer<Element> {
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         observer.on(.completed)
         return Disposables.create()
     }

--- a/RxSwift/Observables/Enumerated.swift
+++ b/RxSwift/Observables/Enumerated.swift
@@ -22,7 +22,6 @@ extension ObservableType {
 }
 
 final private class EnumeratedSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.Element == (index: Int, element: Element) {
-    typealias Element = Element
     var index = 0
     
     func on(_ event: Event<Element>) {

--- a/RxSwift/Observables/Enumerated.swift
+++ b/RxSwift/Observables/Enumerated.swift
@@ -16,13 +16,13 @@ extension ObservableType {
      - returns: An observable sequence that contains tuples of source sequence elements and their indexes.
      */
     public func enumerated()
-        -> Observable<(index: Int, element: E)> {
+        -> Observable<(index: Int, element: Element)> {
         return Enumerated(source: self.asObservable())
     }
 }
 
-final private class EnumeratedSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.E == (index: Int, element: Element) {
-    typealias E = Element
+final private class EnumeratedSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.Element == (index: Int, element: Element) {
+    typealias Element = Element
     var index = 0
     
     func on(_ event: Event<Element>) {
@@ -54,7 +54,7 @@ final private class Enumerated<Element>: Producer<(index: Int, element: Element)
         self._source = source
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == (index: Int, element: Element) {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == (index: Int, element: Element) {
         let sink = EnumeratedSink<Element, O>(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Error.swift
+++ b/RxSwift/Observables/Error.swift
@@ -14,7 +14,7 @@ extension ObservableType {
 
      - returns: The observable sequence that terminates with specified error.
      */
-    public static func error(_ error: Swift.Error) -> Observable<E> {
+    public static func error(_ error: Swift.Error) -> Observable<Element> {
         return ErrorProducer(error: error)
     }
 }
@@ -26,7 +26,7 @@ final private class ErrorProducer<Element>: Producer<Element> {
         self._error = error
     }
     
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         observer.on(.error(self._error))
         return Disposables.create()
     }

--- a/RxSwift/Observables/Filter.swift
+++ b/RxSwift/Observables/Filter.swift
@@ -16,8 +16,8 @@ extension ObservableType {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
      */
-    public func filter(_ predicate: @escaping (E) throws -> Bool)
-        -> Observable<E> {
+    public func filter(_ predicate: @escaping (Element) throws -> Bool)
+        -> Observable<Element> {
         return Filter(source: self.asObservable(), predicate: predicate)
     }
 }
@@ -42,7 +42,7 @@ extension ObservableType {
 
 final private class FilterSink<O: ObserverType>: Sink<O>, ObserverType {
     typealias Predicate = (Element) throws -> Bool
-    typealias Element = O.E
+    typealias Element = O.Element 
     
     private let _predicate: Predicate
     
@@ -82,7 +82,7 @@ final private class Filter<Element>: Producer<Element> {
         self._predicate = predicate
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = FilterSink(predicate: self._predicate, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/First.swift
+++ b/RxSwift/Observables/First.swift
@@ -6,11 +6,11 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-fileprivate final class FirstSink<Element, O: ObserverType> : Sink<O>, ObserverType where O.E == Element? {
-    typealias E = Element
-    typealias Parent = First<E>
+fileprivate final class FirstSink<Element, O: ObserverType> : Sink<O>, ObserverType where O.Element == Element? {
+    typealias Element = Element
+    typealias Parent = First<Element>
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next(let value):
             self.forwardOn(.next(value))
@@ -34,7 +34,7 @@ final class First<Element>: Producer<Element?> {
         self._source = source
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element? {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element? {
         let sink = FirstSink(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/First.swift
+++ b/RxSwift/Observables/First.swift
@@ -7,7 +7,6 @@
 //
 
 fileprivate final class FirstSink<Element, O: ObserverType> : Sink<O>, ObserverType where O.Element == Element? {
-    typealias Element = Element
     typealias Parent = First<Element>
 
     func on(_ event: Event<Element>) {

--- a/RxSwift/Observables/Generate.swift
+++ b/RxSwift/Observables/Generate.swift
@@ -19,13 +19,13 @@ extension ObservableType {
      - parameter scheduler: Scheduler on which to run the generator loop.
      - returns: The generated sequence.
      */
-    public static func generate(initialState: E, condition: @escaping (E) throws -> Bool, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance, iterate: @escaping (E) throws -> E) -> Observable<E> {
+    public static func generate(initialState: Element, condition: @escaping (Element) throws -> Bool, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance, iterate: @escaping (Element) throws -> Element) -> Observable<Element> {
         return Generate(initialState: initialState, condition: condition, iterate: iterate, resultSelector: { $0 }, scheduler: scheduler)
     }
 }
 
 final private class GenerateSink<S, O: ObserverType>: Sink<O> {
-    typealias Parent = Generate<S, O.E>
+    typealias Parent = Generate<S, O.Element>
     
     private let _parent: Parent
     
@@ -63,14 +63,14 @@ final private class GenerateSink<S, O: ObserverType>: Sink<O> {
     }
 }
 
-final private class Generate<S, E>: Producer<E> {
+final private class Generate<S, Element>: Producer<Element> {
     fileprivate let _initialState: S
     fileprivate let _condition: (S) throws -> Bool
     fileprivate let _iterate: (S) throws -> S
-    fileprivate let _resultSelector: (S) throws -> E
+    fileprivate let _resultSelector: (S) throws -> Element
     fileprivate let _scheduler: ImmediateSchedulerType
     
-    init(initialState: S, condition: @escaping (S) throws -> Bool, iterate: @escaping (S) throws -> S, resultSelector: @escaping (S) throws -> E, scheduler: ImmediateSchedulerType) {
+    init(initialState: S, condition: @escaping (S) throws -> Bool, iterate: @escaping (S) throws -> S, resultSelector: @escaping (S) throws -> Element, scheduler: ImmediateSchedulerType) {
         self._initialState = initialState
         self._condition = condition
         self._iterate = iterate
@@ -79,7 +79,7 @@ final private class Generate<S, E>: Producer<E> {
         super.init()
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = GenerateSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/GroupBy.swift
+++ b/RxSwift/Observables/GroupBy.swift
@@ -15,8 +15,8 @@ extension ObservableType {
      - parameter keySelector: A function to extract the key for each element.
      - returns: A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
      */
-    public func groupBy<K: Hashable>(keySelector: @escaping (E) throws -> K)
-        -> Observable<GroupedObservable<K,E>> {
+    public func groupBy<K: Hashable>(keySelector: @escaping (Element) throws -> K)
+        -> Observable<GroupedObservable<K,Element>> {
         return GroupBy(source: self.asObservable(), selector: keySelector)
     }
 }
@@ -30,7 +30,7 @@ final private class GroupedObservableImpl<Element>: Observable<Element> {
         self._refCount = refCount
     }
 
-    override public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    override public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         let release = self._refCount.retain()
         let subscription = self._subject.subscribe(observer)
         return Disposables.create(release, subscription)
@@ -40,9 +40,9 @@ final private class GroupedObservableImpl<Element>: Observable<Element> {
 
 final private class GroupBySink<Key: Hashable, Element, O: ObserverType>
     : Sink<O>
-    , ObserverType where O.E == GroupedObservable<Key, Element> {
-    typealias E = Element
-    typealias ResultType = O.E
+    , ObserverType where O.Element == GroupedObservable<Key, Element> {
+    typealias Element = Element
+    typealias ResultType = O.Element 
     typealias Parent = GroupBy<Key, Element>
 
     private let _parent: Parent
@@ -127,7 +127,7 @@ final private class GroupBy<Key: Hashable, Element>: Producer<GroupedObservable<
         self._selector = selector
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == GroupedObservable<Key,Element> {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == GroupedObservable<Key,Element> {
         let sink = GroupBySink(parent: self, observer: observer, cancel: cancel)
         return (sink: sink, subscription: sink.run())
     }

--- a/RxSwift/Observables/GroupBy.swift
+++ b/RxSwift/Observables/GroupBy.swift
@@ -41,7 +41,6 @@ final private class GroupedObservableImpl<Element>: Observable<Element> {
 final private class GroupBySink<Key: Hashable, Element, O: ObserverType>
     : Sink<O>
     , ObserverType where O.Element == GroupedObservable<Key, Element> {
-    typealias Element = Element
     typealias ResultType = O.Element 
     typealias Parent = GroupBy<Key, Element>
 

--- a/RxSwift/Observables/Just.swift
+++ b/RxSwift/Observables/Just.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter element: Single element in the resulting observable sequence.
      - returns: An observable sequence containing the single specified element.
      */
-    public static func just(_ element: E) -> Observable<E> {
+    public static func just(_ element: Element) -> Observable<Element> {
         return Just(element: element)
     }
 
@@ -28,13 +28,13 @@ extension ObservableType {
      - parameter scheduler: Scheduler to send the single element on.
      - returns: An observable sequence containing the single specified element.
      */
-    public static func just(_ element: E, scheduler: ImmediateSchedulerType) -> Observable<E> {
+    public static func just(_ element: Element, scheduler: ImmediateSchedulerType) -> Observable<Element> {
         return JustScheduled(element: element, scheduler: scheduler)
     }
 }
 
 final private class JustScheduledSink<O: ObserverType>: Sink<O> {
-    typealias Parent = JustScheduled<O.E>
+    typealias Parent = JustScheduled<O.Element>
 
     private let _parent: Parent
 
@@ -65,7 +65,7 @@ final private class JustScheduled<Element>: Producer<Element> {
         self._element = element
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = JustScheduledSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -79,7 +79,7 @@ final private class Just<Element>: Producer<Element> {
         self._element = element
     }
     
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         observer.on(.next(self._element))
         observer.on(.completed)
         return Disposables.create()

--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
 
      */
-    public func map<R>(_ transform: @escaping (E) throws -> R)
+    public func map<R>(_ transform: @escaping (Element) throws -> R)
         -> Observable<R> {
         return self.asObservable().composeMap(transform)
     }
@@ -26,7 +26,7 @@ extension ObservableType {
 final private class MapSink<SourceType, O: ObserverType>: Sink<O>, ObserverType {
     typealias Transform = (SourceType) throws -> ResultType
 
-    typealias ResultType = O.E
+    typealias ResultType = O.Element 
     typealias Element = SourceType
 
     private let _transform: Transform
@@ -94,7 +94,7 @@ final private class Map<SourceType, ResultType>: Producer<ResultType> {
         })
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == ResultType {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == ResultType {
         let sink = MapSink(transform: self._transform, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Materialize.swift
+++ b/RxSwift/Observables/Materialize.swift
@@ -12,13 +12,13 @@ extension ObservableType {
      - seealso: [materialize operator on reactivex.io](http://reactivex.io/documentation/operators/materialize-dematerialize.html)
      - returns: An observable sequence that wraps events in an Event<E>. The returned Observable never errors, but it does complete after observing all of the events of the underlying Observable.
      */
-    public func materialize() -> Observable<Event<E>> {
+    public func materialize() -> Observable<Event<Element>> {
         return Materialize(source: self.asObservable())
     }
 }
 
-fileprivate final class MaterializeSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.E == Event<Element> {
-    
+fileprivate final class MaterializeSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.Element == Event<Element> {
+
     func on(_ event: Event<Element>) {
         self.forwardOn(.next(event))
         if event.isStopEvent {
@@ -28,14 +28,14 @@ fileprivate final class MaterializeSink<Element, O: ObserverType>: Sink<O>, Obse
     }
 }
 
-final private class Materialize<Element>: Producer<Event<Element>> {
-    private let _source: Observable<Element>
-    
-    init(source: Observable<Element>) {
+final private class Materialize<T>: Producer<Event<T>> {
+    private let _source: Observable<T>
+
+    init(source: Observable<T>) {
         self._source = source
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = MaterializeSink(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
 

--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -16,8 +16,8 @@ extension ObservableType {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMap<O: ObservableConvertibleType>(_ selector: @escaping (E) throws -> O)
-        -> Observable<O.E> {
+    public func flatMap<O: ObservableConvertibleType>(_ selector: @escaping (Element) throws -> O)
+        -> Observable<O.Element> {
             return FlatMap(source: self.asObservable(), selector: selector)
     }
 
@@ -34,13 +34,13 @@ extension ObservableType {
      - parameter selector: A transform function to apply to element that was observed while no observable is executing in parallel.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence that was received while no other sequence was being calculated.
      */
-    public func flatMapFirst<O: ObservableConvertibleType>(_ selector: @escaping (E) throws -> O)
-        -> Observable<O.E> {
+    public func flatMapFirst<O: ObservableConvertibleType>(_ selector: @escaping (Element) throws -> O)
+        -> Observable<O.Element> {
             return FlatMapFirst(source: self.asObservable(), selector: selector)
     }
 }
 
-extension ObservableType where E : ObservableConvertibleType {
+extension ObservableType where Element : ObservableConvertibleType {
 
     /**
      Merges elements from all observable sequences in the given enumerable sequence into a single observable sequence.
@@ -49,7 +49,7 @@ extension ObservableType where E : ObservableConvertibleType {
 
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public func merge() -> Observable<E.E> {
+    public func merge() -> Observable<Element.Element> {
         return Merge(source: self.asObservable())
     }
 
@@ -62,12 +62,12 @@ extension ObservableType where E : ObservableConvertibleType {
      - returns: The observable sequence that merges the elements of the inner sequences.
      */
     public func merge(maxConcurrent: Int)
-        -> Observable<E.E> {
+        -> Observable<Element.Element> {
         return MergeLimited(source: self.asObservable(), maxConcurrent: maxConcurrent)
     }
 }
 
-extension ObservableType where E : ObservableConvertibleType {
+extension ObservableType where Element : ObservableConvertibleType {
 
     /**
      Concatenates all inner observable sequences, as long as the previous observable sequence terminated successfully.
@@ -76,7 +76,7 @@ extension ObservableType where E : ObservableConvertibleType {
 
      - returns: An observable sequence that contains the elements of each observed inner sequence, in sequential order.
      */
-    public func concat() -> Observable<E.E> {
+    public func concat() -> Observable<Element.Element> {
         return self.merge(maxConcurrent: 1)
     }
 }
@@ -90,7 +90,7 @@ extension ObservableType {
      - parameter sources: Collection of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge<C: Collection>(_ sources: C) -> Observable<E> where C.Iterator.Element == Observable<E> {
+    public static func merge<C: Collection>(_ sources: C) -> Observable<Element> where C.Iterator.Element == Observable<Element> {
         return MergeArray(sources: Array(sources))
     }
 
@@ -102,7 +102,7 @@ extension ObservableType {
      - parameter sources: Array of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge(_ sources: [Observable<E>]) -> Observable<E> {
+    public static func merge(_ sources: [Observable<Element>]) -> Observable<Element> {
         return MergeArray(sources: sources)
     }
 
@@ -114,7 +114,7 @@ extension ObservableType {
      - parameter sources: Collection of observable sequences to merge.
      - returns: The observable sequence that merges the elements of the observable sequences.
      */
-    public static func merge(_ sources: Observable<E>...) -> Observable<E> {
+    public static func merge(_ sources: Observable<Element>...) -> Observable<Element> {
         return MergeArray(sources: sources)
     }
 }
@@ -130,8 +130,8 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements of each observed inner sequence, in sequential order.
      */
     
-    public func concatMap<O: ObservableConvertibleType>(_ selector: @escaping (E) throws -> O)
-        -> Observable<O.E> {
+    public func concatMap<O: ObservableConvertibleType>(_ selector: @escaping (Element) throws -> O)
+        -> Observable<O.Element> {
             return ConcatMap(source: self.asObservable(), selector: selector)
     }
 }
@@ -139,8 +139,8 @@ extension ObservableType {
 fileprivate final class MergeLimitedSinkIter<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>
     : ObserverType
     , LockOwnerType
-    , SynchronizedOnType where SourceSequence.E == Observer.E {
-    typealias E = Observer.E
+    , SynchronizedOnType where SourceSequence.Element == Observer.Element {
+    typealias Element = Observer.Element
     typealias DisposeKey = CompositeDisposable.DisposeKey
     typealias Parent = MergeLimitedSink<SourceElement, SourceSequence, Observer>
     
@@ -156,11 +156,11 @@ fileprivate final class MergeLimitedSinkIter<SourceElement, SourceSequence: Obse
         self._disposeKey = disposeKey
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next:
             self._parent.forwardOn(event)
@@ -184,7 +184,7 @@ fileprivate final class MergeLimitedSinkIter<SourceElement, SourceSequence: Obse
     }
 }
 
-fileprivate final class ConcatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceElement, SourceSequence, Observer> where Observer.E == SourceSequence.E {
+fileprivate final class ConcatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
     typealias Selector = (SourceElement) throws -> SourceSequence
     
     private let _selector: Selector
@@ -199,7 +199,7 @@ fileprivate final class ConcatMapSink<SourceElement, SourceSequence: ObservableC
     }
 }
 
-fileprivate final class MergeLimitedBasicSink<SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceSequence, SourceSequence, Observer> where Observer.E == SourceSequence.E {
+fileprivate final class MergeLimitedBasicSink<SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceSequence, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
     
     override func performMap(_ element: SourceSequence) throws -> SourceSequence {
         return element
@@ -208,7 +208,7 @@ fileprivate final class MergeLimitedBasicSink<SourceSequence: ObservableConverti
 
 private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>
     : Sink<Observer>
-    , ObserverType where Observer.E == SourceSequence.E {
+    , ObserverType where Observer.Element == SourceSequence.Element {
     typealias QueueType = Queue<SourceSequence>
 
     let _maxConcurrent: Int
@@ -312,7 +312,7 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
     }
 }
 
-final private class MergeLimited<SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.E> {
+final private class MergeLimited<SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.Element> {
     private let _source: Observable<SourceSequence>
     private let _maxConcurrent: Int
     
@@ -321,7 +321,7 @@ final private class MergeLimited<SourceSequence: ObservableConvertibleType>: Pro
         self._maxConcurrent = maxConcurrent
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == SourceSequence.E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
         let sink = MergeLimitedBasicSink<SourceSequence, O>(maxConcurrent: self._maxConcurrent, observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
@@ -330,7 +330,7 @@ final private class MergeLimited<SourceSequence: ObservableConvertibleType>: Pro
 
 // MARK: Merge
 
-fileprivate final class MergeBasicSink<S: ObservableConvertibleType, O: ObserverType> : MergeSink<S, S, O> where O.E == S.E {
+fileprivate final class MergeBasicSink<S: ObservableConvertibleType, O: ObserverType> : MergeSink<S, S, O> where O.Element == S.Element {
     override func performMap(_ element: S) throws -> S {
         return element
     }
@@ -338,7 +338,7 @@ fileprivate final class MergeBasicSink<S: ObservableConvertibleType, O: Observer
 
 // MARK: flatMap
 
-fileprivate final class FlatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.E == SourceSequence.E {
+fileprivate final class FlatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
     typealias Selector = (SourceElement) throws -> SourceSequence
 
     private let _selector: Selector
@@ -355,7 +355,7 @@ fileprivate final class FlatMapSink<SourceElement, SourceSequence: ObservableCon
 
 // MARK: FlatMapFirst
 
-fileprivate final class FlatMapFirstSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.E == SourceSequence.E {
+fileprivate final class FlatMapFirstSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
     typealias Selector = (SourceElement) throws -> SourceSequence
 
     private let _selector: Selector
@@ -374,10 +374,10 @@ fileprivate final class FlatMapFirstSink<SourceElement, SourceSequence: Observab
     }
 }
 
-fileprivate final class MergeSinkIter<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : ObserverType where Observer.E == SourceSequence.E {
+fileprivate final class MergeSinkIter<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : ObserverType where Observer.Element == SourceSequence.Element {
     typealias Parent = MergeSink<SourceElement, SourceSequence, Observer>
     typealias DisposeKey = CompositeDisposable.DisposeKey
-    typealias E = Observer.E
+    typealias Element = Observer.Element
     
     private let _parent: Parent
     private let _disposeKey: DisposeKey
@@ -387,7 +387,7 @@ fileprivate final class MergeSinkIter<SourceElement, SourceSequence: ObservableC
         self._disposeKey = disposeKey
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self._parent._lock.lock(); defer { self._parent._lock.unlock() } // lock {
             switch event {
             case .next(let value):
@@ -407,8 +407,8 @@ fileprivate final class MergeSinkIter<SourceElement, SourceSequence: ObservableC
 
 private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>
     : Sink<Observer>
-    , ObserverType where Observer.E == SourceSequence.E {
-    typealias ResultType = Observer.E
+    , ObserverType where Observer.Element == SourceSequence.Element {
+    typealias ResultType = Observer.Element
     typealias Element = SourceElement
 
     let _lock = RecursiveLock()
@@ -470,7 +470,7 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
         }
     }
 
-    func subscribeInner(_ source: Observable<Observer.E>) {
+    func subscribeInner(_ source: Observable<Observer.Element>) {
         let iterDisposable = SingleAssignmentDisposable()
         if let disposeKey = self._group.insert(iterDisposable) {
             let iter = MergeSinkIter(parent: self, disposeKey: disposeKey)
@@ -479,7 +479,7 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
         }
     }
 
-    func run(_ sources: [Observable<Observer.E>]) -> Disposable {
+    func run(_ sources: [Observable<Observer.Element>]) -> Disposable {
         self._activeCount += sources.count
 
         for source in sources {
@@ -513,7 +513,7 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
 
 // MARK: Producers
 
-final private class FlatMap<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.E> {
+final private class FlatMap<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.Element> {
     typealias Selector = (SourceElement) throws -> SourceSequence
 
     private let _source: Observable<SourceElement>
@@ -525,14 +525,14 @@ final private class FlatMap<SourceElement, SourceSequence: ObservableConvertible
         self._selector = selector
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == SourceSequence.E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
         let sink = FlatMapSink(selector: self._selector, observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
     }
 }
 
-final private class FlatMapFirst<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.E> {
+final private class FlatMapFirst<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.Element> {
     typealias Selector = (SourceElement) throws -> SourceSequence
 
     private let _source: Observable<SourceElement>
@@ -544,14 +544,14 @@ final private class FlatMapFirst<SourceElement, SourceSequence: ObservableConver
         self._selector = selector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == SourceSequence.E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
         let sink = FlatMapFirstSink<SourceElement, SourceSequence, O>(selector: self._selector, observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
     }
 }
 
-final class ConcatMap<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.E> {
+final class ConcatMap<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.Element> {
     typealias Selector = (SourceElement) throws -> SourceSequence
     
     private let _source: Observable<SourceElement>
@@ -562,21 +562,21 @@ final class ConcatMap<SourceElement, SourceSequence: ObservableConvertibleType>:
         self._selector = selector
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == SourceSequence.E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
         let sink = ConcatMapSink<SourceElement, SourceSequence, O>(selector: self._selector, observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
     }
 }
 
-final class Merge<SourceSequence: ObservableConvertibleType> : Producer<SourceSequence.E> {
+final class Merge<SourceSequence: ObservableConvertibleType> : Producer<SourceSequence.Element> {
     private let _source: Observable<SourceSequence>
 
     init(source: Observable<SourceSequence>) {
         self._source = source
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == SourceSequence.E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
         let sink = MergeBasicSink<SourceSequence, O>(observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
@@ -590,8 +590,8 @@ final private class MergeArray<Element>: Producer<Element> {
         self._sources = sources
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
-        let sink = MergeBasicSink<Observable<E>, O>(observer: observer, cancel: cancel)
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+        let sink = MergeBasicSink<Observable<Element>, O>(observer: observer, cancel: cancel)
         let subscription = sink.run(self._sources)
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Observables/Never.swift
+++ b/RxSwift/Observables/Never.swift
@@ -15,13 +15,13 @@ extension ObservableType {
 
      - returns: An observable sequence whose observers will never get called.
      */
-    public static func never() -> Observable<E> {
+    public static func never() -> Observable<Element> {
         return NeverProducer()
     }
 }
 
 final private class NeverProducer<Element>: Producer<Element> {
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         return Disposables.create()
     }
 }

--- a/RxSwift/Observables/Optional.swift
+++ b/RxSwift/Observables/Optional.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter optional: Optional element in the resulting observable sequence.
      - returns: An observable sequence containing the wrapped value or not from given optional.
      */
-    public static func from(optional: E?) -> Observable<E> {
+    public static func from(optional: Element?) -> Observable<Element> {
         return ObservableOptional(optional: optional)
     }
 
@@ -28,14 +28,14 @@ extension ObservableType {
      - parameter scheduler: Scheduler to send the optional element on.
      - returns: An observable sequence containing the wrapped value or not from given optional.
      */
-    public static func from(optional: E?, scheduler: ImmediateSchedulerType) -> Observable<E> {
+    public static func from(optional: Element?, scheduler: ImmediateSchedulerType) -> Observable<Element> {
         return ObservableOptionalScheduled(optional: optional, scheduler: scheduler)
     }
 }
 
 final private class ObservableOptionalScheduledSink<O: ObserverType>: Sink<O> {
-    typealias E = O.E
-    typealias Parent = ObservableOptionalScheduled<E>
+    typealias Element = O.Element 
+    typealias Parent = ObservableOptionalScheduled<Element>
 
     private let _parent: Parent
 
@@ -45,7 +45,7 @@ final private class ObservableOptionalScheduledSink<O: ObserverType>: Sink<O> {
     }
 
     func run() -> Disposable {
-        return self._parent._scheduler.schedule(self._parent._optional) { (optional: E?) -> Disposable in
+        return self._parent._scheduler.schedule(self._parent._optional) { (optional: Element?) -> Disposable in
             if let next = optional {
                 self.forwardOn(.next(next))
                 return self._parent._scheduler.schedule(()) { _ in
@@ -62,30 +62,30 @@ final private class ObservableOptionalScheduledSink<O: ObserverType>: Sink<O> {
     }
 }
 
-final private class ObservableOptionalScheduled<E>: Producer<E> {
-    fileprivate let _optional: E?
+final private class ObservableOptionalScheduled<Element>: Producer<Element> {
+    fileprivate let _optional: Element?
     fileprivate let _scheduler: ImmediateSchedulerType
 
-    init(optional: E?, scheduler: ImmediateSchedulerType) {
+    init(optional: Element?, scheduler: ImmediateSchedulerType) {
         self._optional = optional
         self._scheduler = scheduler
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = ObservableOptionalScheduledSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
     }
 }
 
-final private class ObservableOptional<E>: Producer<E> {
-    private let _optional: E?
+final private class ObservableOptional<Element>: Producer<Element> {
+    private let _optional: Element?
     
-    init(optional: E?) {
+    init(optional: Element?) {
         self._optional = optional
     }
     
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         if let element = self._optional {
             observer.on(.next(element))
         }

--- a/RxSwift/Observables/Producer.swift
+++ b/RxSwift/Observables/Producer.swift
@@ -11,7 +11,7 @@ class Producer<Element> : Observable<Element> {
         super.init()
     }
 
-    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         if !CurrentThreadScheduler.isScheduleRequired {
             // The returned disposable needs to release all references once it was disposed.
             let disposer = SinkDisposer()
@@ -31,7 +31,7 @@ class Producer<Element> : Observable<Element> {
         }
     }
 
-    func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         rxAbstractMethod()
     }
 }

--- a/RxSwift/Observables/Range.swift
+++ b/RxSwift/Observables/Range.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-extension ObservableType where E : RxAbstractInteger {
+extension ObservableType where Element : RxAbstractInteger {
     /**
      Generates an observable sequence of integral numbers within a specified range, using the specified scheduler to generate and send out observer messages.
 
@@ -17,17 +17,17 @@ extension ObservableType where E : RxAbstractInteger {
      - parameter scheduler: Scheduler to run the generator loop on.
      - returns: An observable sequence that contains a range of sequential integral numbers.
      */
-    public static func range(start: E, count: E, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<E> {
-        return RangeProducer<E>(start: start, count: count, scheduler: scheduler)
+    public static func range(start: Element, count: Element, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<Element> {
+        return RangeProducer<Element>(start: start, count: count, scheduler: scheduler)
     }
 }
 
-final private class RangeProducer<E: RxAbstractInteger>: Producer<E> {
-    fileprivate let _start: E
-    fileprivate let _count: E
+final private class RangeProducer<Element: RxAbstractInteger>: Producer<Element> {
+    fileprivate let _start: Element
+    fileprivate let _count: Element
     fileprivate let _scheduler: ImmediateSchedulerType
 
-    init(start: E, count: E, scheduler: ImmediateSchedulerType) {
+    init(start: Element, count: Element, scheduler: ImmediateSchedulerType) {
         guard count >= 0 else {
             rxFatalError("count can't be negative")
         }
@@ -41,15 +41,15 @@ final private class RangeProducer<E: RxAbstractInteger>: Producer<E> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = RangeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
     }
 }
 
-final private class RangeSink<O: ObserverType>: Sink<O> where O.E: RxAbstractInteger {
-    typealias Parent = RangeProducer<O.E>
+final private class RangeSink<O: ObserverType>: Sink<O> where O.Element: RxAbstractInteger {
+    typealias Parent = RangeProducer<O.Element>
     
     private let _parent: Parent
     
@@ -59,7 +59,7 @@ final private class RangeSink<O: ObserverType>: Sink<O> where O.E: RxAbstractInt
     }
     
     func run() -> Disposable {
-        return self._parent._scheduler.scheduleRecursive(0 as O.E) { i, recurse in
+        return self._parent._scheduler.scheduleRecursive(0 as O.Element) { i, recurse in
             if i < self._parent._count {
                 self.forwardOn(.next(self._parent._start + i))
                 recurse(i + 1)

--- a/RxSwift/Observables/Reduce.swift
+++ b/RxSwift/Observables/Reduce.swift
@@ -20,7 +20,7 @@ extension ObservableType {
     - parameter mapResult: A function to transform the final accumulator value into the result value.
     - returns: An observable sequence containing a single element with the final accumulator value.
     */
-    public func reduce<A, R>(_ seed: A, accumulator: @escaping (A, E) throws -> A, mapResult: @escaping (A) throws -> R)
+    public func reduce<A, R>(_ seed: A, accumulator: @escaping (A, Element) throws -> A, mapResult: @escaping (A) throws -> R)
         -> Observable<R> {
         return Reduce(source: self.asObservable(), seed: seed, accumulator: accumulator, mapResult: mapResult)
     }
@@ -36,14 +36,14 @@ extension ObservableType {
     - parameter accumulator: A accumulator function to be invoked on each element.
     - returns: An observable sequence containing a single element with the final accumulator value.
     */
-    public func reduce<A>(_ seed: A, accumulator: @escaping (A, E) throws -> A)
+    public func reduce<A>(_ seed: A, accumulator: @escaping (A, Element) throws -> A)
         -> Observable<A> {
         return Reduce(source: self.asObservable(), seed: seed, accumulator: accumulator, mapResult: { $0 })
     }
 }
 
 final private class ReduceSink<SourceType, AccumulateType, O: ObserverType>: Sink<O>, ObserverType {
-    typealias ResultType = O.E
+    typealias ResultType = O.Element 
     typealias Parent = Reduce<SourceType, AccumulateType, ResultType>
     
     private let _parent: Parent
@@ -100,7 +100,7 @@ final private class Reduce<SourceType, AccumulateType, ResultType>: Producer<Res
         self._mapResult = mapResult
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == ResultType {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == ResultType {
         let sink = ReduceSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Repeat.swift
+++ b/RxSwift/Observables/Repeat.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter scheduler: Scheduler to run the producer loop on.
      - returns: An observable sequence that repeats the given element infinitely.
      */
-    public static func repeatElement(_ element: E, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<E> {
+    public static func repeatElement(_ element: Element, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<Element> {
         return RepeatElement(element: element, scheduler: scheduler)
     }
 }
@@ -30,7 +30,7 @@ final private class RepeatElement<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = RepeatElementSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
 
@@ -39,7 +39,7 @@ final private class RepeatElement<Element>: Producer<Element> {
 }
 
 final private class RepeatElementSink<O: ObserverType>: Sink<O> {
-    typealias Parent = RepeatElement<O.E>
+    typealias Parent = RepeatElement<O.Element>
     
     private let _parent: Parent
     

--- a/RxSwift/Observables/Sample.swift
+++ b/RxSwift/Observables/Sample.swift
@@ -21,7 +21,7 @@ extension ObservableType {
      - returns: Sampled observable sequence.
      */
     public func sample<O: ObservableType>(_ sampler: O)
-        -> Observable<E> {
+        -> Observable<Element> {
             return Sample(source: self.asObservable(), sampler: sampler.asObservable())
     }
 }
@@ -30,7 +30,7 @@ final private class SamplerSink<O: ObserverType, SampleType>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias E = SampleType
+    typealias Element = SampleType
     
     typealias Parent = SampleSequenceSink<O, SampleType>
     
@@ -44,11 +44,11 @@ final private class SamplerSink<O: ObserverType, SampleType>
         self._parent = parent
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next, .completed:
             if let element = _parent._element {
@@ -72,7 +72,7 @@ final private class SampleSequenceSink<O: ObserverType, SampleType>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias Parent = Sample<Element, SampleType>
     
     fileprivate let _parent: Parent
@@ -125,7 +125,7 @@ final private class Sample<Element, SampleType>: Producer<Element> {
         self._sampler = sampler
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = SampleSequenceSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Scan.swift
+++ b/RxSwift/Observables/Scan.swift
@@ -19,7 +19,7 @@ extension ObservableType {
      - parameter accumulator: An accumulator function to be invoked on each element.
      - returns: An observable sequence containing the accumulated values.
      */
-    public func scan<A>(into seed: A, accumulator: @escaping (inout A, E) throws -> Void)
+    public func scan<A>(into seed: A, accumulator: @escaping (inout A, Element) throws -> Void)
         -> Observable<A> {
         return Scan(source: self.asObservable(), seed: seed, accumulator: accumulator)
     }
@@ -35,7 +35,7 @@ extension ObservableType {
      - parameter accumulator: An accumulator function to be invoked on each element.
      - returns: An observable sequence containing the accumulated values.
      */
-    public func scan<A>(_ seed: A, accumulator: @escaping (A, E) throws -> A)
+    public func scan<A>(_ seed: A, accumulator: @escaping (A, Element) throws -> A)
         -> Observable<A> {
         return Scan(source: self.asObservable(), seed: seed) { acc, element in
             let currentAcc = acc
@@ -45,9 +45,9 @@ extension ObservableType {
 }
 
 final private class ScanSink<ElementType, O: ObserverType>: Sink<O>, ObserverType {
-    typealias Accumulate = O.E
+    typealias Accumulate = O.Element 
     typealias Parent = Scan<ElementType, Accumulate>
-    typealias E = ElementType
+    typealias Element = ElementType
     
     fileprivate let _parent: Parent
     fileprivate var _accumulate: Accumulate
@@ -93,7 +93,7 @@ final private class Scan<Element, Accumulate>: Producer<Accumulate> {
         self._accumulator = accumulator
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Accumulate {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Accumulate {
         let sink = ScanSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Scan.swift
+++ b/RxSwift/Observables/Scan.swift
@@ -44,11 +44,10 @@ extension ObservableType {
     }
 }
 
-final private class ScanSink<ElementType, O: ObserverType>: Sink<O>, ObserverType {
+final private class ScanSink<Element, O: ObserverType>: Sink<O>, ObserverType {
     typealias Accumulate = O.Element 
-    typealias Parent = Scan<ElementType, Accumulate>
-    typealias Element = ElementType
-    
+    typealias Parent = Scan<Element, Accumulate>
+
     fileprivate let _parent: Parent
     fileprivate var _accumulate: Accumulate
     
@@ -58,7 +57,7 @@ final private class ScanSink<ElementType, O: ObserverType>: Sink<O>, ObserverTyp
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<ElementType>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next(let element):
             do {

--- a/RxSwift/Observables/Sequence.swift
+++ b/RxSwift/Observables/Sequence.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      - parameter scheduler: Scheduler to send elements on. If `nil`, elements are sent immediately on subscription.
      - returns: The observable sequence whose elements are pulled from the given arguments.
      */
-    public static func of(_ elements: E ..., scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<E> {
+    public static func of(_ elements: Element ..., scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<Element> {
         return ObservableSequence(elements: elements, scheduler: scheduler)
     }
 }
@@ -31,7 +31,7 @@ extension ObservableType {
 
      - returns: The observable sequence whose elements are pulled from the given enumerable sequence.
      */
-    public static func from(_ array: [E], scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<E> {
+    public static func from(_ array: [Element], scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<Element> {
         return ObservableSequence(elements: array, scheduler: scheduler)
     }
 
@@ -42,12 +42,12 @@ extension ObservableType {
 
      - returns: The observable sequence whose elements are pulled from the given enumerable sequence.
      */
-    public static func from<S: Sequence>(_ sequence: S, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<E> where S.Iterator.Element == E {
+    public static func from<S: Sequence>(_ sequence: S, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance) -> Observable<Element> where S.Iterator.Element == Element {
         return ObservableSequence(elements: sequence, scheduler: scheduler)
     }
 }
 
-final private class ObservableSequenceSink<S: Sequence, O: ObserverType>: Sink<O> where S.Iterator.Element == O.E {
+final private class ObservableSequenceSink<S: Sequence, O: ObserverType>: Sink<O> where S.Iterator.Element == O.Element {
     typealias Parent = ObservableSequence<S>
 
     private let _parent: Parent
@@ -81,7 +81,7 @@ final private class ObservableSequence<S: Sequence>: Producer<S.Iterator.Element
         self._scheduler = scheduler
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = ObservableSequenceSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -139,7 +139,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
      */
     public func share(replay: Int = 0, scope: SubjectLifetimeScope = .whileConnected)
-        -> Observable<E> {
+        -> Observable<Element> {
         switch scope {
         case .forever:
             switch replay {
@@ -159,7 +159,7 @@ extension ObservableType {
 fileprivate final class ShareReplay1WhileConnectedConnection<Element>
     : ObserverType
     , SynchronizedUnsubscribeType {
-    typealias E = Element
+    typealias Element = Element
     typealias Observers = AnyObserver<Element>.s
     typealias DisposeKey = Observers.KeyType
 
@@ -181,14 +181,14 @@ fileprivate final class ShareReplay1WhileConnectedConnection<Element>
         #endif
     }
 
-    final func on(_ event: Event<E>) {
+    final func on(_ event: Event<Element>) {
         self._lock.lock()
         let observers = self._synchronized_on(event)
         self._lock.unlock()
         dispatch(observers, event)
     }
 
-    final private func _synchronized_on(_ event: Event<E>) -> Observers {
+    final private func _synchronized_on(_ event: Event<Element>) -> Observers {
         if self._disposed {
             return Observers()
         }
@@ -208,7 +208,7 @@ fileprivate final class ShareReplay1WhileConnectedConnection<Element>
         self._subscription.setDisposable(self._parent._source.subscribe(self))
     }
 
-    final func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    final func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self._lock.lock(); defer { self._lock.unlock() }
         if let element = self._element {
             observer.on(.next(element))
@@ -274,7 +274,7 @@ final private class ShareReplay1WhileConnected<Element>
         self._source = source
     }
 
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self._lock.lock()
 
         let connection = self._synchronized_subscribe(observer)
@@ -292,7 +292,7 @@ final private class ShareReplay1WhileConnected<Element>
     }
 
     @inline(__always)
-    private func _synchronized_subscribe<O : ObserverType>(_ observer: O) -> Connection where O.E == E {
+    private func _synchronized_subscribe<O : ObserverType>(_ observer: O) -> Connection where O.Element == Element {
         let connection: Connection
 
         if let existingConnection = self._connection {
@@ -312,7 +312,7 @@ final private class ShareReplay1WhileConnected<Element>
 fileprivate final class ShareWhileConnectedConnection<Element>
     : ObserverType
     , SynchronizedUnsubscribeType {
-    typealias E = Element
+    typealias Element = Element
     typealias Observers = AnyObserver<Element>.s
     typealias DisposeKey = Observers.KeyType
 
@@ -333,14 +333,14 @@ fileprivate final class ShareWhileConnectedConnection<Element>
         #endif
     }
 
-    final func on(_ event: Event<E>) {
+    final func on(_ event: Event<Element>) {
         self._lock.lock()
         let observers = self._synchronized_on(event)
         self._lock.unlock()
         dispatch(observers, event)
     }
 
-    final private func _synchronized_on(_ event: Event<E>) -> Observers {
+    final private func _synchronized_on(_ event: Event<Element>) -> Observers {
         if self._disposed {
             return Observers()
         }
@@ -359,7 +359,7 @@ fileprivate final class ShareWhileConnectedConnection<Element>
         self._subscription.setDisposable(self._parent._source.subscribe(self))
     }
 
-    final func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    final func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self._lock.lock(); defer { self._lock.unlock() }
 
         let disposeKey = self._observers.insert(observer.on)
@@ -422,7 +422,7 @@ final private class ShareWhileConnected<Element>
         self._source = source
     }
 
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self._lock.lock()
 
         let connection = self._synchronized_subscribe(observer)
@@ -440,7 +440,7 @@ final private class ShareWhileConnected<Element>
     }
 
     @inline(__always)
-    private func _synchronized_subscribe<O : ObserverType>(_ observer: O) -> Connection where O.E == E {
+    private func _synchronized_subscribe<O : ObserverType>(_ observer: O) -> Connection where O.Element == Element {
         let connection: Connection
 
         if let existingConnection = self._connection {

--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -159,7 +159,6 @@ extension ObservableType {
 fileprivate final class ShareReplay1WhileConnectedConnection<Element>
     : ObserverType
     , SynchronizedUnsubscribeType {
-    typealias Element = Element
     typealias Observers = AnyObserver<Element>.s
     typealias DisposeKey = Observers.KeyType
 
@@ -312,7 +311,6 @@ final private class ShareReplay1WhileConnected<Element>
 fileprivate final class ShareWhileConnectedConnection<Element>
     : ObserverType
     , SynchronizedUnsubscribeType {
-    typealias Element = Element
     typealias Observers = AnyObserver<Element>.s
     typealias DisposeKey = Observers.KeyType
 

--- a/RxSwift/Observables/SingleAsync.swift
+++ b/RxSwift/Observables/SingleAsync.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence that emits a single element or throws an exception if more (or none) of them are emitted.
      */
     public func single()
-        -> Observable<E> {
+        -> Observable<Element> {
         return SingleAsync(source: self.asObservable())
     }
 
@@ -30,16 +30,16 @@ extension ObservableType {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that emits a single element or throws an exception if more (or none) of them are emitted.
      */
-    public func single(_ predicate: @escaping (E) throws -> Bool)
-        -> Observable<E> {
+    public func single(_ predicate: @escaping (Element) throws -> Bool)
+        -> Observable<Element> {
         return SingleAsync(source: self.asObservable(), predicate: predicate)
     }
 }
 
 fileprivate final class SingleAsyncSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias ElementType = O.E
+    typealias ElementType = O.Element 
     typealias Parent = SingleAsync<ElementType>
-    typealias E = ElementType
+    typealias Element = ElementType
     
     private let _parent: Parent
     private var _seenValue: Bool = false
@@ -49,7 +49,7 @@ fileprivate final class SingleAsyncSink<O: ObserverType> : Sink<O>, ObserverType
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next(let value):
             do {
@@ -97,7 +97,7 @@ final class SingleAsync<Element>: Producer<Element> {
         self._predicate = predicate
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = SingleAsyncSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/SingleAsync.swift
+++ b/RxSwift/Observables/SingleAsync.swift
@@ -37,9 +37,8 @@ extension ObservableType {
 }
 
 fileprivate final class SingleAsyncSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias ElementType = O.Element 
-    typealias Parent = SingleAsync<ElementType>
-    typealias Element = ElementType
+    typealias Element = O.Element
+    typealias Parent = SingleAsync<Element>
     
     private let _parent: Parent
     private var _seenValue: Bool = false

--- a/RxSwift/Observables/Sink.swift
+++ b/RxSwift/Observables/Sink.swift
@@ -23,7 +23,7 @@ class Sink<O : ObserverType> : Disposable {
         self._cancel = cancel
     }
 
-    final func forwardOn(_ event: Event<O.E>) {
+    final func forwardOn(_ event: Event<O.Element>) {
         #if DEBUG
             self._synchronizationTracker.register(synchronizationErrorMessage: .default)
             defer { self._synchronizationTracker.unregister() }
@@ -55,7 +55,7 @@ class Sink<O : ObserverType> : Disposable {
 }
 
 final class SinkForward<O: ObserverType>: ObserverType {
-    typealias E = O.E
+    typealias Element = O.Element 
 
     private let _forward: Sink<O>
 
@@ -63,7 +63,7 @@ final class SinkForward<O: ObserverType>: ObserverType {
         self._forward = forward
     }
 
-    final func on(_ event: Event<E>) {
+    final func on(_ event: Event<Element>) {
         switch event {
         case .next:
             self._forward._observer.on(event)

--- a/RxSwift/Observables/Skip.swift
+++ b/RxSwift/Observables/Skip.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements that occur after the specified index in the input sequence.
      */
     public func skip(_ count: Int)
-        -> Observable<E> {
+        -> Observable<Element> {
         return SkipCount(source: self.asObservable(), count: count)
     }
 }
@@ -34,7 +34,7 @@ extension ObservableType {
      - returns: An observable sequence with the elements skipped during the specified duration from the start of the source sequence.
      */
     public func skip(_ duration: RxTimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return SkipTime(source: self.asObservable(), duration: duration, scheduler: scheduler)
     }
 }
@@ -42,7 +42,7 @@ extension ObservableType {
 // count version
 
 final private class SkipCountSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias Parent = SkipCount<Element>
     
     let parent: Parent
@@ -85,7 +85,7 @@ final private class SkipCount<Element>: Producer<Element> {
         self.count = count
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = SkipCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self.source.subscribe(sink)
 
@@ -95,7 +95,7 @@ final private class SkipCount<Element>: Producer<Element> {
 
 // time version
 
-final private class SkipTimeSink<ElementType, O: ObserverType>: Sink<O>, ObserverType where O.E == ElementType {
+final private class SkipTimeSink<ElementType, O: ObserverType>: Sink<O>, ObserverType where O.Element == ElementType {
     typealias Parent = SkipTime<ElementType>
     typealias Element = ElementType
 
@@ -151,7 +151,7 @@ final private class SkipTime<Element>: Producer<Element> {
         self.duration = duration
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = SkipTimeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Skip.swift
+++ b/RxSwift/Observables/Skip.swift
@@ -95,9 +95,8 @@ final private class SkipCount<Element>: Producer<Element> {
 
 // time version
 
-final private class SkipTimeSink<ElementType, O: ObserverType>: Sink<O>, ObserverType where O.Element == ElementType {
-    typealias Parent = SkipTime<ElementType>
-    typealias Element = ElementType
+final private class SkipTimeSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.Element == Element {
+    typealias Parent = SkipTime<Element>
 
     let parent: Parent
     

--- a/RxSwift/Observables/SkipUntil.swift
+++ b/RxSwift/Observables/SkipUntil.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence containing the elements of the source sequence that are emitted after the other sequence emits an item.
      */
     public func skipUntil<O: ObservableType>(_ other: O)
-        -> Observable<E> {
+        -> Observable<Element> {
         return SkipUntil(source: self.asObservable(), other: other.asObservable())
     }
 }
@@ -27,7 +27,7 @@ final private class SkipUntilSinkOther<Other, O: ObserverType>
     , LockOwnerType
     , SynchronizedOnType {
     typealias Parent = SkipUntilSink<Other, O>
-    typealias E = Other
+    typealias Element = Other
     
     fileprivate let _parent: Parent
 
@@ -44,11 +44,11 @@ final private class SkipUntilSinkOther<Other, O: ObserverType>
         #endif
     }
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next:
             self._parent._forwardElements = true
@@ -75,8 +75,8 @@ final private class SkipUntilSink<Other, O: ObserverType>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias E = O.E
-    typealias Parent = SkipUntil<E, Other>
+    typealias Element = O.Element 
+    typealias Parent = SkipUntil<Element, Other>
     
     let _lock = RecursiveLock()
     fileprivate let _parent: Parent
@@ -89,11 +89,11 @@ final private class SkipUntilSink<Other, O: ObserverType>
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next:
             if self._forwardElements {
@@ -131,7 +131,7 @@ final private class SkipUntil<Element, Other>: Producer<Element> {
         self._other = other
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = SkipUntilSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/SkipWhile.swift
+++ b/RxSwift/Observables/SkipWhile.swift
@@ -16,13 +16,13 @@ extension ObservableType {
      - parameter predicate: A function to test each element for a condition.
      - returns: An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
      */
-    public func skipWhile(_ predicate: @escaping (E) throws -> Bool) -> Observable<E> {
+    public func skipWhile(_ predicate: @escaping (Element) throws -> Bool) -> Observable<Element> {
         return SkipWhile(source: self.asObservable(), predicate: predicate)
     }
 }
 
 final private class SkipWhileSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias Parent = SkipWhile<Element>
 
     fileprivate let _parent: Parent
@@ -67,7 +67,7 @@ final private class SkipWhile<Element>: Producer<Element> {
         self._predicate = predicate
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = SkipWhileSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/StartWith.swift
+++ b/RxSwift/Observables/StartWith.swift
@@ -16,8 +16,8 @@ extension ObservableType {
      - parameter elements: Elements to prepend to the specified sequence.
      - returns: The source sequence prepended with the specified values.
      */
-    public func startWith(_ elements: E ...)
-        -> Observable<E> {
+    public func startWith(_ elements: Element ...)
+        -> Observable<Element> {
             return StartWith(source: self.asObservable(), elements: elements)
     }
 }
@@ -32,7 +32,7 @@ final private class StartWith<Element>: Producer<Element> {
         super.init()
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         for e in self.elements {
             observer.on(.next(e))
         }

--- a/RxSwift/Observables/SubscribeOn.swift
+++ b/RxSwift/Observables/SubscribeOn.swift
@@ -24,13 +24,13 @@ extension ObservableType {
      - returns: The source sequence whose subscriptions and unsubscriptions happen on the specified scheduler.
      */
     public func subscribeOn(_ scheduler: ImmediateSchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return SubscribeOn(source: self, scheduler: scheduler)
     }
 }
 
-final private class SubscribeOnSink<Ob: ObservableType, O: ObserverType>: Sink<O>, ObserverType where Ob.E == O.E {
-    typealias Element = O.E
+final private class SubscribeOnSink<Ob: ObservableType, O: ObserverType>: Sink<O>, ObserverType where Ob.Element == O.Element {
+    typealias Element = O.Element 
     typealias Parent = SubscribeOn<Ob>
     
     let parent: Parent
@@ -66,7 +66,7 @@ final private class SubscribeOnSink<Ob: ObservableType, O: ObserverType>: Sink<O
     }
 }
 
-final private class SubscribeOn<Ob: ObservableType>: Producer<Ob.E> {
+final private class SubscribeOn<Ob: ObservableType>: Producer<Ob.Element> {
     let source: Ob
     let scheduler: ImmediateSchedulerType
     
@@ -75,7 +75,7 @@ final private class SubscribeOn<Ob: ObservableType>: Producer<Ob.E> {
         self.scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Ob.E {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Ob.Element {
         let sink = SubscribeOnSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/SwitchIfEmpty.swift
+++ b/RxSwift/Observables/SwitchIfEmpty.swift
@@ -15,22 +15,22 @@ extension ObservableType {
      - parameter switchTo: Observable sequence being returned when source sequence is empty.
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
-    public func ifEmpty(switchTo other: Observable<E>) -> Observable<E> {
+    public func ifEmpty(switchTo other: Observable<Element>) -> Observable<Element> {
         return SwitchIfEmpty(source: self.asObservable(), ifEmpty: other)
     }
 }
 
 final private class SwitchIfEmpty<Element>: Producer<Element> {
     
-    private let _source: Observable<E>
-    private let _ifEmpty: Observable<E>
+    private let _source: Observable<Element>
+    private let _ifEmpty: Observable<Element>
     
-    init(source: Observable<E>, ifEmpty: Observable<E>) {
+    init(source: Observable<Element>, ifEmpty: Observable<Element>) {
         self._source = source
         self._ifEmpty = ifEmpty
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = SwitchIfEmptySink(ifEmpty: self._ifEmpty,
                                      observer: observer,
                                      cancel: cancel)
@@ -42,23 +42,23 @@ final private class SwitchIfEmpty<Element>: Producer<Element> {
 
 final private class SwitchIfEmptySink<O: ObserverType>: Sink<O>
     , ObserverType {
-    typealias E = O.E
+    typealias Element = O.Element 
     
-    private let _ifEmpty: Observable<E>
+    private let _ifEmpty: Observable<Element>
     private var _isEmpty = true
     private let _ifEmptySubscription = SingleAssignmentDisposable()
     
-    init(ifEmpty: Observable<E>, observer: O, cancel: Cancelable) {
+    init(ifEmpty: Observable<Element>, observer: O, cancel: Cancelable) {
         self._ifEmpty = ifEmpty
         super.init(observer: observer, cancel: cancel)
     }
     
-    func run(_ source: Observable<O.E>) -> Disposable {
+    func run(_ source: Observable<O.Element>) -> Disposable {
         let subscription = source.subscribe(self)
         return Disposables.create(subscription, _ifEmptySubscription)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next:
             self._isEmpty = false
@@ -80,7 +80,7 @@ final private class SwitchIfEmptySink<O: ObserverType>: Sink<O>
 
 final private class SwitchIfEmptySinkIter<O: ObserverType>
     : ObserverType {
-    typealias E = O.E
+    typealias Element = O.Element 
     typealias Parent = SwitchIfEmptySink<O>
     
     private let _parent: Parent
@@ -89,7 +89,7 @@ final private class SwitchIfEmptySinkIter<O: ObserverType>
         self._parent = parent
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next:
             self._parent.forwardOn(event)

--- a/RxSwift/Observables/Take.swift
+++ b/RxSwift/Observables/Take.swift
@@ -106,13 +106,12 @@ final private class TakeCount<Element>: Producer<Element> {
 
 // time version
 
-final private class TakeTimeSink<ElementType, O: ObserverType>
+final private class TakeTimeSink<Element, O: ObserverType>
     : Sink<O>
     , LockOwnerType
     , ObserverType
-    , SynchronizedOnType where O.Element == ElementType {
-    typealias Parent = TakeTime<ElementType>
-    typealias Element = ElementType
+    , SynchronizedOnType where O.Element == Element {
+    typealias Parent = TakeTime<Element>
 
     fileprivate let _parent: Parent
     

--- a/RxSwift/Observables/Take.swift
+++ b/RxSwift/Observables/Take.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the specified number of elements from the start of the input sequence.
      */
     public func take(_ count: Int)
-        -> Observable<E> {
+        -> Observable<Element> {
         if count == 0 {
             return Observable.empty()
         }
@@ -39,7 +39,7 @@ extension ObservableType {
      - returns: An observable sequence with the elements taken during the specified duration from the start of the source sequence.
      */
     public func take(_ duration: RxTimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return TakeTime(source: self.asObservable(), duration: duration, scheduler: scheduler)
     }
 }
@@ -47,8 +47,8 @@ extension ObservableType {
 // count version
 
 final private class TakeCountSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias E = O.E
-    typealias Parent = TakeCount<E>
+    typealias Element = O.Element 
+    typealias Parent = TakeCount<Element>
     
     private let _parent: Parent
     
@@ -60,7 +60,7 @@ final private class TakeCountSink<O: ObserverType>: Sink<O>, ObserverType {
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next(let value):
             
@@ -97,7 +97,7 @@ final private class TakeCount<Element>: Producer<Element> {
         self._count = count
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = TakeCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)
@@ -110,9 +110,9 @@ final private class TakeTimeSink<ElementType, O: ObserverType>
     : Sink<O>
     , LockOwnerType
     , ObserverType
-    , SynchronizedOnType where O.E == ElementType {
+    , SynchronizedOnType where O.Element == ElementType {
     typealias Parent = TakeTime<ElementType>
-    typealias E = ElementType
+    typealias Element = ElementType
 
     fileprivate let _parent: Parent
     
@@ -123,11 +123,11 @@ final private class TakeTimeSink<ElementType, O: ObserverType>
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next(let value):
             self.forwardOn(.next(value))
@@ -172,7 +172,7 @@ final private class TakeTime<Element>: Producer<Element> {
         self._duration = duration
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = TakeTimeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/TakeLast.swift
+++ b/RxSwift/Observables/TakeLast.swift
@@ -19,26 +19,26 @@ extension ObservableType {
      - returns: An observable sequence containing the specified number of elements from the end of the source sequence.
      */
     public func takeLast(_ count: Int)
-        -> Observable<E> {
+        -> Observable<Element> {
         return TakeLast(source: self.asObservable(), count: count)
     }
 }
 
 final private class TakeLastSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias E = O.E
-    typealias Parent = TakeLast<E>
+    typealias Element = O.Element 
+    typealias Parent = TakeLast<Element>
     
     private let _parent: Parent
     
-    private var _elements: Queue<E>
+    private var _elements: Queue<Element>
     
     init(parent: Parent, observer: O, cancel: Cancelable) {
         self._parent = parent
-        self._elements = Queue<E>(capacity: parent._count + 1)
+        self._elements = Queue<Element>(capacity: parent._count + 1)
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next(let value):
             self._elements.enqueue(value)
@@ -70,7 +70,7 @@ final private class TakeLast<Element>: Producer<Element> {
         self._count = count
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = TakeLastSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/TakeUntil.swift
+++ b/RxSwift/Observables/TakeUntil.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence containing the elements of the source sequence up to the point the other sequence interrupted further propagation.
      */
     public func takeUntil<O: ObservableType>(_ other: O)
-        -> Observable<E> {
+        -> Observable<Element> {
         return TakeUntil(source: self.asObservable(), other: other.asObservable())
     }
 
@@ -31,8 +31,8 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test passes.
      */
     public func takeUntil(_ behavior: TakeUntilBehavior,
-                          predicate: @escaping (E) throws -> Bool)
-        -> Observable<E> {
+                          predicate: @escaping (Element) throws -> Bool)
+        -> Observable<Element> {
         return TakeUntilPredicate(source: self.asObservable(),
                                   behavior: behavior,
                                   predicate: predicate)
@@ -54,7 +54,7 @@ final private class TakeUntilSinkOther<Other, O: ObserverType>
     , LockOwnerType
     , SynchronizedOnType {
     typealias Parent = TakeUntilSink<Other, O>
-    typealias E = Other
+    typealias Element = Other
     
     fileprivate let _parent: Parent
 
@@ -71,11 +71,11 @@ final private class TakeUntilSinkOther<Other, O: ObserverType>
 #endif
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next:
             self._parent.forwardOn(.completed)
@@ -100,8 +100,8 @@ final private class TakeUntilSink<Other, O: ObserverType>
     , LockOwnerType
     , ObserverType
     , SynchronizedOnType {
-    typealias E = O.E
-    typealias Parent = TakeUntil<E, Other>
+    typealias Element = O.Element 
+    typealias Parent = TakeUntil<Element, Other>
     
     fileprivate let _parent: Parent
  
@@ -113,11 +113,11 @@ final private class TakeUntilSink<Other, O: ObserverType>
         super.init(observer: observer, cancel: cancel)
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next:
             self.forwardOn(event)
@@ -150,7 +150,7 @@ final private class TakeUntil<Element, Other>: Producer<Element> {
         self._other = other
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = TakeUntilSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -160,7 +160,7 @@ final private class TakeUntil<Element, Other>: Producer<Element> {
 // MARK: - TakeUntil Predicate
 final private class TakeUntilPredicateSink<O: ObserverType>
     : Sink<O>, ObserverType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias Parent = TakeUntilPredicate<Element>
 
     fileprivate let _parent: Parent
@@ -219,7 +219,7 @@ final private class TakeUntilPredicate<Element>: Producer<Element> {
         self._predicate = predicate
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = TakeUntilPredicateSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/TakeWhile.swift
+++ b/RxSwift/Observables/TakeWhile.swift
@@ -16,8 +16,8 @@ extension ObservableType {
      - parameter predicate: A function to test each element for a condition.
      - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test no longer passes.
      */
-    public func takeWhile(_ predicate: @escaping (E) throws -> Bool)
-        -> Observable<E> {
+    public func takeWhile(_ predicate: @escaping (Element) throws -> Bool)
+        -> Observable<Element> {
         return TakeWhile(source: self.asObservable(), predicate: predicate)
     }
 }
@@ -25,7 +25,7 @@ extension ObservableType {
 final private class TakeWhileSink<O: ObserverType>
     : Sink<O>
     , ObserverType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias Parent = TakeWhile<Element>
 
     fileprivate let _parent: Parent
@@ -77,7 +77,7 @@ final private class TakeWhile<Element>: Producer<Element> {
         self._predicate = predicate
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = TakeWhileSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Throttle.swift
+++ b/RxSwift/Observables/Throttle.swift
@@ -23,7 +23,7 @@ extension ObservableType {
      - returns: The throttled sequence.
      */
     public func throttle(_ dueTime: RxTimeInterval, latest: Bool = true, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return Throttle(source: self.asObservable(), dueTime: dueTime, latest: latest, scheduler: scheduler)
     }
 }
@@ -33,7 +33,7 @@ final private class ThrottleSink<O: ObserverType>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = O.E
+    typealias Element = O.Element 
     typealias ParentType = Throttle<Element>
     
     private let _parent: ParentType
@@ -150,7 +150,7 @@ final private class Throttle<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = ThrottleSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Timeout.swift
+++ b/RxSwift/Observables/Timeout.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      - returns: An observable sequence with a `RxError.timeout` in case of a timeout.
      */
     public func timeout(_ dueTime: RxTimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
             return Timeout(source: self.asObservable(), dueTime: dueTime, other: Observable.error(RxError.timeout), scheduler: scheduler)
     }
 
@@ -33,14 +33,14 @@ extension ObservableType {
      - returns: The source sequence switching to the other sequence in case of a timeout.
      */
     public func timeout<O: ObservableConvertibleType>(_ dueTime: RxTimeInterval, other: O, scheduler: SchedulerType)
-        -> Observable<E> where E == O.E {
+        -> Observable<Element> where Element == O.Element {
             return Timeout(source: self.asObservable(), dueTime: dueTime, other: other.asObservable(), scheduler: scheduler)
     }
 }
 
 final private class TimeoutSink<O: ObserverType>: Sink<O>, LockOwnerType, ObserverType {
-    typealias E = O.E
-    typealias Parent = Timeout<E>
+    typealias Element = O.Element 
+    typealias Parent = Timeout<Element>
     
     private let _parent: Parent
     
@@ -68,7 +68,7 @@ final private class TimeoutSink<O: ObserverType>: Sink<O>, LockOwnerType, Observ
         return Disposables.create(_subscription, _timerD)
     }
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next:
             var onNextWins = false
@@ -143,7 +143,7 @@ final private class Timeout<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Element {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = TimeoutSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Timer.swift
+++ b/RxSwift/Observables/Timer.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-extension ObservableType where E : RxAbstractInteger {
+extension ObservableType where Element : RxAbstractInteger {
     /**
      Returns an observable sequence that produces a value after each period, using the specified scheduler to run timers and to send out observer messages.
 
@@ -17,7 +17,7 @@ extension ObservableType where E : RxAbstractInteger {
      - returns: An observable sequence that produces a value after each period.
      */
     public static func interval(_ period: RxTimeInterval, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return Timer(
             dueTime: period,
             period: period,
@@ -26,7 +26,7 @@ extension ObservableType where E : RxAbstractInteger {
     }
 }
 
-extension ObservableType where E: RxAbstractInteger {
+extension ObservableType where Element: RxAbstractInteger {
     /**
      Returns an observable sequence that periodically produces a value after the specified initial relative due time has elapsed, using the specified scheduler to run timers.
 
@@ -38,7 +38,7 @@ extension ObservableType where E: RxAbstractInteger {
      - returns: An observable sequence that produces a value after due time has elapsed and then each period.
      */
     public static func timer(_ dueTime: RxTimeInterval, period: RxTimeInterval? = nil, scheduler: SchedulerType)
-        -> Observable<E> {
+        -> Observable<Element> {
         return Timer(
             dueTime: dueTime,
             period: period,
@@ -49,8 +49,8 @@ extension ObservableType where E: RxAbstractInteger {
 
 import Foundation
 
-final private class TimerSink<O: ObserverType> : Sink<O> where O.E : RxAbstractInteger  {
-    typealias Parent = Timer<O.E>
+final private class TimerSink<O: ObserverType> : Sink<O> where O.Element : RxAbstractInteger  {
+    typealias Parent = Timer<O.Element>
 
     private let _parent: Parent
     private let _lock = RecursiveLock()
@@ -61,7 +61,7 @@ final private class TimerSink<O: ObserverType> : Sink<O> where O.E : RxAbstractI
     }
 
     func run() -> Disposable {
-        return self._parent._scheduler.schedulePeriodic(0 as O.E, startAfter: self._parent._dueTime, period: self._parent._period!) { state in
+        return self._parent._scheduler.schedulePeriodic(0 as O.Element, startAfter: self._parent._dueTime, period: self._parent._period!) { state in
             self._lock.lock(); defer { self._lock.unlock() }
             self.forwardOn(.next(state))
             return state &+ 1
@@ -69,8 +69,8 @@ final private class TimerSink<O: ObserverType> : Sink<O> where O.E : RxAbstractI
     }
 }
 
-final private class TimerOneOffSink<O: ObserverType>: Sink<O> where O.E: RxAbstractInteger {
-    typealias Parent = Timer<O.E>
+final private class TimerOneOffSink<O: ObserverType>: Sink<O> where O.Element: RxAbstractInteger {
+    typealias Parent = Timer<O.Element>
 
     private let _parent: Parent
 
@@ -90,7 +90,7 @@ final private class TimerOneOffSink<O: ObserverType>: Sink<O> where O.E: RxAbstr
     }
 }
 
-final private class Timer<E: RxAbstractInteger>: Producer<E> {
+final private class Timer<Element: RxAbstractInteger>: Producer<Element> {
     fileprivate let _scheduler: SchedulerType
     fileprivate let _dueTime: RxTimeInterval
     fileprivate let _period: RxTimeInterval?
@@ -101,7 +101,7 @@ final private class Timer<E: RxAbstractInteger>: Producer<E> {
         self._period = period
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         if self._period != nil {
             let sink = TimerSink(parent: self, observer: observer, cancel: cancel)
             let subscription = sink.run()

--- a/RxSwift/Observables/ToArray.swift
+++ b/RxSwift/Observables/ToArray.swift
@@ -19,12 +19,12 @@ extension ObservableType {
     - returns: A Single sequence containing all the emitted elements as array.
     */
     public func toArray()
-        -> Single<[E]> {
+        -> Single<[Element]> {
         return PrimitiveSequence(raw: ToArray(source: self.asObservable()))
     }
 }
 
-final private class ToArraySink<SourceType, O: ObserverType>: Sink<O>, ObserverType where O.E == [SourceType] {
+final private class ToArraySink<SourceType, O: ObserverType>: Sink<O>, ObserverType where O.Element == [SourceType] {
     typealias Parent = ToArray<SourceType>
     
     let _parent: Parent
@@ -58,7 +58,7 @@ final private class ToArray<SourceType>: Producer<[SourceType]> {
         self._source = source
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == [SourceType] {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == [SourceType] {
         let sink = ToArraySink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Using.swift
+++ b/RxSwift/Observables/Using.swift
@@ -16,13 +16,13 @@ extension ObservableType {
      - parameter observableFactory: Factory function to obtain an observable sequence that depends on the obtained resource.
      - returns: An observable sequence whose lifetime controls the lifetime of the dependent resource object.
      */
-    public static func using<Resource: Disposable>(_ resourceFactory: @escaping () throws -> Resource, observableFactory: @escaping (Resource) throws -> Observable<E>) -> Observable<E> {
+    public static func using<Resource: Disposable>(_ resourceFactory: @escaping () throws -> Resource, observableFactory: @escaping (Resource) throws -> Observable<Element>) -> Observable<Element> {
         return Using(resourceFactory: resourceFactory, observableFactory: observableFactory)
     }
 }
 
 final private class UsingSink<ResourceType: Disposable, O: ObserverType>: Sink<O>, ObserverType {
-    typealias SourceType = O.E
+    typealias SourceType = O.Element 
     typealias Parent = Using<SourceType, ResourceType>
 
     private let _parent: Parent
@@ -68,7 +68,7 @@ final private class UsingSink<ResourceType: Disposable, O: ObserverType>: Sink<O
 
 final private class Using<SourceType, ResourceType: Disposable>: Producer<SourceType> {
     
-    typealias E = SourceType
+    typealias Element = SourceType
     
     typealias ResourceFactory = () throws -> ResourceType
     typealias ObservableFactory = (ResourceType) throws -> Observable<SourceType>
@@ -82,7 +82,7 @@ final private class Using<SourceType, ResourceType: Disposable>: Producer<Source
         self._observableFactory = observableFactory
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == E {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
         let sink = UsingSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Window.swift
+++ b/RxSwift/Observables/Window.swift
@@ -19,7 +19,7 @@ extension ObservableType {
      - returns: An observable sequence of windows (instances of `Observable`).
      */
     public func window(timeSpan: RxTimeInterval, count: Int, scheduler: SchedulerType)
-        -> Observable<Observable<E>> {
+        -> Observable<Observable<Element>> {
             return WindowTimeCount(source: self.asObservable(), timeSpan: timeSpan, count: count, scheduler: scheduler)
     }
 }
@@ -28,9 +28,9 @@ final private class WindowTimeCountSink<Element, O: ObserverType>
     : Sink<O>
     , ObserverType
     , LockOwnerType
-    , SynchronizedOnType where O.E == Observable<Element> {
+    , SynchronizedOnType where O.Element == Observable<Element> {
     typealias Parent = WindowTimeCount<Element>
-    typealias E = Element
+    typealias Element = Element
     
     private let _parent: Parent
     
@@ -69,11 +69,11 @@ final private class WindowTimeCountSink<Element, O: ObserverType>
         self.forwardOn(.next(AddRef(source: self._subject, refCount: self._refCountDisposable).asObservable()))
     }
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         var newWindow = false
         var newId = 0
         
@@ -161,7 +161,7 @@ final private class WindowTimeCount<Element>: Producer<Observable<Element>> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == Observable<Element> {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Observable<Element> {
         let sink = WindowTimeCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Window.swift
+++ b/RxSwift/Observables/Window.swift
@@ -30,7 +30,6 @@ final private class WindowTimeCountSink<Element, O: ObserverType>
     , LockOwnerType
     , SynchronizedOnType where O.Element == Observable<Element> {
     typealias Parent = WindowTimeCount<Element>
-    typealias Element = Element
     
     private let _parent: Parent
     

--- a/RxSwift/Observables/WithLatestFrom.swift
+++ b/RxSwift/Observables/WithLatestFrom.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke for each element from the self combined with the latest element from the second source, if any.
      - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
      */
-    public func withLatestFrom<SecondO: ObservableConvertibleType, ResultType>(_ second: SecondO, resultSelector: @escaping (E, SecondO.E) throws -> ResultType) -> Observable<ResultType> {
+    public func withLatestFrom<SecondO: ObservableConvertibleType, ResultType>(_ second: SecondO, resultSelector: @escaping (Element, SecondO.Element) throws -> ResultType) -> Observable<ResultType> {
         return WithLatestFrom(first: self.asObservable(), second: second.asObservable(), resultSelector: resultSelector)
     }
 
@@ -29,7 +29,7 @@ extension ObservableType {
      - parameter second: Second observable source.
      - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
      */
-    public func withLatestFrom<SecondO: ObservableConvertibleType>(_ second: SecondO) -> Observable<SecondO.E> {
+    public func withLatestFrom<SecondO: ObservableConvertibleType>(_ second: SecondO) -> Observable<SecondO.Element> {
         return WithLatestFrom(first: self.asObservable(), second: second.asObservable(), resultSelector: { $1 })
     }
 }
@@ -39,9 +39,9 @@ final private class WithLatestFromSink<FirstType, SecondType, O: ObserverType>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias ResultType = O.E
+    typealias ResultType = O.Element 
     typealias Parent = WithLatestFrom<FirstType, SecondType, ResultType>
-    typealias E = FirstType
+    typealias Element = FirstType
     
     fileprivate let _parent: Parent
     
@@ -64,11 +64,11 @@ final private class WithLatestFromSink<FirstType, SecondType, O: ObserverType>
         return Disposables.create(fstSubscription, sndSubscription)
     }
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case let .next(value):
             guard let latest = self._latest else { return }
@@ -95,9 +95,9 @@ final private class WithLatestFromSecond<FirstType, SecondType, O: ObserverType>
     , LockOwnerType
     , SynchronizedOnType {
     
-    typealias ResultType = O.E
+    typealias ResultType = O.Element 
     typealias Parent = WithLatestFromSink<FirstType, SecondType, O>
-    typealias E = SecondType
+    typealias Element = SecondType
     
     private let _parent: Parent
     private let _disposable: Disposable
@@ -111,11 +111,11 @@ final private class WithLatestFromSecond<FirstType, SecondType, O: ObserverType>
         self._disposable = disposable
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         switch event {
         case let .next(value):
             self._parent._latest = value
@@ -141,7 +141,7 @@ final private class WithLatestFrom<FirstType, SecondType, ResultType>: Producer<
         self._resultSelector = resultSelector
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == ResultType {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == ResultType {
         let sink = WithLatestFromSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Zip+Collection.swift
+++ b/RxSwift/Observables/Zip+Collection.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func zip<C: Collection>(_ collection: C, resultSelector: @escaping ([C.Iterator.Element.E]) throws -> E) -> Observable<E>
+    public static func zip<C: Collection>(_ collection: C, resultSelector: @escaping ([C.Iterator.Element.Element]) throws -> Element) -> Observable<Element>
         where C.Iterator.Element: ObservableType {
         return ZipCollectionType(sources: collection, resultSelector: resultSelector)
     }
@@ -27,8 +27,8 @@ extension ObservableType {
 
      - returns: An observable sequence containing the result of combining elements of the sources.
      */
-    public static func zip<C: Collection>(_ collection: C) -> Observable<[E]>
-        where C.Iterator.Element: ObservableType, C.Iterator.Element.E == E {
+    public static func zip<C: Collection>(_ collection: C) -> Observable<[Element]>
+        where C.Iterator.Element: ObservableType, C.Iterator.Element.Element == Element {
         return ZipCollectionType(sources: collection, resultSelector: { $0 })
     }
     
@@ -36,9 +36,9 @@ extension ObservableType {
 
 final private class ZipCollectionTypeSink<C: Collection, O: ObserverType>
     : Sink<O> where C.Iterator.Element: ObservableConvertibleType {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = ZipCollectionType<C, R>
-    typealias SourceElement = C.Iterator.Element.E
+    typealias SourceElement = C.Iterator.Element.Element
     
     private let _parent: Parent
     
@@ -149,7 +149,7 @@ final private class ZipCollectionTypeSink<C: Collection, O: ObserverType>
 }
 
 final private class ZipCollectionType<C: Collection, R>: Producer<R> where C.Iterator.Element: ObservableConvertibleType {
-    typealias ResultSelector = ([C.Iterator.Element.E]) throws -> R
+    typealias ResultSelector = ([C.Iterator.Element.Element]) throws -> R
     
     let sources: C
     let resultSelector: ResultSelector
@@ -161,7 +161,7 @@ final private class ZipCollectionType<C: Collection, R>: Producer<R> where C.Ite
         self.count = Int(Int64(self.sources.count))
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipCollectionTypeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Zip+arity.swift
+++ b/RxSwift/Observables/Zip+arity.swift
@@ -21,8 +21,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType>
-        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.E, O2.E) throws -> E)
-        -> Observable<E> {
+        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.Element, O2.Element) throws -> Element)
+        -> Observable<Element> {
         return Zip2(
             source1: source1.asObservable(), source2: source2.asObservable(),
             resultSelector: resultSelector
@@ -30,7 +30,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -40,7 +40,7 @@ extension ObservableType where E == Any {
     */
     public static func zip<O1: ObservableType, O2: ObservableType>
         (_ source1: O1, _ source2: O2)
-        -> Observable<(O1.E, O2.E)> {
+        -> Observable<(O1.Element, O2.Element)> {
         return Zip2(
             source1: source1.asObservable(), source2: source2.asObservable(),
             resultSelector: { ($0, $1) }
@@ -49,7 +49,7 @@ extension ObservableType where E == Any {
 }
 
 final class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = Zip2<E1, E2, R>
 
     let _parent: Parent
@@ -108,7 +108,7 @@ final class Zip2<E1, E2, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipSink2_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -129,8 +129,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.E, O2.E, O3.E) throws -> E)
-        -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.Element, O2.Element, O3.Element) throws -> Element)
+        -> Observable<Element> {
         return Zip3(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(),
             resultSelector: resultSelector
@@ -138,7 +138,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -148,7 +148,7 @@ extension ObservableType where E == Any {
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3)
-        -> Observable<(O1.E, O2.E, O3.E)> {
+        -> Observable<(O1.Element, O2.Element, O3.Element)> {
         return Zip3(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(),
             resultSelector: { ($0, $1, $2) }
@@ -157,7 +157,7 @@ extension ObservableType where E == Any {
 }
 
 final class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = Zip3<E1, E2, E3, R>
 
     let _parent: Parent
@@ -224,7 +224,7 @@ final class Zip3<E1, E2, E3, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipSink3_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -245,8 +245,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E) throws -> E)
-        -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
+        -> Observable<Element> {
         return Zip4(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(),
             resultSelector: resultSelector
@@ -254,7 +254,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -264,7 +264,7 @@ extension ObservableType where E == Any {
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4)
-        -> Observable<(O1.E, O2.E, O3.E, O4.E)> {
+        -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element)> {
         return Zip4(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(),
             resultSelector: { ($0, $1, $2, $3) }
@@ -273,7 +273,7 @@ extension ObservableType where E == Any {
 }
 
 final class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = Zip4<E1, E2, E3, E4, R>
 
     let _parent: Parent
@@ -348,7 +348,7 @@ final class Zip4<E1, E2, E3, E4, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipSink4_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -369,8 +369,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E) throws -> E)
-        -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
+        -> Observable<Element> {
         return Zip5(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(),
             resultSelector: resultSelector
@@ -378,7 +378,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -388,7 +388,7 @@ extension ObservableType where E == Any {
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5)
-        -> Observable<(O1.E, O2.E, O3.E, O4.E, O5.E)> {
+        -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element)> {
         return Zip5(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(),
             resultSelector: { ($0, $1, $2, $3, $4) }
@@ -397,7 +397,7 @@ extension ObservableType where E == Any {
 }
 
 final class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = Zip5<E1, E2, E3, E4, E5, R>
 
     let _parent: Parent
@@ -480,7 +480,7 @@ final class Zip5<E1, E2, E3, E4, E5, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipSink5_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -501,8 +501,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E) throws -> E)
-        -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
+        -> Observable<Element> {
         return Zip6(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(),
             resultSelector: resultSelector
@@ -510,7 +510,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -520,7 +520,7 @@ extension ObservableType where E == Any {
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6)
-        -> Observable<(O1.E, O2.E, O3.E, O4.E, O5.E, O6.E)> {
+        -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element)> {
         return Zip6(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(),
             resultSelector: { ($0, $1, $2, $3, $4, $5) }
@@ -529,7 +529,7 @@ extension ObservableType where E == Any {
 }
 
 final class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = Zip6<E1, E2, E3, E4, E5, E6, R>
 
     let _parent: Parent
@@ -620,7 +620,7 @@ final class Zip6<E1, E2, E3, E4, E5, E6, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipSink6_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -641,8 +641,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E) throws -> E)
-        -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
+        -> Observable<Element> {
         return Zip7(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(),
             resultSelector: resultSelector
@@ -650,7 +650,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -660,7 +660,7 @@ extension ObservableType where E == Any {
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7)
-        -> Observable<(O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E)> {
+        -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element)> {
         return Zip7(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(),
             resultSelector: { ($0, $1, $2, $3, $4, $5, $6) }
@@ -669,7 +669,7 @@ extension ObservableType where E == Any {
 }
 
 final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = Zip7<E1, E2, E3, E4, E5, E6, E7, R>
 
     let _parent: Parent
@@ -768,7 +768,7 @@ final class Zip7<E1, E2, E3, E4, E5, E6, E7, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipSink7_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -789,8 +789,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E) throws -> E)
-        -> Observable<E> {
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
+        -> Observable<Element> {
         return Zip8(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(),
             resultSelector: resultSelector
@@ -798,7 +798,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -808,7 +808,7 @@ extension ObservableType where E == Any {
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType>
         (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8)
-        -> Observable<(O1.E, O2.E, O3.E, O4.E, O5.E, O6.E, O7.E, O8.E)> {
+        -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element)> {
         return Zip8(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(),
             resultSelector: { ($0, $1, $2, $3, $4, $5, $6, $7) }
@@ -817,7 +817,7 @@ extension ObservableType where E == Any {
 }
 
 final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = Zip8<E1, E2, E3, E4, E5, E6, E7, E8, R>
 
     let _parent: Parent
@@ -924,7 +924,7 @@ final class Zip8<E1, E2, E3, E4, E5, E6, E7, E8, R> : Producer<R> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipSink8_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Zip+arity.tt
+++ b/RxSwift/Observables/Zip+arity.tt
@@ -20,8 +20,8 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<<%= (Array(1...i).map { "O\($0): ObservableType" }).joined(separator: ", ") %>>
-        (<%= (Array(1...i).map { "_ source\($0): O\($0)" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "O\($0).E" }).joined(separator: ", ") %>) throws -> E)
-        -> Observable<E> {
+        (<%= (Array(1...i).map { "_ source\($0): O\($0)" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "O\($0).E" }).joined(separator: ", ") %>) throws -> Element)
+        -> Observable<Element> {
         return Zip<%= i %>(
             <%= (Array(1...i).map { "source\($0): source\($0).asObservable()" }).joined(separator: ", ") %>,
             resultSelector: resultSelector
@@ -29,7 +29,7 @@ extension ObservableType {
     }
 }
 
-extension ObservableType where E == Any {
+extension ObservableType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -48,7 +48,7 @@ extension ObservableType where E == Any {
 }
 
 final class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, O: ObserverType> : ZipSink<O> {
-    typealias R = O.E
+    typealias R = O.Element 
     typealias Parent = Zip<%= i %><<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, R>
 
     let _parent: Parent
@@ -110,7 +110,7 @@ final class Zip<%= i %><<%= (Array(1...i).map { "E\($0)" }).joined(separator: ",
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.E == R {
+    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == R {
         let sink = ZipSink<%= i %>_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Zip.swift
+++ b/RxSwift/Observables/Zip.swift
@@ -82,12 +82,11 @@ class ZipSink<O: ObserverType> : Sink<O>, ZipSinkProtocol {
     }
 }
 
-final class ZipObserver<ElementType>
+final class ZipObserver<Element>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = ElementType
-    typealias ValueSetter = (ElementType) -> Void
+    typealias ValueSetter = (Element) -> Void
 
     private var _parent: ZipSinkProtocol?
     

--- a/RxSwift/Observables/Zip.swift
+++ b/RxSwift/Observables/Zip.swift
@@ -14,7 +14,7 @@ protocol ZipSinkProtocol : class
 }
 
 class ZipSink<O: ObserverType> : Sink<O>, ZipSinkProtocol {
-    typealias Element = O.E
+    typealias Element = O.Element
     
     let _arity: Int
 
@@ -86,7 +86,7 @@ final class ZipObserver<ElementType>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias E = ElementType
+    typealias Element = ElementType
     typealias ValueSetter = (ElementType) -> Void
 
     private var _parent: ZipSinkProtocol?
@@ -106,11 +106,11 @@ final class ZipObserver<ElementType>
         self._setNextValue = setNextValue
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         self.synchronizedOn(event)
     }
 
-    func _synchronized_on(_ event: Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) {
         if self._parent != nil {
             switch event {
             case .next:

--- a/RxSwift/ObserverType.swift
+++ b/RxSwift/ObserverType.swift
@@ -9,21 +9,24 @@
 /// Supports push-style iteration over an observable sequence.
 public protocol ObserverType {
     /// The type of elements in sequence that observer can observe.
-    associatedtype E
+    associatedtype Element
+
+    @available(*, deprecated, message: "Use `Element` instead.")
+    typealias E = Element
 
     /// Notify observer about sequence event.
     ///
     /// - parameter event: Event that occurred.
-    func on(_ event: Event<E>)
+    func on(_ event: Event<Element>)
 }
 
 /// Convenience API extensions to provide alternate next, error, completed events
 extension ObserverType {
     
-    /// Convenience method equivalent to `on(.next(element: E))`
+    /// Convenience method equivalent to `on(.next(element: Element))`
     ///
     /// - parameter element: Next element to send to observer(s)
-    public func onNext(_ element: E) {
+    public func onNext(_ element: Element) {
         self.on(.next(element))
     }
     

--- a/RxSwift/Observers/AnonymousObserver.swift
+++ b/RxSwift/Observers/AnonymousObserver.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-final class AnonymousObserver<ElementType> : ObserverBase<ElementType> {
-    typealias Element = ElementType
-    
+final class AnonymousObserver<Element>: ObserverBase<Element> {
     typealias EventHandler = (Event<Element>) -> Void
     
     private let _eventHandler : EventHandler

--- a/RxSwift/Observers/ObserverBase.swift
+++ b/RxSwift/Observers/ObserverBase.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-class ObserverBase<ElementType> : Disposable, ObserverType {
-    typealias Element = ElementType
-
+class ObserverBase<Element> : Disposable, ObserverType {
     private let _isStopped = AtomicInt(0)
 
     func on(_ event: Event<Element>) {

--- a/RxSwift/Observers/ObserverBase.swift
+++ b/RxSwift/Observers/ObserverBase.swift
@@ -7,11 +7,11 @@
 //
 
 class ObserverBase<ElementType> : Disposable, ObserverType {
-    typealias E = ElementType
+    typealias Element = ElementType
 
     private let _isStopped = AtomicInt(0)
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .next:
             if load(self._isStopped) == 0 {
@@ -24,7 +24,7 @@ class ObserverBase<ElementType> : Disposable, ObserverType {
         }
     }
 
-    func onCore(_ event: Event<E>) {
+    func onCore(_ event: Event<Element>) {
         rxAbstractMethod()
     }
 

--- a/RxSwift/Observers/TailRecursiveSink.swift
+++ b/RxSwift/Observers/TailRecursiveSink.swift
@@ -18,9 +18,9 @@ enum TailRecursiveSinkCommand {
 /// This class is usually used with `Generator` version of the operators.
 class TailRecursiveSink<S: Sequence, O: ObserverType>
     : Sink<O>
-    , InvocableWithValueType where S.Iterator.Element: ObservableConvertibleType, S.Iterator.Element.E == O.E {
+    , InvocableWithValueType where S.Iterator.Element: ObservableConvertibleType, S.Iterator.Element.Element == O.Element {
     typealias Value = TailRecursiveSinkCommand
-    typealias E = O.E
+    typealias Element = O.Element 
     typealias SequenceGenerator = (generator: S.Iterator, remaining: IntMax?)
 
     var _generators: [SequenceGenerator] = []
@@ -61,14 +61,14 @@ class TailRecursiveSink<S: Sequence, O: ObserverType>
         self.dispose()
     }
 
-    func extract(_ observable: Observable<E>) -> SequenceGenerator? {
+    func extract(_ observable: Observable<Element>) -> SequenceGenerator? {
         rxAbstractMethod()
     }
 
     // should be done on gate locked
 
     private func moveNextCommand() {
-        var next: Observable<E>?
+        var next: Observable<Element>?
 
         repeat {
             guard let (g, left) = self._generators.last else {
@@ -130,7 +130,7 @@ class TailRecursiveSink<S: Sequence, O: ObserverType>
         disposable.setDisposable(self.subscribeToNext(existingNext))
     }
 
-    func subscribeToNext(_ source: Observable<E>) -> Disposable {
+    func subscribeToNext(_ source: Observable<Element>) -> Disposable {
         rxAbstractMethod()
     }
 

--- a/RxSwift/Subjects/AsyncSubject.swift
+++ b/RxSwift/Subjects/AsyncSubject.swift
@@ -54,7 +54,7 @@ public final class AsyncSubject<Element>
     /// Notifies all subscribed observers about next event.
     ///
     /// - parameter event: Event to send to the observers.
-    public func on(_ event: Event<E>) {
+    public func on(_ event: Event<Element>) {
         #if DEBUG
             self._synchronizationTracker.register(synchronizationErrorMessage: .default)
             defer { self._synchronizationTracker.unregister() }
@@ -71,7 +71,7 @@ public final class AsyncSubject<Element>
         }
     }
 
-    func _synchronized_on(_ event: Event<E>) -> (Observers, Event<E>) {
+    func _synchronized_on(_ event: Event<Element>) -> (Observers, Event<Element>) {
         self._lock.lock(); defer { self._lock.unlock() }
         if self._isStopped {
             return (Observers(), .completed)
@@ -108,12 +108,12 @@ public final class AsyncSubject<Element>
     ///
     /// - parameter observer: Observer to subscribe to the subject.
     /// - returns: Disposable object that can be used to unsubscribe the observer from the subject.
-    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self._lock.lock(); defer { self._lock.unlock() }
         return self._synchronized_subscribe(observer)
     }
 
-    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         if let stoppedEvent = self._stoppedEvent {
             switch stoppedEvent {
             case .next:

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -78,7 +78,7 @@ public final class BehaviorSubject<Element>
     /// Notifies all subscribed observers about next event.
     ///
     /// - parameter event: Event to send to the observers.
-    public func on(_ event: Event<E>) {
+    public func on(_ event: Event<Element>) {
         #if DEBUG
             self._synchronizationTracker.register(synchronizationErrorMessage: .default)
             defer { self._synchronizationTracker.unregister() }
@@ -86,7 +86,7 @@ public final class BehaviorSubject<Element>
         dispatch(self._synchronized_on(event), event)
     }
 
-    func _synchronized_on(_ event: Event<E>) -> Observers {
+    func _synchronized_on(_ event: Event<Element>) -> Observers {
         self._lock.lock(); defer { self._lock.unlock() }
         if self._stoppedEvent != nil || self._isDisposed {
             return Observers()
@@ -106,14 +106,14 @@ public final class BehaviorSubject<Element>
     ///
     /// - parameter observer: Observer to subscribe to the subject.
     /// - returns: Disposable object that can be used to unsubscribe the observer from the subject.
-    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self._lock.lock()
         let subscription = self._synchronized_subscribe(observer)
         self._lock.unlock()
         return subscription
     }
 
-    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         if self._isDisposed {
             observer.on(.error(RxError.disposed(object: self)))
             return Disposables.create()

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -64,7 +64,7 @@ public final class PublishSubject<Element>
         dispatch(self._synchronized_on(event), event)
     }
 
-    func _synchronized_on(_ event: Event<E>) -> Observers {
+    func _synchronized_on(_ event: Event<Element>) -> Observers {
         self._lock.lock(); defer { self._lock.unlock() }
         switch event {
         case .next:
@@ -92,14 +92,14 @@ public final class PublishSubject<Element>
     - parameter observer: Observer to subscribe to the subject.
     - returns: Disposable object that can be used to unsubscribe the observer from the subject.
     */
-    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self._lock.lock()
         let subscription = self._synchronized_subscribe(observer)
         self._lock.unlock()
         return subscription
     }
 
-    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         if let stoppedEvent = self._stoppedEvent {
             observer.on(stoppedEvent)
             return Disposables.create()

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -54,7 +54,7 @@ public class ReplaySubject<Element>
     /// Notifies all subscribed observers about next event.
     ///
     /// - parameter event: Event to send to the observers.
-    public func on(_ event: Event<E>) {
+    public func on(_ event: Event<Element>) {
         rxAbstractMethod()
     }
     
@@ -110,7 +110,7 @@ private class ReplayBufferBase<Element>
         rxAbstractMethod()
     }
     
-    func replayBuffer<O: ObserverType>(_ observer: O) where O.E == Element {
+    func replayBuffer<O: ObserverType>(_ observer: O) where O.Element == Element {
         rxAbstractMethod()
     }
     
@@ -122,7 +122,7 @@ private class ReplayBufferBase<Element>
         dispatch(self._synchronized_on(event), event)
     }
 
-    func _synchronized_on(_ event: Event<E>) -> Observers {
+    func _synchronized_on(_ event: Event<Element>) -> Observers {
         self._lock.lock(); defer { self._lock.unlock() }
         if self._isDisposed {
             return Observers()
@@ -146,14 +146,14 @@ private class ReplayBufferBase<Element>
         }
     }
     
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self._lock.lock()
         let subscription = self._synchronized_subscribe(observer)
         self._lock.unlock()
         return subscription
     }
 
-    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         if self._isDisposed {
             observer.on(.error(RxError.disposed(object: self)))
             return Disposables.create()
@@ -219,7 +219,7 @@ fileprivate final class ReplayOne<Element> : ReplayBufferBase<Element> {
         self._value = value
     }
 
-    override func replayBuffer<O: ObserverType>(_ observer: O) where O.E == Element {
+    override func replayBuffer<O: ObserverType>(_ observer: O) where O.Element == Element {
         if let value = self._value {
             observer.on(.next(value))
         }
@@ -242,7 +242,7 @@ private class ReplayManyBase<Element>: ReplayBufferBase<Element> {
         self._queue.enqueue(value)
     }
 
-    override func replayBuffer<O: ObserverType>(_ observer: O) where O.E == Element {
+    override func replayBuffer<O: ObserverType>(_ observer: O) where O.Element == Element {
         for item in self._queue {
             observer.on(.next(item))
         }

--- a/RxSwift/Traits/Completable+AndThen.swift
+++ b/RxSwift/Traits/Completable+AndThen.swift
@@ -15,7 +15,7 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
      - parameter second: Second observable sequence.
      - returns: An observable sequence that contains the elements of `self`, followed by those of the second sequence.
      */
-    public func andThen<E>(_ second: Single<E>) -> Single<E> {
+    public func andThen<Element>(_ second: Single<Element>) -> Single<Element> {
         let completable = self.primitiveSequence.asObservable()
         return Single(raw: ConcatCompletable(completable: completable, second: second.asObservable()))
     }
@@ -28,7 +28,7 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
      - parameter second: Second observable sequence.
      - returns: An observable sequence that contains the elements of `self`, followed by those of the second sequence.
      */
-    public func andThen<E>(_ second: Maybe<E>) -> Maybe<E> {
+    public func andThen<Element>(_ second: Maybe<Element>) -> Maybe<Element> {
         let completable = self.primitiveSequence.asObservable()
         return Maybe(raw: ConcatCompletable(completable: completable, second: second.asObservable()))
     }
@@ -54,7 +54,7 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
      - parameter second: Second observable sequence.
      - returns: An observable sequence that contains the elements of `self`, followed by those of the second sequence.
      */
-    public func andThen<E>(_ second: Observable<E>) -> Observable<E> {
+    public func andThen<Element>(_ second: Observable<Element>) -> Observable<Element> {
         let completable = self.primitiveSequence.asObservable()
         return ConcatCompletable(completable: completable, second: second.asObservable())
     }
@@ -69,7 +69,7 @@ final private class ConcatCompletable<Element>: Producer<Element> {
         self._second = second
     }
 
-    override func run<O>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O : ObserverType, O.E == Element {
+    override func run<O>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O : ObserverType, O.Element == Element {
         let sink = ConcatCompletableSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -79,8 +79,8 @@ final private class ConcatCompletable<Element>: Producer<Element> {
 final private class ConcatCompletableSink<O: ObserverType>
     : Sink<O>
     , ObserverType {
-    typealias E = Never
-    typealias Parent = ConcatCompletable<O.E>
+    typealias Element = Never
+    typealias Parent = ConcatCompletable<O.Element>
 
     private let _parent: Parent
     private let _subscription = SerialDisposable()
@@ -90,7 +90,7 @@ final private class ConcatCompletableSink<O: ObserverType>
         super.init(observer: observer, cancel: cancel)
     }
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         switch event {
         case .error(let error):
             self.forwardOn(.error(error))
@@ -113,7 +113,7 @@ final private class ConcatCompletableSink<O: ObserverType>
 
 final private class ConcatCompletableSinkOther<O: ObserverType>
     : ObserverType {
-    typealias E = O.E
+    typealias Element = O.Element 
 
     typealias Parent = ConcatCompletableSink<O>
     
@@ -123,7 +123,7 @@ final private class ConcatCompletableSinkOther<O: ObserverType>
         self._parent = parent
     }
 
-    func on(_ event: Event<O.E>) {
+    func on(_ event: Event<O.Element>) {
         self._parent.forwardOn(event)
         if event.isStopEvent {
             self._parent.dispose()

--- a/RxSwift/Traits/Completable+AndThen.swift
+++ b/RxSwift/Traits/Completable+AndThen.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Never {
+extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Never {
     /**
      Concatenates the second observable sequence to `self` upon successful termination of `self`.
 

--- a/RxSwift/Traits/Completable.swift
+++ b/RxSwift/Traits/Completable.swift
@@ -23,7 +23,7 @@ public enum CompletableEvent {
     case completed
 }
 
-extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
+extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Swift.Never {
     public typealias CompletableObserver = (CompletableEvent) -> Void
     
     /**
@@ -34,8 +34,8 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(subscribe: @escaping (@escaping CompletableObserver) -> Disposable) -> PrimitiveSequence<TraitType, ElementType> {
-        let source = Observable<ElementType>.create { observer in
+    public static func create(subscribe: @escaping (@escaping CompletableObserver) -> Disposable) -> PrimitiveSequence<Trait, Element> {
+        let source = Observable<Element>.create { observer in
             return subscribe { event in
                 switch event {
                 case .error(let error):
@@ -100,7 +100,7 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
     }
 }
 
-extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
+extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Swift.Never {
     /**
      Returns an observable sequence that terminates with an `error`.
 
@@ -136,7 +136,7 @@ extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType
 
 }
 
-extension PrimitiveSequenceType where TraitType == CompletableTrait, ElementType == Swift.Never {
+extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Swift.Never {
     /**
      Invokes an action for each event in the observable sequence, and propagates all observer messages through the result sequence.
      

--- a/RxSwift/Traits/Maybe.swift
+++ b/RxSwift/Traits/Maybe.swift
@@ -26,8 +26,8 @@ public enum MaybeEvent<Element> {
     case completed
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
-    public typealias MaybeObserver = (MaybeEvent<ElementType>) -> Void
+extension PrimitiveSequenceType where Trait == MaybeTrait {
+    public typealias MaybeObserver = (MaybeEvent<Element>) -> Void
     
     /**
      Creates an observable sequence from a specified subscribe method implementation.
@@ -37,8 +37,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(subscribe: @escaping (@escaping MaybeObserver) -> Disposable) -> PrimitiveSequence<TraitType, ElementType> {
-        let source = Observable<ElementType>.create { observer in
+    public static func create(subscribe: @escaping (@escaping MaybeObserver) -> Disposable) -> PrimitiveSequence<Trait, Element> {
+        let source = Observable<Element>.create { observer in
             return subscribe { event in
                 switch event {
                 case .success(let element):
@@ -60,7 +60,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      
      - returns: Subscription for `observer` that can be used to cancel production of sequence elements and free resources.
      */
-    public func subscribe(_ observer: @escaping (MaybeEvent<ElementType>) -> Void) -> Disposable {
+    public func subscribe(_ observer: @escaping (MaybeEvent<Element>) -> Void) -> Disposable {
         var stopped = false
         return self.primitiveSequence.asObservable().subscribe { event in
             if stopped { return }
@@ -85,7 +85,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(onSuccess: ((ElementType) -> Void)? = nil,
+    public func subscribe(onSuccess: ((Element) -> Void)? = nil,
                           onError: ((Swift.Error) -> Void)? = nil,
                           onCompleted: (() -> Void)? = nil) -> Disposable {
         #if DEBUG
@@ -111,7 +111,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
      Returns an observable sequence that contains a single element.
      
@@ -120,7 +120,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter element: Single element in the resulting observable sequence.
      - returns: An observable sequence containing the single specified element.
      */
-    public static func just(_ element: ElementType) -> Maybe<ElementType> {
+    public static func just(_ element: Element) -> Maybe<Element> {
         return Maybe(raw: Observable.just(element))
     }
     
@@ -133,7 +133,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter scheduler: Scheduler to send the single element on.
      - returns: An observable sequence containing the single specified element.
      */
-    public static func just(_ element: ElementType, scheduler: ImmediateSchedulerType) -> Maybe<ElementType> {
+    public static func just(_ element: Element, scheduler: ImmediateSchedulerType) -> Maybe<Element> {
         return Maybe(raw: Observable.just(element, scheduler: scheduler))
     }
 
@@ -144,7 +144,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
 
      - returns: The observable sequence that terminates with specified error.
      */
-    public static func error(_ error: Swift.Error) -> Maybe<ElementType> {
+    public static func error(_ error: Swift.Error) -> Maybe<Element> {
         return PrimitiveSequence(raw: Observable.error(error))
     }
 
@@ -155,7 +155,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
 
      - returns: An observable sequence whose observers will never get called.
      */
-    public static func never() -> Maybe<ElementType> {
+    public static func never() -> Maybe<Element> {
         return PrimitiveSequence(raw: Observable.never())
     }
 
@@ -166,12 +166,12 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
 
      - returns: An observable sequence with no elements.
      */
-    public static func empty() -> Maybe<ElementType> {
+    public static func empty() -> Maybe<Element> {
         return Maybe(raw: Observable.empty())
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
      Invokes an action for each event in the observable sequence, and propagates all observer messages through the result sequence.
      
@@ -188,8 +188,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onNext: ((ElementType) throws -> Void)? = nil,
-                     afterNext: ((ElementType) throws -> Void)? = nil,
+    public func `do`(onNext: ((Element) throws -> Void)? = nil,
+                     afterNext: ((Element) throws -> Void)? = nil,
                      onError: ((Swift.Error) throws -> Void)? = nil,
                      afterError: ((Swift.Error) throws -> Void)? = nil,
                      onCompleted: (() throws -> Void)? = nil,
@@ -197,7 +197,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
                      onSubscribe: (() -> Void)? = nil,
                      onSubscribed: (() -> Void)? = nil,
                      onDispose: (() -> Void)? = nil)
-        -> Maybe<ElementType> {
+        -> Maybe<Element> {
             return Maybe(raw: self.primitiveSequence.source.do(
                 onNext: onNext,
                 afterNext: afterNext,
@@ -219,8 +219,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
      */
-    public func filter(_ predicate: @escaping (ElementType) throws -> Bool)
-        -> Maybe<ElementType> {
+    public func filter(_ predicate: @escaping (Element) throws -> Bool)
+        -> Maybe<Element> {
             return Maybe(raw: self.primitiveSequence.source.filter(predicate))
     }
     
@@ -233,7 +233,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
      
      */
-    public func map<R>(_ transform: @escaping (ElementType) throws -> R)
+    public func map<R>(_ transform: @escaping (Element) throws -> R)
         -> Maybe<R> {
             return Maybe(raw: self.primitiveSequence.source.map(transform))
     }
@@ -246,7 +246,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMap<R>(_ selector: @escaping (ElementType) throws -> Maybe<R>)
+    public func flatMap<R>(_ selector: @escaping (Element) throws -> Maybe<R>)
         -> Maybe<R> {
             return Maybe<R>(raw: self.primitiveSequence.source.flatMap(selector))
     }
@@ -259,7 +259,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter default: Default element to be sent if the source does not emit any elements
      - returns: An observable sequence which emits default element end completes in case the original sequence is empty
      */
-    public func ifEmpty(default: ElementType) -> Single<ElementType> {
+    public func ifEmpty(default: Element) -> Single<Element> {
         return Single(raw: self.primitiveSequence.source.ifEmpty(default: `default`))
     }
 
@@ -271,7 +271,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter switchTo: Observable sequence being returned when source sequence is empty.
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
-    public func ifEmpty(switchTo other: Maybe<ElementType>) -> Maybe<ElementType> {
+    public func ifEmpty(switchTo other: Maybe<Element>) -> Maybe<Element> {
         return Maybe(raw: self.primitiveSequence.source.ifEmpty(switchTo: other.primitiveSequence.source))
     }
 
@@ -283,7 +283,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter switchTo: Observable sequence being returned when source sequence is empty.
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
-    public func ifEmpty(switchTo other: Single<ElementType>) -> Single<ElementType> {
+    public func ifEmpty(switchTo other: Single<Element>) -> Single<Element> {
         return Single(raw: self.primitiveSequence.source.ifEmpty(switchTo: other.primitiveSequence.source))
     }
 
@@ -295,8 +295,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
      - parameter element: Last element in an observable sequence in case error occurs.
      - returns: An observable sequence containing the source sequence's elements, followed by the `element` in case an error occurred.
      */
-    public func catchErrorJustReturn(_ element: ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public func catchErrorJustReturn(_ element: Element)
+        -> PrimitiveSequence<Trait, Element> {
         return PrimitiveSequence(raw: self.primitiveSequence.source.catchErrorJustReturn(element))
     }
 }

--- a/RxSwift/Traits/ObservableType+PrimitiveSequence.swift
+++ b/RxSwift/Traits/ObservableType+PrimitiveSequence.swift
@@ -15,7 +15,7 @@ extension ObservableType {
 
      - returns: An observable sequence that emits a single element when the source Observable has completed, or throws an exception if more (or none) of them are emitted.
      */
-    public func asSingle() -> Single<E> {
+    public func asSingle() -> Single<Element> {
         return PrimitiveSequence(raw: AsSingle(source: self.asObservable()))
     }
     
@@ -27,7 +27,7 @@ extension ObservableType {
      
      - returns: An observable sequence that emits a single element or nil if the source observable sequence completes without emitting any items.
      */
-    public func first() -> Single<E?> {
+    public func first() -> Single<Element?> {
         return PrimitiveSequence(raw: First(source: self.asObservable()))
     }
 
@@ -39,12 +39,12 @@ extension ObservableType {
 
      - returns: An observable sequence that emits a single element, completes when the source Observable has completed, or throws an exception if more of them are emitted.
      */
-    public func asMaybe() -> Maybe<E> {
+    public func asMaybe() -> Maybe<Element> {
         return PrimitiveSequence(raw: AsMaybe(source: self.asObservable()))
     }
 }
 
-extension ObservableType where E == Never {
+extension ObservableType where Element == Never {
     /**
      - returns: An observable sequence that completes.
      */

--- a/RxSwift/Traits/PrimitiveSequence+Zip+arity.swift
+++ b/RxSwift/Traits/PrimitiveSequence+Zip+arity.swift
@@ -11,7 +11,7 @@
 
 // 2
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -20,8 +20,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, resultSelector: @escaping (E1, E2) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, resultSelector: @escaping (E1, E2) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(),
                 resultSelector: resultSelector)
@@ -29,7 +29,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -37,15 +37,15 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTra
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>)
-        -> PrimitiveSequence<TraitType, (E1, E2)> {
+    public static func zip<E1, E2>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>)
+        -> PrimitiveSequence<Trait, (E1, E2)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable())
             )
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -54,8 +54,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, resultSelector: @escaping (E1, E2) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, resultSelector: @escaping (E1, E2) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(),
                 resultSelector: resultSelector)
@@ -63,7 +63,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -71,8 +71,8 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>)
-        -> PrimitiveSequence<TraitType, (E1, E2)> {
+    public static func zip<E1, E2>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>)
+        -> PrimitiveSequence<Trait, (E1, E2)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable())
             )
@@ -84,7 +84,7 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
 // 3
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -93,8 +93,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, resultSelector: @escaping (E1, E2, E3) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, resultSelector: @escaping (E1, E2, E3) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(),
                 resultSelector: resultSelector)
@@ -102,7 +102,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -110,15 +110,15 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTra
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3)> {
+    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable())
             )
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -127,8 +127,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, resultSelector: @escaping (E1, E2, E3) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, resultSelector: @escaping (E1, E2, E3) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(),
                 resultSelector: resultSelector)
@@ -136,7 +136,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -144,8 +144,8 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3)> {
+    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable())
             )
@@ -157,7 +157,7 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
 // 4
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -166,8 +166,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, resultSelector: @escaping (E1, E2, E3, E4) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, resultSelector: @escaping (E1, E2, E3, E4) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(),
                 resultSelector: resultSelector)
@@ -175,7 +175,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -183,15 +183,15 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTra
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4)> {
+    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable())
             )
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -200,8 +200,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, resultSelector: @escaping (E1, E2, E3, E4) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, resultSelector: @escaping (E1, E2, E3, E4) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(),
                 resultSelector: resultSelector)
@@ -209,7 +209,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -217,8 +217,8 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4)> {
+    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable())
             )
@@ -230,7 +230,7 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
 // 5
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -239,8 +239,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, resultSelector: @escaping (E1, E2, E3, E4, E5) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, resultSelector: @escaping (E1, E2, E3, E4, E5) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(),
                 resultSelector: resultSelector)
@@ -248,7 +248,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -256,15 +256,15 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTra
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4, E5)> {
+    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable())
             )
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -273,8 +273,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, resultSelector: @escaping (E1, E2, E3, E4, E5) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, resultSelector: @escaping (E1, E2, E3, E4, E5) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(),
                 resultSelector: resultSelector)
@@ -282,7 +282,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -290,8 +290,8 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4, E5)> {
+    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable())
             )
@@ -303,7 +303,7 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
 // 6
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -312,8 +312,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(),
                 resultSelector: resultSelector)
@@ -321,7 +321,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -329,15 +329,15 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTra
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4, E5, E6)> {
+    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5, E6)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable())
             )
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -346,8 +346,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(),
                 resultSelector: resultSelector)
@@ -355,7 +355,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -363,8 +363,8 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4, E5, E6)> {
+    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5, E6)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable())
             )
@@ -376,7 +376,7 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
 // 7
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -385,8 +385,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, _ source7: PrimitiveSequence<TraitType, E7>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(),
                 resultSelector: resultSelector)
@@ -394,7 +394,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -402,15 +402,15 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTra
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, _ source7: PrimitiveSequence<TraitType, E7>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4, E5, E6, E7)> {
+    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5, E6, E7)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable())
             )
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -419,8 +419,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, _ source7: PrimitiveSequence<TraitType, E7>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(),
                 resultSelector: resultSelector)
@@ -428,7 +428,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -436,8 +436,8 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, _ source7: PrimitiveSequence<TraitType, E7>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4, E5, E6, E7)> {
+    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5, E6, E7)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable())
             )
@@ -449,7 +449,7 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
 // 8
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -458,8 +458,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, _ source7: PrimitiveSequence<TraitType, E7>, _ source8: PrimitiveSequence<TraitType, E8>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(),
                 resultSelector: resultSelector)
@@ -467,7 +467,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -475,15 +475,15 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTra
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, _ source7: PrimitiveSequence<TraitType, E7>, _ source8: PrimitiveSequence<TraitType, E8>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4, E5, E6, E7, E8)> {
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5, E6, E7, E8)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable())
             )
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -492,8 +492,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, _ source7: PrimitiveSequence<TraitType, E7>, _ source8: PrimitiveSequence<TraitType, E8>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(),
                 resultSelector: resultSelector)
@@ -501,7 +501,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -509,8 +509,8 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<TraitType, E1>, _ source2: PrimitiveSequence<TraitType, E2>, _ source3: PrimitiveSequence<TraitType, E3>, _ source4: PrimitiveSequence<TraitType, E4>, _ source5: PrimitiveSequence<TraitType, E5>, _ source6: PrimitiveSequence<TraitType, E6>, _ source7: PrimitiveSequence<TraitType, E7>, _ source8: PrimitiveSequence<TraitType, E8>)
-        -> PrimitiveSequence<TraitType, (E1, E2, E3, E4, E5, E6, E7, E8)> {
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5, E6, E7, E8)> {
         return PrimitiveSequence(raw: Observable.zip(
                 source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable())
             )

--- a/RxSwift/Traits/PrimitiveSequence+Zip+arity.tt
+++ b/RxSwift/Traits/PrimitiveSequence+Zip+arity.tt
@@ -10,7 +10,7 @@
 
 // <%= i %>
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -19,8 +19,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>>(<%= (Array(1...i).map { "_ source\($0): PrimitiveSequence<TraitType, E\($0)>" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>>(<%= (Array(1...i).map { "_ source\($0): PrimitiveSequence<Trait, E\($0)>" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             <%= (Array(1...i).map { "source\($0).asObservable()" }).joined(separator: ", ") %>,
                 resultSelector: resultSelector)
@@ -28,7 +28,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -36,15 +36,15 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == SingleTra
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>>(<%= (Array(1...i).map { "_ source\($0): PrimitiveSequence<TraitType, E\($0)>" }).joined(separator: ", ") %>)
-        -> PrimitiveSequence<TraitType, (<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>)> {
+    public static func zip<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>>(<%= (Array(1...i).map { "_ source\($0): PrimitiveSequence<Trait, E\($0)>" }).joined(separator: ", ") %>)
+        -> PrimitiveSequence<Trait, (<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>)> {
         return PrimitiveSequence(raw: Observable.zip(
                 <%= (Array(1...i).map { "source\($0).asObservable()" }).joined(separator: ", ") %>)
             )
     }
 }
 
-extension PrimitiveSequenceType where TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -53,8 +53,8 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>>(<%= (Array(1...i).map { "_ source\($0): PrimitiveSequence<TraitType, E\($0)>" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>) throws -> ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>>(<%= (Array(1...i).map { "_ source\($0): PrimitiveSequence<Trait, E\($0)>" }).joined(separator: ", ") %>, resultSelector: @escaping (<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             <%= (Array(1...i).map { "source\($0).asObservable()" }).joined(separator: ", ") %>,
                 resultSelector: resultSelector)
@@ -62,7 +62,7 @@ extension PrimitiveSequenceType where TraitType == MaybeTrait {
     }
 }
 
-extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrait {
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
 
@@ -70,8 +70,8 @@ extension PrimitiveSequenceType where ElementType == Any, TraitType == MaybeTrai
 
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>>(<%= (Array(1...i).map { "_ source\($0): PrimitiveSequence<TraitType, E\($0)>" }).joined(separator: ", ") %>)
-        -> PrimitiveSequence<TraitType, (<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>)> {
+    public static func zip<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>>(<%= (Array(1...i).map { "_ source\($0): PrimitiveSequence<Trait, E\($0)>" }).joined(separator: ", ") %>)
+        -> PrimitiveSequence<Trait, (<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>)> {
         return PrimitiveSequence(raw: Observable.zip(
                 <%= (Array(1...i).map { "source\($0).asObservable()" }).joined(separator: ", ") %>)
             )

--- a/RxSwift/Traits/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence.swift
@@ -18,26 +18,28 @@ public struct PrimitiveSequence<Trait, Element> {
 /// Observable sequences containing 0 or 1 element
 public protocol PrimitiveSequenceType {
     /// Additional constraints
-    associatedtype TraitType
+    associatedtype Trait
+
     /// Sequence element type
-    associatedtype ElementType
+    associatedtype Element
+
+    @available(*, deprecated, message: "Use `Trait` instead.")
+    typealias TraitType = Trait
+
+    @available(*, deprecated, message: "Use `Trait` instead.")
+    typealias ElementType = Element
 
     // Converts `self` to primitive sequence.
     ///
     /// - returns: Observable sequence that represents `self`.
-    var primitiveSequence: PrimitiveSequence<TraitType, ElementType> { get }
+    var primitiveSequence: PrimitiveSequence<Trait, Element> { get }
 }
 
 extension PrimitiveSequence: PrimitiveSequenceType {
-    /// Additional constraints
-    public typealias TraitType = Trait
-    /// Sequence element type
-    public typealias ElementType = Element
-
     // Converts `self` to primitive sequence.
     ///
     /// - returns: Observable sequence that represents `self`.
-    public var primitiveSequence: PrimitiveSequence<TraitType, ElementType> {
+    public var primitiveSequence: PrimitiveSequence<Trait, Element> {
         return self
     }
 }
@@ -246,7 +248,7 @@ extension PrimitiveSequence {
     }
 }
 
-extension PrimitiveSequenceType where ElementType: RxAbstractInteger
+extension PrimitiveSequenceType where Element: RxAbstractInteger
 {
     /**
      Returns an observable sequence that periodically produces a value after the specified initial relative due time has elapsed, using the specified scheduler to run timers.
@@ -258,7 +260,7 @@ extension PrimitiveSequenceType where ElementType: RxAbstractInteger
      - returns: An observable sequence that produces a value after due time has elapsed and then each period.
      */
     public static func timer(_ dueTime: RxTimeInterval, scheduler: SchedulerType)
-        -> PrimitiveSequence<TraitType, ElementType>  {
-        return PrimitiveSequence(raw: Observable<ElementType>.timer(dueTime, scheduler: scheduler))
+        -> PrimitiveSequence<Trait, Element>  {
+        return PrimitiveSequence(raw: Observable<Element>.timer(dueTime, scheduler: scheduler))
     }
 }

--- a/RxSwift/Traits/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence.swift
@@ -44,12 +44,12 @@ extension PrimitiveSequence: PrimitiveSequenceType {
 
 extension PrimitiveSequence: ObservableConvertibleType {
     /// Type of elements in sequence.
-    public typealias E = Element
+    public typealias Element = Element
 
     /// Converts `self` to `Observable` sequence.
     ///
     /// - returns: Observable sequence that represents `self`.
-    public func asObservable() -> Observable<E> {
+    public func asObservable() -> Observable<Element> {
         return self.source
     }
 }
@@ -213,7 +213,7 @@ extension PrimitiveSequence {
      */
     public static func using<Resource: Disposable>(_ resourceFactory: @escaping () throws -> Resource, primitiveSequenceFactory: @escaping (Resource) throws -> PrimitiveSequence<Trait, Element>)
         -> PrimitiveSequence<Trait, Element> {
-            return PrimitiveSequence(raw: Observable.using(resourceFactory, observableFactory: { (resource: Resource) throws -> Observable<E> in
+            return PrimitiveSequence(raw: Observable.using(resourceFactory, observableFactory: { (resource: Resource) throws -> Observable<Element> in
                 return try primitiveSequenceFactory(resource).asObservable()
             }))
     }

--- a/RxSwift/Traits/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence.swift
@@ -43,9 +43,6 @@ extension PrimitiveSequence: PrimitiveSequenceType {
 }
 
 extension PrimitiveSequence: ObservableConvertibleType {
-    /// Type of elements in sequence.
-    public typealias Element = Element
-
     /// Converts `self` to `Observable` sequence.
     ///
     /// - returns: Observable sequence that represents `self`.

--- a/RxSwift/Traits/Single.swift
+++ b/RxSwift/Traits/Single.swift
@@ -23,8 +23,8 @@ public enum SingleEvent<Element> {
     case error(Swift.Error)
 }
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
-    public typealias SingleObserver = (SingleEvent<ElementType>) -> Void
+extension PrimitiveSequenceType where Trait == SingleTrait {
+    public typealias SingleObserver = (SingleEvent<Element>) -> Void
     
     /**
      Creates an observable sequence from a specified subscribe method implementation.
@@ -34,8 +34,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(subscribe: @escaping (@escaping SingleObserver) -> Disposable) -> Single<ElementType> {
-        let source = Observable<ElementType>.create { observer in
+    public static func create(subscribe: @escaping (@escaping SingleObserver) -> Disposable) -> Single<Element> {
+        let source = Observable<Element>.create { observer in
             return subscribe { event in
                 switch event {
                 case .success(let element):
@@ -56,7 +56,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      
      - returns: Subscription for `observer` that can be used to cancel production of sequence elements and free resources.
      */
-    public func subscribe(_ observer: @escaping (SingleEvent<ElementType>) -> Void) -> Disposable {
+    public func subscribe(_ observer: @escaping (SingleEvent<Element>) -> Void) -> Disposable {
         var stopped = false
         return self.primitiveSequence.asObservable().subscribe { event in
             if stopped { return }
@@ -80,7 +80,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter onError: Action to invoke upon errored termination of the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(onSuccess: ((ElementType) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil) -> Disposable {
+    public func subscribe(onSuccess: ((Element) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil) -> Disposable {
         #if DEBUG
              let callStack = Hooks.recordCallStackOnError ? Thread.callStackSymbols : []
         #else
@@ -102,7 +102,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
     }
 }
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
      Returns an observable sequence that contains a single element.
      
@@ -111,7 +111,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter element: Single element in the resulting observable sequence.
      - returns: An observable sequence containing the single specified element.
      */
-    public static func just(_ element: ElementType) -> Single<ElementType> {
+    public static func just(_ element: Element) -> Single<Element> {
         return Single(raw: Observable.just(element))
     }
     
@@ -124,7 +124,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter scheduler: Scheduler to send the single element on.
      - returns: An observable sequence containing the single specified element.
      */
-    public static func just(_ element: ElementType, scheduler: ImmediateSchedulerType) -> Single<ElementType> {
+    public static func just(_ element: Element, scheduler: ImmediateSchedulerType) -> Single<Element> {
         return Single(raw: Observable.just(element, scheduler: scheduler))
     }
 
@@ -135,7 +135,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
 
      - returns: The observable sequence that terminates with specified error.
      */
-    public static func error(_ error: Swift.Error) -> Single<ElementType> {
+    public static func error(_ error: Swift.Error) -> Single<Element> {
         return PrimitiveSequence(raw: Observable.error(error))
     }
 
@@ -146,12 +146,12 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
 
      - returns: An observable sequence whose observers will never get called.
      */
-    public static func never() -> Single<ElementType> {
+    public static func never() -> Single<Element> {
         return PrimitiveSequence(raw: Observable.never())
     }
 }
 
-extension PrimitiveSequenceType where TraitType == SingleTrait {
+extension PrimitiveSequenceType where Trait == SingleTrait {
 
     /**
      Invokes an action for each event in the observable sequence, and propagates all observer messages through the result sequence.
@@ -167,14 +167,14 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onSuccess: ((ElementType) throws -> Void)? = nil,
-                     afterSuccess: ((ElementType) throws -> Void)? = nil,
+    public func `do`(onSuccess: ((Element) throws -> Void)? = nil,
+                     afterSuccess: ((Element) throws -> Void)? = nil,
                      onError: ((Swift.Error) throws -> Void)? = nil,
                      afterError: ((Swift.Error) throws -> Void)? = nil,
                      onSubscribe: (() -> Void)? = nil,
                      onSubscribed: (() -> Void)? = nil,
                      onDispose: (() -> Void)? = nil)
-        -> Single<ElementType> {
+        -> Single<Element> {
             return Single(raw: self.primitiveSequence.source.do(
                 onNext: onSuccess,
                 afterNext: afterSuccess,
@@ -194,8 +194,8 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
      */
-    public func filter(_ predicate: @escaping (ElementType) throws -> Bool)
-        -> Maybe<ElementType> {
+    public func filter(_ predicate: @escaping (Element) throws -> Bool)
+        -> Maybe<Element> {
             return Maybe(raw: self.primitiveSequence.source.filter(predicate))
     }
 
@@ -208,7 +208,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
      
      */
-    public func map<R>(_ transform: @escaping (ElementType) throws -> R)
+    public func map<R>(_ transform: @escaping (Element) throws -> R)
         -> Single<R> {
             return Single(raw: self.primitiveSequence.source.map(transform))
     }
@@ -221,7 +221,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMap<R>(_ selector: @escaping (ElementType) throws -> Single<R>)
+    public func flatMap<R>(_ selector: @escaping (Element) throws -> Single<R>)
         -> Single<R> {
             return Single<R>(raw: self.primitiveSequence.source.flatMap(selector))
     }
@@ -234,7 +234,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMapMaybe<R>(_ selector: @escaping (ElementType) throws -> Maybe<R>)
+    public func flatMapMaybe<R>(_ selector: @escaping (Element) throws -> Maybe<R>)
         -> Maybe<R> {
             return Maybe<R>(raw: self.primitiveSequence.source.flatMap(selector))
     }
@@ -247,7 +247,7 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMapCompletable(_ selector: @escaping (ElementType) throws -> Completable)
+    public func flatMapCompletable(_ selector: @escaping (Element) throws -> Completable)
         -> Completable {
             return Completable(raw: self.primitiveSequence.source.flatMap(selector))
     }
@@ -258,16 +258,16 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func zip<C: Collection, R>(_ collection: C, resultSelector: @escaping ([ElementType]) throws -> R) -> PrimitiveSequence<TraitType, R> where C.Iterator.Element == PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<C: Collection, R>(_ collection: C, resultSelector: @escaping ([Element]) throws -> R) -> PrimitiveSequence<Trait, R> where C.Iterator.Element == PrimitiveSequence<Trait, Element> {
         
         if collection.isEmpty {
-            return PrimitiveSequence<TraitType, R>.deferred {
-                return PrimitiveSequence<TraitType, R>(raw: .just(try resultSelector([])))
+            return PrimitiveSequence<Trait, R>.deferred {
+                return PrimitiveSequence<Trait, R>(raw: .just(try resultSelector([])))
             }
         }
         
         let raw = Observable.zip(collection.map { $0.asObservable() }, resultSelector: resultSelector)
-        return PrimitiveSequence<TraitType, R>(raw: raw)
+        return PrimitiveSequence<Trait, R>(raw: raw)
     }
     
     /**
@@ -275,10 +275,10 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      
      - returns: An observable sequence containing the result of combining elements of the sources.
      */
-    public static func zip<C: Collection>(_ collection: C) -> PrimitiveSequence<TraitType, [ElementType]> where C.Iterator.Element == PrimitiveSequence<TraitType, ElementType> {
+    public static func zip<C: Collection>(_ collection: C) -> PrimitiveSequence<Trait, [Element]> where C.Iterator.Element == PrimitiveSequence<Trait, Element> {
         
         if collection.isEmpty {
-            return PrimitiveSequence<TraitType, [ElementType]>(raw: .just([]))
+            return PrimitiveSequence<Trait, [Element]>(raw: .just([]))
         }
         
         let raw = Observable.zip(collection.map { $0.asObservable() })
@@ -293,15 +293,15 @@ extension PrimitiveSequenceType where TraitType == SingleTrait {
      - parameter element: Last element in an observable sequence in case error occurs.
      - returns: An observable sequence containing the source sequence's elements, followed by the `element` in case an error occurred.
      */
-    public func catchErrorJustReturn(_ element: ElementType)
-        -> PrimitiveSequence<TraitType, ElementType> {
+    public func catchErrorJustReturn(_ element: Element)
+        -> PrimitiveSequence<Trait, Element> {
         return PrimitiveSequence(raw: self.primitiveSequence.source.catchErrorJustReturn(element))
     }
 
     /// Converts `self` to `Maybe` trait.
     ///
     /// - returns: Maybe trait that represents `self`.
-    public func asMaybe() -> Maybe<ElementType> {
+    public func asMaybe() -> Maybe<Element> {
         return Maybe(raw: self.primitiveSequence.source)
     }
 

--- a/RxTest/ColdObservable.swift
+++ b/RxTest/ColdObservable.swift
@@ -21,7 +21,7 @@ final class ColdObservable<Element>
     }
 
     /// Subscribes `observer` to receive events for this sequence.
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         self.subscriptions.append(Subscription(self.testScheduler.clock))
         
         let i = self.subscriptions.count - 1

--- a/RxTest/HotObservable.swift
+++ b/RxTest/HotObservable.swift
@@ -37,7 +37,7 @@ final class HotObservable<Element>
     }
 
     /// Subscribes `observer` to receive events for this sequence.
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         let key = self._observers.insert(observer.on)
         self.subscriptions.append(Subscription(self.testScheduler.clock))
         

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -61,7 +61,7 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
      - parameter type: Optional type hint of the observed sequence elements.
      - returns: Observer that can be used to assert the timing of events.
     */
-    public func createObserver<E>(_ type: E.Type) -> TestableObserver<E> {
+    public func createObserver<Element>(_ type: Element.Type) -> TestableObserver<Element> {
         return TestableObserver(scheduler: self as AnyObject as! TestScheduler)
     }
 

--- a/RxTest/TestableObservable.swift
+++ b/RxTest/TestableObservable.swift
@@ -11,7 +11,7 @@ import RxSwift
 /// Observable sequence that records subscription lifetimes and timestamped events sent to observers.
 public class TestableObservable<Element>
     : ObservableType {
-    public typealias E = Element
+    public typealias Element = Element
     /// Subscriptions recorded during observable lifetime.
     public internal(set) var subscriptions: [Subscription]
 
@@ -29,7 +29,7 @@ public class TestableObservable<Element>
         self.subscriptions = []
     }
 
-    public func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.E == Element {
+    public func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         fatalError("Abstract method")
     }
 }

--- a/RxTest/TestableObservable.swift
+++ b/RxTest/TestableObservable.swift
@@ -11,7 +11,6 @@ import RxSwift
 /// Observable sequence that records subscription lifetimes and timestamped events sent to observers.
 public class TestableObservable<Element>
     : ObservableType {
-    public typealias Element = Element
     /// Subscriptions recorded during observable lifetime.
     public internal(set) var subscriptions: [Subscription]
 

--- a/RxTest/TestableObserver.swift
+++ b/RxTest/TestableObserver.swift
@@ -9,10 +9,8 @@
 import RxSwift
 
 /// Observer that records events together with virtual time when they were received.
-public final class TestableObserver<ElementType>
+public final class TestableObserver<Element>
     : ObserverType {
-    public typealias Element = ElementType
-    
     fileprivate let _scheduler: TestScheduler
 
     /// Recorded events.

--- a/RxTest/XCTest+Rx.swift
+++ b/RxTest/XCTest+Rx.swift
@@ -211,7 +211,7 @@ public func XCTAssertRecordedElements<T: Equatable>(_ stream: [Recorded<Event<T>
     printSequenceDifferences(streamElements, elements, ==)
 }
 
-func printSequenceDifferences<E>(_ lhs: [E], _ rhs: [E], _ equal: (E, E) -> Bool) {
+func printSequenceDifferences<Element>(_ lhs: [Element], _ rhs: [Element], _ equal: (Element, Element) -> Bool) {
     print("Differences:")
     for (index, elements) in zip(lhs, rhs).enumerated() {
         let l = elements.0

--- a/Tests/RxSwiftTests/Observable+PrimitiveSequenceTest.swift
+++ b/Tests/RxSwiftTests/Observable+PrimitiveSequenceTest.swift
@@ -568,10 +568,10 @@ extension ObservablePrimitiveSequenceTest {
     func testCompletable_merge() {
         let factories: [(Completable, Completable) -> Completable] =
             [
-                { ys1, ys2 in Completable.merge(ys1, ys2) },
-                { ys1, ys2 in Completable.merge([ys1, ys2]) },
-                { ys1, ys2 in Completable.merge(AnyCollection([ys1, ys2])) },
-                ]
+                { ys1, ys2 in Completable.zip(ys1, ys2) },
+                { ys1, ys2 in Completable.zip([ys1, ys2]) },
+                { ys1, ys2 in Completable.zip(AnyCollection([ys1, ys2])) },
+            ]
 
         for factory in factories {
             let scheduler = TestScheduler(initialClock: 0)

--- a/Tests/RxSwiftTests/TestImplementations/ElementIndexPair.swift
+++ b/Tests/RxSwiftTests/TestImplementations/ElementIndexPair.swift
@@ -6,16 +6,16 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-struct ElementIndexPair<E: Equatable, I: Equatable> : Equatable {
-    let element: E
+struct ElementIndexPair<Element: Equatable, I: Equatable> : Equatable {
+    let element: Element
     let index: I
     
-    init(_ element: E, _ index: I) {
+    init(_ element: Element, _ index: I) {
         self.element = element
         self.index = index
     }
 }
 
-func == <E, I>(lhs: ElementIndexPair<E, I>, rhs: ElementIndexPair<E, I>) -> Bool {
+func == <Element, I>(lhs: ElementIndexPair<Element, I>, rhs: ElementIndexPair<Element, I>) -> Bool {
     return lhs.element == rhs.element && lhs.index == rhs.index
 }

--- a/Tests/RxSwiftTests/TestImplementations/EquatableArray.swift
+++ b/Tests/RxSwiftTests/TestImplementations/EquatableArray.swift
@@ -13,7 +13,7 @@ struct EquatableArray<Element: Equatable> : Equatable {
     }
 }
 
-func ==<E>(lhs: EquatableArray<E>, rhs: EquatableArray<E>) -> Bool {
+func ==<Element>(lhs: EquatableArray<Element>, rhs: EquatableArray<Element>) -> Bool {
     return lhs.elements == rhs.elements
 }
 

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/BackgroundThreadPrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/BackgroundThreadPrimitiveHotObservable.swift
@@ -11,7 +11,7 @@ import XCTest
 import Dispatch
 
 final class BackgroundThreadPrimitiveHotObservable<ElementType: Equatable> : PrimitiveHotObservable<ElementType> {
-    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         XCTAssertTrue(!DispatchQueue.isMain)
         return super.subscribe(observer)
     }

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/BackgroundThreadPrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/BackgroundThreadPrimitiveHotObservable.swift
@@ -10,7 +10,7 @@ import RxSwift
 import XCTest
 import Dispatch
 
-final class BackgroundThreadPrimitiveHotObservable<ElementType: Equatable> : PrimitiveHotObservable<ElementType> {
+final class BackgroundThreadPrimitiveHotObservable<Element: Equatable> : PrimitiveHotObservable<Element> {
     override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         XCTAssertTrue(!DispatchQueue.isMain)
         return super.subscribe(observer)

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MainThreadPrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MainThreadPrimitiveHotObservable.swift
@@ -10,7 +10,7 @@ import RxSwift
 import XCTest
 import Dispatch
 
-final class MainThreadPrimitiveHotObservable<ElementType: Equatable> : PrimitiveHotObservable<ElementType> {
+final class MainThreadPrimitiveHotObservable<Element: Equatable> : PrimitiveHotObservable<Element> {
     override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         XCTAssertTrue(DispatchQueue.isMain)
         return super.subscribe(observer)

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MainThreadPrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MainThreadPrimitiveHotObservable.swift
@@ -11,7 +11,7 @@ import XCTest
 import Dispatch
 
 final class MainThreadPrimitiveHotObservable<ElementType: Equatable> : PrimitiveHotObservable<ElementType> {
-    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         XCTAssertTrue(DispatchQueue.isMain)
         return super.subscribe(observer)
     }

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
@@ -9,7 +9,6 @@
 import RxSwift
 
 final class MySubject<Element> : SubjectType, ObserverType where Element : Hashable {
-    typealias Element = Element
     typealias SubjectObserverType = MySubject<Element>
 
     var _disposeOn: [Element : Disposable] = [:]

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
@@ -9,8 +9,8 @@
 import RxSwift
 
 final class MySubject<Element> : SubjectType, ObserverType where Element : Hashable {
-    typealias E = Element
-    typealias SubjectObserverType = MySubject<E>
+    typealias Element = Element
+    typealias SubjectObserverType = MySubject<Element>
 
     var _disposeOn: [Element : Disposable] = [:]
     var _observer: AnyObserver<Element>! = nil
@@ -29,7 +29,7 @@ final class MySubject<Element> : SubjectType, ObserverType where Element : Hasha
         _disposeOn[value] = disposable
     }
     
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         _observer.on(event)
         switch event {
         case .next(let value):
@@ -40,7 +40,7 @@ final class MySubject<Element> : SubjectType, ObserverType where Element : Hasha
         }
     }
     
-    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         _subscribeCount += 1
         _observer = AnyObserver(observer)
         
@@ -50,7 +50,7 @@ final class MySubject<Element> : SubjectType, ObserverType where Element : Hasha
         }
     }
 
-    func asObserver() -> MySubject<E> {
+    func asObserver() -> MySubject<Element> {
         return self
     }
 }

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
@@ -13,14 +13,12 @@ import Dispatch
 let SubscribedToHotObservable = Subscription(0)
 let UnsunscribedFromHotObservable = Subscription(0, 0)
 
-class PrimitiveHotObservable<ElementType> : ObservableType {
-    typealias Element = ElementType
-
+class PrimitiveHotObservable<Element> : ObservableType {
     typealias Events = Recorded<Element>
     typealias Observer = AnyObserver<Element>
     
     var _subscriptions = [Subscription]()
-    let _observers = PublishSubject<ElementType>()
+    let _observers = PublishSubject<Element>()
     
     public var subscriptions: [Subscription] {
         lock.lock()

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
@@ -14,10 +14,10 @@ let SubscribedToHotObservable = Subscription(0)
 let UnsunscribedFromHotObservable = Subscription(0, 0)
 
 class PrimitiveHotObservable<ElementType> : ObservableType {
-    typealias E = ElementType
+    typealias Element = ElementType
 
-    typealias Events = Recorded<E>
-    typealias Observer = AnyObserver<E>
+    typealias Events = Recorded<Element>
+    typealias Observer = AnyObserver<Element>
     
     var _subscriptions = [Subscription]()
     let _observers = PublishSubject<ElementType>()
@@ -33,13 +33,13 @@ class PrimitiveHotObservable<ElementType> : ObservableType {
     init() {
     }
 
-    func on(_ event: Event<E>) {
+    func on(_ event: Event<Element>) {
         lock.lock()
         defer { lock.unlock() }
         _observers.on(event)
     }
     
-    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         lock.lock()
         defer { lock.unlock() }
 

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveMockObserver.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveMockObserver.swift
@@ -9,9 +9,7 @@
 import RxSwift
 import RxTest
 
-final class PrimitiveMockObserver<ElementType> : ObserverType {
-    typealias Element = ElementType
-
+final class PrimitiveMockObserver<Element> : ObserverType {
     private let _events = Synchronized([Recorded<Event<Element>>]())
 
     var events: [Recorded<Event<Element>>] {

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/TestConnectableObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/TestConnectableObservable.swift
@@ -8,12 +8,12 @@
 
 import RxSwift
 
-final class TestConnectableObservable<S: SubjectType> : ConnectableObservableType where S.E == S.SubjectObserverType.E {
-    typealias E = S.E
+final class TestConnectableObservable<S: SubjectType> : ConnectableObservableType where S.Element == S.SubjectObserverType.Element {
+    typealias Element = S.Element
 
-    let _o: ConnectableObservable<S.E>
+    let _o: ConnectableObservable<S.Element>
     
-    init(o: Observable<S.E>, s: S) {
+    init(o: Observable<S.Element>, s: S) {
         _o = o.multicast(s)
     }
     
@@ -21,7 +21,7 @@ final class TestConnectableObservable<S: SubjectType> : ConnectableObservableTyp
         return _o.connect()
     }
     
-    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.E == E {
+    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
         return _o.subscribe(observer)
     }
 }


### PR DESCRIPTION
This was a discussion started initially by @devandartist. 
Basically we’re using random associated generic naming everywhere and this PR aims to change everything to Element. It will assist in future generic features that will hopefully be shipped with later Swift versions. 

This PR also provides a deprecation, keeping code backwards-compatible.

Thanks ! 