### PR TITLE
Add breakpoint operator

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -194,6 +194,7 @@ custom_categories:
   - Amb
   - AsMaybe
   - AsSingle
+  - Breakpoint
   - Buffer
   - Catch
   - CombineLatest+Collection

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA56F202A206B002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA570202A206C002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		78436A1D22AD09EC00AE76CC /* Breakpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78436A1C22AD09EC00AE76CC /* Breakpoint.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEC31C89BCB9006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
@@ -962,6 +963,7 @@
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
+		78436A1C22AD09EC00AE76CC /* Breakpoint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Breakpoint.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -1643,6 +1645,7 @@
 				C820A8061EB4DA5900D431BC /* Amb.swift */,
 				C820A8211EB4DA5900D431BC /* AsMaybe.swift */,
 				C820A8221EB4DA5900D431BC /* AsSingle.swift */,
+				78436A1C22AD09EC00AE76CC /* Breakpoint.swift */,
 				C820A7EB1EB4DA5900D431BC /* Buffer.swift */,
 				C820A8011EB4DA5900D431BC /* Catch.swift */,
 				C820A8241EB4DA5900D431BC /* CombineLatest.swift */,
@@ -3689,6 +3692,7 @@
 				C820A8E41EB4DA5A00D431BC /* Error.swift in Sources */,
 				C8093CD71B8A72BE0088E94D /* BinaryDisposable.swift in Sources */,
 				C8FA89141C30405400CD3A17 /* VirtualTimeConverterType.swift in Sources */,
+				78436A1D22AD09EC00AE76CC /* Breakpoint.swift in Sources */,
 				C820A8B01EB4DA5A00D431BC /* SkipUntil.swift in Sources */,
 				C820A8F41EB4DA5A00D431BC /* Create.swift in Sources */,
 				C820A8901EB4DA5A00D431BC /* Scan.swift in Sources */,

