### PR TITLE
Add RelayType & AnyRelay

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -136,9 +136,11 @@ custom_categories:
   - NSView+Rx
 - name: RxRelay
   children:
+  - AnyRelay
   - BehaviorRelay
   - Observable+Bind
   - PublishRelay
+  - RelayType
   - Utils
 - name: RxSwift
   children:

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -50,6 +50,8 @@
 		6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA56F202A206B002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA570202A206C002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		7889220322DF24C700BA25F4 /* RelayType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7889220222DF24C700BA25F4 /* RelayType.swift */; };
+		7889220522DF250900BA25F4 /* AnyRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7889220422DF250900BA25F4 /* AnyRelay.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEC31C89BCB9006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
@@ -962,6 +964,8 @@
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
+		7889220222DF24C700BA25F4 /* RelayType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayType.swift; sourceTree = "<group>"; };
+		7889220422DF250900BA25F4 /* AnyRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyRelay.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -1554,6 +1558,8 @@
 				A2897D61225CA3F3004EA481 /* Observable+Bind.swift */,
 				A2897D68225D023A004EA481 /* Utils.swift */,
 				A2FD4EA4225D0A8100288525 /* Info.plist */,
+				7889220222DF24C700BA25F4 /* RelayType.swift */,
+				7889220422DF250900BA25F4 /* AnyRelay.swift */,
 			);
 			path = RxRelay;
 			sourceTree = "<group>";
@@ -2951,6 +2957,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				A2897D57225CA236004EA481 /* PublishRelay.swift in Sources */,
+				7889220322DF24C700BA25F4 /* RelayType.swift in Sources */,
+				7889220522DF250900BA25F4 /* AnyRelay.swift in Sources */,
 				A2897D58225CA236004EA481 /* BehaviorRelay.swift in Sources */,
 				A2897D62225CA3F3004EA481 /* Observable+Bind.swift in Sources */,
 				A2897D69225D023A004EA481 /* Utils.swift in Sources */,

--- a/RxRelay/AnyRelay.swift
+++ b/RxRelay/AnyRelay.swift
@@ -1,0 +1,54 @@
+//
+//  AnyRelay.swift
+//  RxRelay
+//
+//  Created by Anton Nazarov on 17/07/2019.
+//  Copyright © 2019 Krunoslav Zaher. All rights reserved.
+//
+
+/// A type-erased `RelayType`.
+///
+/// Forwards operations to an arbitrary underlying relay with the same `Element` type, hiding the specifics of the underlying relay type.
+public struct AnyRelay<Element>: RelayType {
+    /// Anonymous element handler type.
+    public typealias ElementHandler = (Element) -> Void
+
+    private let relay: ElementHandler
+
+    /// Construct an instance whose `accept(element)` calls `elementHandler(element)`
+    ///
+    /// - parameter elementHandler: Element handler that observes sequences elements.
+    public init(elementHandler: @escaping ElementHandler) {
+        self.relay = elementHandler
+    }
+
+    /// Construct an instance whose `accept(element)` calls `relay.accept(element)`
+    ///
+    /// - parameter relay: Relay that receives sequence elements.
+    public init<Relay: RelayType>(_ relay: Relay) where Relay.Element == Element {
+        self.relay = relay.accept
+    }
+
+    /// Send `element` to this relay.
+    ///
+    /// - parameter element: Element instance.
+    public func accept(_ element: Element) {
+        return self.relay(element)
+    }
+
+    /// Erases type of relay and returns canonical relay.
+    ///
+    /// - returns: type erased relay.
+    public func asRelay() -> AnyRelay<Element> {
+        return self
+    }
+}
+
+extension RelayType {
+    /// Erases type of relay and returns canonical relay.
+    ///
+    /// - returns: type erased relay.
+    public func asRelay() -> AnyRelay<Element> {
+        return AnyRelay(self)
+    }
+}

--- a/RxRelay/BehaviorRelay.swift
+++ b/RxRelay/BehaviorRelay.swift
@@ -11,7 +11,7 @@ import RxSwift
 /// BehaviorRelay is a wrapper for `BehaviorSubject`.
 ///
 /// Unlike `BehaviorSubject` it can't terminate with error or completed.
