### PR TITLE
UITextField.isSecureTextEntry binder

### DIFF
--- a/RxCocoa/iOS/UITextField+Rx.swift
+++ b/RxCocoa/iOS/UITextField+Rx.swift
@@ -50,6 +50,13 @@ extension Reactive where Base: UITextField {
             }
         )
     }
+
+    /// Bindable sink for `isSecureTextEntry` property.
+    public var isSecureTextEntry: Binder<Bool> {
+        return Binder(self.base) { textField, isSecureTextEntry in
+            textField.isSecureTextEntry = isSecureTextEntry
+        }
+    }
     
 }
 

--- a/Tests/RxCocoaTests/UITextField+RxTests.swift
+++ b/Tests/RxCocoaTests/UITextField+RxTests.swift
@@ -46,6 +46,16 @@ final class UITextFieldTests : RxTest {
             XCTAssertEqual(textField.attributedText!, attributedText)
         }
     }
+
+    func test_isSecureTextEntryObserver() {
+        // because of leak in iOS 11.2
+        if #available(iOS 11.3, tvOS 11.3, *) {
+            let textField = UITextField()
+            XCTAssertFalse(textField.isSecureTextEntry)
+            textField.rx.isSecureTextEntry.onNext(true)
+            XCTAssertTrue(textField.isSecureTextEntry)
+        }
+    }
 }
 
 private extension String {


### PR DESCRIPTION
"Show password" button is a quite common task to implement. It can be implemented easily with `textField.isSecureTextEntry.toggle()` however, it is not a reactive way. With this binder things will become better:
```swift
showPasswordButton.rx.tap
  .scan(true) { isSecureTextEntry, _ in !isSecureTextEntry }
  .bind(to: passwordTextField.rx.isSecureTextEntry)
  .disposed(by: disposeBag)
```
Probably, i have to implement similar for `UITextView`, however i don't think it will be useful. What do you think?

Also added .idea to .gitignore for AppCode users. Can do it in a separate PR if u wish :)