### PR TITLE
Renaming `CompatibleType` to `ReactiveBase`

### DIFF
--- a/RxSwift/Reactive.swift
+++ b/RxSwift/Reactive.swift
@@ -39,7 +39,7 @@ public protocol ReactiveCompatible {
     /// Extended type
     associatedtype ReactiveBase
 
-    @available(*, deprecated, message: "Use `CompatibleType` instead.")
+    @available(*, deprecated, message: "Use `ReactiveBase` instead.")
     typealias CompatibleType = ReactiveBase
 
     /// Reactive extensions.

--- a/RxSwift/Reactive.swift
+++ b/RxSwift/Reactive.swift
@@ -37,13 +37,16 @@ public struct Reactive<Base> {
 /// A type that has reactive extensions.
 public protocol ReactiveCompatible {
     /// Extended type
-    associatedtype CompatibleType
+    associatedtype ReactiveBase
+
+    @available(*, deprecated, message: "Use `CompatibleType` instead.")
+    typealias CompatibleType = ReactiveBase
 
     /// Reactive extensions.
-    static var rx: Reactive<CompatibleType>.Type { get set }
+    static var rx: Reactive<ReactiveBase>.Type { get set }
 
     /// Reactive extensions.
-    var rx: Reactive<CompatibleType> { get set }
+    var rx: Reactive<ReactiveBase> { get set }
 }
 
 extension ReactiveCompatible {


### PR DESCRIPTION
Semantically this associated type refers the generic type parameter `Base` from `Reactive` lens. Thus the associated type is renamed from being called `CompatibleType` to `ReactiveBase` to resemble the targeting type. The old type is deprecated to prevent any source breakage. 