### PR TITLE
Extended BehaviorRelay with KeyPath and Collection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [5.0.1](https://github.com/ReactiveX/RxSwift/releases/tag/5.0.1)
 
 * Reverts Carthage integration from using static to dynamic libraries. #1960
+* Extended `BehaviorRelay` with KeyPath and Collection.
 
 ## [5.0.0](https://github.com/ReactiveX/RxSwift/releases/tag/5.0.0)
 

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -42,6 +42,14 @@
 		4C8DE0E220D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E320D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E420D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
+		4E7D2A302298A7DC0007161A /* BehaviorRelay+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D2A2E2298A7DC0007161A /* BehaviorRelay+Collection.swift */; };
+		4E7D2A312298A7DC0007161A /* BehaviorRelay+KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D2A2F2298A7DC0007161A /* BehaviorRelay+KeyPath.swift */; };
+		4E7D2A342298A8120007161A /* BehaviorRelay+KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D2A322298A8120007161A /* BehaviorRelay+KeyPathTests.swift */; };
+		4E7D2A352298A8120007161A /* BehaviorRelay+KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D2A322298A8120007161A /* BehaviorRelay+KeyPathTests.swift */; };
+		4E7D2A362298A8120007161A /* BehaviorRelay+KeyPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D2A322298A8120007161A /* BehaviorRelay+KeyPathTests.swift */; };
+		4E7D2A372298A8120007161A /* BehaviorRelay+CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D2A332298A8120007161A /* BehaviorRelay+CollectionTests.swift */; };
+		4E7D2A382298A8120007161A /* BehaviorRelay+CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D2A332298A8120007161A /* BehaviorRelay+CollectionTests.swift */; };
+		4E7D2A392298A8120007161A /* BehaviorRelay+CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7D2A332298A8120007161A /* BehaviorRelay+CollectionTests.swift */; };
 		54700CA01CE37E1800EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54700CA11CE37E1900EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54D2138E1CE0824E0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
@@ -957,6 +965,10 @@
 		4C5213A9225D41E60079FC77 /* CompactMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompactMap.swift; sourceTree = "<group>"; };
 		4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+CompactMapTests.swift"; sourceTree = "<group>"; };
 		4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBagTest.swift; sourceTree = "<group>"; };
+		4E7D2A2E2298A7DC0007161A /* BehaviorRelay+Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BehaviorRelay+Collection.swift"; sourceTree = "<group>"; };
+		4E7D2A2F2298A7DC0007161A /* BehaviorRelay+KeyPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BehaviorRelay+KeyPath.swift"; sourceTree = "<group>"; };
+		4E7D2A322298A8120007161A /* BehaviorRelay+KeyPathTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BehaviorRelay+KeyPathTests.swift"; sourceTree = "<group>"; };
+		4E7D2A332298A8120007161A /* BehaviorRelay+CollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BehaviorRelay+CollectionTests.swift"; sourceTree = "<group>"; };
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
@@ -1551,6 +1563,8 @@
 			children = (
 				C8B0F7101F530CA700548EBE /* PublishRelay.swift */,
 				C8C8BCCE1F8944B800501D4D /* BehaviorRelay.swift */,
+				4E7D2A2E2298A7DC0007161A /* BehaviorRelay+Collection.swift */,
+				4E7D2A2F2298A7DC0007161A /* BehaviorRelay+KeyPath.swift */,
 				A2897D61225CA3F3004EA481 /* Observable+Bind.swift */,
 				A2897D68225D023A004EA481 /* Utils.swift */,
 				A2FD4EA4225D0A8100288525 /* Info.plist */,
@@ -1562,6 +1576,8 @@
 			isa = PBXGroup;
 			children = (
 				A2FD4E9B225D04FF00288525 /* Observable+RelayBindTests.swift */,
+				4E7D2A332298A8120007161A /* BehaviorRelay+CollectionTests.swift */,
+				4E7D2A322298A8120007161A /* BehaviorRelay+KeyPathTests.swift */,
 			);
 			path = RxRelayTests;
 			sourceTree = "<group>";
@@ -2950,6 +2966,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4E7D2A312298A7DC0007161A /* BehaviorRelay+KeyPath.swift in Sources */,
+				4E7D2A302298A7DC0007161A /* BehaviorRelay+Collection.swift in Sources */,
 				A2897D57225CA236004EA481 /* PublishRelay.swift in Sources */,
 				A2897D58225CA236004EA481 /* BehaviorRelay.swift in Sources */,
 				A2897D62225CA3F3004EA481 /* Observable+Bind.swift in Sources */,
