### PR TITLE
bind(to keypath:on root:) similar to Combine's `assign(to:on:)`

### DIFF
--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -117,6 +117,29 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
     }
+
+    /**
+     Drive emitted elements to the referenced key path of a specific `Root` object.
+
+     This allows writing code as follows:
+
+     ```
+     driver.drive(\UITextField.text, on: myTextField)
+     ```
+
+     - parameter keyPath: The key path of the property to assign.
+     - parameter object: The object on which to assign the value.
+     - returns: Subscription object used to unsubscribe from the observable sequence.
+     - note: If a weak reference to the Root object cannot be retained, elements will
+     not be bound, and will simply be ignored.
+     */
+    public func drive<Root: AnyObject>(_ keyPath: ReferenceWritableKeyPath<Root, Element>,
+                                       on object: Root) -> Disposable {
+        return drive(onNext: { [weak object] element in
+            guard let object = object else { return }
+            object[keyPath: keyPath] = element
+        })
+    }
 }
 
 

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -95,6 +95,29 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     public func emit(onNext: ((Element) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil) -> Disposable {
         return self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
     }
+
+    /**
+     Emit elements to the referenced key path of a specific `Root` object.
+
+     This allows writing code as follows:
+
+     ```
+     signal.emit(to: \UITextField.text, on: myTextField)
+     ```
+
+     - parameter keyPath: The key path of the property to assign.
+     - parameter object: The object on which to assign the value.
+     - returns: Subscription object used to unsubscribe from the observable sequence.
+     - note: If a weak reference to the Root object cannot be retained, elements will
+     not be bound, and will simply be ignored.
+     */
+    public func emit<Root: AnyObject>(to keyPath: ReferenceWritableKeyPath<Root, Element>,
+                                      on object: Root) -> Disposable {
+        return emit(onNext: { [weak object] element in
+            guard let object = object else { return }
+            object[keyPath: keyPath] = element
+        })
+    }
 }
 
 

--- a/Sources/AllTestz/Observable+BindTests.swift
+++ b/Sources/AllTestz/Observable+BindTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxCocoaTests/Observable+BindTests.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -248,6 +248,8 @@ final class DriverTest_ : DriverTest, RxTestCase {
     ("testDriveBehaviorRelay1", DriverTest.testDriveBehaviorRelay1),
     ("testDriveBehaviorRelay2", DriverTest.testDriveBehaviorRelay2),
     ("testDriveBehaviorRelay3", DriverTest.testDriveBehaviorRelay3),
+    ("testDriveKeyPath", DriverTest.testDriveKeyPath),
+    ("testDriveKeyPathObjectGone", DriverTest.testDriveKeyPathObjectGone),
     ] }
 }
 
@@ -393,6 +395,26 @@ final class ObservableAmbTest_ : ObservableAmbTest, RxTestCase {
     ("testAmb_LoserThrows", ObservableAmbTest.testAmb_LoserThrows),
     ("testAmb_ThrowsBeforeElectionLeft", ObservableAmbTest.testAmb_ThrowsBeforeElectionLeft),
     ("testAmb_ThrowsBeforeElectionRight", ObservableAmbTest.testAmb_ThrowsBeforeElectionRight),
+    ] }
+}
+
+final class ObservableBindTest_ : ObservableBindTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableBindTest_) -> () -> Void)] { return [
+    ("testBindToObserver", ObservableBindTest.testBindToObserver),
+    ("testBindToObservers", ObservableBindTest.testBindToObservers),
+    ("testBindToOptionalObserver", ObservableBindTest.testBindToOptionalObserver),
+    ("testBindToOptionalObservers", ObservableBindTest.testBindToOptionalObservers),
+    ("testBindToOptionalObserverNoAmbiguity", ObservableBindTest.testBindToOptionalObserverNoAmbiguity),
+    ("testBindToCurried1", ObservableBindTest.testBindToCurried1),
+    ("testBindToCurried2", ObservableBindTest.testBindToCurried2),
+    ("testBindToKeyPath", ObservableBindTest.testBindToKeyPath),
+    ("testBindToKeyPathObjectGone", ObservableBindTest.testBindToKeyPathObjectGone),
     ] }
 }
 
