### PR TITLE
Add AllSatisfy operator

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -191,6 +191,7 @@ custom_categories:
 - name: RxSwift/Observables
   children:
   - AddRef
+  - AllSatisfy
   - Amb
   - AsMaybe
   - AsSingle

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -50,6 +50,10 @@
 		6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA56F202A206B002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA570202A206C002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		78677C6222B3B6440001667F /* Observable+AllSatisfyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78677C6122B3B6440001667F /* Observable+AllSatisfyTests.swift */; };
+		78677C6322B3B6440001667F /* Observable+AllSatisfyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78677C6122B3B6440001667F /* Observable+AllSatisfyTests.swift */; };
+		78677C6422B3B6440001667F /* Observable+AllSatisfyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78677C6122B3B6440001667F /* Observable+AllSatisfyTests.swift */; };
+		78A3BFAD22B3AAEA002E86C3 /* AllSatisfy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78A3BFAC22B3AAEA002E86C3 /* AllSatisfy.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEC31C89BCB9006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
@@ -962,6 +966,8 @@
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
+		78677C6122B3B6440001667F /* Observable+AllSatisfyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Observable+AllSatisfyTests.swift"; sourceTree = "<group>"; };
+		78A3BFAC22B3AAEA002E86C3 /* AllSatisfy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllSatisfy.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -1643,6 +1649,7 @@
 				C820A8061EB4DA5900D431BC /* Amb.swift */,
 				C820A8211EB4DA5900D431BC /* AsMaybe.swift */,
 				C820A8221EB4DA5900D431BC /* AsSingle.swift */,
+				78A3BFAC22B3AAEA002E86C3 /* AllSatisfy.swift */,
 				C820A7EB1EB4DA5900D431BC /* Buffer.swift */,
 				C820A8011EB4DA5900D431BC /* Catch.swift */,
 				C820A8241EB4DA5900D431BC /* CombineLatest.swift */,
@@ -1955,6 +1962,7 @@
 				C83509091C38706D0027C24C /* MainSchedulerTests.swift */,
 				C801DE391F6EAD48008DB060 /* MaybeTest.swift */,
 				C820A9491EB4E75E00D431BC /* Observable+AmbTests.swift */,
+				78677C6122B3B6440001667F /* Observable+AllSatisfyTests.swift */,
 				C820AA051EB5139C00D431BC /* Observable+BufferTests.swift */,
 				C820A9891EB4FBD600D431BC /* Observable+CatchTests.swift */,
 				C896A68A1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift */,
@@ -3139,6 +3147,7 @@
 				C835093A1C38706E0027C24C /* RuntimeStateSnapshot.swift in Sources */,
 				C8561B661DFE1169005E97F1 /* ExampleTests.swift in Sources */,
 				C86B1E221D42BF5200130546 /* SchedulerTests.swift in Sources */,
+				78677C6222B3B6440001667F /* Observable+AllSatisfyTests.swift in Sources */,
 				C820A9D61EB50C5C00D431BC /* Observable+DistinctUntilChangedTests.swift in Sources */,
 				C820A9FE1EB5110E00D431BC /* Observable+DematerializeTests.swift in Sources */,
 				C8C4F1711DE9D68000003FA7 /* UIStepper+RxTests.swift in Sources */,
@@ -3323,6 +3332,7 @@
 				C820A9D31EB50B0900D431BC /* Observable+GroupByTests.swift in Sources */,
 				C820AA131EB5145200D431BC /* Observable+DelayTests.swift in Sources */,
 				C820AA0B1EB513C800D431BC /* Observable+WindowTests.swift in Sources */,
+				78677C6322B3B6440001667F /* Observable+AllSatisfyTests.swift in Sources */,
 				1AF67DA31CED427D00C310FA /* PublishSubjectTest.swift in Sources */,
 				C820A9EF1EB50EA100D431BC /* Observable+ScanTests.swift in Sources */,
 				C8353CDD1DA19BA000BE3F5C /* MessageProcessingStage.swift in Sources */,
@@ -3517,6 +3527,7 @@
 				C820A9EC1EB50E3400D431BC /* Observable+RetryWhenTests.swift in Sources */,
 				C8323A901E33FD5200CC0C7F /* Resources.swift in Sources */,
 				C820A98C1EB4FBD600D431BC /* Observable+CatchTests.swift in Sources */,
+				78677C6422B3B6440001667F /* Observable+AllSatisfyTests.swift in Sources */,
 				C820A9AC1EB505A800D431BC /* Observable+WithLatestFromTests.swift in Sources */,
 				C8350A061C38755E0027C24C /* HistoricalSchedulerTest.swift in Sources */,
 				6B9CA570202A206C002C2D11 /* KeyPathBinder+RxTests.swift in Sources */,
@@ -3630,6 +3641,7 @@
 				25F6ECBC1F48C366008552FA /* Maybe.swift in Sources */,
 				C83D73BC1C1DBAEE003DC470 /* InvocableScheduledItem.swift in Sources */,
 				C8093CE51B8A72BE0088E94D /* NopDisposable.swift in Sources */,
