### PR TITLE
PublishSubject, BehaviorRelay and BehaviorSubject are now property wrappers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 language: generic
 sudo: required
 dist: xenial
-osx_image: xcode10.2
+osx_image: xcode11
 
 env:
   - DANGER=1
@@ -29,7 +29,7 @@ matrix:
     include:	
       - osx_image:	
         os: linux	
-        env: TEST=Unix swift=5.0
+        env: TEST=Unix swift=5.1
 
 notifications:
   slack: rxswift:3ykt2Z61f8GkdvhCZTYPduOL

--- a/RxRelay/BehaviorRelay.swift
+++ b/RxRelay/BehaviorRelay.swift
@@ -11,9 +11,16 @@ import RxSwift
 /// BehaviorRelay is a wrapper for `BehaviorSubject`.
 ///
 /// Unlike `BehaviorSubject` it can't terminate with error or completed.
+@propertyWrapper
 public final class BehaviorRelay<Element>: ObservableType {
     private let _subject: BehaviorSubject<Element>
-
+    
+    public var wrappedValue: Observable<Element> { self.asObservable() }
+    public var projectedValue: Element {
+        get { value }
+        set { accept(newValue) }
+    }
+    
     /// Accepts `event` and emits it to subscribers
     public func accept(_ event: Element) {
         self._subject.onNext(event)

--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -9,6 +9,7 @@
 /// Represents a value that changes over time.
 ///
 /// Observers can subscribe to the subject to receive the last (or initial) value and all subsequent notifications.
+@propertyWrapper
 public final class BehaviorSubject<Element>
     : Observable<Element>
     , SubjectType
@@ -44,7 +45,13 @@ public final class BehaviorSubject<Element>
     public var isDisposed: Bool {
         return self._isDisposed
     }
- 
+    
+    public var wrappedValue: Observable<Element> { self.asObservable() }
+    public var projectedValue: Element {
+        get { try! self.value() }
+        set { self.onNext(newValue) }
+    }
+    
     /// Initializes a new instance of the subject that caches its last value and starts with the specified value.
     ///
     /// - parameter value: Initial value sent to observers when no other value has been received by the subject yet.

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -9,6 +9,7 @@
 /// Represents an object that is both an observable sequence as well as an observer.
 ///
 /// Each notification is broadcasted to all subscribed observers.
+@propertyWrapper
 public final class PublishSubject<Element>
     : Observable<Element>
     , SubjectType
@@ -44,6 +45,8 @@ public final class PublishSubject<Element>
     public var isDisposed: Bool {
         return self._isDisposed
     }
+    
+    public var wrappedValue: Observable<Element> { self.asObservable() }
     
     /// Creates a subject.
     public override init() {


### PR DESCRIPTION
This PR makes PublishSubject, BehaviorSubject and BehaviorRelay to be propertyWrappers.

As described in #2073 this will enable users to reduce the amount of boilerplate code that would be needed while implementing common patterns involving these RxSwift types.