@@ -1938,6 +1960,8 @@ final class SignalTests_ : SignalTests, RxTestCase {
     ("testSignalOptionalRelay1", SignalTests.testSignalOptionalRelay1),
     ("testSignalOptionalRelay2", SignalTests.testSignalOptionalRelay2),
     ("testDriveRelayNoAmbiguity", SignalTests.testDriveRelayNoAmbiguity),
+    ("testEmitToKeyPath", SignalTests.testEmitToKeyPath),
+    ("testEmitToKeyPathObjectGone", SignalTests.testEmitToKeyPathObjectGone),
     ] }
 }
 
@@ -2072,6 +2096,7 @@ func XCTMain(_ tests: [() -> Void]) {
         testCase(MaybeTest_.allTests),
         testCase(NSNotificationCenterTests_.allTests),
         testCase(ObservableAmbTest_.allTests),
+        testCase(ObservableBindTest_.allTests),
         testCase(ObservableBlockingTest_.allTests),
         testCase(ObservableBufferTest_.allTests),
         testCase(ObservableCatchTest_.allTests),

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -424,10 +424,6 @@ extension DriverTest {
 
 // MARK: drive key path
 extension DriverTest {
-    class FakeClass {
-        var property = ""
-    }
-
     func testDriveKeyPath() {
         let relay = BehaviorRelay<String>(value: "")
         let driver = relay.asDriver()
@@ -463,4 +459,8 @@ extension DriverTest {
 
         d.dispose()
     }
+}
+
+private class FakeClass {
+    var property = ""
 }

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -421,3 +421,46 @@ extension DriverTest {
         subscription.dispose()
     }
 }
+
+// MARK: drive key path
+extension DriverTest {
+    class FakeClass {
+        var property = ""
+    }
+
+    func testDriveKeyPath() {
+        let relay = BehaviorRelay<String>(value: "")
+        let driver = relay.asDriver()
+        let fake = FakeClass()
+
+        XCTAssertEqual(fake.property, "")
+        let d = driver.drive(\FakeClass.property, on: fake)
+
+        relay.accept("String 1")
+        XCTAssertEqual(fake.property, "String 1")
+
+        relay.accept("String 2")
+        XCTAssertEqual(fake.property, "String 2")
+
+        d.dispose()
+    }
+
+    func testDriveKeyPathObjectGone() {
+        let relay = BehaviorRelay<String>(value: "")
+        let driver = relay.asDriver()
+        var fake: FakeClass! = FakeClass()
+
+        XCTAssertEqual(fake?.property, "")
+        let d = driver.drive(\FakeClass.property, on: fake)
+
+        relay.accept("String 1")
+        XCTAssertEqual(fake?.property, "String 1")
+
+        fake = nil
+
+        relay.accept("String 2")
+        XCTAssertEqual(fake?.property, nil)
+
+        d.dispose()
+    }
+}

--- a/Tests/RxCocoaTests/Observable+BindTests.swift
+++ b/Tests/RxCocoaTests/Observable+BindTests.swift
@@ -153,3 +153,45 @@ extension ObservableBindTest {
         d.dispose()
     }
 }
+
+// MARK: bind(to:) keypath
+
+extension ObservableBindTest {
+    class FakeClass {
+        var property = ""
+    }
+
+    func testBindToKeyPath() {
+        let subject = PublishSubject<String>()
+        let fake = FakeClass()
+
+        XCTAssertEqual(fake.property, "")
+        let d = subject.bind(to: \FakeClass.property, on: fake)
+
+        subject.onNext("String 1")
+        XCTAssertEqual(fake.property, "String 1")
+
+        subject.onNext("String 2")
+        XCTAssertEqual(fake.property, "String 2")
+
+        d.dispose()
+    }
+
+    func testBindToKeyPathObjectGone() {
+        let subject = PublishSubject<String>()
+        var fake: FakeClass! = FakeClass()
+
+        XCTAssertEqual(fake.property, "")
+        let d = subject.bind(to: \FakeClass.property, on: fake)
+
+        subject.onNext("String 1")
+        XCTAssertEqual(fake?.property, "String 1")
+
+        fake = nil
+
+        subject.onNext("String 2")
+        XCTAssertNil(fake?.property)
+
+        d.dispose()
+    }
+}

--- a/Tests/RxCocoaTests/Observable+BindTests.swift
+++ b/Tests/RxCocoaTests/Observable+BindTests.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxTest
 import XCTest
 
-final class ObservableBindTest: RxTest {
+class ObservableBindTest: RxTest {
 
 }
 
@@ -157,10 +157,6 @@ extension ObservableBindTest {
 // MARK: bind(to:) keypath
 
 extension ObservableBindTest {
-    class FakeClass {
-        var property = ""
-    }
-
     func testBindToKeyPath() {
         let subject = PublishSubject<String>()
         let fake = FakeClass()
@@ -194,4 +190,8 @@ extension ObservableBindTest {
 
         d.dispose()
     }
+}
+
+private class FakeClass {
+    var property = ""
 }

--- a/Tests/RxCocoaTests/Signal+Test.swift
+++ b/Tests/RxCocoaTests/Signal+Test.swift
@@ -381,3 +381,46 @@ extension SignalTests {
         XCTAssertEqual(latest, 1)
     }
 }
+
+// MARK: Emit to key path
+extension SignalTests {
+    class FakeClass {
+        var property = ""
+    }
+
+    func testEmitToKeyPath() {
+        let relay = PublishRelay<String>()
+        let signal = relay.asSignal()
+        let fake = FakeClass()
+
+        XCTAssertEqual(fake.property, "")
+        let d = signal.emit(to: \FakeClass.property, on: fake)
+
+        relay.accept("String 1")
+        XCTAssertEqual(fake.property, "String 1")
+
+        relay.accept("String 2")
+        XCTAssertEqual(fake.property, "String 2")
+
+        d.dispose()
+    }
+
+    func testEmitToKeyPathObjectGone() {
+        let relay = PublishRelay<String>()
+        let signal = relay.asSignal()
+        var fake: FakeClass! = FakeClass()
+
+        XCTAssertEqual(fake?.property, "")
+        let d = signal.emit(to: \FakeClass.property, on: fake)
+
+        relay.accept("String 1")
+        XCTAssertEqual(fake?.property, "String 1")
+
+        fake = nil
+
+        relay.accept("String 2")
+        XCTAssertEqual(fake?.property, nil)
+
+        d.dispose()
+    }
+}

--- a/Tests/RxCocoaTests/Signal+Test.swift
+++ b/Tests/RxCocoaTests/Signal+Test.swift
@@ -384,10 +384,6 @@ extension SignalTests {
 
 // MARK: Emit to key path
 extension SignalTests {
-    class FakeClass {
-        var property = ""
-    }
-
     func testEmitToKeyPath() {
         let relay = PublishRelay<String>()
         let signal = relay.asSignal()
@@ -423,4 +419,8 @@ extension SignalTests {
 
         d.dispose()
     }
+}
+
+private class FakeClass {
+    var property = ""
 }

--- a/scripts/package-spm.swift
+++ b/scripts/package-spm.swift
@@ -305,6 +305,7 @@ try packageRelativePath([
         "Tests/TestErrors.swift",
         "Tests/XCTest+AllTests.swift",
         "Platform",
+        "Tests/RxCocoaTests/Observable+BindTests.swift",
         "Tests/RxCocoaTests/Driver+Test.swift",
         "Tests/RxCocoaTests/Signal+Test.swift",
         "Tests/RxCocoaTests/SharedSequence+Extensions.swift",


### PR DESCRIPTION
I wanted to add this operator to mirror [Combine's `assign(to:on:)`](https://developer.apple.com/documentation/combine/currentvaluesubject/3235789-assign) operator.
It's a great addition because it makes `Binder`(s) not as needed for every property you want to bind/drive/emit to. 

It means that instead of having to create a custom Binder for your UI Object, you could just do 

```swift
stream
 .bind(to: \MyObject.property, on: myObjectInstance)
```

Which is much more flexible. 
Any thoughts are extremely welcomed :) 