### PR TITLE
Update `convertURLRequestToCurlCommand(_:)`

### DIFF
--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -64,7 +64,7 @@ private func convertURLRequestToCurlCommand(_ request: URLRequest) -> String {
     let method = request.httpMethod ?? "GET"
     var returnValue = "curl -X \(method) "
 
-    if let httpBody = request.httpBody, request.httpMethod == "POST" {
+    if let httpBody = request.httpBody, request.httpMethod == "POST" || request.httpMethod == "PUT" {
         let maybeBody = String(data: httpBody, encoding: String.Encoding.utf8)
         if let body = maybeBody {
             returnValue += "-d \"\(escapeTerminalString(body))\" "


### PR DESCRIPTION
Ensure that `convertURLRequestToCurlCommand(_:)` prints the httpBody for PUT requests.