### PR TITLE
Fix warnings/deprecations

### DIFF
--- a/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage/Contents.swift
@@ -194,9 +194,9 @@ example("skipWhileWithIndex") {
     let disposeBag = DisposeBag()
     
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
-        .skipWhileWithIndex { element, index in
-            index < 3
-        }
+        .enumerated()
+        .skipWhile { $0.index < 3 }
+        .map { $0.element }
         .subscribe(onNext: { print($0) })
         .disposed(by: disposeBag)
 }

--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -407,8 +407,6 @@ extension Reactive where Base: UISegmentedControl {
     }
 #endif
 
-import RxSwift
-
 @available(*, deprecated, message: "Variable is deprecated. Please use `BehaviorRelay` as a replacement.")
 extension Variable {
     /// Converts `Variable` to `Driver` trait.

--- a/RxCocoa/macOS/NSSlider+Rx.swift
+++ b/RxCocoa/macOS/NSSlider+Rx.swift
@@ -16,7 +16,7 @@ extension Reactive where Base: NSSlider {
     /// Reactive wrapper for `value` property.
     public var value: ControlProperty<Double> {
         return self.base.rx.controlProperty(
-            getter: { control in
+            getter: { control -> Double in
                 return control.doubleValue
             },
             setter: { control, value in

--- a/RxSwift/Reactive.swift
+++ b/RxSwift/Reactive.swift
@@ -55,6 +55,7 @@ extension ReactiveCompatible {
         get {
             return Reactive<Self>.self
         }
+        // swiftlint:disable:next unused_setter_value
         set {
             // this enables using Reactive to "mutate" base type
         }
@@ -65,6 +66,7 @@ extension ReactiveCompatible {
         get {
             return Reactive(self)
         }
+        // swiftlint:disable:next unused_setter_value
         set {
             // this enables using Reactive to "mutate" base object
         }

--- a/Tests/RxSwiftTests/Observable+MergeTests.swift
+++ b/Tests/RxSwiftTests/Observable+MergeTests.swift
@@ -1222,7 +1222,7 @@ extension ObservableMergeTest {
     func testFlatMapFirst_Complete() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
+        let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
             ])),
@@ -1299,7 +1299,7 @@ extension ObservableMergeTest {
     func testFlatMapFirst_Complete_InnerNotComplete() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
+        let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
                 ])),
@@ -1595,7 +1595,7 @@ extension ObservableMergeTest {
     func testFlatMapFirst_Dispose() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
+        let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
                 ])),
@@ -1665,7 +1665,7 @@ extension ObservableMergeTest {
     func testFlatMapFirst_SelectorThrows() {
         let scheduler = TestScheduler(initialClock: 0)
 
-        let xs = scheduler.createHotObservable([
+        let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
                 ])),
@@ -1797,7 +1797,7 @@ extension ObservableMergeTest {
     func testFlatMap_Complete() {
         let scheduler = TestScheduler(initialClock: 0)
         
-        let xs = scheduler.createHotObservable([
+        let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
             ])),
@@ -1887,7 +1887,7 @@ extension ObservableMergeTest {
     func testFlatMap_Complete_InnerNotComplete() {
         let scheduler = TestScheduler(initialClock: 0)
         
-        let xs = scheduler.createHotObservable([
+        let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
                 ])),
@@ -2231,7 +2231,7 @@ extension ObservableMergeTest {
     func testFlatMap_Dispose() {
         let scheduler = TestScheduler(initialClock: 0)
         
-        let xs = scheduler.createHotObservable([
+        let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
                 ])),
@@ -2312,7 +2312,7 @@ extension ObservableMergeTest {
     func testFlatMap_SelectorThrows() {
         let scheduler = TestScheduler(initialClock: 0)
         
-        let xs = scheduler.createHotObservable([
+        let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
                 ])),


### PR DESCRIPTION
As a potential contributor, I would like to see only my warnings in CI logs. However, right now there are few deprecation messages, swiftlint warnings and type-check warnings. This PR fix them all.