--- a/RxSwift/Observables/Breakpoint.swift
+++ b/RxSwift/Observables/Breakpoint.swift
@@ -1,0 +1,175 @@
+//
+//  Breakpoint.swift
+//  RxSwift
+//
+//  Created by Anton Nazarov on 09/06/19.
+//  Copyright © 2017 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+extension ObservableType {
+    /**
+     Raises a debugger signal when a provided closure needs to stop the process in the debugger.
+     - seealso: [breakpoint operator on Combine](https://developer.apple.com/documentation/combine/publisher/3204688-breakpoint)
+
+     - parameter onNext: Predicate to invoke for each element in the observable sequence.  Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - parameter afterNext: Predicate to invoke for each element after the observable has passed an onNext event along to its downstream. Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - parameter onError: Predicate to invoke upon errored termination of the observable sequence. Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - parameter afterError: Predicate to invoke after errored termination of the observable sequence. Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - parameter onCompleted: Predicate to invoke upon graceful termination of the observable sequence. Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - parameter afterCompleted: Predicate to invoke after graceful termination of the observable sequence. Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - parameter onSubscribe: Predicate to invoke before subscribing to source observable sequence. Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - parameter onSubscribed: Predicate to invoke after subscribing to source observable sequence. Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - parameter onDispose: Predicate to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed. Return `true` from this closure to raise `SIGTRAP`, or false to continue.
+     - returns: The source sequence that raises a debugger signal when one of the provided closures returns `true`.
+     */
+    public func breakpoint(
+        onNext: @escaping (Element) throws -> Bool = { _ in false },
+        afterNext: @escaping (Element) throws -> Bool = { _ in false },
+        onError: @escaping (Swift.Error) throws -> Bool = { _ in false },
+        afterError: @escaping (Swift.Error) throws -> Bool = { _ in false },
+        onCompleted: @escaping @autoclosure () throws -> Bool = false,
+        afterCompleted: @escaping @autoclosure () throws -> Bool = false,
+        onSubscribe: @escaping @autoclosure () -> Bool = false,
+        onSubscribed: @escaping @autoclosure () -> Bool = false,
+        onDispose: @escaping @autoclosure () -> Bool = false
+    ) -> Observable<Element> {
+        return Breakpoint(
+            source: self.asObservable(),
+            eventPredicate: {
+                switch $0 {
+                case let .next(element):
+                    return try onNext(element)
+                case let .error(error):
+                    return try onError(error)
+                case .completed:
+                    return try onCompleted()
+                }
+            },
+            afterEventPredicate:  {
+                switch $0 {
+                case let .next(element):
+                    return try afterNext(element)
+                case let .error(error):
+                    return try afterError(error)
+                case .completed:
+                    return try afterCompleted()
+                }
+            },
+            onSubscribe: onSubscribe(),
+            onSubscribed: onSubscribed(),
+            onDispose: onDispose()
+        )
+    }
+
+    /**
+      Raises a debugger signal upon receiving an error.
+      When the upstream Observable fails with an error, this operator raises the `SIGTRAP` signal, which stops the process in the debugger.
+      Otherwise, this Observable passes through values and completions as-is.
+      - seealso: [breakpointOnError operator on Combine](https://developer.apple.com/documentation/combine/publisher/3204689-breakpointonerror)
+      - returns: An Observable that raises a debugger signal upon receiving a failure.
+      */
+    public func breakpointOnError() -> Observable<Element> {
+        return Breakpoint(
+            source: self.asObservable(),
+            eventPredicate: { $0.error != nil },
+            afterEventPredicate: { _ in false }
+        )
+    }
+}
+
+#if DEBUG
+private func raiseBreakpoint() {
+    raise(SIGTRAP)
+}
+#endif
+
+final private class BreakpointSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
+    typealias Element = Observer.Element
+    typealias EventPredicate = (Event<Element>) throws -> Bool
+    typealias AfterEventPredicate = (Event<Element>) throws -> Bool
+
+    private let _eventPredicate: EventPredicate
+    private let _afterEventPredicate: AfterEventPredicate
+
+    init(eventPredicate: @escaping EventPredicate, afterEventPredicate: @escaping AfterEventPredicate, observer: Observer, cancel: Cancelable) {
+        self._eventPredicate = eventPredicate
+        self._afterEventPredicate = afterEventPredicate
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ event: Event<Element>) {
+        do {
+            #if DEBUG
+            if try self._eventPredicate(event) {
+                raiseBreakpoint()
+            }
+            #endif
+            self.forwardOn(event)
+            #if DEBUG
+            if try self._afterEventPredicate(event) {
+                raiseBreakpoint()
+            }
+            #endif
+            if event.isStopEvent {
+                self.dispose()
+            }
+        }
+        catch let error {
+            self.forwardOn(.error(error))
+            self.dispose()
+        }
+    }
+}
+
+final private class Breakpoint<Element>: Producer<Element> {
+    typealias EventPredicate = (Event<Element>) throws -> Bool
+    typealias AfterEventPredicate = (Event<Element>) throws -> Bool
+
+    fileprivate let _source: Observable<Element>
+    fileprivate let _eventPredicate: EventPredicate
+    fileprivate let _afterEventPredicate: EventPredicate
+    fileprivate let _onSubscribe: () -> Bool
+    fileprivate let _onSubscribed: () -> Bool
+    fileprivate let _onDispose: () -> Bool
+
+    init(
+        source: Observable<Element>,
+        eventPredicate: @escaping EventPredicate,
+        afterEventPredicate: @escaping AfterEventPredicate,
+        onSubscribe: @escaping @autoclosure () -> Bool = false,
+        onSubscribed: @escaping @autoclosure () -> Bool = false,
+        onDispose: @escaping @autoclosure () -> Bool = false
+    ) {
+        self._source = source
+        self._eventPredicate = eventPredicate
+        self._afterEventPredicate = afterEventPredicate
+        self._onSubscribe = onSubscribe
+        self._onSubscribed = onSubscribed
+        self._onDispose = onDispose
+    }
+
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Element == Observer.Element {
+        #if DEBUG
+        if _onSubscribe() {
+            raiseBreakpoint()
+        }
+        #endif
+        let sink = BreakpointSink(eventPredicate: self._eventPredicate, afterEventPredicate: self._afterEventPredicate, observer: observer, cancel: cancel)
+        let subscription = self._source.subscribe(sink)
+        #if DEBUG
+        if _onSubscribed() {
+            raiseBreakpoint()
+        }
+        #endif
+        let allSubscriptions = Disposables.create {
+            subscription.dispose()
+            #if DEBUG
+            guard self._onDispose() else { return }
+            raiseBreakpoint()
+            #endif
+        }
+        return (sink: sink, subscription: allSubscriptions)
+    }
+}

--- a/Sources/RxSwift/Breakpoint.swift
+++ b/Sources/RxSwift/Breakpoint.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/Breakpoint.swift


### PR DESCRIPTION
Combine framework introduced breakpoint operator https://developer.apple.com/documentation/combine/publisher/3204689-breakpointonerror
I think it might be quite useful for debugging. It will also help to satisfy requirements of users, who want to try reactive programming not only with iOS 13+

I am not sure about tests and playground examples (it's not possible). What do u think?