### PR TITLE
Add takeUntil for SharedSequence

### DIFF
--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -425,6 +425,22 @@ extension SharedSequence {
     }
 }
 
+// MARK: - TakeUntil
+extension SharedSequence {
+    /**
+     Returns the elements from the source shared sequence until the other observable sequence produces an element.
+
+     - seealso: [takeUntil operator on reactivex.io](http://reactivex.io/documentation/operators/takeuntil.html)
+
+     - parameter other: Observable sequence that terminates propagation of elements of the source sequence.
+     - returns: An observable sequence containing the elements of the source sequence up to the point the other sequence interrupted further propagation.
+     */
+    public func takeUntil<Source: ObservableType>(_ other: Source) -> SharedSequence<SharingStrategy, Element> {
+        let source = self.asObservable().takeUntil(other)
+        return SharedSequence<SharingStrategy, Element>(source)
+    }
+}
+
 // MARK: withLatestFrom
 extension SharedSequenceConvertibleType {
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1892,6 +1892,7 @@ final class SharedSequenceOperatorTests_ : SharedSequenceOperatorTests, RxTestCa
     ("testDriverFromOptionalWhenNil", SharedSequenceOperatorTests.testDriverFromOptionalWhenNil),
     ("testDriverFromSequence", SharedSequenceOperatorTests.testDriverFromSequence),
     ("testDriverFromArray", SharedSequenceOperatorTests.testDriverFromArray),
+    ("testDriverTakeUntilt", SharedSequenceOperatorTests.testDriverTakeUntilt),
     ] }
 }
 

--- a/Tests/RxCocoaTests/SharedSequence+OperatorTest.swift
+++ b/Tests/RxCocoaTests/SharedSequence+OperatorTest.swift
@@ -1088,3 +1088,30 @@ extension SharedSequenceOperatorTests {
         }
     }
 }
+
+// MARK: - TakeUntil
+extension SharedSequenceOperatorTests {
+    func testDriverTakeUntilt() {
+        // Given
+        let scheduler = TestScheduler(initialClock: 0)
+        let completionType = 300
+        let observable = scheduler.createHotObservable([.next(completionType, 1)])
+        let source = scheduler.createHotObservable([
+            .next(250, 1),
+            .next(400, 2)
+        ])
+        // When
+        SharingScheduler.mock(scheduler: scheduler) {
+            let res = scheduler.start {
+                source.asDriver(onErrorJustReturn: -1)
+                    .takeUntil(observable)
+                    .asObservable()
+            }
+            // Then
+            XCTAssertEqual(res.events, [
+                .next(251, 1),
+                .completed(completionType)
+            ])
+        }
+    }
+}


### PR DESCRIPTION
Added takeUntil similar to Observable. It doesn't complete, but stops emit events.

Use case:
Landing screen which has animations, which is triggered by `Driver.timer`. I want animation stops when user taps button
```swift
Driver<Int>.interval(.seconds(5))
  .takeUntil(UIButton().rx.tap.asObservable())
  .drive { *run animation* }
```