-public final class BehaviorRelay<Element>: ObservableType {
+public final class BehaviorRelay<Element>: ObservableType, RelayType {
     private let _subject: BehaviorSubject<Element>
 
     /// Accepts `event` and emits it to subscribers

--- a/RxRelay/Observable+Bind.swift
+++ b/RxRelay/Observable+Bind.swift
@@ -10,37 +10,37 @@ import RxSwift
 
 extension ObservableType {
     /**
-     Creates new subscription and sends elements to publish relay(s).
+     Creates new subscription and sends elements to relay(s).
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target publish relays for sequence elements.
+     - parameter to: Target relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: PublishRelay<Element>...) -> Disposable {
+    public func bind<Relay: RelayType>(to relays: Relay...) -> Disposable where Relay.Element == Element {
         return bind(to: relays)
     }
 
     /**
-     Creates new subscription and sends elements to publish relay(s).
+     Creates new subscription and sends elements to relay(s).
 
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
 
-     - parameter to: Target publish relays for sequence elements.
+     - parameter to: Target relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: PublishRelay<Element?>...) -> Disposable {
-        return self.map { $0 as Element? }.bind(to: relays)
+    public func bind<Relay: RelayType>(to relays: Relay...) -> Disposable where Relay.Element == Optional<Element> {
+        return self.map(Optional.some).bind(to: relays)
     }
 
     /**
-     Creates new subscription and sends elements to publish relay(s).
+     Creates new subscription and sends elements to relay(s).
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target publish relays for sequence elements.
+     - parameter to: Target relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    private func bind(to relays: [PublishRelay<Element>]) -> Disposable {
+    private func bind<Relay: RelayType>(to relays: [Relay]) -> Disposable where Relay.Element == Element {
         return subscribe { e in
             switch e {
             case let .next(element):
@@ -48,53 +48,7 @@ extension ObservableType {
                     $0.accept(element)
                 }
             case let .error(error):
-                rxFatalErrorInDebug("Binding error to publish relay: \(error)")
-            case .completed:
-                break
-            }
-        }
-    }
-
-    /**
-     Creates new subscription and sends elements to behavior relay(s).
-     In case error occurs in debug mode, `fatalError` will be raised.
-     In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target behavior relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    public func bind(to relays: BehaviorRelay<Element>...) -> Disposable {
-        return self.bind(to: relays)
-    }
-
-    /**
-     Creates new subscription and sends elements to behavior relay(s).
-
-     In case error occurs in debug mode, `fatalError` will be raised.
-     In case error occurs in release mode, `error` will be logged.
-
-     - parameter to: Target behavior relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    public func bind(to relays: BehaviorRelay<Element?>...) -> Disposable {
-        return self.map { $0 as Element? }.bind(to: relays)
-    }
-
-    /**
-     Creates new subscription and sends elements to behavior relay(s).
-     In case error occurs in debug mode, `fatalError` will be raised.
-     In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target behavior relay for sequence elements.
-     - returns: Disposable object that can be used to unsubscribe the observer.
-     */
-    private func bind(to relays: [BehaviorRelay<Element>]) -> Disposable {
-        return subscribe { e in
-            switch e {
-            case let .next(element):
-                relays.forEach {
-                    $0.accept(element)
-                }
-            case let .error(error):
-                rxFatalErrorInDebug("Binding error to behavior relay: \(error)")
+                rxFatalErrorInDebug("Binding error to relay: \(error)")
             case .completed:
                 break
             }

--- a/RxRelay/PublishRelay.swift
+++ b/RxRelay/PublishRelay.swift
@@ -11,7 +11,7 @@ import RxSwift
 /// PublishRelay is a wrapper for `PublishSubject`.
 ///
 /// Unlike `PublishSubject` it can't terminate with error or completed.
-public final class PublishRelay<Element>: ObservableType {
+public final class PublishRelay<Element>: ObservableType, RelayType {
     private let _subject: PublishSubject<Element>
     
     // Accepts `event` and emits it to subscribers

--- a/RxRelay/RelayType.swift
+++ b/RxRelay/RelayType.swift
@@ -1,0 +1,15 @@
+//
+//  RelayType.swift
+//  RxRelay
+//
+//  Created by Anton Nazarov on 17/07/2019.
+//  Copyright © 2019 Krunoslav Zaher. All rights reserved.
+//
+
+public protocol RelayType {
+    /// The type of elements in sequence that relay can accept.
+    associatedtype Element
+
+    // Accepts `event` and emits it to subscribers
+    func accept(_ event: Element)
+}

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1164,6 +1164,7 @@ final class ObservableRelayBindTest_ : ObservableRelayBindTest, RxTestCase {
     ("testBindToOptionalBehaviorRelay", ObservableRelayBindTest.testBindToOptionalBehaviorRelay),
     ("testBindToOptionalBehaviorRelays", ObservableRelayBindTest.testBindToOptionalBehaviorRelays),
     ("testBindToBehaviorRelayNoAmbiguity", ObservableRelayBindTest.testBindToBehaviorRelayNoAmbiguity),
+    ("testAnyRelayWorks", ObservableRelayBindTest.testAnyRelayWorks),
     ] }
 }
 

--- a/Sources/RxRelay/AnyRelay.swift
+++ b/Sources/RxRelay/AnyRelay.swift
@@ -1,0 +1,1 @@
+../../RxRelay/AnyRelay.swift

--- a/Sources/RxRelay/RelayType.swift
+++ b/Sources/RxRelay/RelayType.swift
@@ -1,0 +1,1 @@
+../../RxRelay/RelayType.swift

--- a/Tests/RxRelayTests/Observable+RelayBindTests.swift
+++ b/Tests/RxRelayTests/Observable+RelayBindTests.swift
@@ -164,3 +164,20 @@ extension ObservableRelayBindTest {
         XCTAssertEqual(relay.value, 1)
     }
 }
+
+// MARK: - AnyRelay
+extension ObservableRelayBindTest {
+    func testAnyRelayWorks() {
+        // Given
+        var events: [Recorded<Event<Int>>] = []
+        let relay = PublishRelay<Int>()
+        let anyRelay = relay.asRelay()
+        _ = relay.subscribe { event in
+            events.append(Recorded(time: 0, value: event))
+        }
+        // When
+        _ = Observable.just(1).bind(to: anyRelay)
+        // Then
+        XCTAssertEqual(events, [.next(1)])
+    }
+}


### PR DESCRIPTION
## Motivation:

Implementing my ViewModel protocol I want to have input ("action-like") properties, which is useful for binding user intents (touches/swipes). Such sequences of events obviously can't be failed / completed, so `Relay` perfect fit for them.
```swift
protocol ViewModel {
  // Input
  var toggle: PublishRelay<Bool> { get }
}
```

However, I don't want to expose my underlaying type of Relay. Maybe I need to store the latest state with `BehaviourRelay`, maybe not. Moreover, I want to prevent a subscription on my input property `toggle`. I need something like `AnyObserver`, but only accepting `Element` instead of `Event<Element>`.

This PR introduces `RelayType` and `AnyRelay` which help to achieve such behavior:

```swift
protocol ViewModel {
  // Input
  var toggle: AnyRelay<Bool> { get }
}
```
Also I reduce code dublication for Publish/Behaviour relays.