### PR TITLE
Allow to define custom traits

### DIFF
--- a/RxSwift/Traits/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence.swift
@@ -8,9 +8,9 @@
 
 /// Observable sequences containing 0 or 1 element.
 public struct PrimitiveSequence<Trait, Element> {
-    let source: Observable<Element>
+    public let source: Observable<Element>
 
-    init(raw: Observable<Element>) {
+    public init(raw: Observable<Element>) {
         self.source = raw
     }
 }


### PR DESCRIPTION
In our project is more obviously in some cases create trait `Errorless`. I want to explicitly state that the error will not be returned. I found preposition https://github.com/ReactiveX/RxSwift/issues/1272 with reply 

> You can define your own traits if you like, including that have guarantees you want

So I tried to write `Errorless` trait but it's not possible cause traits it's a typealias on `PrimitiveSequence`. And `PrimitiveSequence` has `internal` init. So in firstly you just can't make a instance of our custom trait. And in secondly you can't define basic operations like `filter`/`map` and other because `source` in `PrimitiveSequence` also defined as internal.

I think, we should allow to create custom traits.