+				78A3BFAD22B3AAEA002E86C3 /* AllSatisfy.swift in Sources */,
 				C86781741DB8129E00B2029A /* InfiniteSequence.swift in Sources */,
 				C8093CD31B8A72BE0088E94D /* Disposable.swift in Sources */,
 				C801DE451F6EBB32008DB060 /* ObservableType+PrimitiveSequence.swift in Sources */,

--- a/RxSwift/Observables/AllSatisfy.swift
+++ b/RxSwift/Observables/AllSatisfy.swift
@@ -1,0 +1,79 @@
+//
+//  AllSatisfy.swift
+//  RxSwift
+//
+//  Created by Anton Nazarov on 14/06/2019.
+//  Copyright © 2019 Krunoslav Zaher. All rights reserved.
+//
+
+
+extension ObservableType {
+
+    /**
+    Converts an Observable into a Single that indicates whether all received elements pass a given predicate. If the predicate returns `false`, the Single emits a `false` value and completes. If the upstream Observable finishes normally, this Single emits a `true` value and completes.
+
+     - seealso: [allSatify operator on Swift.Sequence](https://developer.apple.com/documentation/swift/sequence/2996794-allsatisfy)
+
+     - parameter predicate: A closure that evaluates each received element. Return `true` to continue, or `false` to complete.
+     - returns: A Single that emits a Boolean value that indicates whether all received elements pass a given predicate
+     */
+    public func allSatisfy(_ predicate: @escaping (Element) throws -> Bool)
+        -> Single<Bool> {
+            return PrimitiveSequence(raw: AllSatisfy(source: self.asObservable(), predicate: predicate))
+    }
+}
+
+
+final private class AllSatisfySink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == Bool {
+    typealias Predicate = (SourceType) throws -> Bool
+    typealias Element = SourceType
+
+    private let _predicate: Predicate
+
+    init(predicate: @escaping Predicate, observer: Observer, cancel: Cancelable) {
+        self._predicate = predicate
+        super.init(observer: observer, cancel: cancel)
+    }
+
+    func on(_ event: Event<Element>) {
+        switch event {
+        case let .next(value):
+            do {
+                let satisfies = try self._predicate(value)
+                guard !satisfies else { return }
+                self.forwardOn(.next(false))
+                self.forwardOn(.completed)
+                self.dispose()
+            }
+            catch let e {
+                self.forwardOn(.error(e))
+                self.dispose()
+            }
+        case .completed:
+            self.forwardOn(.next(true))
+            self.forwardOn(.completed)
+            self.dispose()
+        case let .error(error):
+            self.forwardOn(.error(error))
+            self.dispose()
+        }
+    }
+}
+
+final private class AllSatisfy<Element>: Producer<Bool> {
+    typealias Predicate = (Element) throws -> Bool
+
+    private let _source: Observable<Element>
+    private let _predicate: Predicate
+
+    init(source: Observable<Element>, predicate: @escaping Predicate) {
+        self._source = source
+        self._predicate = predicate
+    }
+
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Bool {
+        let sink = AllSatisfySink(predicate: self._predicate, observer: observer, cancel: cancel)
+        let subscription = self._source.subscribe(sink)
+        return (sink: sink, subscription: subscription)
+    }
+}

--- a/Sources/AllTestz/Observable+AllSatisfyTests.swift
+++ b/Sources/AllTestz/Observable+AllSatisfyTests.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Observable+AllSatisfyTests.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -375,6 +375,20 @@ final class NSNotificationCenterTests_ : NSNotificationCenterTests, RxTestCase {
     ] }
 }
 
