### PR TITLE
Add `share()` for Single and Maybe

### DIFF
--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1272,6 +1272,12 @@ final class ObservableShareReplayScopeTests_ : ObservableShareReplayScopeTests, 
     ("test_whileConnected_error", ObservableShareReplayScopeTests.test_whileConnected_error),
     ("test_forever_completed", ObservableShareReplayScopeTests.test_forever_completed),
     ("test_whileConnected_completed", ObservableShareReplayScopeTests.test_whileConnected_completed),
+    ("testSingleShareWhileConnected", ObservableShareReplayScopeTests.testSingleShareWhileConnected),
+    ("testSingleShareForever", ObservableShareReplayScopeTests.testSingleShareForever),
+    ("testMaybeReplay1ShareWhileConnected", ObservableShareReplayScopeTests.testMaybeReplay1ShareWhileConnected),
+    ("testMaybeShareReplay1Forever", ObservableShareReplayScopeTests.testMaybeShareReplay1Forever),
+    ("testMaybeShareWhileConnected", ObservableShareReplayScopeTests.testMaybeShareWhileConnected),
+    ("testMaybeShareForever", ObservableShareReplayScopeTests.testMaybeShareForever),
     ] }
 }
 


### PR DESCRIPTION
Added `share()` similar to `Observable` for `Single` and `Maybe`. 

I removed `replay` from `Single.share`, cause passing any value besides 1 would be irrational. It's impossible to replay more than one event from `Single`. `replay: 0` would break the contract, cause `Single` sequence must have one event.

I replaced `replay` in `Maybe.share` on `shouldReplay` flag for the same reason (can't replay more than one element).

If that implementation is ok, I also will add `.share` for `Completable`.