@@ -3143,6 +3161,7 @@
 				C820A9FE1EB5110E00D431BC /* Observable+DematerializeTests.swift in Sources */,
 				C8C4F1711DE9D68000003FA7 /* UIStepper+RxTests.swift in Sources */,
 				C820A9D21EB50B0900D431BC /* Observable+GroupByTests.swift in Sources */,
+				4E7D2A372298A8120007161A /* BehaviorRelay+CollectionTests.swift in Sources */,
 				C83509441C38706E0027C24C /* MySubject.swift in Sources */,
 				C835095F1C38706E0027C24C /* Observable+SubscriptionTest.swift in Sources */,
 				C8C217D71CB710200038A2E6 /* UICollectionView+RxTests.swift in Sources */,
@@ -3216,6 +3235,7 @@
 				84E4D3961C9B011000ADFDC9 /* UISearchController+RxTests.swift in Sources */,
 				C8C4F15F1DE9CC5B00003FA7 /* UISwitch+RxTests.swift in Sources */,
 				ECBBA5A11DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift in Sources */,
+				4E7D2A342298A8120007161A /* BehaviorRelay+KeyPathTests.swift in Sources */,
 				C820A9A61EB5056C00D431BC /* Observable+SkipUntilTests.swift in Sources */,
 				88718D011CE5DE2600D88D60 /* UITabBar+RxTests.swift in Sources */,
 				C8D970EC1F532FD30058F2FE /* SectionedViewDataSourceMock.swift in Sources */,
@@ -3307,6 +3327,7 @@
 				C822BACF1DB424EC00F98810 /* Reactive+Tests.swift in Sources */,
 				C8C4F17E1DE9DF0200003FA7 /* UILabel+RxTests.swift in Sources */,
 				C83509C01C3875220027C24C /* DelegateProxyTest.swift in Sources */,
+				4E7D2A382298A8120007161A /* BehaviorRelay+CollectionTests.swift in Sources */,
 				C820A9F31EB5109300D431BC /* Observable+DefaultIfEmpty.swift in Sources */,
 				C801DE371F6EAD3C008DB060 /* SingleTest.swift in Sources */,
 				C8350A131C38756A0027C24C /* Observable+SubscriptionTest.swift in Sources */,
@@ -3332,6 +3353,7 @@
 				D9080AD91EA06189002B433B /* UINavigationController+RxTests.swift in Sources */,
 				C8C4F17A1DE9DF0200003FA7 /* UIBarButtonItem+RxTests.swift in Sources */,
 				C8350A151C38756A0027C24C /* ObserverTests.swift in Sources */,
+				4E7D2A352298A8120007161A /* BehaviorRelay+KeyPathTests.swift in Sources */,
 				1AF67DA71CED430100C310FA /* ReplaySubjectTest.swift in Sources */,
 				C82FF0F01F93DD2E00BDB34D /* ObservableType+SubscriptionTests.swift in Sources */,
 				C820A9531EB4ECC000D431BC /* Observable+ToArrayTests.swift in Sources */,
@@ -3455,6 +3477,7 @@
 				C820A9D41EB50B0900D431BC /* Observable+GroupByTests.swift in Sources */,
 				C820AA101EB5140100D431BC /* Observable+TimeoutTests.swift in Sources */,
 				C81B6AAC1DB2C15C0047CF86 /* Platform.Darwin.swift in Sources */,
+				4E7D2A392298A8120007161A /* BehaviorRelay+CollectionTests.swift in Sources */,
 				C8350A2B1C3875B60027C24C /* RxMutableBox.swift in Sources */,
 				C8350A071C38755E0027C24C /* MainSchedulerTests.swift in Sources */,
 				C8D970F41F532FD30058F2FE /* SharedSequence+OperatorTest.swift in Sources */,
@@ -3531,6 +3554,7 @@
 				1E3079AE21FB52330072A7E6 /* AtomicTests.swift in Sources */,
 				C8F03F431DBB98DB00AECC4C /* Anomalies.swift in Sources */,
 				C8D970E81F532FD30058F2FE /* SharedSequence+Test.swift in Sources */,
