### PR TITLE
Change TestScheduler.start return type on ObservableConvertibleType.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 * Add `UITextField.isSecureTextEntry` binder. #1968
 * Remove "custom" `Result` in favor of `Foundation.Resault`. #2006
 * Fix compilation error in `SharedSequence.createUnsafe`. #2014
+* Add `SharedSequence` conformance to `ObservableConvertibleType`. #2019
 
 ## [5.0.1](https://github.com/ReactiveX/RxSwift/releases/tag/5.0.1)
 

--- a/RxCocoa/Traits/SharedSequence/SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence.swift
@@ -19,7 +19,7 @@ import RxSwift
 
     To find out more about units and how to use them, please visit `Documentation/Traits.md`.
 */
-public struct SharedSequence<SharingStrategy: SharingStrategyProtocol, Element> : SharedSequenceConvertibleType {
+public struct SharedSequence<SharingStrategy: SharingStrategyProtocol, Element> : SharedSequenceConvertibleType, ObservableConvertibleType {
     let source: Observable<Element>
 
     init(_ source: Observable<Element>) {

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -87,19 +87,20 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
     /**
     Starts the test scheduler and uses the specified virtual times to invoke the factory function, subscribe to the resulting sequence, and dispose the subscription.
     
-    - parameter create: Factory method to create an observable sequence.
+    - parameter create: Factory method to create an observable convertible sequence.
     - parameter created: Virtual time at which to invoke the factory to create an observable sequence.
     - parameter subscribed: Virtual time at which to subscribe to the created observable sequence.
     - parameter disposed: Virtual time at which to dispose the subscription.
     - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
     */
-    public func start<Element>(created: TestTime, subscribed: TestTime, disposed: TestTime, create: @escaping () -> Observable<Element>) -> TestableObserver<Element> {
+    public func start<Element, OutputSequence: ObservableConvertibleType>(created: TestTime, subscribed: TestTime, disposed: TestTime, create: @escaping () -> OutputSequence)
+        -> TestableObserver<Element> where OutputSequence.Element == Element {
         var source: Observable<Element>?
         var subscription: Disposable?
         let observer = self.createObserver(Element.self)
         
         _ = self.scheduleAbsoluteVirtual((), time: created) { _ in
-            source = create()
+            source = create().asObservable()
             return Disposables.create()
         }
         
@@ -129,7 +130,8 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
      - parameter disposed: Virtual time at which to dispose the subscription.
      - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
      */
-    public func start<Element>(disposed: TestTime, create: @escaping () -> Observable<Element>) -> TestableObserver<Element> {
+    public func start<Element, OutputSequence: ObservableConvertibleType>(disposed: TestTime, create: @escaping () -> OutputSequence)
+        -> TestableObserver<Element> where OutputSequence.Element == Element {
         self.start(created: Defaults.created, subscribed: Defaults.subscribed, disposed: disposed, create: create)
     }
 
@@ -144,8 +146,9 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
      - parameter create: Factory method to create an observable sequence.
      - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
      */
-    public func start<Element>(_ create: @escaping () -> Observable<Element>) -> TestableObserver<Element> {
-        self.start(created: Defaults.created, subscribed: Defaults.subscribed, disposed: Defaults.disposed, create: create)
+    public func start<Element, OutputSequence: ObservableConvertibleType>(_ create: @escaping () -> OutputSequence)
+        -> TestableObserver<Element> where OutputSequence.Element == Element {
+         self.start(created: Defaults.created, subscribed: Defaults.subscribed, disposed: Defaults.disposed, create: create)
     }
 }
 

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -126,7 +126,7 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
      * created at virtual time `Defaults.created`           -> 100
      * subscribed to at virtual time `Defaults.subscribed`  -> 200
 
-     - parameter create: Factory method to create an observable sequence.
+     - parameter create: Factory method to create an observable convertible sequence.
      - parameter disposed: Virtual time at which to dispose the subscription.
      - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
      */
@@ -143,7 +143,7 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
      * subscribed to at virtual time `Defaults.subscribed`  -> 200
      * subscription will be disposed at `Defaults.disposed` -> 1000
 
-     - parameter create: Factory method to create an observable sequence.
+     - parameter create: Factory method to create an observable convertible sequence.
      - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
      */
     public func start<Element, OutputSequence: ObservableConvertibleType>(_ create: @escaping () -> OutputSequence)

--- a/Tests/RxCocoaTests/SharedSequence+OperatorTest.swift
+++ b/Tests/RxCocoaTests/SharedSequence+OperatorTest.swift
@@ -1083,7 +1083,7 @@ extension SharedSequenceOperatorTests {
         let scheduler = TestScheduler(initialClock: 0)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let res = scheduler.start { Driver.from(optional: 1 as Int?).asObservable() }
+            let res = scheduler.start { Driver.from(optional: 1 as Int?) }
             XCTAssertEqual(res.events, [
                 .next(201, 1),
                 .completed(202)
@@ -1095,7 +1095,7 @@ extension SharedSequenceOperatorTests {
         let scheduler = TestScheduler(initialClock: 0)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let res = scheduler.start { Driver.from(optional: nil as Int?).asObservable() }
+            let res = scheduler.start { Driver.from(optional: nil as Int?) }
             XCTAssertEqual(res.events, [
                 .completed(201)
                 ])
@@ -1111,7 +1111,7 @@ extension SharedSequenceOperatorTests {
         let scheduler = TestScheduler(initialClock: 0)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let res = scheduler.start { Driver.from(AnySequence([10])).asObservable() }
+            let res = scheduler.start { Driver.from(AnySequence([10])) }
             XCTAssertEqual(res.events, [
                 .next(201, 10),
                 .completed(202)
@@ -1123,7 +1123,7 @@ extension SharedSequenceOperatorTests {
         let scheduler = TestScheduler(initialClock: 0)
 
         SharingScheduler.mock(scheduler: scheduler) {
-            let res = scheduler.start { Driver.from([20]).asObservable() }
+            let res = scheduler.start { Driver.from([20]) }
             XCTAssertEqual(res.events, [
                 .next(201, 20),
                 .completed(202)

--- a/Tests/RxSwiftTests/Completable+AndThen.swift
+++ b/Tests/RxSwiftTests/Completable+AndThen.swift
@@ -25,7 +25,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.andThen(x2.asCompletable()).asObservable()
+            x1.andThen(x2.asCompletable())
         }
 
         XCTAssertEqual(res.events, [
@@ -49,7 +49,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asCompletable()).asObservable()
+            x1.asCompletable().andThen(x2.asCompletable())
         }
 
         XCTAssertEqual(res.events, [
@@ -77,7 +77,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asCompletable()).asObservable()
+            x1.asCompletable().andThen(x2.asCompletable())
         }
 
         XCTAssertEqual(res.events, [
@@ -104,7 +104,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asCompletable()).asObservable()
+            x1.asCompletable().andThen(x2.asCompletable())
         }
 
         XCTAssertEqual(res.events, [
@@ -148,7 +148,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.andThen(x2.asSingle()).asObservable()
+            x1.andThen(x2.asSingle())
         }
 
         XCTAssertEqual(res.events, [
@@ -174,7 +174,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asSingle()).asObservable()
+            x1.asCompletable().andThen(x2.asSingle())
         }
 
         XCTAssertEqual(res.events, [
@@ -205,7 +205,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asSingle()).asObservable()
+            x1.asCompletable().andThen(x2.asSingle())
         }
 
         XCTAssertEqual(res.events, [
@@ -232,7 +232,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asSingle()).asObservable()
+            x1.asCompletable().andThen(x2.asSingle())
         }
 
         XCTAssertEqual(res.events, [
@@ -276,7 +276,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.andThen(x2.asMaybe()).asObservable()
+            x1.andThen(x2.asMaybe())
         }
 
         XCTAssertEqual(res.events, [
@@ -302,7 +302,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asMaybe()).asObservable()
+            x1.asCompletable().andThen(x2.asMaybe())
         }
 
         XCTAssertEqual(res.events, [
@@ -333,7 +333,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asMaybe()).asObservable()
+            x1.asCompletable().andThen(x2.asMaybe())
         }
 
         XCTAssertEqual(res.events, [
@@ -360,7 +360,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asMaybe()).asObservable()
+            x1.asCompletable().andThen(x2.asMaybe())
         }
 
         XCTAssertEqual(res.events, [
@@ -388,7 +388,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.asCompletable().andThen(x2.asMaybe()).asObservable()
+            x1.asCompletable().andThen(x2.asMaybe())
         }
 
         XCTAssertEqual(res.events, [
@@ -432,7 +432,7 @@ extension CompletableAndThenTest {
             ])
 
         let res = scheduler.start {
-            x1.andThen(x2.asObservable()).asObservable()
+            x1.andThen(x2.asObservable())
         }
 
         XCTAssertEqual(res.events, [

--- a/Tests/RxSwiftTests/CompletableTest.swift
+++ b/Tests/RxSwiftTests/CompletableTest.swift
@@ -63,7 +63,7 @@ extension CompletableTest {
                 return Disposables.create {
                     disposedTime = scheduler.clock
                 }
-                }.asObservable()
+                }
         }
 
         XCTAssertEqual(res.events, [
@@ -96,7 +96,7 @@ extension CompletableTest {
                 return Disposables.create {
                     disposedTime = scheduler.clock
                 }
-                }.asObservable()
+                }
         }
 
         XCTAssertEqual(res.events, [
@@ -173,7 +173,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.empty().delaySubscription(.seconds(2), scheduler: scheduler) as Completable).asObservable()
+            Completable.empty().delaySubscription(.seconds(2), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -185,7 +185,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.empty().delay(.seconds(2), scheduler: scheduler) as Completable).asObservable()
+            Completable.empty().delay(.seconds(2), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -197,7 +197,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.empty().observeOn(scheduler) as Completable).asObservable()
+            Completable.empty().observeOn(scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -209,7 +209,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.empty().subscribeOn(scheduler) as Completable).asObservable()
+            Completable.empty().subscribeOn(scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -221,7 +221,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.error(testError).catchError { _ in Completable.empty() } as Completable).asObservable()
+            Completable.error(testError).catchError { _ in Completable.empty() }
         }
 
         XCTAssertEqual(res.events, [
@@ -234,7 +234,7 @@ extension CompletableTest {
 
         var isFirst = true
         let res = scheduler.start {
-            (Completable.error(testError)
+            Completable.error(testError)
                 .catchError { e in
                     defer {
                         isFirst = false
@@ -245,8 +245,7 @@ extension CompletableTest {
 
                     return Completable.empty()
                 }
-                .retry(2) as Completable
-            ).asObservable()
+                .retry(2)
         }
 
         XCTAssertEqual(res.events, [
@@ -259,7 +258,7 @@ extension CompletableTest {
 
         var isFirst = true
         let res = scheduler.start {
-            (Completable.error(testError)
+            Completable.error(testError)
                 .catchError { e in
                     defer {
                         isFirst = false
@@ -272,8 +271,7 @@ extension CompletableTest {
                 }
                 .retryWhen { (e: Observable<Error>) in
                     return e
-                } as Completable
-            ).asObservable()
+                }
         }
 
         XCTAssertEqual(res.events, [
@@ -286,7 +284,7 @@ extension CompletableTest {
 
         var isFirst = true
         let res = scheduler.start {
-            (Completable.error(testError)
+            Completable.error(testError)
                 .catchError { e in
                     defer {
                         isFirst = false
@@ -299,8 +297,7 @@ extension CompletableTest {
                 }
                 .retryWhen { (e: Observable<TestError>) in
                     return e
-                } as Completable
-            ).asObservable()
+                }
         }
 
         XCTAssertEqual(res.events, [
@@ -312,7 +309,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.empty().debug() as Completable).asObservable()
+            Completable.empty().debug()
         }
 
         XCTAssertEqual(res.events, [
@@ -342,7 +339,7 @@ extension CompletableTest {
                     .completed(100)
                     ])
                 return xs.asObservable().asCompletable()
-            }).asObservable()
+            })
         }
 
         XCTAssert(disposable === _d)
@@ -372,7 +369,7 @@ extension CompletableTest {
             ]).asCompletable()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(5), scheduler: scheduler) as Completable).asObservable()
+            xs.timeout(.seconds(5), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -392,7 +389,7 @@ extension CompletableTest {
             ]).asCompletable()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(5), other: xs2, scheduler: scheduler) as Completable).asObservable()
+            xs.timeout(.seconds(5), other: xs2, scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -408,7 +405,7 @@ extension CompletableTest {
             ]).asCompletable()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(30), scheduler: scheduler) as Completable).asObservable()
+            xs.timeout(.seconds(30), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -428,7 +425,7 @@ extension CompletableTest {
             ]).asCompletable()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(30), other: xs2, scheduler: scheduler) as Completable).asObservable()
+            xs.timeout(.seconds(30), other: xs2, scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -442,7 +439,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.empty().do(onError: { _ in () }, onSubscribe: { () in () }, onSubscribed: { () in () }, onDispose: { () in () }) as Completable).asObservable()
+            Completable.empty().do(onError: { _ in () }, onSubscribe: { () in () }, onSubscribed: { () in () }, onDispose: { () in () })
         }
 
         XCTAssertEqual(res.events, [
@@ -454,7 +451,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.empty().concat(Completable.empty()) as Completable).asObservable()
+            Completable.empty().concat(Completable.empty())
         }
 
         XCTAssertEqual(res.events, [
@@ -466,7 +463,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.concat(AnySequence([Completable.empty()])) as Completable).asObservable()
+            Completable.concat(AnySequence([Completable.empty()]))
         }
 
         XCTAssertEqual(res.events, [
@@ -478,7 +475,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.concat([Completable.empty()]) as Completable).asObservable()
+            Completable.concat([Completable.empty()])
         }
 
         XCTAssertEqual(res.events, [
@@ -490,7 +487,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.concat(Completable.empty(), Completable.empty()) as Completable).asObservable()
+            Completable.concat(Completable.empty(), Completable.empty())
         }
 
         XCTAssertEqual(res.events, [
@@ -502,7 +499,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.zip(AnyCollection([Completable.empty(), Completable.empty()])) as Completable).asObservable()
+            Completable.zip(AnyCollection([Completable.empty(), Completable.empty()]))
         }
 
         XCTAssertEqual(res.events, [
@@ -514,7 +511,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.zip([Completable.empty(), Completable.empty()]) as Completable).asObservable()
+            Completable.zip([Completable.empty(), Completable.empty()])
         }
 
         XCTAssertEqual(res.events, [
@@ -526,7 +523,7 @@ extension CompletableTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Completable.zip(Completable.empty(), Completable.empty()) as Completable).asObservable()
+            Completable.zip(Completable.empty(), Completable.empty())
         }
 
         XCTAssertEqual(res.events, [

--- a/Tests/RxSwiftTests/DisposableTest.swift
+++ b/Tests/RxSwiftTests/DisposableTest.swift
@@ -65,8 +65,8 @@ extension DisposableTest {
             .completed(600)
             ])
         
-        let res = scheduler.start(disposed: 400) { () -> Observable<Int> in
-            return xs.asObservable()
+        let res = scheduler.start(disposed: 400) {
+            xs
         }
         
         XCTAssertEqual(res.events, [

--- a/Tests/RxSwiftTests/MaybeTest.swift
+++ b/Tests/RxSwiftTests/MaybeTest.swift
@@ -78,7 +78,7 @@ extension MaybeTest {
                 return Disposables.create {
                     disposedTime = scheduler.clock
                 }
-                }.asObservable()
+            }
         }
 
         XCTAssertEqual(res.events, [
@@ -115,7 +115,7 @@ extension MaybeTest {
                 return Disposables.create {
                     disposedTime = scheduler.clock
                 }
-                }.asObservable()
+            }
         }
 
         XCTAssertEqual(res.events, [
@@ -148,7 +148,7 @@ extension MaybeTest {
                 return Disposables.create {
                     disposedTime = scheduler.clock
                 }
-                }.asObservable()
+            }
         }
 
         XCTAssertEqual(res.events, [
@@ -235,7 +235,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.just(1).delaySubscription(.seconds(2), scheduler: scheduler) as Maybe<Int>).asObservable()
+            Maybe.just(1).delaySubscription(.seconds(2), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -248,7 +248,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.just(1).delay(.seconds(2), scheduler: scheduler) as Maybe<Int>).asObservable()
+            Maybe.just(1).delay(.seconds(2), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -261,7 +261,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.just(1).observeOn(scheduler) as Maybe<Int>).asObservable()
+            Maybe.just(1).observeOn(scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -274,7 +274,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.just(1).subscribeOn(scheduler) as Maybe<Int>).asObservable()
+            Maybe.just(1).subscribeOn(scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -287,7 +287,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.error(testError).catchError { _ in Maybe.just(2) } as Maybe<Int>).asObservable()
+            Maybe.error(testError).catchError { _ in Maybe.just(2) }
         }
 
         XCTAssertEqual(res.events, [
@@ -300,7 +300,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.error(testError).catchErrorJustReturn(2) as Maybe<Int>).asObservable()
+            Maybe.error(testError).catchErrorJustReturn(2)
         }
 
         XCTAssertEqual(res.events, [
@@ -314,7 +314,7 @@ extension MaybeTest {
 
         var isFirst = true
         let res = scheduler.start {
-            (Maybe.error(testError)
+            Maybe.error(testError)
                 .catchError { e in
                     defer {
                         isFirst = false
@@ -326,7 +326,6 @@ extension MaybeTest {
                     return Maybe.just(2)
                 }
                 .retry(2) as Maybe<Int>
-            ).asObservable()
         }
 
         XCTAssertEqual(res.events, [
@@ -340,7 +339,7 @@ extension MaybeTest {
 
         var isFirst = true
         let res = scheduler.start {
-            (Maybe.error(testError)
+            Maybe.error(testError)
                 .catchError { e in
                     defer {
                         isFirst = false
@@ -354,7 +353,6 @@ extension MaybeTest {
                 .retryWhen { (e: Observable<Error>) in
                     return e
                 } as Maybe<Int>
-            ).asObservable()
         }
 
         XCTAssertEqual(res.events, [
@@ -368,7 +366,7 @@ extension MaybeTest {
 
         var isFirst = true
         let res = scheduler.start {
-            (Maybe.error(testError)
+            Maybe.error(testError)
                 .catchError { e in
                     defer {
                         isFirst = false
@@ -382,7 +380,6 @@ extension MaybeTest {
                 .retryWhen { (e: Observable<TestError>) in
                     return e
                 } as Maybe<Int>
-            ).asObservable()
         }
 
         XCTAssertEqual(res.events, [
@@ -395,7 +392,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.just(1).debug() as Maybe<Int>).asObservable()
+            Maybe.just(1).debug()
         }
 
         XCTAssertEqual(res.events, [
@@ -427,7 +424,7 @@ extension MaybeTest {
                     .completed(100)
                     ])
                 return xs.asObservable().asMaybe()
-            }).asObservable()
+            })
         }
 
         XCTAssert(disposable === _d)
@@ -459,7 +456,7 @@ extension MaybeTest {
             ]).asMaybe()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(5), scheduler: scheduler) as Maybe<Int>).asObservable()
+            xs.timeout(.seconds(5), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -481,7 +478,7 @@ extension MaybeTest {
         ]).asMaybe()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(5), other: xs2, scheduler: scheduler) as Maybe<Int>).asObservable()
+            xs.timeout(.seconds(5), other: xs2, scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -499,7 +496,7 @@ extension MaybeTest {
         ]).asMaybe()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(30), scheduler: scheduler) as Maybe<Int>).asObservable()
+            xs.timeout(.seconds(30), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -522,7 +519,7 @@ extension MaybeTest {
         ]).asMaybe()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(30), other: xs2, scheduler: scheduler) as Maybe<Int>).asObservable()
+            xs.timeout(.seconds(30), other: xs2, scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -537,7 +534,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe<Int>.timer(.seconds(2), scheduler: scheduler) as Maybe<Int>).asObservable()
+            Maybe<Int>.timer(.seconds(2), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -552,7 +549,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe<Int>.just(1).do(onNext: { _ in () }, afterNext: { _ in () }, onError: { _ in () }, afterError: { _ in }, onSubscribe: { () in () }, onSubscribed: { () in () }, onDispose: { () in () }) as Maybe<Int>).asObservable()
+            Maybe<Int>.just(1).do(onNext: { _ in () }, afterNext: { _ in () }, onError: { _ in () }, afterError: { _ in }, onSubscribe: { () in () }, onSubscribed: { () in () }, onDispose: { () in () })
         }
 
         XCTAssertEqual(res.events, [
@@ -565,7 +562,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe<Int>.just(1).filter { _ in false } as Maybe<Int>).asObservable()
+            Maybe<Int>.just(1).filter { _ in false }
         }
 
         XCTAssertEqual(res.events, [
@@ -577,7 +574,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe<Int>.just(1).map { $0 * 2 } as Maybe<Int>).asObservable()
+            Maybe<Int>.just(1).map { $0 * 2 }
         }
 
         XCTAssertEqual(res.events, [
@@ -615,7 +612,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe<Int>.just(1).flatMap { .just($0 * 2) } as Maybe<Int>).asObservable()
+            Maybe<Int>.just(1).flatMap { .just($0 * 2) }
         }
 
         XCTAssertEqual(res.events, [
@@ -628,7 +625,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            ((Maybe<Int>.empty().ifEmpty(default: 5) as Single<Int>).asObservable())
+            Maybe<Int>.empty().ifEmpty(default: 5) as Single<Int>
         }
 
         XCTAssertEqual(res.events, [
@@ -643,7 +640,7 @@ extension MaybeTest {
         let switchSource = Maybe.just(10)
 
         let res = scheduler.start {
-            ((source.ifEmpty(switchTo: switchSource) as Maybe<Int>).asObservable())
+            source.ifEmpty(switchTo: switchSource) as Maybe<Int>
         }
 
         XCTAssertEqual(res.events, [
@@ -658,7 +655,7 @@ extension MaybeTest {
         let switchSource = Single.just(10)
 
         let res = scheduler.start {
-            ((source.ifEmpty(switchTo: switchSource) as Single<Int>).asObservable())
+            source.ifEmpty(switchTo: switchSource)
         }
 
         XCTAssertEqual(res.events, [
@@ -673,7 +670,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.zip(Maybe.just(1), Maybe.just(2)) as Maybe<(Int, Int)>).map { $0.0 + $0.1 }.asObservable()
+            (Maybe.zip(Maybe.just(1), Maybe.just(2)) as Maybe<(Int, Int)>).map { $0.0 + $0.1 }
         }
 
         XCTAssertEqual(res.events, [
@@ -686,7 +683,7 @@ extension MaybeTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Maybe.zip(Maybe.just(1), Maybe.just(2)) { $0 + $1 } as Maybe<Int>).asObservable()
+            Maybe.zip(Maybe.just(1), Maybe.just(2)) { $0 + $1 }
         }
 
         XCTAssertEqual(res.events, [

--- a/Tests/RxSwiftTests/Observable+FilterTests.swift
+++ b/Tests/RxSwiftTests/Observable+FilterTests.swift
@@ -231,7 +231,7 @@ extension ObservableFilterTest {
             ])
 
         let res = scheduler.start {
-            (xs.ignoreElements() as Completable).asObservable()
+            xs.ignoreElements()
         }
 
         XCTAssertEqual(res.events, [

--- a/Tests/RxSwiftTests/Observable+PrimitiveSequenceTest.swift
+++ b/Tests/RxSwiftTests/Observable+PrimitiveSequenceTest.swift
@@ -24,9 +24,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.asSingle()
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.asSingle()
         }
 
         XCTAssertEqual(res.events, [
@@ -48,9 +47,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.asSingle()
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.asSingle()
         }
 
         XCTAssertEqual(res.events, [
@@ -74,9 +72,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.asSingle()
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.asSingle()
         }
 
         XCTAssertEqual(res.events, [
@@ -96,9 +93,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(210, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.asSingle()
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.asSingle()
         }
 
         XCTAssertEqual(res.events, [
@@ -119,9 +115,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(210, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.asSingle()
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.asSingle()
         }
 
         XCTAssertEqual(res.events, [
@@ -182,9 +177,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
         
-        let res: TestableObserver<Int> = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.first().map { $0 ?? -1 }
-            return single.asObservable()
+        let res: TestableObserver<Int> = scheduler.start {
+            xs.first().map { $0 ?? -1 }
         }
         
         XCTAssertEqual(res.events, [
@@ -207,9 +201,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
         
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.first().map { $0 ?? -1 }
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.first().map { $0 ?? -1 }
         }
         
         XCTAssertEqual(res.events, [
@@ -233,9 +226,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
         
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.first().map { $0 ?? -1 }
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.first().map { $0 ?? -1 }
         }
         
         XCTAssertEqual(res.events, [
@@ -259,9 +251,8 @@ extension ObservablePrimitiveSequenceTest {
             .next(300, 5)
             ])
         
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.first().map { $0 ?? -1 }
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.first().map { $0 ?? -1 }
         }
         
         XCTAssertEqual(res.events, [
@@ -282,9 +273,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(210, testError)
             ])
         
-        let res = scheduler.start { () -> Observable<Int> in
-            let single: Single<Int> = xs.first().map { $0 ?? -1 }
-            return single.asObservable()
+        let res = scheduler.start {
+            xs.first().map { $0 ?? -1 }
         }
         
         XCTAssertEqual(res.events, [
@@ -317,9 +307,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let maybe: Maybe<Int> = xs.asMaybe()
-            return maybe.asObservable()
+        let res = scheduler.start {
+            xs.asMaybe()
         }
 
         XCTAssertEqual(res.events, [
@@ -341,9 +330,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let maybe: Maybe<Int> = xs.asMaybe()
-            return maybe.asObservable()
+        let res = scheduler.start {
+            xs.asMaybe()
         }
 
         XCTAssertEqual(res.events, [
@@ -367,9 +355,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let maybe: Maybe<Int> = xs.asMaybe()
-            return maybe.asObservable()
+        let res = scheduler.start {
+            xs.asMaybe()
         }
 
         XCTAssertEqual(res.events, [
@@ -389,9 +376,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(210, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let maybe: Maybe<Int> = xs.asMaybe()
-            return maybe.asObservable()
+        let res = scheduler.start {
+            xs.asMaybe()
         }
 
         XCTAssertEqual(res.events, [
@@ -412,9 +398,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(210, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Int> in
-            let maybe: Maybe<Int> = xs.asMaybe()
-            return maybe.asObservable()
+        let res = scheduler.start {
+            xs.asMaybe()
         }
 
         XCTAssertEqual(res.events, [
@@ -496,9 +481,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(260, testError)
             ])
 
-        let res = scheduler.start { () -> Observable<Never> in
-            let completable: Completable = xs.asCompletable()
-            return completable.asObservable()
+        let res = scheduler.start {
+            return xs.asCompletable()
         }
 
         XCTAssertEqual(res.events, [
@@ -517,9 +501,8 @@ extension ObservablePrimitiveSequenceTest {
             .error(210, testError, Never.self)
             ])
 
-        let res = scheduler.start { () -> Observable<Never> in
-            let completable: Completable = xs.asCompletable()
-            return completable.asObservable()
+        let res = scheduler.start {
+            return xs.asCompletable()
         }
 
         XCTAssertEqual(res.events, [
@@ -585,9 +568,8 @@ extension ObservablePrimitiveSequenceTest {
                 .completed(300, Never.self)
                 ])
 
-            let res = scheduler.start { () -> Observable<Never> in
-                let completable: Completable = factory(ys1.asCompletable(), ys2.asCompletable())
-                return completable.asObservable()
+            let res = scheduler.start {
+                factory(ys1.asCompletable(), ys2.asCompletable())
             }
 
             XCTAssertEqual(res.events, [
@@ -625,9 +607,8 @@ extension ObservablePrimitiveSequenceTest {
                 .completed(300, Never.self)
                 ])
 
-            let res = scheduler.start { () -> Observable<Never> in
-                let completable: Completable = factory(ys1.asCompletable(), ys2.asCompletable())
-                return completable.asObservable()
+            let res = scheduler.start {
+                factory(ys1.asCompletable(), ys2.asCompletable())
             }
 
             XCTAssertEqual(res.events, [

--- a/Tests/RxSwiftTests/Observable+ToArrayTests.swift
+++ b/Tests/RxSwiftTests/Observable+ToArrayTests.swift
@@ -25,7 +25,7 @@ extension ObservableToArrayTest {
             ])
 
         let res = scheduler.start {
-            return xs.toArray().map { EquatableArray($0) }.asObservable()
+            return xs.toArray().map { EquatableArray($0) }
         }
 
         let correctMessages = Recorded.events(
@@ -53,7 +53,7 @@ extension ObservableToArrayTest {
             ])
 
         let res = scheduler.start {
-            return xs.toArray().map { EquatableArray($0) }.asObservable()
+            return xs.toArray().map { EquatableArray($0) }
         }
 
         let correctMessages = Recorded.events(
@@ -77,7 +77,7 @@ extension ObservableToArrayTest {
             ])
 
         let res = scheduler.start {
-            return xs.toArray().map { EquatableArray($0) }.asObservable()
+            return xs.toArray().map { EquatableArray($0) }
         }
 
         let correctMessages = Recorded.events(
@@ -101,7 +101,7 @@ extension ObservableToArrayTest {
             ])
 
         let res = scheduler.start {
-            return xs.toArray().map { EquatableArray($0) }.asObservable()
+            return xs.toArray().map { EquatableArray($0) }
         }
 
         let correctMessages: [Recorded<Event<EquatableArray<Int>>>] = [
@@ -123,7 +123,7 @@ extension ObservableToArrayTest {
             ])
 
         let res = scheduler.start {
-            return xs.toArray().map { EquatableArray($0) }.asObservable()
+            return xs.toArray().map { EquatableArray($0) }
         }
 
         let correctMessages = [
@@ -150,7 +150,7 @@ extension ObservableToArrayTest {
             ])
 
         let res = scheduler.start {
-            return xs.toArray().map { EquatableArray($0) }.asObservable()
+            return xs.toArray().map { EquatableArray($0) }
         }
 
         let correctMessages = [

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -63,7 +63,7 @@ extension SingleTest {
                 return Disposables.create {
                     disposedTime = scheduler.clock
                 }
-                }.asObservable()
+                }
         }
 
         XCTAssertEqual(res.events, [
@@ -97,7 +97,7 @@ extension SingleTest {
                 return Disposables.create {
                     disposedTime = scheduler.clock
                 }
-                }.asObservable()
+                }
         }
 
         XCTAssertEqual(res.events, [
@@ -184,7 +184,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.just(1).delay(.seconds(2), scheduler: scheduler) as Single<Int>).asObservable()
+            Single.just(1).delay(.seconds(2), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -197,7 +197,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.just(1).delaySubscription(.seconds(2), scheduler: scheduler) as Single<Int>).asObservable()
+            Single.just(1).delaySubscription(.seconds(2), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -210,7 +210,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.just(1).observeOn(scheduler) as Single<Int>).asObservable()
+            Single.just(1).observeOn(scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -223,7 +223,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.just(1).subscribeOn(scheduler) as Single<Int>).asObservable()
+            Single.just(1).subscribeOn(scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -236,7 +236,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.error(testError).catchError { _ in Single.just(2) } as Single<Int>).asObservable()
+            Single.error(testError).catchError { _ in Single.just(2) }
         }
 
         XCTAssertEqual(res.events, [
@@ -249,7 +249,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.error(testError).catchErrorJustReturn(2) as Single<Int>).asObservable()
+            Single.error(testError).catchErrorJustReturn(2)
         }
 
         XCTAssertEqual(res.events, [
@@ -275,7 +275,7 @@ extension SingleTest {
                     return Single.just(2)
                 }
                 .retry(2) as Single<Int>
-            ).asObservable()
+            )
         }
 
         XCTAssertEqual(res.events, [
@@ -303,7 +303,7 @@ extension SingleTest {
                 .retryWhen { (e: Observable<Error>) in
                     return e
                 } as Single<Int>
-            ).asObservable()
+            )
         }
 
         XCTAssertEqual(res.events, [
@@ -331,7 +331,7 @@ extension SingleTest {
                 .retryWhen { (e: Observable<TestError>) in
                     return e
                 } as Single<Int>
-            ).asObservable()
+            )
         }
 
         XCTAssertEqual(res.events, [
@@ -344,7 +344,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.just(1).debug() as Single<Int>).asObservable()
+            Single.just(1).debug()
         }
 
         XCTAssertEqual(res.events, [
@@ -376,7 +376,7 @@ extension SingleTest {
                     .completed(100)
                     ])
                 return xs.asObservable().asSingle()
-            }).asObservable()
+            })
         }
 
         XCTAssert(disposable === _d)
@@ -408,7 +408,7 @@ extension SingleTest {
             ]).asSingle()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(5), scheduler: scheduler) as Single<Int>).asObservable()
+            xs.timeout(.seconds(5), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -430,7 +430,7 @@ extension SingleTest {
             ]).asSingle()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(5), other: xs2, scheduler: scheduler) as Single<Int>).asObservable()
+            xs.timeout(.seconds(5), other: xs2, scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -448,7 +448,7 @@ extension SingleTest {
             ]).asSingle()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(30), scheduler: scheduler) as Single<Int>).asObservable()
+            xs.timeout(.seconds(30), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -471,7 +471,7 @@ extension SingleTest {
             ]).asSingle()
 
         let res = scheduler.start {
-            (xs.timeout(.seconds(30), other: xs2, scheduler: scheduler) as Single<Int>).asObservable()
+            xs.timeout(.seconds(30), other: xs2, scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -486,7 +486,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.timer(.seconds(2), scheduler: scheduler) as Single<Int>).asObservable()
+            Single<Int>.timer(.seconds(2), scheduler: scheduler)
         }
 
         XCTAssertEqual(res.events, [
@@ -501,7 +501,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(1).do(onSuccess: { _ in () }, onError: { _ in () }, onSubscribe: { () in () }, onSubscribed: { () in () }, onDispose: { () in () }) as Single<Int>).asObservable()
+            Single<Int>.just(1).do(onSuccess: { _ in () }, onError: { _ in () }, onSubscribe: { () in () }, onSubscribed: { () in () }, onDispose: { () in () })
         }
 
         XCTAssertEqual(res.events, [
@@ -514,7 +514,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(1).filter { _ in false } as Maybe<Int>).asObservable()
+            Single<Int>.just(1).filter { _ in false }
         }
 
         XCTAssertEqual(res.events, [
@@ -526,7 +526,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(1).map { $0 * 2 } as Single<Int>).asObservable()
+            Single<Int>.just(1).map { $0 * 2 }
         }
 
         XCTAssertEqual(res.events, [
@@ -564,7 +564,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(1).flatMap { .just($0 * 2) } as Single<Int>).asObservable()
+            Single<Int>.just(1).flatMap { .just($0 * 2) }
         }
 
         XCTAssertEqual(res.events, [
@@ -577,7 +577,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(1).flatMapMaybe { Maybe.just($0 * 2) } as Maybe<Int>).asObservable()
+            Single<Int>.just(1).flatMapMaybe { Maybe.just($0 * 2) }
         }
 
         XCTAssertEqual(res.events, [
@@ -590,7 +590,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(10).flatMapCompletable { _ in Completable.empty() } as Completable).asObservable()
+            Single<Int>.just(10).flatMapCompletable { _ in Completable.empty() }
         }
 
         XCTAssertEqual(res.events, [
@@ -602,7 +602,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(1).asMaybe() as Maybe<Int>).asObservable()
+            Single<Int>.just(1).asMaybe() as Maybe<Int>
         }
 
         XCTAssertEqual(res.events, [
@@ -615,7 +615,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.just(5).asCompletable() as Completable).asObservable()
+            Single<Int>.just(5).asCompletable() as Completable
         }
 
         XCTAssertEqual(res.events, [
@@ -627,7 +627,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single<Int>.error(testError).asCompletable() as Completable).asObservable()
+            Single<Int>.error(testError).asCompletable() as Completable
         }
 
         XCTAssertEqual(res.events, [
@@ -641,7 +641,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.zip(Single.just(1), Single.just(2)) as Single<(Int, Int)>).map { $0.0 + $0.1 }.asObservable()
+            (Single.zip(Single.just(1), Single.just(2)) as Single<(Int, Int)>).map { $0.0 + $0.1 }
         }
 
         XCTAssertEqual(res.events, [
@@ -654,7 +654,7 @@ extension SingleTest {
         let scheduler = TestScheduler(initialClock: 0)
 
         let res = scheduler.start {
-            (Single.zip(Single.just(1), Single.just(2)) { $0 + $1 } as Single<Int>).asObservable()
+            Single.zip(Single.just(1), Single.just(2)) { $0 + $1 }
         }
 
         XCTAssertEqual(res.events, [


### PR DESCRIPTION
Tests are additional documentation to the project. IMO they should be as clean as possible. `TestScheduler.start` closure return param was `Observable`. That's why when testing traits developer always called `.asObservable`. This boilerplate code could be reduced with changing return type to `ObservableConvertivleType`

Also, I added `SharedSequence` conformance to `ObservableConvertibleType`