### PR TITLE
Support project Catalyst

### DIFF
--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -220,6 +220,9 @@ extension ObservableType {
             fatalError()
         }
     }
+#endif
+
+#if os(iOS) && !targetEnvironment(UIKitForMac)
     extension UIWebView {
         @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
         public func createRxDelegateProxy() -> RxWebViewDelegateProxy {

--- a/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(UIKitForMac)
 
 import UIKit
 import RxSwift

--- a/RxCocoa/iOS/UIWebView+Rx.swift
+++ b/RxCocoa/iOS/UIWebView+Rx.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-#if os(iOS)
+#if os(iOS) && !targetEnvironment(UIKitForMac)
 
     import UIKit
     import RxSwift

--- a/scripts/validate-podspec.sh
+++ b/scripts/validate-podspec.sh
@@ -48,7 +48,11 @@ popd
 function validate() {
     local PODSPEC=$1
 
-    pod lib lint $PODSPEC --verbose --no-clean "${SWIFT_VERSION}"
+    validate=(pod lib lint $PODSPEC --verbose --no-clean ${arg} "${SWIFT_VERSION}")
+    if [ $TARGET = "RxCocoa" ]; then
+      validate+=(--allow-warnings)
+    fi
+    echo "${validate[@]}"
 }
 
 for TARGET_ITERATOR in ${TARGETS[@]}


### PR DESCRIPTION
Using RxSwift in an iOS app compiled for Mac currently yields nasty errors because `UIWebView` is deprecated and not supported in UIKit for Mac:
```
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_UIWebView", referenced from:
      objc-class-ref in RxWebViewDelegateProxy.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

The official documentation states `#if !targetEnvironment(UIKitForMac)` is the best way of dealing with these issues ([source](https://developer.apple.com/documentation/uikit/creating_a_mac_version_of_your_ipad_app)).

This PR adds some extra conditions to support compiling with project Catalyst.