### PR TITLE
Let Xcode suggest fixes for renamed associatedtypes

### DIFF
--- a/RxSwift/Event.swift
+++ b/RxSwift/Event.swift
@@ -94,7 +94,7 @@ public protocol EventConvertible {
     /// Type of element in event
     associatedtype Element
 
-    @available(*, deprecated, message: "Use `Element` instead.")
+    @available(*, deprecated, renamed: "Element")
     typealias ElementType = Element
 
     /// Event representation of this instance

--- a/RxSwift/ObservableConvertibleType.swift
+++ b/RxSwift/ObservableConvertibleType.swift
@@ -11,7 +11,7 @@ public protocol ObservableConvertibleType {
     /// Type of elements in sequence.
     associatedtype Element
 
-    @available(*, deprecated, message: "Use `Element` instead.")
+    @available(*, deprecated, renamed: "Element")
     typealias E = Element
 
     /// Converts `self` to `Observable` sequence.

--- a/RxSwift/ObserverType.swift
+++ b/RxSwift/ObserverType.swift
@@ -11,7 +11,7 @@ public protocol ObserverType {
     /// The type of elements in sequence that observer can observe.
     associatedtype Element
 
-    @available(*, deprecated, message: "Use `Element` instead.")
+    @available(*, deprecated, renamed: "Element")
     typealias E = Element
 
     /// Notify observer about sequence event.

--- a/RxSwift/Reactive.swift
+++ b/RxSwift/Reactive.swift
@@ -39,7 +39,7 @@ public protocol ReactiveCompatible {
     /// Extended type
     associatedtype ReactiveBase
 
-    @available(*, deprecated, message: "Use `ReactiveBase` instead.")
+    @available(*, deprecated, renamed: "ReactiveBase")
     typealias CompatibleType = ReactiveBase
 
     /// Reactive extensions.

--- a/RxSwift/Subjects/SubjectType.swift
+++ b/RxSwift/Subjects/SubjectType.swift
@@ -13,7 +13,7 @@ public protocol SubjectType : ObservableType {
     /// Usually this type is type of subject itself, but it doesn't have to be.
     associatedtype Observer: ObserverType
 
-    @available(*, deprecated, message: "Use `Observer` instead.")
+    @available(*, deprecated, renamed: "Observer")
     typealias SubjectObserverType = Observer
 
     /// Returns observer interface for subject.

--- a/RxSwift/Traits/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence.swift
@@ -23,10 +23,10 @@ public protocol PrimitiveSequenceType {
     /// Sequence element type
     associatedtype Element
 
-    @available(*, deprecated, message: "Use `Trait` instead.")
+    @available(*, deprecated, renamed: "Trait")
     typealias TraitType = Trait
 
-    @available(*, deprecated, message: "Use `Element` instead.")
+    @available(*, deprecated, renamed: "Element")
     typealias ElementType = Element
 
     // Converts `self` to primitive sequence.


### PR DESCRIPTION
…by using `@available(*, deprecated, renamed: "Foo")` instead of `@available(*, deprecated, message: "Use `Foo` instead.")`. 

I might have missed some, but these were the ones that came across my path when I migrated one of my projects to 5.0
