### PR TITLE
Use WKWebView over deprecated UIWebView

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -100,7 +100,7 @@ custom_categories:
   - UITextView+Rx
   - UIView+Rx
   - UIViewController+Rx
-  - UIWebView+Rx
+  - WKWebView+Rx
 - name: RxCocoa/iOS/Protocols
   children:
   - RxCollectionViewDataSourceType

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## Master
+
+* Replace bindings on deprecated UIWebView with WKWebView.
+
 ## [5.0.1](https://github.com/ReactiveX/RxSwift/releases/tag/5.0.1)
 
 * Reverts Carthage integration from using static to dynamic libraries. #1960

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -31,8 +31,8 @@
 		271A97411CFC996B00D64125 /* UIViewController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97401CFC996B00D64125 /* UIViewController+Rx.swift */; };
 		271A97441CFC9F7B00D64125 /* UIViewController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */; };
 		4583D8231FE94BBA00AA1BB1 /* Recorded+Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */; };
-		4613456F1D9A4467001ABAF2 /* UIWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */; };
-		461345711D9A4543001ABAF2 /* UIWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */; };
+		4613456F1D9A4467001ABAF2 /* WKWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613456E1D9A4467001ABAF2 /* WKWebView+RxTests.swift */; };
+		461345711D9A4543001ABAF2 /* WKWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461345701D9A4543001ABAF2 /* WKWebView+Rx.swift */; };
 		4613457C1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */; };
 		46307D4E1CDE77D800E47A1C /* UIAlertAction+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */; };
 		4C5213AA225D41E60079FC77 /* CompactMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5213A9225D41E60079FC77 /* CompactMap.swift */; };
@@ -949,8 +949,8 @@
 		271A97401CFC996B00D64125 /* UIViewController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+Rx.swift"; sourceTree = "<group>"; };
 		271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIViewController+RxTests.swift"; sourceTree = "<group>"; };
 		4583D8211FE94BB100AA1BB1 /* Recorded+Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Recorded+Event.swift"; sourceTree = "<group>"; };
-		4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+RxTests.swift"; sourceTree = "<group>"; };
-		461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWebView+Rx.swift"; sourceTree = "<group>"; };
+		4613456E1D9A4467001ABAF2 /* WKWebView+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+RxTests.swift"; sourceTree = "<group>"; };
+		461345701D9A4543001ABAF2 /* WKWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+Rx.swift"; sourceTree = "<group>"; };
 		4613457B1D9A4AEE001ABAF2 /* RxWebViewDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxWebViewDelegateProxy.swift; sourceTree = "<group>"; };
 		46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIAlertAction+Rx.swift"; sourceTree = "<group>"; };
 		4C5213A9225D41E60079FC77 /* CompactMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompactMap.swift; sourceTree = "<group>"; };
@@ -1187,7 +1187,7 @@
 		C83508DD1C38706D0027C24C /* ControlEventTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlEventTests.swift; sourceTree = "<group>"; };
 		C83508DE1C38706D0027C24C /* ControlPropertyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlPropertyTests.swift; sourceTree = "<group>"; };
 		C83508DF1C38706D0027C24C /* DelegateProxyTest+Cocoa.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "DelegateProxyTest+Cocoa.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
-		C83508E01C38706D0027C24C /* DelegateProxyTest+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "DelegateProxyTest+UIKit.swift"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		C83508E01C38706D0027C24C /* DelegateProxyTest+UIKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = "DelegateProxyTest+UIKit.swift"; sourceTree = "<group>"; };
 		C83508E11C38706D0027C24C /* DelegateProxyTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelegateProxyTest.swift; sourceTree = "<group>"; };
 		C83508E41C38706D0027C24C /* KVOObservableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KVOObservableTests.swift; sourceTree = "<group>"; };
 		C83508E51C38706D0027C24C /* NSLayoutConstraint+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+RxTests.swift"; sourceTree = "<group>"; };
@@ -1926,7 +1926,7 @@
 				C8F27DB11CE6711600D5FB4F /* UITextView+RxTests.swift */,
 				C83508F11C38706D0027C24C /* UIView+RxTests.swift */,
 				271A97421CFC99FE00D64125 /* UIViewController+RxTests.swift */,
