### PR TITLE
Fix iOS 13 UITableViewAlertForLayoutOutsideViewHierarchy warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 **Note 2**: Starting with RxSwift 6.x, RxSwift will no longer follow Swift versioning. Meaning, RxSwift can possibly move to v6, v7 or v8 while Swift is still in 5.x.
 
+* Fix `DelegateProxy` call to `layoutIfNeeded` for an object without a window. #2076
 * Remove `UIWebView` Reactive Extensions due to Apple hard deprecation. #2062
 * Minimum Swift version is now 5.1. #2077
 * Remove scoped imports in favor of library evolution. #2103

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -323,8 +323,12 @@ extension DelegateProxyType where ParentObject: HasPrefetchDataSource, Self.Dele
                 , DelegateProxy.Delegate: AnyObject {
                 let proxy = DelegateProxy.proxy(for: object)
                 let unregisterDelegate = DelegateProxy.installForwardDelegate(dataSource, retainDelegate: retainDataSource, onProxyForObject: object)
-                // this is needed to flush any delayed old state (https://github.com/RxSwiftCommunity/RxDataSources/pull/75)
-                object.layoutIfNeeded()
+
+                // Do not perform layoutIfNeeded if the object is still not in the view heirarchy
+                if object.window != nil {
+                    // this is needed to flush any delayed old state (https://github.com/RxSwiftCommunity/RxDataSources/pull/75)
+                    object.layoutIfNeeded()
+                }
 
                 let subscription = self.asObservable()
                     .observeOn(MainScheduler())


### PR DESCRIPTION
Fixes `UITableViewAlertForLayoutOutsideViewHierarchy` warning on **iOS 13** by checking if `layoutIfNeeded()`  needs to be called by performing a check if the `object` is currently attached to a window.