### PR TITLE
Remove dubbed errors policy from docs #trivial

### DIFF
--- a/RxCocoa/Traits/ControlEvent.swift
+++ b/RxCocoa/Traits/ControlEvent.swift
@@ -20,10 +20,9 @@ public protocol ControlEventType : ObservableType {
 
     Properties:
 
-    - it never fails,
     - it doesn’t send any initial value on subscription,
     - it `Complete`s the sequence when the control deallocates,
-    - it never errors out, and
+    - it never errors out
     - it delivers events on `MainScheduler.instance`.
 
     **The implementation of `ControlEvent` will ensure that sequence of events is being subscribed on main scheduler

--- a/RxCocoa/Traits/ControlProperty.swift
+++ b/RxCocoa/Traits/ControlProperty.swift
@@ -23,7 +23,6 @@ public protocol ControlPropertyType : ObservableType, ObserverType {
 
     It's properties are:
 
-    - it never fails
     - `shareReplay(1)` behavior
         - it's stateful, upon subscription (calling subscribe) last element is immediately replayed if it was produced
     - it will `Complete` sequence on control being deallocated


### PR DESCRIPTION
I thought that:
> it never fails

and 

> it never errors out

mean the same thing - no `.error` even can be emitted.

Please fix me if I am wrong :)