-				4613456E1D9A4467001ABAF2 /* UIWebView+RxTests.swift */,
+				4613456E1D9A4467001ABAF2 /* WKWebView+RxTests.swift */,
 				C8A81CA51E05EAF70008DEF4 /* Binder+Tests.swift */,
 				6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */,
 			);
@@ -2206,7 +2206,7 @@
 				54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */,
 				844BC8B31CE4FD7500F5C7CB /* UIPickerView+Rx.swift */,
 				46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */,
-				461345701D9A4543001ABAF2 /* UIWebView+Rx.swift */,
+				461345701D9A4543001ABAF2 /* WKWebView+Rx.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -2963,7 +2963,7 @@
 				C83E39822189066F001F4F0E /* NSSlider+Rx.swift in Sources */,
 				844BC8B41CE4FD7500F5C7CB /* UIPickerView+Rx.swift in Sources */,
 				C89AB20E1DAAC3350065FBE6 /* Logging.swift in Sources */,
-				461345711D9A4543001ABAF2 /* UIWebView+Rx.swift in Sources */,
+				461345711D9A4543001ABAF2 /* WKWebView+Rx.swift in Sources */,
 				C83E39802189066F001F4F0E /* NSControl+Rx.swift in Sources */,
 				C8093EE31B8A732E0088E94D /* DelegateProxyType.swift in Sources */,
 				C8093EFD1B8A732E0088E94D /* RxTarget.swift in Sources */,
@@ -3191,7 +3191,7 @@
 				C898147E1E75AD380035949C /* PrimitiveSequenceTest+zip+arity.swift in Sources */,
 				C8C4F1631DE9D0A800003FA7 /* UIProgressView+RxTests.swift in Sources */,
 				C8A81CA61E05EAF70008DEF4 /* Binder+Tests.swift in Sources */,
-				4613456F1D9A4467001ABAF2 /* UIWebView+RxTests.swift in Sources */,
+				4613456F1D9A4467001ABAF2 /* WKWebView+RxTests.swift in Sources */,
 				C820A9BA1EB5097700D431BC /* Observable+TakeTests.swift in Sources */,
 				C835094C1C38706E0027C24C /* AssumptionsTest.swift in Sources */,
 				6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */,

--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -220,12 +220,6 @@ extension ObservableType {
             fatalError()
         }
     }
-    extension UIWebView {
-        @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
-        public func createRxDelegateProxy() -> RxWebViewDelegateProxy {
-            fatalError()
-        }
-    }
 #endif
 
 #if os(macOS)

--- a/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
@@ -9,19 +9,25 @@
 #if os(iOS)
 
 import UIKit
+import WebKit
 import RxSwift
 