+				4E7D2A362298A8120007161A /* BehaviorRelay+KeyPathTests.swift in Sources */,
 				C83509CC1C3875230027C24C /* NSLayoutConstraint+RxTests.swift in Sources */,
 				C896A68D1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift in Sources */,
 				C820A9A41EB5011700D431BC /* Observable+TakeUntilTests.swift in Sources */,

--- a/RxRelay/BehaviorRelay+Collection.swift
+++ b/RxRelay/BehaviorRelay+Collection.swift
@@ -1,0 +1,81 @@
+//
+//  BehaviorRelay+Append.swift
+//
+//  Created by Cristiano Maria Coppotelli on 15/05/2019.
+//  Copyright © 2019 Cristiano Maria Coppotelli. All rights reserved.
+//
+
+public extension BehaviorRelay where Element : Collection {
+    
+    /// Removes an element from the observable sequence, accepting the updated value.
+    ///
+    /// - Parameter at: The integer index where the value to remove resides.
+    final func acceptRemoving<Value>(at index: Int) where Element == Array<Value> {
+        var newValue = self.value
+        newValue.remove(at: index)
+        self.accept(newValue)
+    }
+    
+    /// Removes elements from the obeservable sequence at the given indexes, accepting the updated
+    /// value.
+    ///
+    /// - Parameter at: Integer indexes where the values to remove reside.
+    ///
+    /// - Complexity: O(n) where n is the length of the given indexes array.
+    final func acceptRemoving<Value>(at indexes: [Int]) where Element == Array<Value> {
+        var newValue = self.value
+        indexes.forEach { newValue.remove(at: $0) }
+        self.accept(newValue)
+    }
+    
+    /// Removes elements from the observable sequence satisfying the given predicate, accepting the
+    /// updated value.
+    ///
+    /// - Parameter where: The predicate to test values against.
+    final func acceptRemoving<Value>(where predicate: @escaping((Value) throws -> Bool)) where Element == Array<Value> {
+        var newValue = self.value
+        try? newValue.removeAll(where: predicate)
+        self.accept(newValue)
+    }
+    
+    /// Appends an element to the observable sequence, accepting the updated value.
+    ///
+    /// - Parameter element: The value to append.
+    final func acceptAppending<Value>(_ element: Value) where Element == Array<Value> {
+        var newValue = self.value
+        newValue.append(element)
+        self.accept(newValue)
+    }
+    
+    /// Appends elements to the observable sequence, accepting the updated value.
+    ///
+    /// - Parameter contentsOf: An array of elements from which elements are appended to the
+    ///                         observable sequence.
+    final func acceptAppending<Value>(contentsOf sequence: [Value]) where Element == Array<Value> {
+        var newValue = self.value
+        newValue.append(contentsOf: sequence)
+        self.accept(newValue)
+    }
+    
+    /// Updates an element at the given index of the observable sequence, accepting the updated value.
+    ///
+    /// - Parameter at: The integer index where the value to update resides.
+    /// - Parameter with: The value to replace the old with.
+    final func acceptUpdating<Value>(at index: Int, with updatedValue: Value) where Element == Array<Value> {
+        var newValue = self.value
+        newValue[index] = updatedValue
+        self.accept(newValue)
+    }
+    
+    /// Updates an element identified with the given key, with the new value, accepting the updated
+    /// value.
+    ///
+    /// - Parameter value: The value to replace the old with.
+    /// - Parameter forKey: The dictionary key to retrieve the value to update.
+    final func acceptUpdating<Key, Value>(value: Value, forKey key: Key) where Element == Dictionary<Key, Value> {
+        var newValue = self.value
+        newValue[key] = value
+        self.accept(newValue)
+    }
+    
+}

