### PR TITLE
Fix EXPANDABLE_SHARED_SEQUENCE Method

### DIFF
--- a/RxCocoa/Traits/SharedSequence/SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence.swift
@@ -37,8 +37,8 @@ public struct SharedSequence<SharingStrategy: SharingStrategyProtocol, Element> 
      By defining `EXPANDABLE_SHARED_SEQUENCE` one agrees that it's up to him to ensure shared sequence
      properties are preserved after extension.
     */
-    public static func createUnsafe<Source: ObservableType>(source: Source) -> SharedSequence<Sequence, Source.Element> {
-        return SharedSequence<Sequence, Source.Element>(raw: source.asObservable())
+    public static func createUnsafe<Source: ObservableType>(source: Source) -> SharedSequence<SharingStrategy, Source.Element> {
+        return SharedSequence<SharingStrategy, Source.Element>(raw: source.asObservable())
     }
     #endif
 


### PR DESCRIPTION
I fixed compile error on available method by defining `EXPANDABLE_SHARED_SEQUENCE`.
<img width="696" alt="Screen Shot 2019-06-20 at 10 28 04" src="https://user-images.githubusercontent.com/6450502/59811753-394f4180-9346-11e9-85de-9e0df8f68999.png">
