### PR TITLE
Rename UIKitForMac to macCatalyst

### DIFF
--- a/RxCocoa/Deprecated.swift
+++ b/RxCocoa/Deprecated.swift
@@ -222,7 +222,7 @@ extension ObservableType {
     }
 #endif
 
-#if os(iOS) && !targetEnvironment(UIKitForMac)
+#if os(iOS) && !targetEnvironment(macCatalyst)
     extension UIWebView {
         @available(*, unavailable, message: "createRxDelegateProxy is now unavailable, check DelegateProxyFactory")
         public func createRxDelegateProxy() -> RxWebViewDelegateProxy {

--- a/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-#if os(iOS) && !targetEnvironment(UIKitForMac)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 
 import UIKit
 import RxSwift

--- a/RxCocoa/iOS/UIWebView+Rx.swift
+++ b/RxCocoa/iOS/UIWebView+Rx.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-#if os(iOS) && !targetEnvironment(UIKitForMac)
+#if os(iOS) && !targetEnvironment(macCatalyst)
 
     import UIKit
     import RxSwift


### PR DESCRIPTION
Xcode 11 GM changed UIKitForMac to macCatalyst. 