--- a/RxRelay/BehaviorRelay+KeyPath.swift
+++ b/RxRelay/BehaviorRelay+KeyPath.swift
@@ -1,0 +1,55 @@
+//
+//  BehaviorRelay+KeyPath.swift
+//  AppUtilities
+//
+//  Created by Cristiano Maria Coppotelli on 24/05/2019.
+//  Copyright © 2019 Cristiano Maria Coppotelli. All rights reserved.
+//
+
+public extension BehaviorRelay {
+    
+    /// Updates an element at the given keyPath, accepting the updated value.
+    ///
+    /// This generic function empowers you to update a stored property on the BehaviorRelay's value,
+    /// prior to knowing how the actual Element type is made out of.
+    ///
+    /// This is made possible thanks to a combination of Generics and Swift KeyPaths.
+    ///
+    /// Example of usage, asserting Element == UIView, for changing its background color:
+    ///
+    ///     self.behaviorRelay.acceptUpdating(atKeyPath: \UIView.backgroundColor, with: .red)
+    ///
+    /// - Parameter atKeyPath: The writable key path pointing to the stored property to update.
+    /// - Parameter with: The value to update the property with.
+    ///
+    /// - Note: This implementation is for Element's stored property being updated having reference
+    ///         semantics.
+    final func acceptUpdating<Value>(atKeyPath keyPath: ReferenceWritableKeyPath<Element, Value>, with updatedValue: Value) where Value: AnyObject {
+        let newStream = self.value
+        newStream[keyPath: keyPath] = updatedValue
+        self.accept(newStream)
+    }
+    
+    /// Updates an element at the given keyPath, accepting the updated value.
+    ///
+    /// This generic function empowers you to update a stored property on the BehaviorRelay's value,
+    /// prior to knowing how the actual Element type is made out of.
+    ///
+    /// This is made possible thanks to a combination of Generics and Swift KeyPaths.
+    ///
+    /// Example of usage, asserting Element == UIView, for changing its background color:
+    ///
+    ///     self.behaviorRelay.acceptUpdating(atKeyPath: \UIView.backgroundColor, with: .red)
+    ///
+    /// - Parameter atKeyPath: The writable key path pointing to the stored property to update.
+    /// - Parameter with: The value to update the property with.
+    ///
+    /// - Note: This implementation is for Element's stored property being updated having reference
+    ///         semantics.
+    final func acceptUpdating<Value>(atKeyPath keyPath: WritableKeyPath<Element, Value>, with updatedValue: Value) {
+        var newStream = self.value
+        newStream[keyPath: keyPath] = updatedValue
+        self.accept(newStream)
+    }
+    
+}

--- a/Tests/RxRelayTests/BehaviorRelay+CollectionTests.swift
+++ b/Tests/RxRelayTests/BehaviorRelay+CollectionTests.swift
@@ -1,0 +1,132 @@
+//
+//  BehaviorRelay+CollectionTests.swift
+//  RxRelay
+//
+//  Created by Cristiano Maria Coppotelli on 24/05/2019.
+//  Copyright © 2019 Krunoslav Zaher. All rights reserved.
+//
+
+import RxSwift
+import RxTest
+import XCTest
+
+class BehaviorRelayCollectionTests: RxTest {}
+
+extension BehaviorRelayCollectionTests {
+    
+    func testAcceptUpdatingAtIndex() {
+        let relay = BehaviorRelay(value: [1,2,3,4,5])
+        let indexToUpdate = 0
+        let updatedValue = 32
+        var firstRecorded = [Recorded<Event<[Int]>>]()
+        var secondRecorded = [Recorded<Event<[Int]>>]()
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptUpdating(at: indexToUpdate, with: updatedValue)
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssertNotEqual(firstRecorded, secondRecorded)
+        XCTAssert(relay.value[indexToUpdate] == updatedValue)
+    }
+    
+    func testAcceptAppendingElement() {
+        let relay = BehaviorRelay(value: [1,2,3,4,5])
+        var firstRecorded = [Recorded<Event<[Int]>>]()
+        var secondRecorded = [Recorded<Event<[Int]>>]()
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptAppending(32)
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssertNotEqual(firstRecorded, secondRecorded)
+    }
+    
+    func testAcceptAppendingElements() {
+        let relay = BehaviorRelay(value: [1,2,3,4,5])
+        var firstRecorded = [Recorded<Event<[Int]>>]()
+        var secondRecorded = [Recorded<Event<[Int]>>]()
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptAppending(contentsOf: [32, 22])
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssertNotEqual(firstRecorded, secondRecorded)
+    }
+    
+    func testAcceptUpdatingValue() {
+        let relay = BehaviorRelay(value: [1: 1, 2: 2, 3: 3])
+        var firstRecorded = [Recorded<Event<[Int: Int]>>]()
+        var secondRecorded = [Recorded<Event<[Int: Int]>>]()
+        let key = 1
+        let updatedValue = 32
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptUpdating(value: updatedValue, forKey: key)
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssertNotEqual(firstRecorded, secondRecorded)
+        XCTAssert(relay.value[key] == updatedValue)
+    }
+    
+    func testAcceptRemovingAtIndex() {
+        let relay = BehaviorRelay(value: [1,2,3,4,5])
+        let indexToRemove = 1
+        var firstRecorded = [Recorded<Event<[Int]>>]()
+        var secondRecorded = [Recorded<Event<[Int]>>]()
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptRemoving(at: indexToRemove)
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssertNotEqual(firstRecorded, secondRecorded)
+    }
+    
+    func testAcceptRemovingAtIndexes() {
+        let relay = BehaviorRelay(value: [1,2,3,4,5])
+        let indexesToRemove = [0,1]
+        var firstRecorded = [Recorded<Event<[Int]>>]()
+        var secondRecorded = [Recorded<Event<[Int]>>]()
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptRemoving(at: indexesToRemove)
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssertNotEqual(firstRecorded, secondRecorded)
+    }
+    
+    func testAcceptRemovingWithPredicate() {
+        let relay = BehaviorRelay(value: [1,2,3,4,5])
+        let predicate: ((Int) throws -> Bool ) = { value in
+            return relay.value.first(where: { $0 == value }) == value
+        }
+        var firstRecorded = [Recorded<Event<[Int]>>]()
+        var secondRecorded = [Recorded<Event<[Int]>>]()
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptRemoving(where: predicate)
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssertNotEqual(firstRecorded, secondRecorded)
+    }
+}

