### PR TITLE
Prefer private over fileprivate

### DIFF
--- a/Platform/DataStructures/Bag.swift
+++ b/Platform/DataStructures/Bag.swift
@@ -35,7 +35,7 @@ struct Bag<T> : CustomDebugStringConvertible {
     
     typealias Entry = (key: BagKey, value: T)
  
-    fileprivate var _nextKey: BagKey = BagKey(rawValue: 0)
+    private var _nextKey: BagKey = BagKey(rawValue: 0)
 
     // data
 

--- a/Platform/DataStructures/PriorityQueue.swift
+++ b/Platform/DataStructures/PriorityQueue.swift
@@ -10,7 +10,7 @@ struct PriorityQueue<Element> {
     private let _hasHigherPriority: (Element, Element) -> Bool
     private let _isEqual: (Element, Element) -> Bool
 
-    fileprivate var _elements = [Element]()
+    private var _elements = [Element]()
 
     init(hasHigherPriority: @escaping (Element, Element) -> Bool, isEqual: @escaping (Element, Element) -> Bool) {
         _hasHigherPriority = hasHigherPriority

--- a/RxBlocking/BlockingObservable+Operators.swift
+++ b/RxBlocking/BlockingObservable+Operators.swift
@@ -101,7 +101,7 @@ extension BlockingObservable {
 }
 
 extension BlockingObservable {
-    fileprivate func materializeResult(max: Int? = nil, predicate: @escaping (Element) throws -> Bool = { _ in true }) -> MaterializedSequenceResult<Element> {
+    private func materializeResult(max: Int? = nil, predicate: @escaping (Element) throws -> Bool = { _ in true }) -> MaterializedSequenceResult<Element> {
         var elements = [Element]()
         var error: Swift.Error?
         
@@ -159,7 +159,7 @@ extension BlockingObservable {
         return MaterializedSequenceResult.completed(elements: elements)
     }
     
-    fileprivate func elementsOrThrow(_ results: MaterializedSequenceResult<Element>) throws -> [Element] {
+    private func elementsOrThrow(_ results: MaterializedSequenceResult<Element>) throws -> [Element] {
         switch results {
         case .failed(_, let error):
             throw error

--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -26,8 +26,8 @@
         /// Parent object associated with delegate proxy.
         private weak var _parentObject: ParentObject?
 
-        fileprivate let _currentDelegateFor: (ParentObject) -> AnyObject?
-        fileprivate let _setCurrentDelegateTo: (AnyObject?, ParentObject) -> Void
+        private let _currentDelegateFor: (ParentObject) -> AnyObject?
+        private let _setCurrentDelegateTo: (AnyObject?, ParentObject) -> Void
 
         /// Initializes new instance.
         ///
@@ -258,7 +258,7 @@
 
     private let mainScheduler = MainScheduler()
 
-    fileprivate final class MessageDispatcher {
+    private final class MessageDispatcher {
         private let dispatcher: PublishSubject<[Any]>
         private let result: Observable<[Any]>
 

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -240,18 +240,18 @@ extension DelegateProxyType {
 }
 
 
-// fileprivate extensions
+// private extensions
 extension DelegateProxyType {
-    fileprivate static var factory: DelegateProxyFactory {
+    private static var factory: DelegateProxyFactory {
         return DelegateProxyFactory.sharedFactory(for: self)
     }
 
-    fileprivate static func assignedProxy(for object: ParentObject) -> AnyObject? {
+    private static func assignedProxy(for object: ParentObject) -> AnyObject? {
         let maybeDelegate = objc_getAssociatedObject(object, self.identifier)
         return castOptionalOrFatalError(maybeDelegate)
     }
 
-    fileprivate static func assignProxy(_ proxy: AnyObject, toObject object: ParentObject) {
+    private static func assignProxy(_ proxy: AnyObject, toObject object: ParentObject) {
         objc_setAssociatedObject(object, self.identifier, proxy, .OBJC_ASSOCIATION_RETAIN)
     }
 }

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -202,7 +202,7 @@ extension Reactive where Base: AnyObject {
         }
     }
 
-    fileprivate func registerMessageInterceptor<T: MessageInterceptorSubject>(_ selector: Selector) throws -> T {
+    private func registerMessageInterceptor<T: MessageInterceptorSubject>(_ selector: Selector) throws -> T {
         let rxSelector = RX_selector(selector)
         let selectorReference = RX_reference_from_selector(rxSelector)
 
@@ -251,7 +251,7 @@ extension Reactive where Base: AnyObject {
         var targetImplementation: IMP { get set }
     }
 
-    fileprivate final class DeallocatingProxy
+    private final class DeallocatingProxy
         : MessageInterceptorSubject
         , RXDeallocatingObserver {
         typealias Element = ()
@@ -276,7 +276,7 @@ extension Reactive where Base: AnyObject {
         }
     }
 
-    fileprivate final class MessageSentProxy
+    private final class MessageSentProxy
         : MessageInterceptorSubject
         , RXMessageSentObserver {
         typealias Element = [AnyObject]
@@ -310,7 +310,7 @@ extension Reactive where Base: AnyObject {
 #endif
 
 
-fileprivate final class DeallocObservable {
+private final class DeallocObservable {
     let _subject = ReplaySubject<Void>.create(bufferSize:1)
 
     init() {
@@ -333,7 +333,7 @@ private protocol KVOObservableProtocol {
     var options: KeyValueObservingOptions { get }
 }
 
-fileprivate final class KVOObserver
+private final class KVOObserver
     : _RXKVOObserver
     , Disposable {
     typealias Callback = (Any?) -> Void
@@ -361,7 +361,7 @@ fileprivate final class KVOObserver
     }
 }
 
-fileprivate final class KVOObservable<Element>
+private final class KVOObservable<Element>
     : ObservableType
     , KVOObservableProtocol {
     typealias Element = Element?
@@ -397,7 +397,7 @@ fileprivate final class KVOObservable<Element>
 
 }
 
-fileprivate extension KeyValueObservingOptions {
+private extension KeyValueObservingOptions {
     var nsOptions: NSKeyValueObservingOptions {
         var result: UInt = 0
         if self.contains(.new) {
@@ -438,7 +438,7 @@ fileprivate extension KeyValueObservingOptions {
         return properyRuntimeInfo.range(of: ",W,") != nil
     }
 
-    fileprivate extension ObservableType where Element == AnyObject? {
+    private extension ObservableType where Element == AnyObject? {
         func finishWithNilWhenDealloc(_ target: NSObject)
             -> Observable<AnyObject?> {
                 let deallocating = target.rx.deallocating

--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -60,7 +60,7 @@ private func escapeTerminalString(_ value: String) -> String {
     return value.replacingOccurrences(of: "\"", with: "\\\"", options:[], range: nil)
 }
 
-fileprivate func convertURLRequestToCurlCommand(_ request: URLRequest) -> String {
+private func convertURLRequestToCurlCommand(_ request: URLRequest) -> String {
     let method = request.httpMethod ?? "GET"
     var returnValue = "curl -X \(method) "
 

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourcePrefetchingProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourcePrefetchingProxy.swift
@@ -17,10 +17,10 @@ extension UICollectionView: HasPrefetchDataSource {
 }
 
 @available(iOS 10.0, tvOS 10.0, *)
-fileprivate let collectionViewPrefetchDataSourceNotSet = CollectionViewPrefetchDataSourceNotSet()
+private let collectionViewPrefetchDataSourceNotSet = CollectionViewPrefetchDataSourceNotSet()
 
 @available(iOS 10.0, tvOS 10.0, *)
-fileprivate final class CollectionViewPrefetchDataSourceNotSet
+private final class CollectionViewPrefetchDataSourceNotSet
     : NSObject
     , UICollectionViewDataSourcePrefetching {
 
@@ -48,7 +48,7 @@ open class RxCollectionViewDataSourcePrefetchingProxy
         self.register { RxCollectionViewDataSourcePrefetchingProxy(collectionView: $0) }
     }
 
-    fileprivate var _prefetchItemsPublishSubject: PublishSubject<[IndexPath]>?
+    private var _prefetchItemsPublishSubject: PublishSubject<[IndexPath]>?
 
     /// Optimized version used for observing prefetch items callbacks.
     internal var prefetchItemsPublishSubject: PublishSubject<[IndexPath]> {

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
@@ -15,9 +15,9 @@ extension UICollectionView: HasDataSource {
     public typealias DataSource = UICollectionViewDataSource
 }
 
-fileprivate let collectionViewDataSourceNotSet = CollectionViewDataSourceNotSet()
+private let collectionViewDataSourceNotSet = CollectionViewDataSourceNotSet()
 
-fileprivate final class CollectionViewDataSourceNotSet
+private final class CollectionViewDataSourceNotSet
     : NSObject
     , UICollectionViewDataSource {
 

--- a/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
@@ -38,8 +38,8 @@ open class RxScrollViewDelegateProxy
         self.register { RxTextViewDelegateProxy(textView: $0) }
     }
 
-    fileprivate var _contentOffsetBehaviorSubject: BehaviorSubject<CGPoint>?
-    fileprivate var _contentOffsetPublishSubject: PublishSubject<()>?
+    private var _contentOffsetBehaviorSubject: BehaviorSubject<CGPoint>?
+    private var _contentOffsetPublishSubject: PublishSubject<()>?
 
     /// Optimized version used for observing content offset changes.
     internal var contentOffsetBehaviorSubject: BehaviorSubject<CGPoint> {

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourcePrefetchingProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourcePrefetchingProxy.swift
@@ -17,10 +17,10 @@ extension UITableView: HasPrefetchDataSource {
 }
 
 @available(iOS 10.0, tvOS 10.0, *)
-fileprivate let tableViewPrefetchDataSourceNotSet = TableViewPrefetchDataSourceNotSet()
+private let tableViewPrefetchDataSourceNotSet = TableViewPrefetchDataSourceNotSet()
 
 @available(iOS 10.0, tvOS 10.0, *)
-fileprivate final class TableViewPrefetchDataSourceNotSet
+private final class TableViewPrefetchDataSourceNotSet
     : NSObject
     , UITableViewDataSourcePrefetching {
 
@@ -48,7 +48,7 @@ open class RxTableViewDataSourcePrefetchingProxy
         self.register { RxTableViewDataSourcePrefetchingProxy(tableView: $0) }
     }
 
-    fileprivate var _prefetchRowsPublishSubject: PublishSubject<[IndexPath]>?
+    private var _prefetchRowsPublishSubject: PublishSubject<[IndexPath]>?
 
     /// Optimized version used for observing prefetch rows callbacks.
     internal var prefetchRowsPublishSubject: PublishSubject<[IndexPath]> {

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
@@ -15,9 +15,9 @@ extension UITableView: HasDataSource {
     public typealias DataSource = UITableViewDataSource
 }
 
-fileprivate let tableViewDataSourceNotSet = TableViewDataSourceNotSet()
+private let tableViewDataSourceNotSet = TableViewDataSourceNotSet()
 
-fileprivate final class TableViewDataSourceNotSet
+private final class TableViewDataSourceNotSet
     : NSObject
     , UITableViewDataSource {
 
@@ -50,7 +50,7 @@ open class RxTableViewDataSourceProxy
         self.register { RxTableViewDataSourceProxy(tableView: $0) }
     }
 
-    fileprivate weak var _requiredMethodsDataSource: UITableViewDataSource? = tableViewDataSourceNotSet
+    private weak var _requiredMethodsDataSource: UITableViewDataSource? = tableViewDataSourceNotSet
 
     // MARK: delegate
 

--- a/RxCocoa/iOS/UIBarButtonItem+Rx.swift
+++ b/RxCocoa/iOS/UIBarButtonItem+Rx.swift
@@ -11,7 +11,7 @@
 import UIKit
 import RxSwift
 
-fileprivate var rx_tap_key: UInt8 = 0
+private var rx_tap_key: UInt8 = 0
 
 extension Reactive where Base: UIBarButtonItem {
     

--- a/RxExample/Extensions/CLLocationManager+Rx.swift
+++ b/RxExample/Extensions/CLLocationManager+Rx.swift
@@ -207,7 +207,7 @@ extension Reactive where Base: CLLocationManager {
 }
 
 
-fileprivate func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T {
+private func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T {
     guard let returnValue = object as? T else {
         throw RxCocoaError.castingError(object: object, targetType: resultType)
     }
@@ -215,7 +215,7 @@ fileprivate func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T
     return returnValue
 }
 
-fileprivate func castOptionalOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T? {
+private func castOptionalOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T? {
     if NSNull().isEqual(object) {
         return nil
     }

--- a/RxExample/Extensions/UIImagePickerController+Rx.swift
+++ b/RxExample/Extensions/UIImagePickerController+Rx.swift
@@ -39,7 +39,7 @@
     
 #endif
 
-fileprivate func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T {
+private func castOrThrow<T>(_ resultType: T.Type, _ object: Any) throws -> T {
     guard let returnValue = object as? T else {
         throw RxCocoaError.castingError(object: object, targetType: resultType)
     }

--- a/RxExample/RxDataSources/Differentiator/Diff.swift
+++ b/RxExample/RxDataSources/Differentiator/Diff.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-fileprivate extension AnimatableSectionModelType {
+private extension AnimatableSectionModelType {
     init(safeOriginal: Self, safeItems: [Item]) throws {
         self.init(original: safeOriginal, items: safeItems)
 

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesAPI.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesAPI.swift
@@ -53,7 +53,7 @@ class GitHubSearchRepositoriesAPI {
     // *****************************************************************************************
     static let sharedAPI = GitHubSearchRepositoriesAPI(reachabilityService: try! DefaultReachabilityService())
 
-    fileprivate let _reachabilityService: ReachabilityService
+    private let _reachabilityService: ReachabilityService
 
     private init(reachabilityService: ReachabilityService) {
         _reachabilityService = reachabilityService
@@ -94,7 +94,7 @@ extension GitHubSearchRepositoriesAPI {
     private static let parseLinksPattern = "\\s*,?\\s*<([^\\>]*)>\\s*;\\s*rel=\"([^\"]*)\""
     private static let linksRegex = try! NSRegularExpression(pattern: parseLinksPattern, options: [.allowCommentsAndWhitespace])
 
-    fileprivate static func parseLinks(_ links: String) throws -> [String: String] {
+    private static func parseLinks(_ links: String) throws -> [String: String] {
 
         let length = (links as NSString).length
         let matches = GitHubSearchRepositoriesAPI.linksRegex.matches(in: links, options: NSRegularExpression.MatchingOptions(), range: NSRange(location: 0, length: length))
@@ -119,7 +119,7 @@ extension GitHubSearchRepositoriesAPI {
         return result
     }
 
-    fileprivate static func parseNextURL(_ httpResponse: HTTPURLResponse) throws -> URL? {
+    private static func parseNextURL(_ httpResponse: HTTPURLResponse) throws -> URL? {
         guard let serializedLinks = httpResponse.allHeaderFields["Link"] as? String else {
             return nil
         }
@@ -137,7 +137,7 @@ extension GitHubSearchRepositoriesAPI {
         return nextUrl
     }
 
-    fileprivate static func parseJSON(_ httpResponse: HTTPURLResponse, data: Data) throws -> AnyObject {
+    private static func parseJSON(_ httpResponse: HTTPURLResponse, data: Data) throws -> AnyObject {
         if !(200 ..< 300 ~= httpResponse.statusCode) {
             throw exampleError("Call failed")
         }

--- a/RxExample/RxExample/Examples/SimpleValidation/SimpleValidationViewController.swift
+++ b/RxExample/RxExample/Examples/SimpleValidation/SimpleValidationViewController.swift
@@ -10,8 +10,8 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-fileprivate let minimalUsernameLength = 5
-fileprivate let minimalPasswordLength = 5
+private let minimalUsernameLength = 5
+private let minimalPasswordLength = 5
 
 class SimpleValidationViewController : ViewController {
 

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchCell.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/Views/WikipediaSearchCell.swift
@@ -72,7 +72,7 @@ public class WikipediaSearchCell: UITableViewCell {
 
 }
 
-fileprivate protocol ReusableView: class {
+private protocol ReusableView: class {
     var disposeBag: DisposeBag? { get }
     func prepareForReuse()
 }
@@ -85,7 +85,7 @@ extension CollectionViewImageCell : ReusableView {
 
 }
 
-fileprivate extension ReusableView {
+private extension ReusableView {
     func installHackBecauseOfAutomationLeaksOnIOS10(firstViewThatDoesntLeak: UIView) {
         if #available(iOS 10.0, *) {
             if OSApplication.isInUITest  {

--- a/RxExample/RxExample/Feedbacks.swift
+++ b/RxExample/RxExample/Feedbacks.swift
@@ -281,7 +281,7 @@ extension Observable {
  - `events` map events from UI to events of a given system.
  */
 public class Bindings<Event>: Disposable {
-    fileprivate let subscriptions: [Disposable]
+    private let subscriptions: [Disposable]
     fileprivate let events: [Observable<Event>]
 
     /**

--- a/RxExample/RxExample/Services/Reachability.swift
+++ b/RxExample/RxExample/Services/Reachability.swift
@@ -91,9 +91,9 @@ public class Reachability {
         return .notReachable
     }
     
-    fileprivate var previousFlags: SCNetworkReachabilityFlags?
+    private var previousFlags: SCNetworkReachabilityFlags?
     
-    fileprivate var isRunningOnDevice: Bool = {
+    private var isRunningOnDevice: Bool = {
         #if targetEnvironment(simulator)
             return false
         #else
@@ -101,10 +101,10 @@ public class Reachability {
         #endif
     }()
     
-    fileprivate var notifierRunning = false
-    fileprivate var reachabilityRef: SCNetworkReachability?
+    private var notifierRunning = false
+    private var reachabilityRef: SCNetworkReachability?
     
-    fileprivate let reachabilitySerialQueue = DispatchQueue(label: "uk.co.ashleymills.reachability")
+    private let reachabilitySerialQueue = DispatchQueue(label: "uk.co.ashleymills.reachability")
     
     required public init(reachabilityRef: SCNetworkReachability) {
         reachableOnWWAN = true
@@ -227,7 +227,7 @@ public extension Reachability {
     }
 }
 
-fileprivate extension Reachability {
+private extension Reachability {
     
     func reachabilityChanged() {
         

--- a/RxSwift/Deprecated.swift
+++ b/RxSwift/Deprecated.swift
@@ -179,7 +179,7 @@ public final class Variable<Element> {
     private var _value: Element
 
     #if DEBUG
-    fileprivate let _synchronizationTracker = SynchronizationTracker()
+    private let _synchronizationTracker = SynchronizationTracker()
     #endif
 
     /// Gets or sets current value of variable.

--- a/RxSwift/Disposables/AnonymousDisposable.swift
+++ b/RxSwift/Disposables/AnonymousDisposable.swift
@@ -9,7 +9,7 @@
 /// Represents an Action-based disposable.
 ///
 /// When dispose method is called, disposal action will be dereferenced.
-fileprivate final class AnonymousDisposable : DisposeBase, Cancelable {
+private final class AnonymousDisposable : DisposeBase, Cancelable {
     public typealias DisposeAction = () -> Void
 
     private let _isDisposed = AtomicInt(0)
@@ -23,7 +23,7 @@ fileprivate final class AnonymousDisposable : DisposeBase, Cancelable {
     /// Constructs a new disposable with the given action used for disposal.
     ///
     /// - parameter disposeAction: Disposal action which will be run upon calling `dispose`.
-    fileprivate init(_ disposeAction: @escaping DisposeAction) {
+    private init(_ disposeAction: @escaping DisposeAction) {
         self._disposeAction = disposeAction
         super.init()
     }

--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -32,8 +32,8 @@ public final class DisposeBag: DisposeBase {
     private var _lock = SpinLock()
     
     // state
-    fileprivate var _disposables = [Disposable]()
-    fileprivate var _isDisposed = false
+    private var _disposables = [Disposable]()
+    private var _isDisposed = false
     
     /// Constructs new empty dispose bag.
     public override init() {

--- a/RxSwift/Disposables/NopDisposable.swift
+++ b/RxSwift/Disposables/NopDisposable.swift
@@ -9,11 +9,11 @@
 /// Represents a disposable that does nothing on disposal.
 ///
 /// Nop = No Operation
-fileprivate struct NopDisposable : Disposable {
+private struct NopDisposable : Disposable {
  
     fileprivate static let noOp: Disposable = NopDisposable()
     
-    fileprivate init() {
+    private init() {
         
     }
     

--- a/RxSwift/Disposables/SingleAssignmentDisposable.swift
+++ b/RxSwift/Disposables/SingleAssignmentDisposable.swift
@@ -13,7 +13,7 @@ If an underlying disposable resource has already been set, future attempts to se
 */
 public final class SingleAssignmentDisposable : DisposeBase, Cancelable {
 
-    fileprivate enum DisposeState: Int32 {
+    private enum DisposeState: Int32 {
         case disposed = 1
         case disposableSet = 2
     }

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -89,14 +89,14 @@ extension Hooks {
     public typealias DefaultErrorHandler = (_ subscriptionCallStack: [String], _ error: Error) -> Void
     public typealias CustomCaptureSubscriptionCallstack = () -> [String]
 
-    fileprivate static let _lock = RecursiveLock()
-    fileprivate static var _defaultErrorHandler: DefaultErrorHandler = { subscriptionCallStack, error in
+    private static let _lock = RecursiveLock()
+    private static var _defaultErrorHandler: DefaultErrorHandler = { subscriptionCallStack, error in
         #if DEBUG
             let serializedCallStack = subscriptionCallStack.joined(separator: "\n")
             print("Unhandled error happened: \(error)\n subscription called from:\n\(serializedCallStack)")
         #endif
     }
-    fileprivate static var _customCaptureSubscriptionCallstack: CustomCaptureSubscriptionCallstack = {
+    private static var _customCaptureSubscriptionCallstack: CustomCaptureSubscriptionCallstack = {
         #if DEBUG
             return Thread.callStackSymbols
         #else

--- a/RxSwift/Observables/Amb.swift
+++ b/RxSwift/Observables/Amb.swift
@@ -39,7 +39,7 @@ extension ObservableType {
     }
 }
 
-fileprivate enum AmbState {
+private enum AmbState {
     case neither
     case left
     case right
@@ -51,7 +51,7 @@ final private class AmbObserver<Observer: ObserverType>: ObserverType {
     typealias This = AmbObserver<Observer>
     typealias Sink = (This, Event<Element>) -> Void
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
     fileprivate var _sink: Sink
     fileprivate var _cancel: Disposable
     

--- a/RxSwift/Observables/AsMaybe.swift
+++ b/RxSwift/Observables/AsMaybe.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-fileprivate final class AsMaybeSink<Observer: ObserverType> : Sink<Observer>, ObserverType {
+private final class AsMaybeSink<Observer: ObserverType> : Sink<Observer>, ObserverType {
     typealias Element = Observer.Element
 
     private var _element: Event<Element>?
@@ -34,7 +34,7 @@ fileprivate final class AsMaybeSink<Observer: ObserverType> : Sink<Observer>, Ob
 }
 
 final class AsMaybe<Element>: Producer<Element> {
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
 
     init(source: Observable<Element>) {
         self._source = source

--- a/RxSwift/Observables/AsSingle.swift
+++ b/RxSwift/Observables/AsSingle.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-fileprivate final class AsSingleSink<Observer: ObserverType> : Sink<Observer>, ObserverType { 
+private final class AsSingleSink<Observer: ObserverType> : Sink<Observer>, ObserverType {
     typealias Element = Observer.Element
 
     private var _element: Event<Element>?
@@ -37,7 +37,7 @@ fileprivate final class AsSingleSink<Observer: ObserverType> : Sink<Observer>, O
 }
 
 final class AsSingle<Element>: Producer<Element> {
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
 
     init(source: Observable<Element>) {
         self._source = source

--- a/RxSwift/Observables/Create.swift
+++ b/RxSwift/Observables/Create.swift
@@ -30,7 +30,7 @@ final private class AnonymousObservableSink<Observer: ObserverType>: Sink<Observ
     private let _isStopped = AtomicInt(0)
 
     #if DEBUG
-        fileprivate let _synchronizationTracker = SynchronizationTracker()
+        private let _synchronizationTracker = SynchronizationTracker()
     #endif
 
     override init(observer: Observer, cancel: Cancelable) {

--- a/RxSwift/Observables/Debug.swift
+++ b/RxSwift/Observables/Debug.swift
@@ -26,9 +26,9 @@ extension ObservableType {
     }
 }
 
-fileprivate let dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+private let dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
 
-fileprivate func logEvent(_ identifier: String, dateFormat: DateFormatter, content: String) {
+private func logEvent(_ identifier: String, dateFormat: DateFormatter, content: String) {
     print("\(dateFormat.string(from: Date())): \(identifier) -> \(content)")
 }
 
@@ -75,7 +75,7 @@ final private class DebugSink<Source: ObservableType, Observer: ObserverType>: S
 final private class Debug<Source: ObservableType>: Producer<Source.Element> {
     fileprivate let _identifier: String
     fileprivate let _trimOutput: Bool
-    fileprivate let _source: Source
+    private let _source: Source
 
     init(source: Source, identifier: String?, trimOutput: Bool, file: String, line: UInt, function: String) {
         self._trimOutput = trimOutput

--- a/RxSwift/Observables/Dematerialize.swift
+++ b/RxSwift/Observables/Dematerialize.swift
@@ -18,7 +18,7 @@ extension ObservableType where Element: EventConvertible {
 
 }
 
-fileprivate final class DematerializeSink<T: EventConvertible, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == T.Element {
+private final class DematerializeSink<T: EventConvertible, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == T.Element {
     fileprivate func on(_ event: Event<T>) {
         switch event {
         case .next(let element):

--- a/RxSwift/Observables/DistinctUntilChanged.swift
+++ b/RxSwift/Observables/DistinctUntilChanged.swift
@@ -107,7 +107,7 @@ final private class DistinctUntilChanged<Element, Key>: Producer<Element> {
     typealias KeySelector = (Element) throws -> Key
     typealias EqualityComparer = (Key, Key) throws -> Bool
     
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
     fileprivate let _selector: KeySelector
     fileprivate let _comparer: EqualityComparer
     

--- a/RxSwift/Observables/Do.swift
+++ b/RxSwift/Observables/Do.swift
@@ -81,12 +81,12 @@ final private class Do<Element>: Producer<Element> {
     typealias EventHandler = (Event<Element>) throws -> Void
     typealias AfterEventHandler = (Event<Element>) throws -> Void
     
-    fileprivate let _source: Observable<Element>
-    fileprivate let _eventHandler: EventHandler
-    fileprivate let _afterEventHandler: AfterEventHandler
-    fileprivate let _onSubscribe: (() -> Void)?
-    fileprivate let _onSubscribed: (() -> Void)?
-    fileprivate let _onDispose: (() -> Void)?
+    private let _source: Observable<Element>
+    private let _eventHandler: EventHandler
+    private let _afterEventHandler: AfterEventHandler
+    private let _onSubscribe: (() -> Void)?
+    private let _onSubscribed: (() -> Void)?
+    private let _onDispose: (() -> Void)?
     
     init(source: Observable<Element>, eventHandler: @escaping EventHandler, afterEventHandler: @escaping AfterEventHandler, onSubscribe: (() -> Void)?, onSubscribed: (() -> Void)?, onDispose: (() -> Void)?) {
         self._source = source

--- a/RxSwift/Observables/First.swift
+++ b/RxSwift/Observables/First.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-fileprivate final class FirstSink<Element, Observer: ObserverType> : Sink<Observer>, ObserverType where Observer.Element == Element? {
+private final class FirstSink<Element, Observer: ObserverType> : Sink<Observer>, ObserverType where Observer.Element == Element? {
     typealias Parent = First<Element>
 
     func on(_ event: Event<Element>) {
@@ -27,7 +27,7 @@ fileprivate final class FirstSink<Element, Observer: ObserverType> : Sink<Observ
 }
 
 final class First<Element>: Producer<Element?> {
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
 
     init(source: Observable<Element>) {
         self._source = source

--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -58,7 +58,7 @@ final private class MapSink<SourceType, Observer: ObserverType>: Sink<Observer>,
 }
 
 #if TRACE_RESOURCES
-    fileprivate let _numberOfMapOperators = AtomicInt(0)
+    private let _numberOfMapOperators = AtomicInt(0)
     extension Resources {
         public static var numberOfMapOperators: Int32 {
             return load(_numberOfMapOperators)

--- a/RxSwift/Observables/Materialize.swift
+++ b/RxSwift/Observables/Materialize.swift
@@ -17,7 +17,7 @@ extension ObservableType {
     }
 }
 
-fileprivate final class MaterializeSink<Element, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == Event<Element> {
+private final class MaterializeSink<Element, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == Event<Element> {
 
     func on(_ event: Event<Element>) {
         self.forwardOn(.next(event))

--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -136,7 +136,7 @@ extension ObservableType {
     }
 }
 
-fileprivate final class MergeLimitedSinkIter<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>
+private final class MergeLimitedSinkIter<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType where SourceSequence.Element == Observer.Element {
@@ -184,7 +184,7 @@ fileprivate final class MergeLimitedSinkIter<SourceElement, SourceSequence: Obse
     }
 }
 
-fileprivate final class ConcatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
+private final class ConcatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
     typealias Selector = (SourceElement) throws -> SourceSequence
     
     private let _selector: Selector
@@ -199,7 +199,7 @@ fileprivate final class ConcatMapSink<SourceElement, SourceSequence: ObservableC
     }
 }
 
-fileprivate final class MergeLimitedBasicSink<SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceSequence, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
+private final class MergeLimitedBasicSink<SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceSequence, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
     
     override func performMap(_ element: SourceSequence) throws -> SourceSequence {
         return element
@@ -330,7 +330,7 @@ final private class MergeLimited<SourceSequence: ObservableConvertibleType>: Pro
 
 // MARK: Merge
 
-fileprivate final class MergeBasicSink<Source: ObservableConvertibleType, Observer: ObserverType> : MergeSink<Source, Source, Observer> where Observer.Element == Source.Element {
+private final class MergeBasicSink<Source: ObservableConvertibleType, Observer: ObserverType> : MergeSink<Source, Source, Observer> where Observer.Element == Source.Element {
     override func performMap(_ element: Source) throws -> Source {
         return element
     }
@@ -338,7 +338,7 @@ fileprivate final class MergeBasicSink<Source: ObservableConvertibleType, Observ
 
 // MARK: flatMap
 
-fileprivate final class FlatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
+private final class FlatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
     typealias Selector = (SourceElement) throws -> SourceSequence
 
     private let _selector: Selector
@@ -355,7 +355,7 @@ fileprivate final class FlatMapSink<SourceElement, SourceSequence: ObservableCon
 
 // MARK: FlatMapFirst
 
-fileprivate final class FlatMapFirstSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
+private final class FlatMapFirstSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
     typealias Selector = (SourceElement) throws -> SourceSequence
 
     private let _selector: Selector
@@ -374,7 +374,7 @@ fileprivate final class FlatMapFirstSink<SourceElement, SourceSequence: Observab
     }
 }
 
-fileprivate final class MergeSinkIter<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : ObserverType where Observer.Element == SourceSequence.Element {
+private final class MergeSinkIter<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : ObserverType where Observer.Element == SourceSequence.Element {
     typealias Parent = MergeSink<SourceElement, SourceSequence, Observer>
     typealias DisposeKey = CompositeDisposable.DisposeKey
     typealias Element = Observer.Element

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -198,8 +198,8 @@ final private class ConnectableObservableAdapter<Subject: SubjectType>
     : ConnectableObservable<Subject.Element> {
     typealias ConnectionType = Connection<Subject>
 
-    fileprivate let _source: Observable<Subject.Observer.Element>
-    fileprivate let _makeSubject: () -> Subject
+    private let _source: Observable<Subject.Observer.Element>
+    private let _makeSubject: () -> Subject
 
     fileprivate let _lock = RecursiveLock()
     fileprivate var _subject: Subject?
@@ -229,7 +229,7 @@ final private class ConnectableObservableAdapter<Subject: SubjectType>
         }
     }
 
-    fileprivate var lazySubject: Subject {
+    private var lazySubject: Subject {
         if let subject = self._subject {
             return subject
         }

--- a/RxSwift/Observables/ObserveOn.swift
+++ b/RxSwift/Observables/ObserveOn.swift
@@ -151,7 +151,7 @@ final private class ObserveOnSink<Observer: ObserverType>: ObserverBase<Observer
 }
 
 #if TRACE_RESOURCES
-    fileprivate let _numberOfSerialDispatchQueueObservables = AtomicInt(0)
+    private let _numberOfSerialDispatchQueueObservables = AtomicInt(0)
     extension Resources {
         /**
          Counts number of `SerialDispatchQueueObservables`.

--- a/RxSwift/Observables/Producer.swift
+++ b/RxSwift/Observables/Producer.swift
@@ -36,8 +36,8 @@ class Producer<Element> : Observable<Element> {
     }
 }
 
-fileprivate final class SinkDisposer: Cancelable {
-    fileprivate enum DisposeState: Int32 {
+private final class SinkDisposer: Cancelable {
+    private enum DisposeState: Int32 {
         case disposed = 1
         case sinkAndSubscriptionSet = 2
     }

--- a/RxSwift/Observables/Reduce.swift
+++ b/RxSwift/Observables/Reduce.swift
@@ -88,7 +88,7 @@ final private class Reduce<SourceType, AccumulateType, ResultType>: Producer<Res
     typealias AccumulatorType = (AccumulateType, SourceType) throws -> AccumulateType
     typealias ResultSelectorType = (AccumulateType) throws -> ResultType
     
-    fileprivate let _source: Observable<SourceType>
+    private let _source: Observable<SourceType>
     fileprivate let _seed: AccumulateType
     fileprivate let _accumulator: AccumulatorType
     fileprivate let _mapResult: ResultSelectorType

--- a/RxSwift/Observables/RetryWhen.swift
+++ b/RxSwift/Observables/RetryWhen.swift
@@ -43,7 +43,7 @@ final private class RetryTriggerSink<Sequence: Swift.Sequence, Observer: Observe
     
     typealias Parent = RetryWhenSequenceSinkIter<Sequence, Observer, TriggerObservable, Error>
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
 
     init(parent: Parent) {
         self._parent = parent
@@ -71,8 +71,8 @@ final private class RetryWhenSequenceSinkIter<Sequence: Swift.Sequence, Observer
     typealias Parent = RetryWhenSequenceSink<Sequence, Observer, TriggerObservable, Error>
 
     fileprivate let _parent: Parent
-    fileprivate let _errorHandlerSubscription = SingleAssignmentDisposable()
-    fileprivate let _subscription: Disposable
+    private let _errorHandlerSubscription = SingleAssignmentDisposable()
+    private let _subscription: Disposable
 
     init(parent: Parent, subscription: Disposable) {
         self._parent = parent
@@ -117,11 +117,11 @@ final private class RetryWhenSequenceSink<Sequence: Swift.Sequence, Observer: Ob
     
     let _lock = RecursiveLock()
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
     
     fileprivate var _lastError: Swift.Error?
     fileprivate let _errorSubject = PublishSubject<Error>()
-    fileprivate let _handler: Observable<TriggerObservable.Element>
+    private let _handler: Observable<TriggerObservable.Element>
     fileprivate let _notifier = PublishSubject<TriggerObservable.Element>()
 
     init(parent: Parent, observer: Observer, cancel: Cancelable) {
@@ -166,7 +166,7 @@ final private class RetryWhenSequenceSink<Sequence: Swift.Sequence, Observer: Ob
 final private class RetryWhenSequence<Sequence: Swift.Sequence, TriggerObservable: ObservableType, Error>: Producer<Sequence.Element.Element> where Sequence.Element: ObservableType {
     typealias Element = Sequence.Element.Element
     
-    fileprivate let _sources: Sequence
+    private let _sources: Sequence
     fileprivate let _notificationHandler: (Observable<Error>) -> TriggerObservable
     
     init(sources: Sequence, notificationHandler: @escaping (Observable<Error>) -> TriggerObservable) {

--- a/RxSwift/Observables/Sample.swift
+++ b/RxSwift/Observables/Sample.swift
@@ -34,7 +34,7 @@ final private class SamplerSink<Observer: ObserverType, SampleType>
     
     typealias Parent = SampleSequenceSink<Observer, SampleType>
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
 
     var _lock: RecursiveLock {
         return self._parent._lock
@@ -75,7 +75,7 @@ final private class SampleSequenceSink<Observer: ObserverType, SampleType>
     typealias Element = Observer.Element 
     typealias Parent = Sample<Element, SampleType>
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
 
     let _lock = RecursiveLock()
     
@@ -83,7 +83,7 @@ final private class SampleSequenceSink<Observer: ObserverType, SampleType>
     fileprivate var _element = nil as Element?
     fileprivate var _atEnd = false
     
-    fileprivate let _sourceSubscription = SingleAssignmentDisposable()
+    private let _sourceSubscription = SingleAssignmentDisposable()
     
     init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent

--- a/RxSwift/Observables/Scan.swift
+++ b/RxSwift/Observables/Scan.swift
@@ -48,8 +48,8 @@ final private class ScanSink<Element, Observer: ObserverType>: Sink<Observer>, O
     typealias Accumulate = Observer.Element 
     typealias Parent = Scan<Element, Accumulate>
 
-    fileprivate let _parent: Parent
-    fileprivate var _accumulate: Accumulate
+    private let _parent: Parent
+    private var _accumulate: Accumulate
     
     init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
@@ -82,7 +82,7 @@ final private class ScanSink<Element, Observer: ObserverType>: Sink<Observer>, O
 final private class Scan<Element, Accumulate>: Producer<Accumulate> {
     typealias Accumulator = (inout Accumulate, Element) throws -> Void
     
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
     fileprivate let _seed: Accumulate
     fileprivate let _accumulator: Accumulator
     

--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -156,7 +156,7 @@ extension ObservableType {
     }
 }
 
-fileprivate final class ShareReplay1WhileConnectedConnection<Element>
+private final class ShareReplay1WhileConnectedConnection<Element>
     : ObserverType
     , SynchronizedUnsubscribeType {
     typealias Observers = AnyObserver<Element>.s
@@ -169,7 +169,7 @@ fileprivate final class ShareReplay1WhileConnectedConnection<Element>
     private let _lock: RecursiveLock
     private var _disposed: Bool = false
     fileprivate var _observers = Observers()
-    fileprivate var _element: Element?
+    private var _element: Element?
 
     init(parent: Parent, lock: RecursiveLock) {
         self._parent = parent
@@ -265,7 +265,7 @@ final private class ShareReplay1WhileConnected<Element>
 
     fileprivate let _source: Observable<Element>
 
-    fileprivate let _lock = RecursiveLock()
+    private let _lock = RecursiveLock()
 
     fileprivate var _connection: Connection?
 
@@ -308,7 +308,7 @@ final private class ShareReplay1WhileConnected<Element>
     }
 }
 
-fileprivate final class ShareWhileConnectedConnection<Element>
+private final class ShareWhileConnectedConnection<Element>
     : ObserverType
     , SynchronizedUnsubscribeType {
     typealias Observers = AnyObserver<Element>.s
@@ -412,7 +412,7 @@ final private class ShareWhileConnected<Element>
 
     fileprivate let _source: Observable<Element>
 
-    fileprivate let _lock = RecursiveLock()
+    private let _lock = RecursiveLock()
 
     fileprivate var _connection: Connection?
 

--- a/RxSwift/Observables/SingleAsync.swift
+++ b/RxSwift/Observables/SingleAsync.swift
@@ -36,7 +36,7 @@ extension ObservableType {
     }
 }
 
-fileprivate final class SingleAsyncSink<Observer: ObserverType> : Sink<Observer>, ObserverType {
+private final class SingleAsyncSink<Observer: ObserverType> : Sink<Observer>, ObserverType {
     typealias Element = Observer.Element
     typealias Parent = SingleAsync<Element>
     
@@ -88,7 +88,7 @@ fileprivate final class SingleAsyncSink<Observer: ObserverType> : Sink<Observer>
 final class SingleAsync<Element>: Producer<Element> {
     typealias Predicate = (Element) throws -> Bool
     
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
     fileprivate let _predicate: Predicate?
     
     init(source: Observable<Element>, predicate: Predicate? = nil) {

--- a/RxSwift/Observables/Sink.swift
+++ b/RxSwift/Observables/Sink.swift
@@ -9,10 +9,10 @@
 class Sink<Observer: ObserverType> : Disposable {
     fileprivate let _observer: Observer
     fileprivate let _cancel: Cancelable
-    fileprivate let _disposed = AtomicInt(0)
+    private let _disposed = AtomicInt(0)
 
     #if DEBUG
-        fileprivate let _synchronizationTracker = SynchronizationTracker()
+        private let _synchronizationTracker = SynchronizationTracker()
     #endif
 
     init(observer: Observer, cancel: Cancelable) {

--- a/RxSwift/Observables/SkipUntil.swift
+++ b/RxSwift/Observables/SkipUntil.swift
@@ -29,7 +29,7 @@ final private class SkipUntilSinkOther<Other, Observer: ObserverType>
     typealias Parent = SkipUntilSink<Other, Observer>
     typealias Element = Other
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
 
     var _lock: RecursiveLock {
         return self._parent._lock
@@ -79,10 +79,10 @@ final private class SkipUntilSink<Other, Observer: ObserverType>
     typealias Parent = SkipUntil<Element, Other>
     
     let _lock = RecursiveLock()
-    fileprivate let _parent: Parent
+    private let _parent: Parent
     fileprivate var _forwardElements = false
     
-    fileprivate let _sourceSubscription = SingleAssignmentDisposable()
+    private let _sourceSubscription = SingleAssignmentDisposable()
 
     init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent

--- a/RxSwift/Observables/SkipWhile.swift
+++ b/RxSwift/Observables/SkipWhile.swift
@@ -25,8 +25,8 @@ final private class SkipWhileSink<Observer: ObserverType>: Sink<Observer>, Obser
     typealias Element = Observer.Element 
     typealias Parent = SkipWhile<Element>
 
-    fileprivate let _parent: Parent
-    fileprivate var _running = false
+    private let _parent: Parent
+    private var _running = false
 
     init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
@@ -59,7 +59,7 @@ final private class SkipWhileSink<Observer: ObserverType>: Sink<Observer>, Obser
 final private class SkipWhile<Element>: Producer<Element> {
     typealias Predicate = (Element) throws -> Bool
 
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
     fileprivate let _predicate: Predicate
 
     init(source: Observable<Element>, predicate: @escaping Predicate) {

--- a/RxSwift/Observables/Switch.swift
+++ b/RxSwift/Observables/Switch.swift
@@ -48,8 +48,8 @@ private class SwitchSink<SourceType, Source: ObservableConvertibleType, Observer
     , ObserverType where Source.Element == Observer.Element {
     typealias Element = SourceType
 
-    fileprivate let _subscriptions: SingleAssignmentDisposable = SingleAssignmentDisposable()
-    fileprivate let _innerSubscription: SerialDisposable = SerialDisposable()
+    private let _subscriptions: SingleAssignmentDisposable = SingleAssignmentDisposable()
+    private let _innerSubscription: SerialDisposable = SerialDisposable()
 
     let _lock = RecursiveLock()
     
@@ -126,9 +126,9 @@ final private class SwitchSinkIter<SourceType, Source: ObservableConvertibleType
     typealias Element = Source.Element
     typealias Parent = SwitchSink<SourceType, Source, Observer>
     
-    fileprivate let _parent: Parent
-    fileprivate let _id: Int
-    fileprivate let _self: Disposable
+    private let _parent: Parent
+    private let _id: Int
+    private let _self: Disposable
 
     var _lock: RecursiveLock {
         return self._parent._lock
@@ -187,7 +187,7 @@ final private class SwitchIdentitySink<Source: ObservableConvertibleType, Observ
 final private class MapSwitchSink<SourceType, Source: ObservableConvertibleType, Observer: ObserverType>: SwitchSink<SourceType, Source, Observer> where Observer.Element == Source.Element {
     typealias Selector = (SourceType) throws -> Source
 
-    fileprivate let _selector: Selector
+    private let _selector: Selector
 
     init(selector: @escaping Selector, observer: Observer, cancel: Cancelable) {
         self._selector = selector
@@ -202,7 +202,7 @@ final private class MapSwitchSink<SourceType, Source: ObservableConvertibleType,
 // MARK: Producers
 
 final private class Switch<Source: ObservableConvertibleType>: Producer<Source.Element> {
-    fileprivate let _source: Observable<Source>
+    private let _source: Observable<Source>
     
     init(source: Observable<Source>) {
         self._source = source
@@ -218,8 +218,8 @@ final private class Switch<Source: ObservableConvertibleType>: Producer<Source.E
 final private class FlatMapLatest<SourceType, Source: ObservableConvertibleType>: Producer<Source.Element> {
     typealias Selector = (SourceType) throws -> Source
 
-    fileprivate let _source: Observable<SourceType>
-    fileprivate let _selector: Selector
+    private let _source: Observable<SourceType>
+    private let _selector: Selector
 
     init(source: Observable<SourceType>, selector: @escaping Selector) {
         self._source = source

--- a/RxSwift/Observables/Take.swift
+++ b/RxSwift/Observables/Take.swift
@@ -86,7 +86,7 @@ final private class TakeCountSink<Observer: ObserverType>: Sink<Observer>, Obser
 }
 
 final private class TakeCount<Element>: Producer<Element> {
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
     fileprivate let _count: Int
     
     init(source: Observable<Element>, count: Int) {
@@ -113,7 +113,7 @@ final private class TakeTimeSink<Element, Observer: ObserverType>
     , SynchronizedOnType where Observer.Element == Element {
     typealias Parent = TakeTime<Element>
 
-    fileprivate let _parent: Parent
+    private let _parent: Parent
     
     let _lock = RecursiveLock()
     

--- a/RxSwift/Observables/TakeLast.swift
+++ b/RxSwift/Observables/TakeLast.swift
@@ -59,7 +59,7 @@ final private class TakeLastSink<Observer: ObserverType>: Sink<Observer>, Observ
 }
 
 final private class TakeLast<Element>: Producer<Element> {
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
     fileprivate let _count: Int
     
     init(source: Observable<Element>, count: Int) {

--- a/RxSwift/Observables/TakeUntil.swift
+++ b/RxSwift/Observables/TakeUntil.swift
@@ -56,7 +56,7 @@ final private class TakeUntilSinkOther<Other, Observer: ObserverType>
     typealias Parent = TakeUntilSink<Other, Observer>
     typealias Element = Other
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
 
     var _lock: RecursiveLock {
         return self._parent._lock
@@ -103,7 +103,7 @@ final private class TakeUntilSink<Other, Observer: ObserverType>
     typealias Element = Observer.Element 
     typealias Parent = TakeUntil<Element, Other>
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
  
     let _lock = RecursiveLock()
     
@@ -163,8 +163,8 @@ final private class TakeUntilPredicateSink<Observer: ObserverType>
     typealias Element = Observer.Element 
     typealias Parent = TakeUntilPredicate<Element>
 
-    fileprivate let _parent: Parent
-    fileprivate var _running = true
+    private let _parent: Parent
+    private var _running = true
 
     init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
@@ -207,7 +207,7 @@ final private class TakeUntilPredicateSink<Observer: ObserverType>
 final private class TakeUntilPredicate<Element>: Producer<Element> {
     typealias Predicate = (Element) throws -> Bool
 
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
     fileprivate let _predicate: Predicate
     fileprivate let _behavior: TakeUntilBehavior
 

--- a/RxSwift/Observables/TakeWhile.swift
+++ b/RxSwift/Observables/TakeWhile.swift
@@ -28,9 +28,9 @@ final private class TakeWhileSink<Observer: ObserverType>
     typealias Element = Observer.Element 
     typealias Parent = TakeWhile<Element>
 
-    fileprivate let _parent: Parent
+    private let _parent: Parent
 
-    fileprivate var _running = true
+    private var _running = true
 
     init(parent: Parent, observer: Observer, cancel: Cancelable) {
         self._parent = parent
@@ -69,7 +69,7 @@ final private class TakeWhileSink<Observer: ObserverType>
 final private class TakeWhile<Element>: Producer<Element> {
     typealias Predicate = (Element) throws -> Bool
 
-    fileprivate let _source: Observable<Element>
+    private let _source: Observable<Element>
     fileprivate let _predicate: Predicate
 
     init(source: Observable<Element>, predicate: @escaping Predicate) {

--- a/RxSwift/Observables/WithLatestFrom.swift
+++ b/RxSwift/Observables/WithLatestFrom.swift
@@ -43,9 +43,9 @@ final private class WithLatestFromSink<FirstType, SecondType, Observer: Observer
     typealias Parent = WithLatestFrom<FirstType, SecondType, ResultType>
     typealias Element = FirstType
     
-    fileprivate let _parent: Parent
+    private let _parent: Parent
     
-    var _lock = RecursiveLock()
+    fileprivate var _lock = RecursiveLock()
     fileprivate var _latest: SecondType?
 
     init(parent: Parent, observer: Observer, cancel: Cancelable) {

--- a/RxSwift/Rx.swift
+++ b/RxSwift/Rx.swift
@@ -7,7 +7,7 @@
 //
 
 #if TRACE_RESOURCES
-    fileprivate let resourceCount = AtomicInt(0)
+    private let resourceCount = AtomicInt(0)
 
     /// Resource utilization information
     public struct Resources {

--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -73,7 +73,7 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
     }
 
     /// Gets a value that indicates whether the caller must call a `schedule` method.
-    public static fileprivate(set) var isScheduleRequired: Bool {
+    public static private(set) var isScheduleRequired: Bool {
         get {
             return pthread_getspecific(CurrentThreadScheduler.isScheduleRequiredKey) == nil
         }

--- a/RxSwift/Schedulers/VirtualTimeScheduler.swift
+++ b/RxSwift/Schedulers/VirtualTimeScheduler.swift
@@ -17,7 +17,7 @@ open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
 
     private var _clock: VirtualTime
 
-    fileprivate var _schedulerQueue : PriorityQueue<VirtualSchedulerItem<VirtualTime>>
+    private var _schedulerQueue : PriorityQueue<VirtualSchedulerItem<VirtualTime>>
     private var _converter: Converter
 
     private var _nextId = 0

--- a/RxSwift/Subjects/AsyncSubject.swift
+++ b/RxSwift/Subjects/AsyncSubject.swift
@@ -39,7 +39,7 @@ public final class AsyncSubject<Element>
     private var _lastElement: Element?
 
     #if DEBUG
-        fileprivate let _synchronizationTracker = SynchronizationTracker()
+        private let _synchronizationTracker = SynchronizationTracker()
     #endif
 
 

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -37,7 +37,7 @@ public final class BehaviorSubject<Element>
     private var _stoppedEvent: Event<Element>?
 
     #if DEBUG
-        fileprivate let _synchronizationTracker = SynchronizationTracker()
+        private let _synchronizationTracker = SynchronizationTracker()
     #endif
 
     /// Indicates whether the subject has been disposed.

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -37,7 +37,7 @@ public final class PublishSubject<Element>
     private var _stoppedEvent = nil as Event<Element>?
 
     #if DEBUG
-        fileprivate let _synchronizationTracker = SynchronizationTracker()
+        private let _synchronizationTracker = SynchronizationTracker()
     #endif
 
     /// Indicates whether the subject has been isDisposed.

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -204,7 +204,7 @@ private class ReplayBufferBase<Element>
     }
 }
 
-fileprivate final class ReplayOne<Element> : ReplayBufferBase<Element> {
+private final class ReplayOne<Element> : ReplayBufferBase<Element> {
     private var _value: Element?
     
     override init() {
@@ -254,7 +254,7 @@ private class ReplayManyBase<Element>: ReplayBufferBase<Element> {
     }
 }
 
-fileprivate final class ReplayMany<Element> : ReplayManyBase<Element> {
+private final class ReplayMany<Element> : ReplayManyBase<Element> {
     private let _bufferSize: Int
     
     init(bufferSize: Int) {
@@ -270,7 +270,7 @@ fileprivate final class ReplayMany<Element> : ReplayManyBase<Element> {
     }
 }
 
-fileprivate final class ReplayAll<Element> : ReplayManyBase<Element> {
+private final class ReplayAll<Element> : ReplayManyBase<Element> {
     init() {
         super.init(queueSize: 0)
     }

--- a/RxTest/TestableObserver.swift
+++ b/RxTest/TestableObserver.swift
@@ -11,10 +11,10 @@ import RxSwift
 /// Observer that records events together with virtual time when they were received.
 public final class TestableObserver<Element>
     : ObserverType {
-    fileprivate let _scheduler: TestScheduler
+    private let _scheduler: TestScheduler
 
     /// Recorded events.
-    public fileprivate(set) var events = [Recorded<Event<Element>>]()
+    public private(set) var events = [Recorded<Event<Element>>]()
     
     init(scheduler: TestScheduler) {
         self._scheduler = scheduler

--- a/Tests/Microoptimizations/PerformanceTools.swift
+++ b/Tests/Microoptimizations/PerformanceTools.swift
@@ -11,10 +11,10 @@ import Foundation
 import Dispatch
 #endif
 
-fileprivate var mallocFunctions: [(@convention(c) (UnsafeMutablePointer<_malloc_zone_t>?, Int) -> UnsafeMutableRawPointer?)] = []
+private var mallocFunctions: [(@convention(c) (UnsafeMutablePointer<_malloc_zone_t>?, Int) -> UnsafeMutableRawPointer?)] = []
 
-fileprivate var allocCalls: Int64 = 0
-fileprivate var bytesAllocated: Int64 = 0
+private var allocCalls: Int64 = 0
+private var bytesAllocated: Int64 = 0
 
 func call0(_ p: UnsafeMutablePointer<_malloc_zone_t>?, size: Int) -> UnsafeMutableRawPointer? {
     OSAtomicIncrement64Barrier(&allocCalls)
@@ -49,7 +49,7 @@ func getMemoryInfo() -> (bytes: Int64, allocations: Int64) {
     return (bytesAllocated, allocCalls)
 }
 
-fileprivate var registeredMallocHooks = false
+private var registeredMallocHooks = false
 
 func registerMallocHooks() {
     if registeredMallocHooks {
@@ -122,7 +122,7 @@ final class B {
 let numberOfObjects = 1000000
 let aliveAtTheEnd = numberOfObjects / 10
 
-fileprivate var objects: [AnyObject] = []
+private var objects: [AnyObject] = []
 
 func fragmentMemory() {
     objects = [AnyObject](repeating: A(), count: aliveAtTheEnd)
@@ -164,7 +164,7 @@ func measureMemoryUsage(work: () -> Void) -> (bytesAllocated: UInt64, allocation
     return (approxValuePerIteration(bytesAfter - bytes), approxValuePerIteration(allocationsAfter - allocations))
 }
 
-fileprivate var fragmentedMemory = false
+private var fragmentedMemory = false
 
 func compareTwoImplementations(benchmarkTime: Bool, benchmarkMemory: Bool, first: () -> Void, second: () -> Void) {
     if !fragmentedMemory {

--- a/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+UIKit.swift
@@ -124,7 +124,7 @@ extension DelegateProxyTest {
 final class ExtendTableViewDelegateProxy
     : RxTableViewDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UITableViewSubclass1?
+    weak private(set) var control: UITableViewSubclass1?
 
     init(tableViewSubclass: UITableViewSubclass1) {
         self.control = tableViewSubclass
@@ -151,7 +151,7 @@ final class UITableViewSubclass1
 final class ExtendTableViewDataSourceProxy
     : RxTableViewDataSourceProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UITableViewSubclass2?
+    weak private(set) var control: UITableViewSubclass2?
 
     init(tableViewSubclass: UITableViewSubclass2) {
         self.control = tableViewSubclass
@@ -181,7 +181,7 @@ final class UITableViewSubclass2
 final class ExtendTableViewDataSourcePrefetchingProxy
     : RxTableViewDataSourcePrefetchingProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UITableViewSubclass3?
+    weak private(set) var control: UITableViewSubclass3?
 
     init(parentObject: UITableViewSubclass3) {
         self.control = parentObject
@@ -212,7 +212,7 @@ final class UITableViewSubclass3
 final class ExtendCollectionViewDelegateProxy
     : RxCollectionViewDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UICollectionViewSubclass1?
+    weak private(set) var control: UICollectionViewSubclass1?
 
     init(parentObject: UICollectionViewSubclass1) {
         self.control = parentObject
@@ -239,7 +239,7 @@ final class UICollectionViewSubclass1
 final class ExtendCollectionViewDataSourceProxy
     : RxCollectionViewDataSourceProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UICollectionViewSubclass2?
+    weak private(set) var control: UICollectionViewSubclass2?
 
     init(parentObject: UICollectionViewSubclass2) {
         self.control = parentObject
@@ -270,7 +270,7 @@ final class UICollectionViewSubclass2
 final class ExtendCollectionViewDataSourcePrefetchingProxy
     : RxCollectionViewDataSourcePrefetchingProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UICollectionViewSubclass3?
+    weak private(set) var control: UICollectionViewSubclass3?
 
     init(parentObject: UICollectionViewSubclass3) {
         self.control = parentObject
@@ -301,7 +301,7 @@ final class UICollectionViewSubclass3
 final class ExtendScrollViewDelegateProxy
     : RxScrollViewDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UIScrollViewSubclass?
+    weak private(set) var control: UIScrollViewSubclass?
 
     init(scrollViewSubclass: UIScrollViewSubclass) {
         self.control = scrollViewSubclass
@@ -329,7 +329,7 @@ final class UIScrollViewSubclass
 final class ExtendSearchBarDelegateProxy
     : RxSearchBarDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UISearchBarSubclass?
+    weak private(set) var control: UISearchBarSubclass?
     
     init(searchBarSubclass: UISearchBarSubclass) {
         self.control = searchBarSubclass
@@ -357,7 +357,7 @@ final class UISearchBarSubclass
 final class ExtendTextViewDelegateProxy
     : RxTextViewDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UITextViewSubclass?
+    weak private(set) var control: UITextViewSubclass?
 
     init(textViewSubclass: UITextViewSubclass) {
         self.control = textViewSubclass
@@ -435,7 +435,7 @@ final class UIPickerViewSubclass
 final class ExtendPickerViewDataSourceProxy
     : RxPickerViewDataSourceProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UIPickerViewSubclass2?
+    weak private(set) var control: UIPickerViewSubclass2?
         
     init(pickerViewSubclass: UIPickerViewSubclass2) {
         self.control = pickerViewSubclass
@@ -516,7 +516,7 @@ final class NSTextStorageSubclass
 final class ExtendNavigationControllerDelegateProxy
     : RxNavigationControllerDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UINavigationControllerSubclass?
+    weak private(set) var control: UINavigationControllerSubclass?
 
     init(navigationControllerSubclass: UINavigationControllerSubclass) {
         self.control = navigationControllerSubclass
@@ -527,7 +527,7 @@ final class ExtendNavigationControllerDelegateProxy
 final class ExtendTabBarControllerDelegateProxy
     : RxTabBarControllerDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var tabBarControllerSubclass: UITabBarControllerSubclass?
+    weak private(set) var tabBarControllerSubclass: UITabBarControllerSubclass?
     
     init(tabBarControllerSubclass: UITabBarControllerSubclass) {
         self.tabBarControllerSubclass = tabBarControllerSubclass
@@ -538,7 +538,7 @@ final class ExtendTabBarControllerDelegateProxy
 final class ExtendTabBarDelegateProxy
     : RxTabBarDelegateProxy
     , TestDelegateProtocol {
-    weak fileprivate(set) var control: UITabBarSubclass?
+    weak private(set) var control: UITabBarSubclass?
     
     init(tabBarSubclass: UITabBarSubclass) {
         self.control = tabBarSubclass

--- a/Tests/RxCocoaTests/NSTextField+RxTests.swift
+++ b/Tests/RxCocoaTests/NSTextField+RxTests.swift
@@ -58,7 +58,7 @@ extension NSTextFieldTests {
 
 }
 
-fileprivate final class TextFieldDelegate: NSObject, NSTextFieldDelegate {
+private final class TextFieldDelegate: NSObject, NSTextFieldDelegate {
 
     var didChange = false
 

--- a/Tests/RxCocoaTests/NSTextView+RxTests.swift
+++ b/Tests/RxCocoaTests/NSTextView+RxTests.swift
@@ -59,7 +59,7 @@ extension NSTextViewTests {
     }
 }
 
-fileprivate final class TextViewDelegate: NSObject, NSTextViewDelegate {
+private final class TextViewDelegate: NSObject, NSTextViewDelegate {
     var numberOfChanges = 0
 
     func textDidChange(_ notification: Notification) {

--- a/Tests/RxCocoaTests/RuntimeStateSnapshot.swift
+++ b/Tests/RxCocoaTests/RuntimeStateSnapshot.swift
@@ -18,7 +18,7 @@ final class ObjectRuntimeState {
         actingAs = ClassRuntimeState(RXObjCTestRuntime.objCClass(target))
     }
 
-    fileprivate static func changesFrom(_ from: ClassRuntimeState, to: ClassRuntimeState) -> [ObjectRuntimeChange] {
+    private static func changesFrom(_ from: ClassRuntimeState, to: ClassRuntimeState) -> [ObjectRuntimeChange] {
         if from.targetClass == to.targetClass {
             var changes = [ObjectRuntimeChange]()
             for (selector, implementation) in to.implementations {

--- a/Tests/RxCocoaTests/UIControl+RxTests.swift
+++ b/Tests/RxCocoaTests/UIControl+RxTests.swift
@@ -162,7 +162,7 @@ extension UIControlTests {
     }
 }
 
-fileprivate extension UIControl {
+private extension UIControl {
     func forceSendActions(for: UIControl.Event) {
         for target in self.allTargets {
             for selector in self.actions(forTarget: target, forControlEvent: `for`) ?? [] {

--- a/Tests/RxCocoaTests/UIWebView+RxTests.swift
+++ b/Tests/RxCocoaTests/UIWebView+RxTests.swift
@@ -16,7 +16,7 @@ import XCTest
 
 final class UIWebViewTests: RxTest {}
 
-fileprivate let testHTMLString = "<html><head></head><body><h1>🔥</h1></body></html>"
+private let testHTMLString = "<html><head></head><body><h1>🔥</h1></body></html>"
     
 extension UIWebViewTests {
         

--- a/Tests/RxSwiftTests/AtomicTests.swift
+++ b/Tests/RxSwiftTests/AtomicTests.swift
@@ -41,7 +41,7 @@ private struct AtomicIntSanityCheck {
         return self.atom
     }
 }
-fileprivate typealias AtomicPrimitive = AtomicIntSanityCheck
+private typealias AtomicPrimitive = AtomicIntSanityCheck
 #endif
 
 class AtomicTests: RxTest {}

--- a/Tests/RxSwiftTests/Observable+MaterializeTests.swift
+++ b/Tests/RxSwiftTests/Observable+MaterializeTests.swift
@@ -95,7 +95,7 @@ extension ObservableMaterializeTest {
     #endif
 }
 
-fileprivate func materializedRecoredEventsComparison<T: Equatable>(lhs: [Recorded<Event<Event<T>>>], rhs: [Recorded<Event<Event<T>>>]) -> Bool {
+private func materializedRecoredEventsComparison<T: Equatable>(lhs: [Recorded<Event<Event<T>>>], rhs: [Recorded<Event<Event<T>>>]) -> Bool {
     guard lhs.count == rhs.count else {
         return false
     }

--- a/Tests/RxSwiftTests/RecursiveLockTest.swift
+++ b/Tests/RxSwiftTests/RecursiveLockTest.swift
@@ -75,7 +75,7 @@ class RecursiveLockTests: RxTest {
     }
 }
 
-fileprivate protocol Lock {
+private protocol Lock {
     func lock()
     func unlock()
 }

--- a/Tests/RxTest.swift
+++ b/Tests/RxTest.swift
@@ -48,7 +48,7 @@ class RxTest
     : XCTestCase {
 
 #if TRACE_RESOURCES
-    fileprivate var startResourceCount: Int32 = 0
+    private var startResourceCount: Int32 = 0
 #endif
 
     var accumulateStatistics: Bool {


### PR DESCRIPTION
Swift 3 is gone and we can use private properties in extensions. Also, there are few other cases when `fileprivate` can be replaced with `private`. 
Pros:
- compiler will provide optimizations
- contributor will be less confused with `fileprivate` usage