### PR TITLE
Rename O constraint to Observer where applicable

### DIFF
--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter to: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
-    public func bind<O: ObserverType>(to observers: O...) -> Disposable where O.Element == Element {
+    public func bind<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element {
         return self.bind(to: observers)
     }
 
@@ -27,7 +27,7 @@ extension ObservableType {
      - parameter to: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
-    public func bind<O: ObserverType>(to observers: O...) -> Disposable where O.Element == Element? {
+    public func bind<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element? {
         return self.map { $0 as Element? }.bind(to: observers)
     }
 
@@ -38,7 +38,7 @@ extension ObservableType {
      - parameter to: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
-    private func bind<O: ObserverType>(to observers: [O]) -> Disposable where O.Element == Element {
+    private func bind<Observer: ObserverType>(to observers: [Observer]) -> Disposable where Observer.Element == Element {
         return self.subscribe { event in
             observers.forEach { $0.on(event) }
         }

--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -22,7 +22,7 @@ extension ObservableType {
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     @available(*, deprecated, renamed: "bind(to:)")
-    public func bindTo<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func bindTo<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         return self.subscribe(observer)
     }
 
@@ -36,7 +36,7 @@ extension ObservableType {
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     @available(*, deprecated, renamed: "bind(to:)")
-    public func bindTo<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element? {
+    public func bindTo<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element? {
         return self.map { $0 }.subscribe(observer)
     }
 

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -383,7 +383,7 @@ fileprivate final class KVOObservable<Element>
         }
     }
 
-    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element? {
+    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element? {
         let observer = KVOObserver(parent: self) { value in
             if value as? NSNull != nil {
                 observer.on(.next(nil))

--- a/RxCocoa/Traits/ControlEvent.swift
+++ b/RxCocoa/Traits/ControlEvent.swift
@@ -53,7 +53,7 @@ public struct ControlEvent<PropertyType> : ControlEventType {
     ///
     /// - parameter observer: Observer to subscribe to events.
     /// - returns: Disposable object that can be used to unsubscribe the observer from receiving control events.
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         return self._events.subscribe(observer)
     }
 

--- a/RxCocoa/Traits/ControlProperty.swift
+++ b/RxCocoa/Traits/ControlProperty.swift
@@ -62,7 +62,7 @@ public struct ControlProperty<PropertyType> : ControlPropertyType {
     ///
     /// - parameter observer: Observer to subscribe to property values.
     /// - returns: Disposable object that can be used to unsubscribe the observer from receiving control property values.
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         return self._values.subscribe(observer)
     }
 

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -22,7 +22,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     - parameter observer: Observer that receives events.
     - returns: Disposable object that can be used to unsubscribe the observer from the subject.
     */
-    public func drive<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func drive<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.asSharedSequence().asObservable().subscribe(observer)
     }
@@ -36,7 +36,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
      - parameter observer: Observer that receives events.
      - returns: Disposable object that can be used to unsubscribe the observer from the subject.
      */
-    public func drive<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element? {
+    public func drive<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element? {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.asSharedSequence().asObservable().map { $0 as Element? }.subscribe(observer)
     }

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -18,7 +18,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - parameter to: Observer that receives events.
      - returns: Disposable object that can be used to unsubscribe the observer from the subject.
      */
-    public func emit<O: ObserverType>(to observer: O) -> Disposable where O.Element == Element {
+    public func emit<Observer: ObserverType>(to observer: Observer) -> Disposable where Observer.Element == Element {
         return self.asSharedSequence().asObservable().subscribe(observer)
     }
 
@@ -30,7 +30,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - parameter to: Observer that receives events.
      - returns: Disposable object that can be used to unsubscribe the observer from the subject.
      */
-    public func emit<O: ObserverType>(to observer: O) -> Disposable where O.Element == Element? {
+    public func emit<Observer: ObserverType>(to observer: Observer) -> Disposable where Observer.Element == Element? {
         return self.asSharedSequence().asObservable().map { $0 as Element? }.subscribe(observer)
     }
 

--- a/RxRelay/BehaviorRelay.swift
+++ b/RxRelay/BehaviorRelay.swift
@@ -31,7 +31,7 @@ public final class BehaviorRelay<Element>: ObservableType {
     }
 
     /// Subscribes observer
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         return self._subject.subscribe(observer)
     }
 

--- a/RxRelay/PublishRelay.swift
+++ b/RxRelay/PublishRelay.swift
@@ -25,7 +25,7 @@ public final class PublishRelay<Element>: ObservableType {
     }
 
     /// Subscribes observer
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         return self._subject.subscribe(observer)
     }
     

--- a/RxSwift/AnyObserver.swift
+++ b/RxSwift/AnyObserver.swift
@@ -25,7 +25,7 @@ public struct AnyObserver<Element> : ObserverType {
     /// Construct an instance whose `on(event)` calls `observer.on(event)`
     ///
     /// - parameter observer: Observer that receives sequence events.
-    public init<O : ObserverType>(_ observer: O) where O.Element == Element {
+    public init<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
         self.observer = observer.on
     }
     

--- a/RxSwift/GroupedObservable.swift
+++ b/RxSwift/GroupedObservable.swift
@@ -24,7 +24,7 @@ public struct GroupedObservable<Key, Element> : ObservableType {
     }
 
     /// Subscribes `observer` to receive events for this sequence.
-    public func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         return self.source.subscribe(observer)
     }
 

--- a/RxSwift/Observable.swift
+++ b/RxSwift/Observable.swift
@@ -16,7 +16,7 @@ public class Observable<Element> : ObservableType {
 #endif
     }
     
-    public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         rxAbstractMethod()
     }
     

--- a/RxSwift/ObservableType.swift
+++ b/RxSwift/ObservableType.swift
@@ -31,7 +31,7 @@ public protocol ObservableType: ObservableConvertibleType {
     
     - returns: Subscription for `observer` that can be used to cancel production of sequence elements and free resources.
     */
-    func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element
+    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element
 }
 
 extension ObservableType {

--- a/RxSwift/Observables/AddRef.swift
+++ b/RxSwift/Observables/AddRef.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-final class AddRefSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final class AddRefSink<Observer: ObserverType> : Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     
-    override init(observer: O, cancel: Cancelable) {
+    override init(observer: Observer, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
     }
     
@@ -34,7 +34,7 @@ final class AddRef<Element> : Producer<Element> {
         self._refCount = refCount
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let releaseDisposable = self._refCount.retain()
         let sink = AddRefSink(observer: observer, cancel: cancel)
         let subscription = Disposables.create(releaseDisposable, self._source.subscribe(sink))

--- a/RxSwift/Observables/Amb.swift
+++ b/RxSwift/Observables/Amb.swift
@@ -45,10 +45,10 @@ fileprivate enum AmbState {
     case right
 }
 
-final private class AmbObserver<O: ObserverType>: ObserverType {
-    typealias Element = O.Element 
-    typealias Parent = AmbSink<O>
-    typealias This = AmbObserver<O>
+final private class AmbObserver<Observer: ObserverType>: ObserverType {
+    typealias Element = Observer.Element 
+    typealias Parent = AmbSink<Observer>
+    typealias This = AmbObserver<Observer>
     typealias Sink = (This, Event<Element>) -> Void
     
     fileprivate let _parent: Parent
@@ -79,10 +79,10 @@ final private class AmbObserver<O: ObserverType>: ObserverType {
     }
 }
 
-final private class AmbSink<O: ObserverType>: Sink<O> {
-    typealias Element = O.Element
+final private class AmbSink<Observer: ObserverType>: Sink<Observer> {
+    typealias Element = Observer.Element
     typealias Parent = Amb<Element>
-    typealias AmbObserverType = AmbObserver<O>
+    typealias AmbObserverType = AmbObserver<Observer>
 
     private let _parent: Parent
     
@@ -90,7 +90,7 @@ final private class AmbSink<O: ObserverType>: Sink<O> {
     // state
     private var _choice = AmbState.neither
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -149,7 +149,7 @@ final private class Amb<Element>: Producer<Element> {
         self._right = right
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = AmbSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/AsMaybe.swift
+++ b/RxSwift/Observables/AsMaybe.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-fileprivate final class AsMaybeSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias Element = O.Element
+fileprivate final class AsMaybeSink<Observer: ObserverType> : Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element
 
     private var _element: Event<Element>?
 
@@ -40,7 +40,7 @@ final class AsMaybe<Element>: Producer<Element> {
         self._source = source
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = AsMaybeSink(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/AsSingle.swift
+++ b/RxSwift/Observables/AsSingle.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-fileprivate final class AsSingleSink<O: ObserverType> : Sink<O>, ObserverType { 
-    typealias Element = O.Element
+fileprivate final class AsSingleSink<Observer: ObserverType> : Sink<Observer>, ObserverType { 
+    typealias Element = Observer.Element
 
     private var _element: Event<Element>?
 
@@ -43,7 +43,7 @@ final class AsSingle<Element>: Producer<Element> {
         self._source = source
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = AsSingleSink(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Buffer.swift
+++ b/RxSwift/Observables/Buffer.swift
@@ -40,18 +40,18 @@ final private class BufferTimeCount<Element>: Producer<[Element]> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == [Element] {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == [Element] {
         let sink = BufferTimeCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
     }
 }
 
-final private class BufferTimeCountSink<Element, O: ObserverType>
-    : Sink<O>
+final private class BufferTimeCountSink<Element, Observer: ObserverType>
+    : Sink<Observer>
     , LockOwnerType
     , ObserverType
-    , SynchronizedOnType where O.Element == [Element] {
+    , SynchronizedOnType where Observer.Element == [Element] {
     typealias Parent = BufferTimeCount<Element>
     
     private let _parent: Parent
@@ -63,7 +63,7 @@ final private class BufferTimeCountSink<Element, O: ObserverType>
     private var _buffer = [Element]()
     private var _windowID = 0
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }

--- a/RxSwift/Observables/Catch.swift
+++ b/RxSwift/Observables/Catch.swift
@@ -83,9 +83,9 @@ extension ObservableType {
 
 // catch with callback
 
-final private class CatchSinkProxy<O: ObserverType>: ObserverType {
-    typealias Element = O.Element 
-    typealias Parent = CatchSink<O>
+final private class CatchSinkProxy<Observer: ObserverType>: ObserverType {
+    typealias Element = Observer.Element 
+    typealias Parent = CatchSink<Observer>
     
     private let _parent: Parent
     
@@ -105,14 +105,14 @@ final private class CatchSinkProxy<O: ObserverType>: ObserverType {
     }
 }
 
-final private class CatchSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class CatchSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias Parent = Catch<Element>
     
     private let _parent: Parent
     private let _subscription = SerialDisposable()
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -159,7 +159,7 @@ final private class Catch<Element>: Producer<Element> {
         self._handler = handler
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = CatchSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -168,15 +168,15 @@ final private class Catch<Element>: Producer<Element> {
 
 // catch enumerable
 
-final private class CatchSequenceSink<Sequence: Swift.Sequence, O: ObserverType>
-    : TailRecursiveSink<Sequence, O>
-    , ObserverType where Sequence.Element: ObservableConvertibleType, Sequence.Element.Element == O.Element {
-    typealias Element = O.Element 
+final private class CatchSequenceSink<Sequence: Swift.Sequence, Observer: ObserverType>
+    : TailRecursiveSink<Sequence, Observer>
+    , ObserverType where Sequence.Element: ObservableConvertibleType, Sequence.Element.Element == Observer.Element {
+    typealias Element = Observer.Element
     typealias Parent = CatchSequence<Sequence>
-    
+
     private var _lastError: Swift.Error?
     
-    override init(observer: O, cancel: Cancelable) {
+    override init(observer: Observer, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
     }
     
@@ -226,9 +226,9 @@ final private class CatchSequence<Sequence: Swift.Sequence>: Producer<Sequence.E
     init(sources: Sequence) {
         self.sources = sources
     }
-    
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
-        let sink = CatchSequenceSink<Sequence, O>(observer: observer, cancel: cancel)
+
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
+        let sink = CatchSequenceSink<Sequence, Observer>(observer: observer, cancel: cancel)
         let subscription = sink.run((self.sources.makeIterator(), nil))
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Observables/CombineLatest+Collection.swift
+++ b/RxSwift/Observables/CombineLatest+Collection.swift
@@ -33,9 +33,9 @@ extension ObservableType {
     }
 }
 
-final private class CombineLatestCollectionTypeSink<Collection: Swift.Collection, O: ObserverType>
-    : Sink<O> where Collection.Element: ObservableConvertibleType {
-    typealias Result = O.Element 
+final private class CombineLatestCollectionTypeSink<Collection: Swift.Collection, Observer: ObserverType>
+    : Sink<Observer> where Collection.Element: ObservableConvertibleType {
+    typealias Result = Observer.Element 
     typealias Parent = CombineLatestCollectionType<Collection, Result>
     typealias SourceElement = Collection.Element.Element
     
@@ -50,7 +50,7 @@ final private class CombineLatestCollectionTypeSink<Collection: Swift.Collection
     var _numberOfDone = 0
     var _subscriptions: [SingleAssignmentDisposable]
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._values = [SourceElement?](repeating: nil, count: parent._count)
         self._isDone = [Bool](repeating: false, count: parent._count)
@@ -158,7 +158,7 @@ final private class CombineLatestCollectionType<Collection: Swift.Collection, Re
         self._count = Int(Int64(self._sources.count))
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestCollectionTypeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/CombineLatest+arity.swift
+++ b/RxSwift/Observables/CombineLatest+arity.swift
@@ -48,8 +48,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> {
-    typealias Result = O.Element
+final class CombineLatestSink2_<E1, E2, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
     typealias Parent = CombineLatest2<E1, E2, Result>
 
     let _parent: Parent
@@ -57,7 +57,7 @@ final class CombineLatestSink2_<E1, E2, O: ObserverType> : CombineLatestSink<O> 
     var _latestElement1: E1! = nil
     var _latestElement2: E2! = nil
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 2, observer: observer, cancel: cancel)
     }
@@ -98,7 +98,7 @@ final class CombineLatest2<E1, E2, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestSink2_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -146,8 +146,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink<O> {
-    typealias Result = O.Element
+final class CombineLatestSink3_<E1, E2, E3, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
     typealias Parent = CombineLatest3<E1, E2, E3, Result>
 
     let _parent: Parent
@@ -156,7 +156,7 @@ final class CombineLatestSink3_<E1, E2, E3, O: ObserverType> : CombineLatestSink
     var _latestElement2: E2! = nil
     var _latestElement3: E3! = nil
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 3, observer: observer, cancel: cancel)
     }
@@ -203,7 +203,7 @@ final class CombineLatest3<E1, E2, E3, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestSink3_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -251,8 +251,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatestSink<O> {
-    typealias Result = O.Element
+final class CombineLatestSink4_<E1, E2, E3, E4, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
     typealias Parent = CombineLatest4<E1, E2, E3, E4, Result>
 
     let _parent: Parent
@@ -262,7 +262,7 @@ final class CombineLatestSink4_<E1, E2, E3, E4, O: ObserverType> : CombineLatest
     var _latestElement3: E3! = nil
     var _latestElement4: E4! = nil
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 4, observer: observer, cancel: cancel)
     }
@@ -315,7 +315,7 @@ final class CombineLatest4<E1, E2, E3, E4, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestSink4_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -363,8 +363,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLatestSink<O> {
-    typealias Result = O.Element
+final class CombineLatestSink5_<E1, E2, E3, E4, E5, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
     typealias Parent = CombineLatest5<E1, E2, E3, E4, E5, Result>
 
     let _parent: Parent
@@ -375,7 +375,7 @@ final class CombineLatestSink5_<E1, E2, E3, E4, E5, O: ObserverType> : CombineLa
     var _latestElement4: E4! = nil
     var _latestElement5: E5! = nil
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 5, observer: observer, cancel: cancel)
     }
@@ -434,7 +434,7 @@ final class CombineLatest5<E1, E2, E3, E4, E5, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestSink5_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -482,8 +482,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : CombineLatestSink<O> {
-    typealias Result = O.Element
+final class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
     typealias Parent = CombineLatest6<E1, E2, E3, E4, E5, E6, Result>
 
     let _parent: Parent
@@ -495,7 +495,7 @@ final class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : Combi
     var _latestElement5: E5! = nil
     var _latestElement6: E6! = nil
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 6, observer: observer, cancel: cancel)
     }
@@ -560,7 +560,7 @@ final class CombineLatest6<E1, E2, E3, E4, E5, E6, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestSink6_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -608,8 +608,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : CombineLatestSink<O> {
-    typealias Result = O.Element
+final class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
     typealias Parent = CombineLatest7<E1, E2, E3, E4, E5, E6, E7, Result>
 
     let _parent: Parent
@@ -622,7 +622,7 @@ final class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : C
     var _latestElement6: E6! = nil
     var _latestElement7: E7! = nil
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 7, observer: observer, cancel: cancel)
     }
@@ -693,7 +693,7 @@ final class CombineLatest7<E1, E2, E3, E4, E5, E6, E7, Result> : Producer<Result
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestSink7_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -741,8 +741,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : CombineLatestSink<O> {
-    typealias Result = O.Element
+final class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
     typealias Parent = CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, Result>
 
     let _parent: Parent
@@ -756,7 +756,7 @@ final class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType>
     var _latestElement7: E7! = nil
     var _latestElement8: E8! = nil
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 8, observer: observer, cancel: cancel)
     }
@@ -833,7 +833,7 @@ final class CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, Result> : Producer<Re
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestSink8_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/CombineLatest+arity.tt
+++ b/RxSwift/Observables/CombineLatest+arity.tt
@@ -47,8 +47,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class CombineLatestSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, O: ObserverType> : CombineLatestSink<O> {
-    typealias Result = O.Element
+final class CombineLatestSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
     typealias Parent = CombineLatest<%= i %><<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, Result>
 
     let _parent: Parent
@@ -57,7 +57,7 @@ final class CombineLatestSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joine
 "    var _latestElement\($0): E\($0)! = nil"
 }).joined(separator: "\n") %>
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: <%= i %>, observer: observer, cancel: cancel)
     }
@@ -102,7 +102,7 @@ final class CombineLatest<%= i %><<%= (Array(1...i).map { "E\($0)" }).joined(sep
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = CombineLatestSink<%= i %>_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/CombineLatest.swift
+++ b/RxSwift/Observables/CombineLatest.swift
@@ -12,10 +12,10 @@ protocol CombineLatestProtocol : class {
     func done(_ index: Int)
 }
 
-class CombineLatestSink<O: ObserverType>
-    : Sink<O>
+class CombineLatestSink<Observer: ObserverType>
+    : Sink<Observer>
     , CombineLatestProtocol {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
    
     let _lock = RecursiveLock()
 
@@ -25,7 +25,7 @@ class CombineLatestSink<O: ObserverType>
     private var _hasValue: [Bool]
     private var _isDone: [Bool]
    
-    init(arity: Int, observer: O, cancel: Cancelable) {
+    init(arity: Int, observer: Observer, cancel: Cancelable) {
         self._arity = arity
         self._hasValue = [Bool](repeating: false, count: arity)
         self._isDone = [Bool](repeating: false, count: arity)

--- a/RxSwift/Observables/CompactMap.swift
+++ b/RxSwift/Observables/CompactMap.swift
@@ -27,15 +27,15 @@ extension ObservableType {
     }
 }
 
-final private class CompactMapSink<SourceType, O: ObserverType>: Sink<O>, ObserverType {
+final private class CompactMapSink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType {
     typealias Transform = (SourceType) throws -> ResultType?
 
-    typealias ResultType = O.Element 
+    typealias ResultType = Observer.Element 
     typealias Element = SourceType
 
     private let _transform: Transform
 
-    init(transform: @escaping Transform, observer: O, cancel: Cancelable) {
+    init(transform: @escaping Transform, observer: Observer, cancel: Cancelable) {
         self._transform = transform
         super.init(observer: observer, cancel: cancel)
     }
@@ -74,7 +74,7 @@ final private class CompactMap<SourceType, ResultType>: Producer<ResultType> {
         self._transform = transform
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == ResultType {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == ResultType {
         let sink = CompactMapSink(transform: self._transform, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Concat.swift
+++ b/RxSwift/Observables/Concat.swift
@@ -76,12 +76,12 @@ extension ObservableType {
     }
 }
 
-final private class ConcatSink<Sequence: Swift.Sequence, O: ObserverType>
-    : TailRecursiveSink<Sequence, O>
-    , ObserverType where Sequence.Element: ObservableConvertibleType, Sequence.Element.Element == O.Element {
-    typealias Element = O.Element 
+final private class ConcatSink<Sequence: Swift.Sequence, Observer: ObserverType>
+    : TailRecursiveSink<Sequence, Observer>
+    , ObserverType where Sequence.Element: ObservableConvertibleType, Sequence.Element.Element == Observer.Element {
+    typealias Element = Observer.Element 
     
-    override init(observer: O, cancel: Cancelable) {
+    override init(observer: Observer, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
     }
     
@@ -122,8 +122,8 @@ final private class Concat<Sequence: Swift.Sequence>: Producer<Sequence.Element.
         self._count = count
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
-        let sink = ConcatSink<Sequence, O>(observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
+        let sink = ConcatSink<Sequence, Observer>(observer: observer, cancel: cancel)
         let subscription = sink.run((self._sources.makeIterator(), self._count))
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Observables/Create.swift
+++ b/RxSwift/Observables/Create.swift
@@ -22,8 +22,8 @@ extension ObservableType {
     }
 }
 
-final private class AnonymousObservableSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class AnonymousObservableSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias Parent = AnonymousObservable<Element>
 
     // state
@@ -33,7 +33,7 @@ final private class AnonymousObservableSink<O: ObserverType>: Sink<O>, ObserverT
         fileprivate let _synchronizationTracker = SynchronizationTracker()
     #endif
 
-    override init(observer: O, cancel: Cancelable) {
+    override init(observer: Observer, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
     }
 
@@ -70,7 +70,7 @@ final private class AnonymousObservable<Element>: Producer<Element> {
         self._subscribeHandler = subscribeHandler
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = AnonymousObservableSink(observer: observer, cancel: cancel)
         let subscription = sink.run(self)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Debounce.swift
+++ b/RxSwift/Observables/Debounce.swift
@@ -23,12 +23,12 @@ extension ObservableType {
     }
 }
 
-final private class DebounceSink<O: ObserverType>
-    : Sink<O>
+final private class DebounceSink<Observer: ObserverType>
+    : Sink<Observer>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
     typealias ParentType = Debounce<Element>
 
     private let _parent: ParentType
@@ -41,7 +41,7 @@ final private class DebounceSink<O: ObserverType>
 
     let cancellable = SerialDisposable()
 
-    init(parent: ParentType, observer: O, cancel: Cancelable) {
+    init(parent: ParentType, observer: Observer, cancel: Cancelable) {
         self._parent = parent
 
         super.init(observer: observer, cancel: cancel)
@@ -109,7 +109,7 @@ final private class Debounce<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = DebounceSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Debug.swift
+++ b/RxSwift/Observables/Debug.swift
@@ -32,14 +32,14 @@ fileprivate func logEvent(_ identifier: String, dateFormat: DateFormatter, conte
     print("\(dateFormat.string(from: Date())): \(identifier) -> \(content)")
 }
 
-final private class DebugSink<Source: ObservableType, O: ObserverType>: Sink<O>, ObserverType where O.Element == Source.Element {
-    typealias Element = O.Element 
+final private class DebugSink<Source: ObservableType, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == Source.Element {
+    typealias Element = Observer.Element 
     typealias Parent = Debug<Source>
     
     private let _parent: Parent
     private let _timestampFormatter = DateFormatter()
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._timestampFormatter.dateFormat = dateFormat
 
@@ -95,7 +95,7 @@ final private class Debug<Source: ObservableType>: Producer<Source.Element> {
         self._source = source
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Source.Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Source.Element {
         let sink = DebugSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/DefaultIfEmpty.swift
+++ b/RxSwift/Observables/DefaultIfEmpty.swift
@@ -21,12 +21,12 @@ extension ObservableType {
     }
 }
 
-final private class DefaultIfEmptySink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class DefaultIfEmptySink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     private let _default: Element
     private var _isEmpty = true
     
-    init(default: Element, observer: O, cancel: Cancelable) {
+    init(default: Element, observer: Observer, cancel: Cancelable) {
         self._default = `default`
         super.init(observer: observer, cancel: cancel)
     }
@@ -58,7 +58,7 @@ final private class DefaultIfEmpty<SourceType>: Producer<SourceType> {
         self._default = `default`
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceType {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == SourceType {
         let sink = DefaultIfEmptySink(default: self._default, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Deferred.swift
+++ b/RxSwift/Observables/Deferred.swift
@@ -21,12 +21,12 @@ extension ObservableType {
     }
 }
 
-final private class DeferredSink<S: ObservableType, O: ObserverType>: Sink<O>, ObserverType where S.Element == O.Element {
-    typealias Element = O.Element 
+final private class DeferredSink<S: ObservableType, Observer: ObserverType>: Sink<Observer>, ObserverType where S.Element == Observer.Element {
+    typealias Element = Observer.Element 
 
     private let _observableFactory: () throws -> S
 
-    init(observableFactory: @escaping () throws -> S, observer: O, cancel: Cancelable) {
+    init(observableFactory: @escaping () throws -> S, observer: Observer, cancel: Cancelable) {
         self._observableFactory = observableFactory
         super.init(observer: observer, cancel: cancel)
     }
@@ -66,7 +66,7 @@ final private class Deferred<S: ObservableType>: Producer<S.Element> {
         self._observableFactory = observableFactory
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == S.Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == S.Element {
         let sink = DeferredSink(observableFactory: self._observableFactory, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Delay.swift
+++ b/RxSwift/Observables/Delay.swift
@@ -25,10 +25,10 @@ extension ObservableType {
     }
 }
 
-final private class DelaySink<O: ObserverType>
-    : Sink<O>
+final private class DelaySink<Observer: ObserverType>
+    : Sink<Observer>
     , ObserverType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
     typealias Source = Observable<Element>
     typealias DisposeKey = Bag<Disposable>.KeyType
     
@@ -50,7 +50,7 @@ final private class DelaySink<O: ObserverType>
     private var _queue = Queue<(eventTime: RxTime, event: Event<Element>)>(capacity: 0)
     private var _disposed = false
     
-    init(observer: O, dueTime: RxTimeInterval, scheduler: SchedulerType, cancel: Cancelable) {
+    init(observer: Observer, dueTime: RxTimeInterval, scheduler: SchedulerType, cancel: Cancelable) {
         self._dueTime = dueTime
         self._scheduler = scheduler
         super.init(observer: observer, cancel: cancel)
@@ -168,7 +168,7 @@ final private class Delay<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = DelaySink(observer: observer, dueTime: self._dueTime, scheduler: self._scheduler, cancel: cancel)
         let subscription = sink.run(source: self._source)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/DelaySubscription.swift
+++ b/RxSwift/Observables/DelaySubscription.swift
@@ -23,9 +23,9 @@ extension ObservableType {
     }
 }
 
-final private class DelaySubscriptionSink<O: ObserverType>
-    : Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class DelaySubscriptionSink<Observer: ObserverType>
+    : Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     
     func on(_ event: Event<Element>) {
         self.forwardOn(event)
@@ -47,7 +47,7 @@ final private class DelaySubscription<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = DelaySubscriptionSink(observer: observer, cancel: cancel)
         let subscription = self._scheduler.scheduleRelative((), dueTime: self._dueTime) { _ in
             return self._source.subscribe(sink)

--- a/RxSwift/Observables/Dematerialize.swift
+++ b/RxSwift/Observables/Dematerialize.swift
@@ -18,7 +18,7 @@ extension ObservableType where Element: EventConvertible {
 
 }
 
-fileprivate final class DematerializeSink<T: EventConvertible, O: ObserverType>: Sink<O>, ObserverType where O.Element == T.Element {
+fileprivate final class DematerializeSink<T: EventConvertible, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == T.Element {
     fileprivate func on(_ event: Event<T>) {
         switch event {
         case .next(let element):
@@ -43,8 +43,8 @@ final private class Dematerialize<T: EventConvertible>: Producer<T.Element> {
         self._source = source
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == T.Element {
-        let sink = DematerializeSink<T, O>(observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == T.Element {
+        let sink = DematerializeSink<T, Observer>(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Observables/DistinctUntilChanged.swift
+++ b/RxSwift/Observables/DistinctUntilChanged.swift
@@ -63,13 +63,13 @@ extension ObservableType {
     }
 }
 
-final private class DistinctUntilChangedSink<O: ObserverType, Key>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class DistinctUntilChangedSink<Observer: ObserverType, Key>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     
     private let _parent: DistinctUntilChanged<Element, Key>
     private var _currentKey: Key?
     
-    init(parent: DistinctUntilChanged<Element, Key>, observer: O, cancel: Cancelable) {
+    init(parent: DistinctUntilChanged<Element, Key>, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -117,7 +117,7 @@ final private class DistinctUntilChanged<Element, Key>: Producer<Element> {
         self._comparer = comparer
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = DistinctUntilChangedSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Do.swift
+++ b/RxSwift/Observables/Do.swift
@@ -47,15 +47,15 @@ extension ObservableType {
     }
 }
 
-final private class DoSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class DoSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias EventHandler = (Event<Element>) throws -> Void
     typealias AfterEventHandler = (Event<Element>) throws -> Void
     
     private let _eventHandler: EventHandler
     private let _afterEventHandler: AfterEventHandler
     
-    init(eventHandler: @escaping EventHandler, afterEventHandler: @escaping AfterEventHandler, observer: O, cancel: Cancelable) {
+    init(eventHandler: @escaping EventHandler, afterEventHandler: @escaping AfterEventHandler, observer: Observer, cancel: Cancelable) {
         self._eventHandler = eventHandler
         self._afterEventHandler = afterEventHandler
         super.init(observer: observer, cancel: cancel)
@@ -97,7 +97,7 @@ final private class Do<Element>: Producer<Element> {
         self._onDispose = onDispose
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         self._onSubscribe?()
         let sink = DoSink(eventHandler: self._eventHandler, afterEventHandler: self._afterEventHandler, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)

--- a/RxSwift/Observables/ElementAt.swift
+++ b/RxSwift/Observables/ElementAt.swift
@@ -22,14 +22,14 @@ extension ObservableType {
     }
 }
 
-final private class ElementAtSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias SourceType = O.Element 
+final private class ElementAtSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias SourceType = Observer.Element
     typealias Parent = ElementAt<SourceType>
     
     let _parent: Parent
     var _i: Int
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._i = parent._index
         
@@ -84,7 +84,7 @@ final private class ElementAt<SourceType>: Producer<SourceType> {
         self._throwOnEmpty = throwOnEmpty
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceType {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == SourceType {
         let sink = ElementAtSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Empty.swift
+++ b/RxSwift/Observables/Empty.swift
@@ -20,7 +20,7 @@ extension ObservableType {
 }
 
 final private class EmptyProducer<Element>: Producer<Element> {
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         observer.on(.completed)
         return Disposables.create()
     }

--- a/RxSwift/Observables/Enumerated.swift
+++ b/RxSwift/Observables/Enumerated.swift
@@ -21,7 +21,7 @@ extension ObservableType {
     }
 }
 
-final private class EnumeratedSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.Element == (index: Int, element: Element) {
+final private class EnumeratedSink<Element, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == (index: Int, element: Element) {
     var index = 0
     
     func on(_ event: Event<Element>) {
@@ -53,8 +53,8 @@ final private class Enumerated<Element>: Producer<(index: Int, element: Element)
         self._source = source
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == (index: Int, element: Element) {
-        let sink = EnumeratedSink<Element, O>(observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == (index: Int, element: Element) {
+        let sink = EnumeratedSink<Element, Observer>(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Observables/Error.swift
+++ b/RxSwift/Observables/Error.swift
@@ -26,7 +26,7 @@ final private class ErrorProducer<Element>: Producer<Element> {
         self._error = error
     }
     
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         observer.on(.error(self._error))
         return Disposables.create()
     }

--- a/RxSwift/Observables/Filter.swift
+++ b/RxSwift/Observables/Filter.swift
@@ -40,13 +40,13 @@ extension ObservableType {
     }
 }
 
-final private class FilterSink<O: ObserverType>: Sink<O>, ObserverType {
+final private class FilterSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
     typealias Predicate = (Element) throws -> Bool
-    typealias Element = O.Element 
+    typealias Element = Observer.Element
     
     private let _predicate: Predicate
     
-    init(predicate: @escaping Predicate, observer: O, cancel: Cancelable) {
+    init(predicate: @escaping Predicate, observer: Observer, cancel: Cancelable) {
         self._predicate = predicate
         super.init(observer: observer, cancel: cancel)
     }
@@ -82,7 +82,7 @@ final private class Filter<Element>: Producer<Element> {
         self._predicate = predicate
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = FilterSink(predicate: self._predicate, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/First.swift
+++ b/RxSwift/Observables/First.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-fileprivate final class FirstSink<Element, O: ObserverType> : Sink<O>, ObserverType where O.Element == Element? {
+fileprivate final class FirstSink<Element, Observer: ObserverType> : Sink<Observer>, ObserverType where Observer.Element == Element? {
     typealias Parent = First<Element>
 
     func on(_ event: Event<Element>) {
@@ -33,7 +33,7 @@ final class First<Element>: Producer<Element?> {
         self._source = source
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element? {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element? {
         let sink = FirstSink(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Generate.swift
+++ b/RxSwift/Observables/Generate.swift
@@ -24,14 +24,14 @@ extension ObservableType {
     }
 }
 
-final private class GenerateSink<Sequence, O: ObserverType>: Sink<O> {
-    typealias Parent = Generate<Sequence, O.Element>
+final private class GenerateSink<Sequence, Observer: ObserverType>: Sink<Observer> {
+    typealias Parent = Generate<Sequence, Observer.Element>
     
     private let _parent: Parent
     
     private var _state: Sequence
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._state = parent._initialState
         super.init(observer: observer, cancel: cancel)
@@ -79,7 +79,7 @@ final private class Generate<Sequence, Element>: Producer<Element> {
         super.init()
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = GenerateSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/GroupBy.swift
+++ b/RxSwift/Observables/GroupBy.swift
@@ -30,7 +30,7 @@ final private class GroupedObservableImpl<Element>: Observable<Element> {
         self._refCount = refCount
     }
 
-    override public func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override public func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         let release = self._refCount.retain()
         let subscription = self._subject.subscribe(observer)
         return Disposables.create(release, subscription)
@@ -38,10 +38,10 @@ final private class GroupedObservableImpl<Element>: Observable<Element> {
 }
 
 
-final private class GroupBySink<Key: Hashable, Element, O: ObserverType>
-    : Sink<O>
-    , ObserverType where O.Element == GroupedObservable<Key, Element> {
-    typealias ResultType = O.Element 
+final private class GroupBySink<Key: Hashable, Element, Observer: ObserverType>
+    : Sink<Observer>
+    , ObserverType where Observer.Element == GroupedObservable<Key, Element> {
+    typealias ResultType = Observer.Element 
     typealias Parent = GroupBy<Key, Element>
 
     private let _parent: Parent
@@ -49,7 +49,7 @@ final private class GroupBySink<Key: Hashable, Element, O: ObserverType>
     private var _refCountDisposable: RefCountDisposable!
     private var _groupedSubjectTable: [Key: PublishSubject<Element>]
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._groupedSubjectTable = [Key: PublishSubject<Element>]()
         super.init(observer: observer, cancel: cancel)
@@ -126,7 +126,7 @@ final private class GroupBy<Key: Hashable, Element>: Producer<GroupedObservable<
         self._selector = selector
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == GroupedObservable<Key,Element> {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == GroupedObservable<Key,Element> {
         let sink = GroupBySink(parent: self, observer: observer, cancel: cancel)
         return (sink: sink, subscription: sink.run())
     }

--- a/RxSwift/Observables/Just.swift
+++ b/RxSwift/Observables/Just.swift
@@ -33,12 +33,12 @@ extension ObservableType {
     }
 }
 
-final private class JustScheduledSink<O: ObserverType>: Sink<O> {
-    typealias Parent = JustScheduled<O.Element>
+final private class JustScheduledSink<Observer: ObserverType>: Sink<Observer> {
+    typealias Parent = JustScheduled<Observer.Element>
 
     private let _parent: Parent
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -65,7 +65,7 @@ final private class JustScheduled<Element>: Producer<Element> {
         self._element = element
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = JustScheduledSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -79,7 +79,7 @@ final private class Just<Element>: Producer<Element> {
         self._element = element
     }
     
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         observer.on(.next(self._element))
         observer.on(.completed)
         return Disposables.create()

--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -23,15 +23,15 @@ extension ObservableType {
     }
 }
 
-final private class MapSink<SourceType, O: ObserverType>: Sink<O>, ObserverType {
+final private class MapSink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType {
     typealias Transform = (SourceType) throws -> ResultType
 
-    typealias ResultType = O.Element 
+    typealias ResultType = Observer.Element 
     typealias Element = SourceType
 
     private let _transform: Transform
 
-    init(transform: @escaping Transform, observer: O, cancel: Cancelable) {
+    init(transform: @escaping Transform, observer: Observer, cancel: Cancelable) {
         self._transform = transform
         super.init(observer: observer, cancel: cancel)
     }
@@ -94,7 +94,7 @@ final private class Map<SourceType, ResultType>: Producer<ResultType> {
         })
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == ResultType {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == ResultType {
         let sink = MapSink(transform: self._transform, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Materialize.swift
+++ b/RxSwift/Observables/Materialize.swift
@@ -17,7 +17,7 @@ extension ObservableType {
     }
 }
 
-fileprivate final class MaterializeSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.Element == Event<Element> {
+fileprivate final class MaterializeSink<Element, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == Event<Element> {
 
     func on(_ event: Event<Element>) {
         self.forwardOn(.next(event))
@@ -35,7 +35,7 @@ final private class Materialize<T>: Producer<Event<T>> {
         self._source = source
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = MaterializeSink(observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
 

--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -321,8 +321,8 @@ final private class MergeLimited<SourceSequence: ObservableConvertibleType>: Pro
         self._maxConcurrent = maxConcurrent
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
-        let sink = MergeLimitedBasicSink<SourceSequence, O>(maxConcurrent: self._maxConcurrent, observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == SourceSequence.Element {
+        let sink = MergeLimitedBasicSink<SourceSequence, Observer>(maxConcurrent: self._maxConcurrent, observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
     }
@@ -330,7 +330,7 @@ final private class MergeLimited<SourceSequence: ObservableConvertibleType>: Pro
 
 // MARK: Merge
 
-fileprivate final class MergeBasicSink<S: ObservableConvertibleType, O: ObserverType> : MergeSink<S, S, O> where O.Element == S.Element {
+fileprivate final class MergeBasicSink<S: ObservableConvertibleType, Observer: ObserverType> : MergeSink<S, S, Observer> where Observer.Element == S.Element {
     override func performMap(_ element: S) throws -> S {
         return element
     }
@@ -525,7 +525,7 @@ final private class FlatMap<SourceElement, SourceSequence: ObservableConvertible
         self._selector = selector
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == SourceSequence.Element {
         let sink = FlatMapSink(selector: self._selector, observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
@@ -544,8 +544,8 @@ final private class FlatMapFirst<SourceElement, SourceSequence: ObservableConver
         self._selector = selector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
-        let sink = FlatMapFirstSink<SourceElement, SourceSequence, O>(selector: self._selector, observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == SourceSequence.Element {
+        let sink = FlatMapFirstSink<SourceElement, SourceSequence, Observer>(selector: self._selector, observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
     }
@@ -562,8 +562,8 @@ final class ConcatMap<SourceElement, SourceSequence: ObservableConvertibleType>:
         self._selector = selector
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
-        let sink = ConcatMapSink<SourceElement, SourceSequence, O>(selector: self._selector, observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == SourceSequence.Element {
+        let sink = ConcatMapSink<SourceElement, SourceSequence, Observer>(selector: self._selector, observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
     }
@@ -576,8 +576,8 @@ final class Merge<SourceSequence: ObservableConvertibleType> : Producer<SourceSe
         self._source = source
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == SourceSequence.Element {
-        let sink = MergeBasicSink<SourceSequence, O>(observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == SourceSequence.Element {
+        let sink = MergeBasicSink<SourceSequence, Observer>(observer: observer, cancel: cancel)
         let subscription = sink.run(self._source)
         return (sink: sink, subscription: subscription)
     }
@@ -590,8 +590,8 @@ final private class MergeArray<Element>: Producer<Element> {
         self._sources = sources
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
-        let sink = MergeBasicSink<Observable<Element>, O>(observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
+        let sink = MergeBasicSink<Observable<Element>, Observer>(observer: observer, cancel: cancel)
         let subscription = sink.run(self._sources)
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -239,22 +239,22 @@ final private class ConnectableObservableAdapter<Subject: SubjectType>
         return subject
     }
 
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Subject.Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Subject.Element {
         return self.lazySubject.subscribe(observer)
     }
 }
 
-final private class RefCountSink<CO: ConnectableObservableType, O: ObserverType>
-    : Sink<O>
-    , ObserverType where CO.Element == O.Element {
-    typealias Element = O.Element 
+final private class RefCountSink<CO: ConnectableObservableType, Observer: ObserverType>
+    : Sink<Observer>
+    , ObserverType where CO.Element == Observer.Element {
+    typealias Element = Observer.Element 
     typealias Parent = RefCount<CO>
 
     private let _parent: Parent
 
     private var _connectionIdSnapshot: Int64 = -1
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -338,21 +338,21 @@ final private class RefCount<CO: ConnectableObservableType>: Producer<CO.Element
         self._source = source
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == CO.Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == CO.Element {
         let sink = RefCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
     }
 }
 
-final private class MulticastSink<Subject: SubjectType, O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class MulticastSink<Subject: SubjectType, Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias ResultType = Element
-    typealias MutlicastType = Multicast<Subject, O.Element>
+    typealias MutlicastType = Multicast<Subject, Observer.Element>
 
     private let _parent: MutlicastType
 
-    init(parent: MutlicastType, observer: O, cancel: Cancelable) {
+    init(parent: MutlicastType, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -400,7 +400,7 @@ final private class Multicast<Subject: SubjectType, Result>: Producer<Result> {
         self._selector = selector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = MulticastSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Never.swift
+++ b/RxSwift/Observables/Never.swift
@@ -21,7 +21,7 @@ extension ObservableType {
 }
 
 final private class NeverProducer<Element>: Producer<Element> {
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         return Disposables.create()
     }
 }

--- a/RxSwift/Observables/Optional.swift
+++ b/RxSwift/Observables/Optional.swift
@@ -33,13 +33,13 @@ extension ObservableType {
     }
 }
 
-final private class ObservableOptionalScheduledSink<O: ObserverType>: Sink<O> {
-    typealias Element = O.Element 
+final private class ObservableOptionalScheduledSink<Observer: ObserverType>: Sink<Observer> {
+    typealias Element = Observer.Element 
     typealias Parent = ObservableOptionalScheduled<Element>
 
     private let _parent: Parent
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -71,7 +71,7 @@ final private class ObservableOptionalScheduled<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = ObservableOptionalScheduledSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -85,7 +85,7 @@ final private class ObservableOptional<Element>: Producer<Element> {
         self._optional = optional
     }
     
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         if let element = self._optional {
             observer.on(.next(element))
         }

--- a/RxSwift/Observables/Producer.swift
+++ b/RxSwift/Observables/Producer.swift
@@ -11,7 +11,7 @@ class Producer<Element> : Observable<Element> {
         super.init()
     }
 
-    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         if !CurrentThreadScheduler.isScheduleRequired {
             // The returned disposable needs to release all references once it was disposed.
             let disposer = SinkDisposer()
@@ -31,7 +31,7 @@ class Producer<Element> : Observable<Element> {
         }
     }
 
-    func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         rxAbstractMethod()
     }
 }

--- a/RxSwift/Observables/Range.swift
+++ b/RxSwift/Observables/Range.swift
@@ -41,25 +41,25 @@ final private class RangeProducer<Element: RxAbstractInteger>: Producer<Element>
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = RangeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
     }
 }
 
-final private class RangeSink<O: ObserverType>: Sink<O> where O.Element: RxAbstractInteger {
-    typealias Parent = RangeProducer<O.Element>
+final private class RangeSink<Observer: ObserverType>: Sink<Observer> where Observer.Element: RxAbstractInteger {
+    typealias Parent = RangeProducer<Observer.Element>
     
     private let _parent: Parent
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
     
     func run() -> Disposable {
-        return self._parent._scheduler.scheduleRecursive(0 as O.Element) { i, recurse in
+        return self._parent._scheduler.scheduleRecursive(0 as Observer.Element) { i, recurse in
             if i < self._parent._count {
                 self.forwardOn(.next(self._parent._start + i))
                 recurse(i + 1)

--- a/RxSwift/Observables/Reduce.swift
+++ b/RxSwift/Observables/Reduce.swift
@@ -42,14 +42,14 @@ extension ObservableType {
     }
 }
 
-final private class ReduceSink<SourceType, AccumulateType, O: ObserverType>: Sink<O>, ObserverType {
-    typealias ResultType = O.Element 
+final private class ReduceSink<SourceType, AccumulateType, Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias ResultType = Observer.Element 
     typealias Parent = Reduce<SourceType, AccumulateType, ResultType>
     
     private let _parent: Parent
     private var _accumulation: AccumulateType
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._accumulation = parent._seed
         
@@ -100,7 +100,7 @@ final private class Reduce<SourceType, AccumulateType, ResultType>: Producer<Res
         self._mapResult = mapResult
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == ResultType {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == ResultType {
         let sink = ReduceSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Repeat.swift
+++ b/RxSwift/Observables/Repeat.swift
@@ -30,7 +30,7 @@ final private class RepeatElement<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = RepeatElementSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
 
@@ -38,12 +38,12 @@ final private class RepeatElement<Element>: Producer<Element> {
     }
 }
 
-final private class RepeatElementSink<O: ObserverType>: Sink<O> {
-    typealias Parent = RepeatElement<O.Element>
+final private class RepeatElementSink<Observer: ObserverType>: Sink<Observer> {
+    typealias Parent = RepeatElement<Observer.Element>
     
     private let _parent: Parent
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }

--- a/RxSwift/Observables/RetryWhen.swift
+++ b/RxSwift/Observables/RetryWhen.swift
@@ -37,11 +37,11 @@ extension ObservableType {
     }
 }
 
-final private class RetryTriggerSink<Sequence: Swift.Sequence, O: ObserverType, TriggerObservable: ObservableType, Error>
-    : ObserverType where Sequence.Element: ObservableType, Sequence.Element.Element == O.Element {
+final private class RetryTriggerSink<Sequence: Swift.Sequence, Observer: ObserverType, TriggerObservable: ObservableType, Error>
+    : ObserverType where Sequence.Element: ObservableType, Sequence.Element.Element == Observer.Element {
     typealias Element = TriggerObservable.Element
     
-    typealias Parent = RetryWhenSequenceSinkIter<Sequence, O, TriggerObservable, Error>
+    typealias Parent = RetryWhenSequenceSinkIter<Sequence, Observer, TriggerObservable, Error>
     
     fileprivate let _parent: Parent
 
@@ -64,11 +64,11 @@ final private class RetryTriggerSink<Sequence: Swift.Sequence, O: ObserverType, 
     }
 }
 
-final private class RetryWhenSequenceSinkIter<Sequence: Swift.Sequence, O: ObserverType, TriggerObservable: ObservableType, Error>
+final private class RetryWhenSequenceSinkIter<Sequence: Swift.Sequence, Observer: ObserverType, TriggerObservable: ObservableType, Error>
     : ObserverType
-    , Disposable where Sequence.Element: ObservableType, Sequence.Element.Element == O.Element {
-    typealias Element = O.Element 
-    typealias Parent = RetryWhenSequenceSink<Sequence, O, TriggerObservable, Error>
+    , Disposable where Sequence.Element: ObservableType, Sequence.Element.Element == Observer.Element {
+    typealias Element = Observer.Element 
+    typealias Parent = RetryWhenSequenceSink<Sequence, Observer, TriggerObservable, Error>
 
     fileprivate let _parent: Parent
     fileprivate let _errorHandlerSubscription = SingleAssignmentDisposable()
@@ -110,9 +110,9 @@ final private class RetryWhenSequenceSinkIter<Sequence: Swift.Sequence, O: Obser
     }
 }
 
-final private class RetryWhenSequenceSink<Sequence: Swift.Sequence, O: ObserverType, TriggerObservable: ObservableType, Error>
-    : TailRecursiveSink<Sequence, O> where Sequence.Element: ObservableType, Sequence.Element.Element == O.Element {
-    typealias Element = O.Element 
+final private class RetryWhenSequenceSink<Sequence: Swift.Sequence, Observer: ObserverType, TriggerObservable: ObservableType, Error>
+    : TailRecursiveSink<Sequence, Observer> where Sequence.Element: ObservableType, Sequence.Element.Element == Observer.Element {
+    typealias Element = Observer.Element 
     typealias Parent = RetryWhenSequence<Sequence, TriggerObservable, Error>
     
     let _lock = RecursiveLock()
@@ -124,7 +124,7 @@ final private class RetryWhenSequenceSink<Sequence: Swift.Sequence, O: ObserverT
     fileprivate let _handler: Observable<TriggerObservable.Element>
     fileprivate let _notifier = PublishSubject<TriggerObservable.Element>()
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._handler = parent._notificationHandler(self._errorSubject).asObservable()
         super.init(observer: observer, cancel: cancel)
@@ -174,8 +174,8 @@ final private class RetryWhenSequence<Sequence: Swift.Sequence, TriggerObservabl
         self._notificationHandler = notificationHandler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
-        let sink = RetryWhenSequenceSink<Sequence, O, TriggerObservable, Error>(parent: self, observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
+        let sink = RetryWhenSequenceSink<Sequence, Observer, TriggerObservable, Error>(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run((self._sources.makeIterator(), nil))
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/Observables/Sample.swift
+++ b/RxSwift/Observables/Sample.swift
@@ -26,13 +26,13 @@ extension ObservableType {
     }
 }
 
-final private class SamplerSink<O: ObserverType, SampleType>
+final private class SamplerSink<Observer: ObserverType, SampleType>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
     typealias Element = SampleType
     
-    typealias Parent = SampleSequenceSink<O, SampleType>
+    typealias Parent = SampleSequenceSink<Observer, SampleType>
     
     fileprivate let _parent: Parent
 
@@ -67,12 +67,12 @@ final private class SamplerSink<O: ObserverType, SampleType>
     }
 }
 
-final private class SampleSequenceSink<O: ObserverType, SampleType>
-    : Sink<O>
+final private class SampleSequenceSink<Observer: ObserverType, SampleType>
+    : Sink<Observer>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
     typealias Parent = Sample<Element, SampleType>
     
     fileprivate let _parent: Parent
@@ -85,7 +85,7 @@ final private class SampleSequenceSink<O: ObserverType, SampleType>
     
     fileprivate let _sourceSubscription = SingleAssignmentDisposable()
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -125,7 +125,7 @@ final private class Sample<Element, SampleType>: Producer<Element> {
         self._sampler = sampler
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = SampleSequenceSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Scan.swift
+++ b/RxSwift/Observables/Scan.swift
@@ -44,14 +44,14 @@ extension ObservableType {
     }
 }
 
-final private class ScanSink<Element, O: ObserverType>: Sink<O>, ObserverType {
-    typealias Accumulate = O.Element 
+final private class ScanSink<Element, Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Accumulate = Observer.Element 
     typealias Parent = Scan<Element, Accumulate>
 
     fileprivate let _parent: Parent
     fileprivate var _accumulate: Accumulate
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._accumulate = parent._seed
         super.init(observer: observer, cancel: cancel)
@@ -92,7 +92,7 @@ final private class Scan<Element, Accumulate>: Producer<Accumulate> {
         self._accumulator = accumulator
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Accumulate {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Accumulate {
         let sink = ScanSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Sequence.swift
+++ b/RxSwift/Observables/Sequence.swift
@@ -47,12 +47,12 @@ extension ObservableType {
     }
 }
 
-final private class ObservableSequenceSink<Sequence: Swift.Sequence, O: ObserverType>: Sink<O> where Sequence.Element == O.Element {
+final private class ObservableSequenceSink<Sequence: Swift.Sequence, Observer: ObserverType>: Sink<Observer> where Sequence.Element == Observer.Element {
     typealias Parent = ObservableSequence<Sequence>
 
     private let _parent: Parent
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -81,7 +81,7 @@ final private class ObservableSequence<Sequence: Swift.Sequence>: Producer<Seque
         self._scheduler = scheduler
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = ObservableSequenceSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -207,7 +207,7 @@ fileprivate final class ShareReplay1WhileConnectedConnection<Element>
         self._subscription.setDisposable(self._parent._source.subscribe(self))
     }
 
-    final func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    final func _synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self._lock.lock(); defer { self._lock.unlock() }
         if let element = self._element {
             observer.on(.next(element))
@@ -273,7 +273,7 @@ final private class ShareReplay1WhileConnected<Element>
         self._source = source
     }
 
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self._lock.lock()
 
         let connection = self._synchronized_subscribe(observer)
@@ -291,7 +291,7 @@ final private class ShareReplay1WhileConnected<Element>
     }
 
     @inline(__always)
-    private func _synchronized_subscribe<O : ObserverType>(_ observer: O) -> Connection where O.Element == Element {
+    private func _synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Connection where Observer.Element == Element {
         let connection: Connection
 
         if let existingConnection = self._connection {
@@ -357,7 +357,7 @@ fileprivate final class ShareWhileConnectedConnection<Element>
         self._subscription.setDisposable(self._parent._source.subscribe(self))
     }
 
-    final func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    final func _synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self._lock.lock(); defer { self._lock.unlock() }
 
         let disposeKey = self._observers.insert(observer.on)
@@ -420,7 +420,7 @@ final private class ShareWhileConnected<Element>
         self._source = source
     }
 
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self._lock.lock()
 
         let connection = self._synchronized_subscribe(observer)
@@ -438,7 +438,7 @@ final private class ShareWhileConnected<Element>
     }
 
     @inline(__always)
-    private func _synchronized_subscribe<O : ObserverType>(_ observer: O) -> Connection where O.Element == Element {
+    private func _synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Connection where Observer.Element == Element {
         let connection: Connection
 
         if let existingConnection = self._connection {

--- a/RxSwift/Observables/SingleAsync.swift
+++ b/RxSwift/Observables/SingleAsync.swift
@@ -36,14 +36,14 @@ extension ObservableType {
     }
 }
 
-fileprivate final class SingleAsyncSink<O: ObserverType> : Sink<O>, ObserverType {
-    typealias Element = O.Element
+fileprivate final class SingleAsyncSink<Observer: ObserverType> : Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element
     typealias Parent = SingleAsync<Element>
     
     private let _parent: Parent
     private var _seenValue: Bool = false
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -96,7 +96,7 @@ final class SingleAsync<Element>: Producer<Element> {
         self._predicate = predicate
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = SingleAsyncSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Sink.swift
+++ b/RxSwift/Observables/Sink.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-class Sink<O : ObserverType> : Disposable {
-    fileprivate let _observer: O
+class Sink<Observer: ObserverType> : Disposable {
+    fileprivate let _observer: Observer
     fileprivate let _cancel: Cancelable
     fileprivate let _disposed = AtomicInt(0)
 
@@ -15,7 +15,7 @@ class Sink<O : ObserverType> : Disposable {
         fileprivate let _synchronizationTracker = SynchronizationTracker()
     #endif
 
-    init(observer: O, cancel: Cancelable) {
+    init(observer: Observer, cancel: Cancelable) {
 #if TRACE_RESOURCES
         _ = Resources.incrementTotal()
 #endif
@@ -23,7 +23,7 @@ class Sink<O : ObserverType> : Disposable {
         self._cancel = cancel
     }
 
-    final func forwardOn(_ event: Event<O.Element>) {
+    final func forwardOn(_ event: Event<Observer.Element>) {
         #if DEBUG
             self._synchronizationTracker.register(synchronizationErrorMessage: .default)
             defer { self._synchronizationTracker.unregister() }
@@ -34,7 +34,7 @@ class Sink<O : ObserverType> : Disposable {
         self._observer.on(event)
     }
 
-    final func forwarder() -> SinkForward<O> {
+    final func forwarder() -> SinkForward<Observer> {
         return SinkForward(forward: self)
     }
 
@@ -54,12 +54,12 @@ class Sink<O : ObserverType> : Disposable {
     }
 }
 
-final class SinkForward<O: ObserverType>: ObserverType {
-    typealias Element = O.Element 
+final class SinkForward<Observer: ObserverType>: ObserverType {
+    typealias Element = Observer.Element 
 
-    private let _forward: Sink<O>
+    private let _forward: Sink<Observer>
 
-    init(forward: Sink<O>) {
+    init(forward: Sink<Observer>) {
         self._forward = forward
     }
 

--- a/RxSwift/Observables/Skip.swift
+++ b/RxSwift/Observables/Skip.swift
@@ -41,15 +41,15 @@ extension ObservableType {
 
 // count version
 
-final private class SkipCountSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class SkipCountSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias Parent = SkipCount<Element>
     
     let parent: Parent
     
     var remaining: Int
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self.parent = parent
         self.remaining = parent.count
         super.init(observer: observer, cancel: cancel)
@@ -85,7 +85,7 @@ final private class SkipCount<Element>: Producer<Element> {
         self.count = count
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = SkipCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self.source.subscribe(sink)
 
@@ -95,7 +95,7 @@ final private class SkipCount<Element>: Producer<Element> {
 
 // time version
 
-final private class SkipTimeSink<Element, O: ObserverType>: Sink<O>, ObserverType where O.Element == Element {
+final private class SkipTimeSink<Element, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == Element {
     typealias Parent = SkipTime<Element>
 
     let parent: Parent
@@ -103,7 +103,7 @@ final private class SkipTimeSink<Element, O: ObserverType>: Sink<O>, ObserverTyp
     // state
     var open = false
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self.parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -150,7 +150,7 @@ final private class SkipTime<Element>: Producer<Element> {
         self.duration = duration
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = SkipTimeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/SkipUntil.swift
+++ b/RxSwift/Observables/SkipUntil.swift
@@ -22,11 +22,11 @@ extension ObservableType {
     }
 }
 
-final private class SkipUntilSinkOther<Other, O: ObserverType>
+final private class SkipUntilSinkOther<Other, Observer: ObserverType>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Parent = SkipUntilSink<Other, O>
+    typealias Parent = SkipUntilSink<Other, Observer>
     typealias Element = Other
     
     fileprivate let _parent: Parent
@@ -70,12 +70,12 @@ final private class SkipUntilSinkOther<Other, O: ObserverType>
 }
 
 
-final private class SkipUntilSink<Other, O: ObserverType>
-    : Sink<O>
+final private class SkipUntilSink<Other, Observer: ObserverType>
+    : Sink<Observer>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
     typealias Parent = SkipUntil<Element, Other>
     
     let _lock = RecursiveLock()
@@ -84,7 +84,7 @@ final private class SkipUntilSink<Other, O: ObserverType>
     
     fileprivate let _sourceSubscription = SingleAssignmentDisposable()
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -131,7 +131,7 @@ final private class SkipUntil<Element, Other>: Producer<Element> {
         self._other = other
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = SkipUntilSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/SkipWhile.swift
+++ b/RxSwift/Observables/SkipWhile.swift
@@ -21,14 +21,14 @@ extension ObservableType {
     }
 }
 
-final private class SkipWhileSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class SkipWhileSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias Parent = SkipWhile<Element>
 
     fileprivate let _parent: Parent
     fileprivate var _running = false
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -67,7 +67,7 @@ final private class SkipWhile<Element>: Producer<Element> {
         self._predicate = predicate
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = SkipWhileSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/StartWith.swift
+++ b/RxSwift/Observables/StartWith.swift
@@ -32,7 +32,7 @@ final private class StartWith<Element>: Producer<Element> {
         super.init()
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         for e in self.elements {
             observer.on(.next(e))
         }

--- a/RxSwift/Observables/SubscribeOn.swift
+++ b/RxSwift/Observables/SubscribeOn.swift
@@ -29,13 +29,13 @@ extension ObservableType {
     }
 }
 
-final private class SubscribeOnSink<Ob: ObservableType, O: ObserverType>: Sink<O>, ObserverType where Ob.Element == O.Element {
-    typealias Element = O.Element 
+final private class SubscribeOnSink<Ob: ObservableType, Observer: ObserverType>: Sink<Observer>, ObserverType where Ob.Element == Observer.Element {
+    typealias Element = Observer.Element 
     typealias Parent = SubscribeOn<Ob>
     
     let parent: Parent
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self.parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -75,7 +75,7 @@ final private class SubscribeOn<Ob: ObservableType>: Producer<Ob.Element> {
         self.scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Ob.Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Ob.Element {
         let sink = SubscribeOnSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/SwitchIfEmpty.swift
+++ b/RxSwift/Observables/SwitchIfEmpty.swift
@@ -30,7 +30,7 @@ final private class SwitchIfEmpty<Element>: Producer<Element> {
         self._ifEmpty = ifEmpty
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = SwitchIfEmptySink(ifEmpty: self._ifEmpty,
                                      observer: observer,
                                      cancel: cancel)
@@ -40,20 +40,20 @@ final private class SwitchIfEmpty<Element>: Producer<Element> {
     }
 }
 
-final private class SwitchIfEmptySink<O: ObserverType>: Sink<O>
+final private class SwitchIfEmptySink<Observer: ObserverType>: Sink<Observer>
     , ObserverType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element
     
     private let _ifEmpty: Observable<Element>
     private var _isEmpty = true
     private let _ifEmptySubscription = SingleAssignmentDisposable()
     
-    init(ifEmpty: Observable<Element>, observer: O, cancel: Cancelable) {
+    init(ifEmpty: Observable<Element>, observer: Observer, cancel: Cancelable) {
         self._ifEmpty = ifEmpty
         super.init(observer: observer, cancel: cancel)
     }
     
-    func run(_ source: Observable<O.Element>) -> Disposable {
+    func run(_ source: Observable<Observer.Element>) -> Disposable {
         let subscription = source.subscribe(self)
         return Disposables.create(subscription, _ifEmptySubscription)
     }
@@ -78,10 +78,10 @@ final private class SwitchIfEmptySink<O: ObserverType>: Sink<O>
     }
 }
 
-final private class SwitchIfEmptySinkIter<O: ObserverType>
+final private class SwitchIfEmptySinkIter<Observer: ObserverType>
     : ObserverType {
-    typealias Element = O.Element 
-    typealias Parent = SwitchIfEmptySink<O>
+    typealias Element = Observer.Element
+    typealias Parent = SwitchIfEmptySink<Observer>
     
     private let _parent: Parent
 

--- a/RxSwift/Observables/Take.swift
+++ b/RxSwift/Observables/Take.swift
@@ -46,15 +46,15 @@ extension ObservableType {
 
 // count version
 
-final private class TakeCountSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class TakeCountSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias Parent = TakeCount<Element>
     
     private let _parent: Parent
     
     private var _remaining: Int
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._remaining = parent._count
         super.init(observer: observer, cancel: cancel)
@@ -97,7 +97,7 @@ final private class TakeCount<Element>: Producer<Element> {
         self._count = count
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = TakeCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)
@@ -106,18 +106,18 @@ final private class TakeCount<Element>: Producer<Element> {
 
 // time version
 
-final private class TakeTimeSink<Element, O: ObserverType>
-    : Sink<O>
+final private class TakeTimeSink<Element, Observer: ObserverType>
+    : Sink<Observer>
     , LockOwnerType
     , ObserverType
-    , SynchronizedOnType where O.Element == Element {
+    , SynchronizedOnType where Observer.Element == Element {
     typealias Parent = TakeTime<Element>
 
     fileprivate let _parent: Parent
     
     let _lock = RecursiveLock()
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -171,7 +171,7 @@ final private class TakeTime<Element>: Producer<Element> {
         self._duration = duration
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = TakeTimeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/TakeLast.swift
+++ b/RxSwift/Observables/TakeLast.swift
@@ -24,15 +24,15 @@ extension ObservableType {
     }
 }
 
-final private class TakeLastSink<O: ObserverType>: Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class TakeLastSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias Parent = TakeLast<Element>
     
     private let _parent: Parent
     
     private var _elements: Queue<Element>
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._elements = Queue<Element>(capacity: parent._count + 1)
         super.init(observer: observer, cancel: cancel)
@@ -70,7 +70,7 @@ final private class TakeLast<Element>: Producer<Element> {
         self._count = count
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = TakeLastSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/TakeUntil.swift
+++ b/RxSwift/Observables/TakeUntil.swift
@@ -49,11 +49,11 @@ public enum TakeUntilBehavior {
 }
 
 // MARK: - TakeUntil Observable
-final private class TakeUntilSinkOther<Other, O: ObserverType>
+final private class TakeUntilSinkOther<Other, Observer: ObserverType>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Parent = TakeUntilSink<Other, O>
+    typealias Parent = TakeUntilSink<Other, Observer>
     typealias Element = Other
     
     fileprivate let _parent: Parent
@@ -95,12 +95,12 @@ final private class TakeUntilSinkOther<Other, O: ObserverType>
 #endif
 }
 
-final private class TakeUntilSink<Other, O: ObserverType>
-    : Sink<O>
+final private class TakeUntilSink<Other, Observer: ObserverType>
+    : Sink<Observer>
     , LockOwnerType
     , ObserverType
     , SynchronizedOnType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
     typealias Parent = TakeUntil<Element, Other>
     
     fileprivate let _parent: Parent
@@ -108,7 +108,7 @@ final private class TakeUntilSink<Other, O: ObserverType>
     let _lock = RecursiveLock()
     
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -150,7 +150,7 @@ final private class TakeUntil<Element, Other>: Producer<Element> {
         self._other = other
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = TakeUntilSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -158,15 +158,15 @@ final private class TakeUntil<Element, Other>: Producer<Element> {
 }
 
 // MARK: - TakeUntil Predicate
-final private class TakeUntilPredicateSink<O: ObserverType>
-    : Sink<O>, ObserverType {
-    typealias Element = O.Element 
+final private class TakeUntilPredicateSink<Observer: ObserverType>
+    : Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element 
     typealias Parent = TakeUntilPredicate<Element>
 
     fileprivate let _parent: Parent
     fileprivate var _running = true
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -219,7 +219,7 @@ final private class TakeUntilPredicate<Element>: Producer<Element> {
         self._predicate = predicate
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = TakeUntilPredicateSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/TakeWhile.swift
+++ b/RxSwift/Observables/TakeWhile.swift
@@ -22,17 +22,17 @@ extension ObservableType {
     }
 }
 
-final private class TakeWhileSink<O: ObserverType>
-    : Sink<O>
+final private class TakeWhileSink<Observer: ObserverType>
+    : Sink<Observer>
     , ObserverType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
     typealias Parent = TakeWhile<Element>
 
     fileprivate let _parent: Parent
 
     fileprivate var _running = true
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -77,7 +77,7 @@ final private class TakeWhile<Element>: Producer<Element> {
         self._predicate = predicate
     }
 
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = TakeWhileSink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Throttle.swift
+++ b/RxSwift/Observables/Throttle.swift
@@ -28,12 +28,12 @@ extension ObservableType {
     }
 }
 
-final private class ThrottleSink<O: ObserverType>
-    : Sink<O>
+final private class ThrottleSink<Observer: ObserverType>
+    : Sink<Observer>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
     typealias ParentType = Throttle<Element>
     
     private let _parent: ParentType
@@ -47,7 +47,7 @@ final private class ThrottleSink<O: ObserverType>
 
     let cancellable = SerialDisposable()
     
-    init(parent: ParentType, observer: O, cancel: Cancelable) {
+    init(parent: ParentType, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         
         super.init(observer: observer, cancel: cancel)
@@ -150,7 +150,7 @@ final private class Throttle<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = ThrottleSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Timeout.swift
+++ b/RxSwift/Observables/Timeout.swift
@@ -38,8 +38,8 @@ extension ObservableType {
     }
 }
 
-final private class TimeoutSink<O: ObserverType>: Sink<O>, LockOwnerType, ObserverType {
-    typealias Element = O.Element 
+final private class TimeoutSink<Observer: ObserverType>: Sink<Observer>, LockOwnerType, ObserverType {
+    typealias Element = Observer.Element 
     typealias Parent = Timeout<Element>
     
     private let _parent: Parent
@@ -52,7 +52,7 @@ final private class TimeoutSink<O: ObserverType>: Sink<O>, LockOwnerType, Observ
     private var _id = 0
     private var _switched = false
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -143,7 +143,7 @@ final private class Timeout<Element>: Producer<Element> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = TimeoutSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Timer.swift
+++ b/RxSwift/Observables/Timer.swift
@@ -49,19 +49,19 @@ extension ObservableType where Element: RxAbstractInteger {
 
 import Foundation
 
-final private class TimerSink<O: ObserverType> : Sink<O> where O.Element : RxAbstractInteger  {
-    typealias Parent = Timer<O.Element>
+final private class TimerSink<Observer: ObserverType> : Sink<Observer> where Observer.Element : RxAbstractInteger  {
+    typealias Parent = Timer<Observer.Element>
 
     private let _parent: Parent
     private let _lock = RecursiveLock()
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
 
     func run() -> Disposable {
-        return self._parent._scheduler.schedulePeriodic(0 as O.Element, startAfter: self._parent._dueTime, period: self._parent._period!) { state in
+        return self._parent._scheduler.schedulePeriodic(0 as Observer.Element, startAfter: self._parent._dueTime, period: self._parent._period!) { state in
             self._lock.lock(); defer { self._lock.unlock() }
             self.forwardOn(.next(state))
             return state &+ 1
@@ -69,12 +69,12 @@ final private class TimerSink<O: ObserverType> : Sink<O> where O.Element : RxAbs
     }
 }
 
-final private class TimerOneOffSink<O: ObserverType>: Sink<O> where O.Element: RxAbstractInteger {
-    typealias Parent = Timer<O.Element>
+final private class TimerOneOffSink<Observer: ObserverType>: Sink<Observer> where Observer.Element: RxAbstractInteger {
+    typealias Parent = Timer<Observer.Element>
 
     private let _parent: Parent
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -101,7 +101,7 @@ final private class Timer<Element: RxAbstractInteger>: Producer<Element> {
         self._period = period
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         if self._period != nil {
             let sink = TimerSink(parent: self, observer: observer, cancel: cancel)
             let subscription = sink.run()

--- a/RxSwift/Observables/ToArray.swift
+++ b/RxSwift/Observables/ToArray.swift
@@ -24,13 +24,13 @@ extension ObservableType {
     }
 }
 
-final private class ToArraySink<SourceType, O: ObserverType>: Sink<O>, ObserverType where O.Element == [SourceType] {
+final private class ToArraySink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == [SourceType] {
     typealias Parent = ToArray<SourceType>
     
     let _parent: Parent
     var _list = [SourceType]()
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         
         super.init(observer: observer, cancel: cancel)
@@ -58,7 +58,7 @@ final private class ToArray<SourceType>: Producer<[SourceType]> {
         self._source = source
     }
     
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == [SourceType] {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == [SourceType] {
         let sink = ToArraySink(parent: self, observer: observer, cancel: cancel)
         let subscription = self._source.subscribe(sink)
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Using.swift
+++ b/RxSwift/Observables/Using.swift
@@ -21,13 +21,13 @@ extension ObservableType {
     }
 }
 
-final private class UsingSink<ResourceType: Disposable, O: ObserverType>: Sink<O>, ObserverType {
-    typealias SourceType = O.Element 
+final private class UsingSink<ResourceType: Disposable, Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias SourceType = Observer.Element 
     typealias Parent = Using<SourceType, ResourceType>
 
     private let _parent: Parent
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -82,7 +82,7 @@ final private class Using<SourceType, ResourceType: Disposable>: Producer<Source
         self._observableFactory = observableFactory
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = UsingSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Window.swift
+++ b/RxSwift/Observables/Window.swift
@@ -24,11 +24,11 @@ extension ObservableType {
     }
 }
 
-final private class WindowTimeCountSink<Element, O: ObserverType>
-    : Sink<O>
+final private class WindowTimeCountSink<Element, Observer: ObserverType>
+    : Sink<Observer>
     , ObserverType
     , LockOwnerType
-    , SynchronizedOnType where O.Element == Observable<Element> {
+    , SynchronizedOnType where Observer.Element == Observable<Element> {
     typealias Parent = WindowTimeCount<Element>
     
     private let _parent: Parent
@@ -43,7 +43,7 @@ final private class WindowTimeCountSink<Element, O: ObserverType>
     private let _refCountDisposable: RefCountDisposable
     private let _groupDisposable = CompositeDisposable()
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         
         _ = self._groupDisposable.insert(self._timerD)
@@ -160,7 +160,7 @@ final private class WindowTimeCount<Element>: Producer<Observable<Element>> {
         self._scheduler = scheduler
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Observable<Element> {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Observable<Element> {
         let sink = WindowTimeCountSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/WithLatestFrom.swift
+++ b/RxSwift/Observables/WithLatestFrom.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke for each element from the self combined with the latest element from the second source, if any.
      - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
      */
-    public func withLatestFrom<SecondO: ObservableConvertibleType, ResultType>(_ second: SecondO, resultSelector: @escaping (Element, SecondO.Element) throws -> ResultType) -> Observable<ResultType> {
+    public func withLatestFrom<O: ObservableConvertibleType, ResultType>(_ second: O, resultSelector: @escaping (Element, O.Element) throws -> ResultType) -> Observable<ResultType> {
         return WithLatestFrom(first: self.asObservable(), second: second.asObservable(), resultSelector: resultSelector)
     }
 
@@ -34,12 +34,12 @@ extension ObservableType {
     }
 }
 
-final private class WithLatestFromSink<FirstType, SecondType, O: ObserverType>
-    : Sink<O>
+final private class WithLatestFromSink<FirstType, SecondType, Observer: ObserverType>
+    : Sink<Observer>
     , ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias ResultType = O.Element 
+    typealias ResultType = Observer.Element
     typealias Parent = WithLatestFrom<FirstType, SecondType, ResultType>
     typealias Element = FirstType
     
@@ -48,7 +48,7 @@ final private class WithLatestFromSink<FirstType, SecondType, O: ObserverType>
     var _lock = RecursiveLock()
     fileprivate var _latest: SecondType?
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         
         super.init(observer: observer, cancel: cancel)
@@ -90,13 +90,13 @@ final private class WithLatestFromSink<FirstType, SecondType, O: ObserverType>
     }
 }
 
-final private class WithLatestFromSecond<FirstType, SecondType, O: ObserverType>
+final private class WithLatestFromSecond<FirstType, SecondType, Observer: ObserverType>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
     
-    typealias ResultType = O.Element 
-    typealias Parent = WithLatestFromSink<FirstType, SecondType, O>
+    typealias ResultType = Observer.Element
+    typealias Parent = WithLatestFromSink<FirstType, SecondType, Observer>
     typealias Element = SecondType
     
     private let _parent: Parent
@@ -141,7 +141,7 @@ final private class WithLatestFrom<FirstType, SecondType, ResultType>: Producer<
         self._resultSelector = resultSelector
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == ResultType {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == ResultType {
         let sink = WithLatestFromSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Zip+Collection.swift
+++ b/RxSwift/Observables/Zip+Collection.swift
@@ -34,9 +34,9 @@ extension ObservableType {
     
 }
 
-final private class ZipCollectionTypeSink<Collection: Swift.Collection, O: ObserverType>
-    : Sink<O> where Collection.Element: ObservableConvertibleType {
-    typealias Result = O.Element 
+final private class ZipCollectionTypeSink<Collection: Swift.Collection, Observer: ObserverType>
+    : Sink<Observer> where Collection.Element: ObservableConvertibleType {
+    typealias Result = Observer.Element 
     typealias Parent = ZipCollectionType<Collection, Result>
     typealias SourceElement = Collection.Element.Element
     
@@ -51,7 +51,7 @@ final private class ZipCollectionTypeSink<Collection: Swift.Collection, O: Obser
     private var _numberOfDone = 0
     private var _subscriptions: [SingleAssignmentDisposable]
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         self._values = [Queue<SourceElement>](repeating: Queue(capacity: 4), count: parent.count)
         self._isDone = [Bool](repeating: false, count: parent.count)
@@ -161,7 +161,7 @@ final private class ZipCollectionType<Collection: Swift.Collection, Result>: Pro
         self.count = Int(Int64(self.sources.count))
     }
     
-    override func run<O : ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipCollectionTypeSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Zip+arity.swift
+++ b/RxSwift/Observables/Zip+arity.swift
@@ -48,8 +48,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
-    typealias Result = O.Element 
+final class ZipSink2_<E1, E2, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
     typealias Parent = Zip2<E1, E2, Result>
 
     let _parent: Parent
@@ -57,7 +57,7 @@ final class ZipSink2_<E1, E2, O: ObserverType> : ZipSink<O> {
     var _values1: Queue<E1> = Queue(capacity: 2)
     var _values2: Queue<E2> = Queue(capacity: 2)
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 2, observer: observer, cancel: cancel)
     }
@@ -108,7 +108,7 @@ final class Zip2<E1, E2, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipSink2_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -156,8 +156,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
-    typealias Result = O.Element 
+final class ZipSink3_<E1, E2, E3, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
     typealias Parent = Zip3<E1, E2, E3, Result>
 
     let _parent: Parent
@@ -166,7 +166,7 @@ final class ZipSink3_<E1, E2, E3, O: ObserverType> : ZipSink<O> {
     var _values2: Queue<E2> = Queue(capacity: 2)
     var _values3: Queue<E3> = Queue(capacity: 2)
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 3, observer: observer, cancel: cancel)
     }
@@ -224,7 +224,7 @@ final class Zip3<E1, E2, E3, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipSink3_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -272,8 +272,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
-    typealias Result = O.Element 
+final class ZipSink4_<E1, E2, E3, E4, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
     typealias Parent = Zip4<E1, E2, E3, E4, Result>
 
     let _parent: Parent
@@ -283,7 +283,7 @@ final class ZipSink4_<E1, E2, E3, E4, O: ObserverType> : ZipSink<O> {
     var _values3: Queue<E3> = Queue(capacity: 2)
     var _values4: Queue<E4> = Queue(capacity: 2)
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 4, observer: observer, cancel: cancel)
     }
@@ -348,7 +348,7 @@ final class Zip4<E1, E2, E3, E4, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipSink4_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -396,8 +396,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
-    typealias Result = O.Element 
+final class ZipSink5_<E1, E2, E3, E4, E5, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
     typealias Parent = Zip5<E1, E2, E3, E4, E5, Result>
 
     let _parent: Parent
@@ -408,7 +408,7 @@ final class ZipSink5_<E1, E2, E3, E4, E5, O: ObserverType> : ZipSink<O> {
     var _values4: Queue<E4> = Queue(capacity: 2)
     var _values5: Queue<E5> = Queue(capacity: 2)
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 5, observer: observer, cancel: cancel)
     }
@@ -480,7 +480,7 @@ final class Zip5<E1, E2, E3, E4, E5, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipSink5_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -528,8 +528,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
-    typealias Result = O.Element 
+final class ZipSink6_<E1, E2, E3, E4, E5, E6, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
     typealias Parent = Zip6<E1, E2, E3, E4, E5, E6, Result>
 
     let _parent: Parent
@@ -541,7 +541,7 @@ final class ZipSink6_<E1, E2, E3, E4, E5, E6, O: ObserverType> : ZipSink<O> {
     var _values5: Queue<E5> = Queue(capacity: 2)
     var _values6: Queue<E6> = Queue(capacity: 2)
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 6, observer: observer, cancel: cancel)
     }
@@ -620,7 +620,7 @@ final class Zip6<E1, E2, E3, E4, E5, E6, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipSink6_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -668,8 +668,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> {
-    typealias Result = O.Element 
+final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
     typealias Parent = Zip7<E1, E2, E3, E4, E5, E6, E7, Result>
 
     let _parent: Parent
@@ -682,7 +682,7 @@ final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, O: ObserverType> : ZipSink<O> 
     var _values6: Queue<E6> = Queue(capacity: 2)
     var _values7: Queue<E7> = Queue(capacity: 2)
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 7, observer: observer, cancel: cancel)
     }
@@ -768,7 +768,7 @@ final class Zip7<E1, E2, E3, E4, E5, E6, E7, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipSink7_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
@@ -816,8 +816,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink<O> {
-    typealias Result = O.Element 
+final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
     typealias Parent = Zip8<E1, E2, E3, E4, E5, E6, E7, E8, Result>
 
     let _parent: Parent
@@ -831,7 +831,7 @@ final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, O: ObserverType> : ZipSink
     var _values7: Queue<E7> = Queue(capacity: 2)
     var _values8: Queue<E8> = Queue(capacity: 2)
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: 8, observer: observer, cancel: cancel)
     }
@@ -924,7 +924,7 @@ final class Zip8<E1, E2, E3, E4, E5, E6, E7, E8, Result> : Producer<Result> {
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipSink8_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Zip+arity.tt
+++ b/RxSwift/Observables/Zip+arity.tt
@@ -47,8 +47,8 @@ extension ObservableType where Element == Any {
     }
 }
 
-final class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, O: ObserverType> : ZipSink<O> {
-    typealias Result = O.Element 
+final class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
     typealias Parent = Zip<%= i %><<%= (Array(1...i).map { "E\($0)" }).joined(separator: ", ") %>, Result>
 
     let _parent: Parent
@@ -57,7 +57,7 @@ final class ZipSink<%= i %>_<<%= (Array(1...i).map { "E\($0)" }).joined(separato
 "    var _values\($0): Queue<E\($0)> = Queue(capacity: 2)"
 }).joined(separator: "\n") %>
 
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(arity: <%= i %>, observer: observer, cancel: cancel)
     }
@@ -110,7 +110,7 @@ final class Zip<%= i %><<%= (Array(1...i).map { "E\($0)" }).joined(separator: ",
         self._resultSelector = resultSelector
     }
 
-    override func run<O: ObserverType>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O.Element == Result {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
         let sink = ZipSink<%= i %>_(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)

--- a/RxSwift/Observables/Zip.swift
+++ b/RxSwift/Observables/Zip.swift
@@ -13,8 +13,8 @@ protocol ZipSinkProtocol : class
     func done(_ index: Int)
 }
 
-class ZipSink<O: ObserverType> : Sink<O>, ZipSinkProtocol {
-    typealias Element = O.Element
+class ZipSink<Observer: ObserverType> : Sink<Observer>, ZipSinkProtocol {
+    typealias Element = Observer.Element
     
     let _arity: Int
 
@@ -23,7 +23,7 @@ class ZipSink<O: ObserverType> : Sink<O>, ZipSinkProtocol {
     // state
     private var _isDone: [Bool]
     
-    init(arity: Int, observer: O, cancel: Cancelable) {
+    init(arity: Int, observer: Observer, cancel: Cancelable) {
         self._isDone = [Bool](repeating: false, count: arity)
         self._arity = arity
         

--- a/RxSwift/Observers/TailRecursiveSink.swift
+++ b/RxSwift/Observers/TailRecursiveSink.swift
@@ -16,11 +16,11 @@ enum TailRecursiveSinkCommand {
 #endif
 
 /// This class is usually used with `Generator` version of the operators.
-class TailRecursiveSink<Sequence: Swift.Sequence, O: ObserverType>
-    : Sink<O>
-    , InvocableWithValueType where Sequence.Element: ObservableConvertibleType, Sequence.Element.Element == O.Element {
+class TailRecursiveSink<Sequence: Swift.Sequence, Observer: ObserverType>
+    : Sink<Observer>
+    , InvocableWithValueType where Sequence.Element: ObservableConvertibleType, Sequence.Element.Element == Observer.Element {
     typealias Value = TailRecursiveSinkCommand
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
     typealias SequenceGenerator = (generator: Sequence.Iterator, remaining: IntMax?)
 
     var _generators: [SequenceGenerator] = []
@@ -28,9 +28,9 @@ class TailRecursiveSink<Sequence: Swift.Sequence, O: ObserverType>
     var _subscription = SerialDisposable()
 
     // this is thread safe object
-    var _gate = AsyncLock<InvocableScheduledItem<TailRecursiveSink<Sequence, O>>>()
+    var _gate = AsyncLock<InvocableScheduledItem<TailRecursiveSink<Sequence, Observer>>>()
 
-    override init(observer: O, cancel: Cancelable) {
+    override init(observer: Observer, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
     }
 

--- a/RxSwift/Subjects/AsyncSubject.swift
+++ b/RxSwift/Subjects/AsyncSubject.swift
@@ -108,12 +108,12 @@ public final class AsyncSubject<Element>
     ///
     /// - parameter observer: Observer to subscribe to the subject.
     /// - returns: Disposable object that can be used to unsubscribe the observer from the subject.
-    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self._lock.lock(); defer { self._lock.unlock() }
         return self._synchronized_subscribe(observer)
     }
 
-    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    func _synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         if let stoppedEvent = self._stoppedEvent {
             switch stoppedEvent {
             case .next:

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -106,14 +106,14 @@ public final class BehaviorSubject<Element>
     ///
     /// - parameter observer: Observer to subscribe to the subject.
     /// - returns: Disposable object that can be used to unsubscribe the observer from the subject.
-    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self._lock.lock()
         let subscription = self._synchronized_subscribe(observer)
         self._lock.unlock()
         return subscription
     }
 
-    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    func _synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         if self._isDisposed {
             observer.on(.error(RxError.disposed(object: self)))
             return Disposables.create()

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -92,14 +92,14 @@ public final class PublishSubject<Element>
     - parameter observer: Observer to subscribe to the subject.
     - returns: Disposable object that can be used to unsubscribe the observer from the subject.
     */
-    public override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self._lock.lock()
         let subscription = self._synchronized_subscribe(observer)
         self._lock.unlock()
         return subscription
     }
 
-    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    func _synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         if let stoppedEvent = self._stoppedEvent {
             observer.on(stoppedEvent)
             return Disposables.create()

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -110,7 +110,7 @@ private class ReplayBufferBase<Element>
         rxAbstractMethod()
     }
     
-    func replayBuffer<O: ObserverType>(_ observer: O) where O.Element == Element {
+    func replayBuffer<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
         rxAbstractMethod()
     }
     
@@ -146,14 +146,14 @@ private class ReplayBufferBase<Element>
         }
     }
     
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self._lock.lock()
         let subscription = self._synchronized_subscribe(observer)
         self._lock.unlock()
         return subscription
     }
 
-    func _synchronized_subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    func _synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         if self._isDisposed {
             observer.on(.error(RxError.disposed(object: self)))
             return Disposables.create()
@@ -219,7 +219,7 @@ fileprivate final class ReplayOne<Element> : ReplayBufferBase<Element> {
         self._value = value
     }
 
-    override func replayBuffer<O: ObserverType>(_ observer: O) where O.Element == Element {
+    override func replayBuffer<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
         if let value = self._value {
             observer.on(.next(value))
         }
@@ -242,7 +242,7 @@ private class ReplayManyBase<Element>: ReplayBufferBase<Element> {
         self._queue.enqueue(value)
     }
 
-    override func replayBuffer<O: ObserverType>(_ observer: O) where O.Element == Element {
+    override func replayBuffer<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
         for item in self._queue {
             observer.on(.next(item))
         }

--- a/RxSwift/Traits/Completable+AndThen.swift
+++ b/RxSwift/Traits/Completable+AndThen.swift
@@ -69,23 +69,23 @@ final private class ConcatCompletable<Element>: Producer<Element> {
         self._second = second
     }
 
-    override func run<O>(_ observer: O, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where O : ObserverType, O.Element == Element {
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element {
         let sink = ConcatCompletableSink(parent: self, observer: observer, cancel: cancel)
         let subscription = sink.run()
         return (sink: sink, subscription: subscription)
     }
 }
 
-final private class ConcatCompletableSink<O: ObserverType>
-    : Sink<O>
+final private class ConcatCompletableSink<Observer: ObserverType>
+    : Sink<Observer>
     , ObserverType {
     typealias Element = Never
-    typealias Parent = ConcatCompletable<O.Element>
+    typealias Parent = ConcatCompletable<Observer.Element>
 
     private let _parent: Parent
     private let _subscription = SerialDisposable()
     
-    init(parent: Parent, observer: O, cancel: Cancelable) {
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
         super.init(observer: observer, cancel: cancel)
     }
@@ -111,11 +111,11 @@ final private class ConcatCompletableSink<O: ObserverType>
     }
 }
 
-final private class ConcatCompletableSinkOther<O: ObserverType>
+final private class ConcatCompletableSinkOther<Observer: ObserverType>
     : ObserverType {
-    typealias Element = O.Element 
+    typealias Element = Observer.Element 
 
-    typealias Parent = ConcatCompletableSink<O>
+    typealias Parent = ConcatCompletableSink<Observer>
     
     private let _parent: Parent
 
@@ -123,7 +123,7 @@ final private class ConcatCompletableSinkOther<O: ObserverType>
         self._parent = parent
     }
 
-    func on(_ event: Event<O.Element>) {
+    func on(_ event: Event<Observer.Element>) {
         self._parent.forwardOn(event)
         if event.isStopEvent {
             self._parent.dispose()

--- a/RxTest/ColdObservable.swift
+++ b/RxTest/ColdObservable.swift
@@ -21,7 +21,7 @@ final class ColdObservable<Element>
     }
 
     /// Subscribes `observer` to receive events for this sequence.
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         self.subscriptions.append(Subscription(self.testScheduler.clock))
         
         let i = self.subscriptions.count - 1

--- a/RxTest/HotObservable.swift
+++ b/RxTest/HotObservable.swift
@@ -37,7 +37,7 @@ final class HotObservable<Element>
     }
 
     /// Subscribes `observer` to receive events for this sequence.
-    override func subscribe<O: ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         let key = self._observers.insert(observer.on)
         self.subscriptions.append(Subscription(self.testScheduler.clock))
         

--- a/RxTest/TestableObservable.swift
+++ b/RxTest/TestableObservable.swift
@@ -28,7 +28,7 @@ public class TestableObservable<Element>
         self.subscriptions = []
     }
 
-    public func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    public func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         fatalError("Abstract method")
     }
 }

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/BackgroundThreadPrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/BackgroundThreadPrimitiveHotObservable.swift
@@ -11,7 +11,7 @@ import XCTest
 import Dispatch
 
 final class BackgroundThreadPrimitiveHotObservable<Element: Equatable> : PrimitiveHotObservable<Element> {
-    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         XCTAssertTrue(!DispatchQueue.isMain)
         return super.subscribe(observer)
     }

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MainThreadPrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MainThreadPrimitiveHotObservable.swift
@@ -11,7 +11,7 @@ import XCTest
 import Dispatch
 
 final class MainThreadPrimitiveHotObservable<Element: Equatable> : PrimitiveHotObservable<Element> {
-    override func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         XCTAssertTrue(DispatchQueue.isMain)
         return super.subscribe(observer)
     }

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/MySubject.swift
@@ -39,7 +39,7 @@ final class MySubject<Element> : SubjectType, ObserverType where Element : Hasha
         }
     }
     
-    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         _subscribeCount += 1
         _observer = AnyObserver(observer)
         

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/PrimitiveHotObservable.swift
@@ -37,7 +37,7 @@ class PrimitiveHotObservable<Element> : ObservableType {
         _observers.on(event)
     }
     
-    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         lock.lock()
         defer { lock.unlock() }
 

--- a/Tests/RxSwiftTests/TestImplementations/Mocks/TestConnectableObservable.swift
+++ b/Tests/RxSwiftTests/TestImplementations/Mocks/TestConnectableObservable.swift
@@ -21,7 +21,7 @@ final class TestConnectableObservable<Subject: SubjectType> : ConnectableObserva
         return _o.connect()
     }
     
-    func subscribe<O : ObserverType>(_ observer: O) -> Disposable where O.Element == Element {
+    func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
         return _o.subscribe(observer)
     }
 }


### PR DESCRIPTION
This is one of the last two big refactors for generic constraints. 
Once this is merged I'll do the same for `O: ObservableConvertibleType` (etc.)