--- a/Tests/RxRelayTests/BehaviorRelay+KeyPathTests.swift
+++ b/Tests/RxRelayTests/BehaviorRelay+KeyPathTests.swift
@@ -1,0 +1,57 @@
+//
+//  BehaviorRelay+KeyPathTests.swift
+//  Rx
+//
+//  Created by Cristiano Maria Coppotelli on 24/05/2019.
+//  Copyright © 2019 Krunoslav Zaher. All rights reserved.
+//
+
+import RxSwift
+import RxTest
+import XCTest
+
+class BehaviorRelayKeyPathTests: RxTest {}
+
+fileprivate class KeyPathUpdatedReferenced {
+    var referencedFromPath: KeyPathUpdatedReferenced = KeyPathUpdatedReferenced()
+}
+
+fileprivate struct KeyPathUpdatedValue {
+    var referencedFromPath: Int = 0
+}
+
+extension BehaviorRelayKeyPathTests {
+    
+    func acceptUpdatingAtKeyPathReference() {
+        let relay = BehaviorRelay(value: KeyPathUpdatedReferenced())
+        let updatedValue = KeyPathUpdatedReferenced()
+        var firstRecorded = [Recorded<Event<KeyPathUpdatedReferenced>>]()
+        var secondRecorded = [Recorded<Event<KeyPathUpdatedReferenced>>]()
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptUpdating(atKeyPath: \KeyPathUpdatedReferenced.referencedFromPath, with: updatedValue)
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssert(relay.value.referencedFromPath === updatedValue)
+    }
+    
+    func acceptUpdatingAtKeyPathValue() {
+        let relay = BehaviorRelay(value: KeyPathUpdatedValue())
+        let updatedValue = 100
+        var firstRecorded = [Recorded<Event<KeyPathUpdatedValue>>]()
+        var secondRecorded = [Recorded<Event<KeyPathUpdatedValue>>]()
+        relay.accept(relay.value)
+        _ = relay.subscribe { event in
+            firstRecorded.append(Recorded(time: 0, value: event))
+        }
+        relay.acceptUpdating(atKeyPath: \KeyPathUpdatedValue.referencedFromPath, with: updatedValue)
+        _ = relay.subscribe { event in
+            secondRecorded.append(Recorded(time: 0, value: event))
+        }
+        XCTAssert(relay.value.referencedFromPath == updatedValue)
+    }
+    
+}


### PR DESCRIPTION
Hello there, as I moved away my code base from Variable, which was extensively used by my team, I figured out a way to let my code behave as it was with variables, plus behavior relay immutability.

I have implemented some methods, which I believe can be useful to others, that "mimic" the collections functions signatures when Element is a collection (a very small set of these), for manipulating a subrange of the value, and accepting the updated one.

Also, two methods which make use of key paths to update a value's store property, prior to knowing who Element will be, thanks to generics.

Thanks in advance.