-extension UIWebView: HasDelegate {
-    public typealias Delegate = UIWebViewDelegate
+extension WKWebView: HasDelegate {
+    public var delegate: WKNavigationDelegate? {
+        get { return navigationDelegate }
+        set { navigationDelegate = newValue }
+    }
+
+    public typealias Delegate = WKNavigationDelegate
 }
 
 open class RxWebViewDelegateProxy
-    : DelegateProxy<UIWebView, UIWebViewDelegate>
+    : DelegateProxy<WKWebView, WKNavigationDelegate>
     , DelegateProxyType 
-    , UIWebViewDelegate {
+    , WKNavigationDelegate {
 
     /// Typed parent object.
-    public weak private(set) var webView: UIWebView?
+    public weak private(set) var webView: WKWebView?
 
     /// - parameter webView: Parent object for delegate proxy.
     public init(webView: ParentObject) {

--- a/RxCocoa/iOS/WKWebView+Rx.swift
+++ b/RxCocoa/iOS/WKWebView+Rx.swift
@@ -1,5 +1,5 @@
 //
-//  UIWebView+Rx.swift
+//  WKWebView+Rx.swift
 //  RxCocoa
 //
 //  Created by Andrew Breckenridge on 8/30/16.
@@ -9,34 +9,35 @@
 #if os(iOS)
 
     import UIKit
+    import WebKit
     import RxSwift
 
-    extension Reactive where Base: UIWebView {
+    extension Reactive where Base: WKWebView {
 
         /// Reactive wrapper for `delegate`.
         /// For more information take a look at `DelegateProxyType` protocol documentation.
-        public var delegate: DelegateProxy<UIWebView, UIWebViewDelegate> {
+        public var delegate: DelegateProxy<WKWebView, WKNavigationDelegate> {
             return RxWebViewDelegateProxy.proxy(for: base)
         }
 
         /// Reactive wrapper for `delegate` message.
         public var didStartLoad: Observable<Void> {
             return delegate
-                .methodInvoked(#selector(UIWebViewDelegate.webViewDidStartLoad(_:)))
+                .methodInvoked(#selector(WKNavigationDelegate.webView(_:didStartProvisionalNavigation:)))
                 .map { _ in }
         }
 
         /// Reactive wrapper for `delegate` message.
         public var didFinishLoad: Observable<Void> {
             return delegate
-                .methodInvoked(#selector(UIWebViewDelegate.webViewDidFinishLoad(_:)))
+                .methodInvoked(#selector(WKNavigationDelegate.webView(_:didFinish:)))
                 .map { _ in }
         }
         
         /// Reactive wrapper for `delegate` message.
         public var didFailLoad: Observable<Error> {
             return delegate
-                .methodInvoked(#selector(UIWebViewDelegate.webView(_:didFailLoadWithError:)))
+                .methodInvoked(#selector(WKNavigationDelegate.webView(_:didFail:withError:)))
                 .map { a in
                     return try castOrThrow(Error.self, a[1])
                 }

--- a/Sources/RxCocoa/UIWebView+Rx.swift
+++ b/Sources/RxCocoa/UIWebView+Rx.swift
@@ -1,1 +1,0 @@
-../../RxCocoa/iOS/UIWebView+Rx.swift

--- a/Sources/RxCocoa/WKWebView+Rx.swift
+++ b/Sources/RxCocoa/WKWebView+Rx.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/iOS/WKWebView+Rx.swift

--- a/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import WebKit
 @testable import RxCocoa
 @testable import RxSwift
 import XCTest
@@ -94,8 +95,8 @@ extension DelegateProxyTest {
 
 #if os(iOS)
 extension DelegateProxyTest {
-    func test_UIWebViewDelegateExtension() {
-        performDelegateTest(UIWebViewSubclass(frame: CGRect.zero)) { ExtendWebViewDelegateProxy(webViewSubclass: $0) }
+    func test_WKWebViewDelegateExtension() {
+        performDelegateTest(WKWebViewSubclass(frame: CGRect.zero)) { ExtendWebViewDelegateProxy(webViewSubclass: $0) }
     }
 }
 #endif
@@ -462,21 +463,21 @@ final class UIPickerViewSubclass2: UIPickerView, TestDelegateControl {
 final class ExtendWebViewDelegateProxy
     : RxWebViewDelegateProxy
     , TestDelegateProtocol {
-    init(webViewSubclass: UIWebViewSubclass) {
+    init(webViewSubclass: WKWebViewSubclass) {
         super.init(webView: webViewSubclass)
     }
 }
 
-final class UIWebViewSubclass: UIWebView, TestDelegateControl {
+final class WKWebViewSubclass: WKWebView, TestDelegateControl {
     func doThatTest(_ value: Int) {
         (delegate as! TestDelegateProtocol).testEventHappened?(value)
     }
 
-    var delegateProxy: DelegateProxy<UIWebView, UIWebViewDelegate> {
+    var delegateProxy: DelegateProxy<WKWebView, WKNavigationDelegate> {
         return self.rx.delegate
     }
 
-    func setMineForwardDelegate(_ testDelegate: UIWebViewDelegate) -> Disposable {
+    func setMineForwardDelegate(_ testDelegate: WKNavigationDelegate) -> Disposable {
         return RxWebViewDelegateProxy.installForwardDelegate(testDelegate,
                                                              retainDelegate: false,
                                                              onProxyForObject: self)

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -9,6 +9,7 @@
 import XCTest
 import RxSwift
 import RxCocoa
+import WebKit
 #if os(iOS)
 import UIKit
 #endif
@@ -767,7 +768,7 @@ extension MockTestDelegateProtocol
 #if os(iOS)
 extension MockTestDelegateProtocol
     : UIPickerViewDelegate
-    , UIWebViewDelegate
+    , WKNavigationDelegate
 {
 }
 #endif

--- a/Tests/RxCocoaTests/WKWebView+RxTests.swift
+++ b/Tests/RxCocoaTests/WKWebView+RxTests.swift
@@ -1,5 +1,5 @@
 //
-//  UIWebView+RxTests.swift
+//  WKWebView+RxTests.swift
 //  Tests
 //
 //  Created by Andrew Breckenridge on 8/30/16.
@@ -9,54 +9,56 @@
 #if os(iOS)
     
 import UIKit
+import WebKit
 import RxSwift
 import RxCocoa
 import RxBlocking
 import XCTest
 
-final class UIWebViewTests: RxTest {}
+final class WKWebViewTests: RxTest {}
 
 fileprivate let testHTMLString = "<html><head></head><body><h1>🔥</h1></body></html>"
     
-extension UIWebViewTests {
+extension WKWebViewTests {
         
     func testDidStartLoad() {
-        let webView = UIWebView()
+        let webView = WKWebView()
         var didStartLoad = false
 
         let subscription = webView.rx.didStartLoad.subscribe(onNext: { _ in
             didStartLoad = true
         })
 
-        webView.delegate!.webViewDidStartLoad!(webView)
+        webView.navigationDelegate!.webView?(webView, didStartProvisionalNavigation: nil)
 
         XCTAssertTrue(didStartLoad)
         subscription.dispose()
     }
     
     func testDidFinishLoad() {
-        let webView = UIWebView()
+        let webView = WKWebView()
         var didFinishLoad = false
 
         let subscription = webView.rx.didFinishLoad.subscribe(onNext: { _ in
             didFinishLoad = true
         })
 
-        webView.delegate!.webViewDidFinishLoad!(webView)
+        webView.navigationDelegate!.webView?(webView, didFinish: nil)
 
         XCTAssertTrue(didFinishLoad)
         subscription.dispose()
     }
 
     func testDidFailLoad() {
-        let webView = UIWebView()
+        let webView = WKWebView()
         var didFailLoad = false
 
         let subscription = webView.rx.didFailLoad.subscribe { _ in
             didFailLoad = true
         }
 
-        webView.delegate!.webView!(webView, didFailLoadWithError: NSError(domain: "", code: 0, userInfo: .none))
+        let error = NSError(domain: "", code: 0, userInfo: .none)
+        webView.navigationDelegate!.webView!(webView, didFail: nil, withError: error)
 
         XCTAssertTrue(didFailLoad)
         subscription.dispose()


### PR DESCRIPTION
`UIWebView` is deprecated and will inevitably be removed at some point in the future. Apple urges developers to adopt `WKWebView` instead. This PR replaces the existing bindings for `UIWebView` with similar bindings for `WKWebView`.

This PR is required in order to support Project Catalyst builds (iOS apps on MacOS), as `UIWebView` is the cause of nasty errors:
```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_UIWebView", referenced from:
      objc-class-ref in RxWebViewDelegateProxy.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```