### PR TITLE
Documentation: Fixed compile errors on 'Automatic input validation' code from Examples.md

### DIFF
--- a/Documentation/Examples.md
+++ b/Documentation/Examples.md
@@ -136,7 +136,7 @@ self.usernameOutlet.rx.text
             // Convenience for constructing synchronous result.
             // In case there is mixed synchronous and asynchronous code inside the same
             // method, this will construct an async result that is resolved immediately.
-            return Observable.just(Availability.invalid(message: "Username can't be empty."))
+            return Observable.just(.invalid(message: "Username can't be empty."))
         }
 
         // ...
@@ -150,10 +150,10 @@ self.usernameOutlet.rx.text
         return API.usernameAvailable(username)
           .map { available in
               if available {
-                  return Availability.available(message: "Username available")
+                  return .available(message: "Username available")
               }
               else {
-                  return Availability.taken(message: "Username already taken")
+                  return .taken(message: "Username already taken")
               }
           }
           // use `loadingValue` until server responds
@@ -168,9 +168,9 @@ self.usernameOutlet.rx.text
 // Now we need to bind that to the user interface somehow.
 // Good old `subscribe(onNext:)` can do that.
 // That's the end of `Observable` chain.
-    .subscribe(onNext: { validity in
-        self.errorLabel.textColor = validationColor(validity)
-        self.errorLabel.text = validity.message
+    .subscribe(onNext: { [weak self] validity in
+        self?.errorLabel.textColor = validationColor(validity)
+        self?.errorLabel.text = validity.message
     })
 // This will produce a `Disposable` object that can unbind everything and cancel
 // pending async operations.

--- a/Documentation/Examples.md
+++ b/Documentation/Examples.md
@@ -129,10 +129,10 @@ enum Availability {
 // bind UI control values directly
 // use username from `usernameOutlet` as username values source
 self.usernameOutlet.rx.text
-    .map { username in
+    .map { username -> Observable<Availability> in
 
         // synchronous validation, nothing special here
-        if username.isEmpty {
+        guard let username = username, !username.isEmpty else {
             // Convenience for constructing synchronous result.
             // In case there is mixed synchronous and asynchronous code inside the same
             // method, this will construct an async result that is resolved immediately.
@@ -153,7 +153,7 @@ self.usernameOutlet.rx.text
                   return Availability.available(message: "Username available")
               }
               else {
-                  return Availability.unavailable(message: "Username already taken")
+                  return Availability.taken(message: "Username already taken")
               }
           }
           // use `loadingValue` until server responds
@@ -169,8 +169,8 @@ self.usernameOutlet.rx.text
 // Good old `subscribe(onNext:)` can do that.
 // That's the end of `Observable` chain.
     .subscribe(onNext: { validity in
-        errorLabel.textColor = validationColor(validity)
-        errorLabel.text = validity.message
+        self.errorLabel.textColor = validationColor(validity)
+        self.errorLabel.text = validity.message
     })
 // This will produce a `Disposable` object that can unbind everything and cancel
 // pending async operations.


### PR DESCRIPTION
This PR fixes a few compile errors on the [Automatic input validation](https://github.com/ReactiveX/RxSwift/blob/master/Documentation/Examples.md#automatic-input-validation) code sample from the **Examples.md** document. 

<img width="780" alt="Screen Shot 2019-05-05 at 20 26 39" src="https://user-images.githubusercontent.com/14804033/57201823-584f6b00-6f74-11e9-9e4a-bd46ffeefe75.png"> _Error from on Xcode 10.2.1_

There are no errors on the RxSwift code but we can agree that it's best having error-free code blocks when possible.

Would it be useful to add the implementations of the complementary functions under a **detail** tag? It's the only code block from that document that doesn't compile but it's already long enough. 

Example: 
<details>
  <summary>Extra code</summary>
  <p>

```swift
class API {
    static func usernameAvailable(_ username: String) -> Observable<Bool> {
        return Observable.just(Bool.random())
    }
}

func validationColor(_ validity: Availability) -> UIColor {
    switch validity {
    case .taken, .invalid:
        return .red
    case .pending:
        return .orange
    case .available:
        return .green
    }
}
```
  </p>
</details>