### PR TITLE
Add materialize and dematerialize for Single

### DIFF
--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -2108,6 +2108,12 @@ final class SingleTest_ : SingleTest, RxTestCase {
     ("testZipCollection_tuple", SingleTest.testZipCollection_tuple),
     ("testZipCollection_tuple_when_empty", SingleTest.testZipCollection_tuple_when_empty),
     ("testDefaultErrorHandler", SingleTest.testDefaultErrorHandler),
+    ("testMaterializeNever", SingleTest.testMaterializeNever),
+    ("testMaterializeEmits", SingleTest.testMaterializeEmits),
+    ("testMaterializeThrow", SingleTest.testMaterializeThrow),
+    ("testDematerializeNever", SingleTest.testDematerializeNever),
+    ("testDematerializeEmits", SingleTest.testDematerializeEmits),
+    ("testDematerializeThrow", SingleTest.testDematerializeThrow),
     ] }
 }
 


### PR DESCRIPTION
Working with `Single` events instead of elements might be important in some cases. For instance with `RxSwiftExt` `.elements()` and `.errros()` operators.  Using `single.asObervable().materialize()` looks strange for me. It can be cutted to simple `single.materialize()`. 
I can't see any reasons why this operator is not added to `PrimitiveSequence`. 

Here is the same PR for RxJava - https://github.com/ReactiveX/RxJava/pull/6278