+final class ObservableAllSatisfyTests_ : ObservableAllSatisfyTests, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (ObservableAllSatisfyTests_) -> () -> Void)] { return [
+    ("testAllSatisfySuccessTrue", ObservableAllSatisfyTests.testAllSatisfySuccessTrue),
+    ("testAllSatisfySuccessFalse", ObservableAllSatisfyTests.testAllSatisfySuccessFalse),
+    ("testAllSatisfyFailure", ObservableAllSatisfyTests.testAllSatisfyFailure),
+    ] }
+}
+
 final class ObservableAmbTest_ : ObservableAmbTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -2065,6 +2079,7 @@ func XCTMain(_ tests: [() -> Void]) {
         testCase(MainSchedulerTest_.allTests),
         testCase(MaybeTest_.allTests),
         testCase(NSNotificationCenterTests_.allTests),
+        testCase(ObservableAllSatisfyTests_.allTests),
         testCase(ObservableAmbTest_.allTests),
         testCase(ObservableBlockingTest_.allTests),
         testCase(ObservableBufferTest_.allTests),

--- a/Sources/RxSwift/AllSatisfy.swift
+++ b/Sources/RxSwift/AllSatisfy.swift
@@ -1,0 +1,1 @@
+../../RxSwift/Observables/AllSatisfy.swift

--- a/Tests/RxSwiftTests/Observable+AllSatisfyTests.swift
+++ b/Tests/RxSwiftTests/Observable+AllSatisfyTests.swift
@@ -1,0 +1,146 @@
+//
+//  Observable+AllSatisfyTests.swift
+//  Rx
+//
+//  Created by Anton Nazarov on 14/06/2019.
+//  Copyright © 2019 Krunoslav Zaher. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+class ObservableAllSatisfyTests: RxTest {
+    private var scheduler: TestScheduler!
+
+    override func setUp() {
+        super.setUp()
+        scheduler = TestScheduler(initialClock: 0)
+    }
+
+    override func tearDown() {
+        scheduler = nil
+        super.tearDown()
+    }
+}
+
+extension ObservableAllSatisfyTests {
+    func testAllSatisfySuccessTrue() {
+        // Given
+        let scheduler = TestScheduler(initialClock: 0)
+        let notEmittedEventsCount = 2
+        let expectedCompletionTime = 600
+        var invoked = 0
+        let expectedNextEvents = Recorded.events([
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11)
+        ])
+        let source = scheduler.createHotObservable(expectedNextEvents + [.completed(expectedCompletionTime)])
+        // When
+        let res = scheduler.start {
+            source.allSatisfy {
+                invoked += 1
+                return $0 < 20
+            }
+            .asObservable()
+        }
+        // Expect
+        XCTAssertEqual(res.events, [.next(expectedCompletionTime, true), .completed(expectedCompletionTime)])
+        XCTAssertEqual(source.subscriptions, [Subscription(Defaults.subscribed, expectedCompletionTime)])
+        XCTAssertEqual(invoked, expectedNextEvents.count - notEmittedEventsCount)
+    }
+
+    func testAllSatisfySuccessFalse() {
+        // Given
+        let scheduler = TestScheduler(initialClock: 0)
+        let expectedCompletionTime = 230
+        var invoked = 0
+        let source = scheduler.createHotObservable([
+            .next(110, 1),
+            .next(180, 2),
+            .next(expectedCompletionTime, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7),
+            .next(450, 8),
+            .next(470, 9),
+            .next(560, 10),
+            .next(580, 11),
+            .completed(600)
+        ])
+        // When
+        let res = scheduler.start {
+            source.allSatisfy {
+                invoked += 1
+                return $0 > 20
+            }
+            .asObservable()
+        }
+        // Expect
+        XCTAssertEqual(res.events, [.next(expectedCompletionTime, false), .completed(expectedCompletionTime)])
+        XCTAssertEqual(source.subscriptions, [Subscription(Defaults.subscribed, expectedCompletionTime)])
+        XCTAssertEqual(invoked, 1)
+    }
+
+    func testAllSatisfyFailure() {
+        // Given
+        let scheduler = TestScheduler(initialClock: 0)
+        let expectedErrorTime = 400
+        let notEmittedEventsCount = 2
+        var invoked = 0
+        let expectedNextEvents = Recorded.events([
+            .next(110, 1),
+            .next(180, 2),
+            .next(230, 3),
+            .next(270, 4),
+            .next(340, 5),
+            .next(380, 6),
+            .next(390, 7)
+        ])
+        let source = scheduler.createHotObservable(
+            expectedNextEvents + [
+                .error(expectedErrorTime, testError),
+                .next(470, 9),
+                .next(560, 10),
+                .next(580, 11),
+                .completed(600)
+            ]
+        )
+        // When
+        let res = scheduler.start {
+            source.allSatisfy {
+                invoked += 1
+                return $0 < 20
+            }
+            .asObservable()
+        }
+        // Expect
+        XCTAssertEqual(res.events, [.error(expectedErrorTime, testError)])
+        XCTAssertEqual(source.subscriptions, [Subscription(Defaults.subscribed, expectedErrorTime)])
+        XCTAssertEqual(invoked, expectedNextEvents.count - notEmittedEventsCount)
+    }
+
+    #if TRACE_RESOURCES
+    func testAllSatisfyReleasesResourcesOnSuccessTrue() {
+        _ = Observable.just(1).allSatisfy { _ in true }.subscribe()
+    }
+
+    func testAllSatisfyReleasesResourcesOnSuccessFalse() {
+        _ = Observable.just(1).allSatisfy { _ in false }.subscribe()
+    }
+
+    func testAllSatisfyReleasesResourcesOnFailure() {
+        _ = Observable.error(testError).allSatisfy { $0 > 0 }.subscribe()
+    }
+    #endif
+}

--- a/Tests/RxSwiftTests/Observable+AllSatisfyTests.swift
+++ b/Tests/RxSwiftTests/Observable+AllSatisfyTests.swift
@@ -1,6 +1,6 @@
 //
 //  Observable+AllSatisfyTests.swift
-//  Rx
+//  Tests
 //
 //  Created by Anton Nazarov on 14/06/2019.
 //  Copyright © 2019 Krunoslav Zaher. All rights reserved.


### PR DESCRIPTION
No words about Combine. 
`allSatisfy` is a Swift.Sequence member. It might be useful for dealing with sequences.
https://developer.apple.com/documentation/swift/sequence/2996794-allsatisfy

If you find it useful, I will also add it for `SharedSequence`
https://github.com/ReactiveX/RxSwift/issues/2007
