### PR TITLE
RxTest function builder

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA56F202A206B002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA570202A206C002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
+		78564EA5234881A200BF451E /* ArrayBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78564EA4234881A200BF451E /* ArrayBuilder.swift */; };
 		7EDBAEB41C89B1A6006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
 		7EDBAEBC1C89B9B7006CBE67 /* UITabBarItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */; };
 		7EDBAEC31C89BCB9006CBE67 /* UITabBarItem+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */; };
@@ -955,6 +956,7 @@
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
+		78564EA4234881A200BF451E /* ArrayBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayBuilder.swift; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEB71C89B9B7006CBE67 /* UITabBarItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+Rx.swift"; sourceTree = "<group>"; };
 		7F600F3D1C5D0C0100535B1D /* UIRefreshControl+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Rx.swift"; sourceTree = "<group>"; };
@@ -2412,6 +2414,7 @@
 				C8BF34CA1C2E426800416CAE /* Platform.Linux.swift */,
 				C8F03F491DBBAC0A00AECC4C /* DispatchQueue+Extensions.swift */,
 				C85217F61E33FBBE0015DD38 /* RecursiveLock.swift */,
+				78564EA4234881A200BF451E /* ArrayBuilder.swift */,
 			);
 			path = Platform;
 			sourceTree = "<group>";
@@ -3677,6 +3680,7 @@
 				C820A8F41EB4DA5A00D431BC /* Create.swift in Sources */,
 				C820A8901EB4DA5A00D431BC /* Scan.swift in Sources */,
 				CB883B401BE24C15000AC2EE /* RefCountDisposable.swift in Sources */,
+				78564EA5234881A200BF451E /* ArrayBuilder.swift in Sources */,
 				C84CC54E1BDCF48200E06A64 /* LockOwnerType.swift in Sources */,
 				C8FA89151C30405400CD3A17 /* VirtualTimeScheduler.swift in Sources */,
 				C84CC5531BDCF49300E06A64 /* SynchronizedOnType.swift in Sources */,

--- a/RxSwift/Platform/ArrayBuilder.swift
+++ b/RxSwift/Platform/ArrayBuilder.swift
@@ -1,0 +1,14 @@
+//
+//  ArrayBuilder.swift
+//  RxSwift
+//
+//  Created by Anton Nazarov on 10/5/19.
+//  Copyright © 2019 Krunoslav Zaher. All rights reserved.
+//
+
+@_functionBuilder
+public struct ArrayBuilder {    
+    public func buildBlock<Element>(_ elements: Element...) -> [Element] {
+        elements
+    }
+}

--- a/RxTest/Recorded+Event.swift
+++ b/RxTest/Recorded+Event.swift
@@ -75,6 +75,10 @@ extension Recorded {
         return self.events(recordedEvents)
     }
     
+    public static func events<T>(@ArrayBuilder builder: () -> [Recorded<Event<T>>]) -> [Recorded<Event<T>>] where Value == Event<T> {
+        builder()
+    }
+    
     
     /**
      Convenience method for recording a sequence of events. Its primary use case is improving readability in cases where type inference is unable to deduce the type of recorded events.

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -44,7 +44,11 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
     public func createHotObservable<Element>(_ events: [Recorded<Event<Element>>]) -> TestableObservable<Element> {
         return HotObservable(testScheduler: self as AnyObject as! TestScheduler, recordedEvents: events)
     }
-
+    
+    public func createHotObservable<Element>(@ArrayBuilder builder: () -> [Recorded<Event<Element>>]) -> TestableObservable<Element> {
+        createHotObservable(builder())
+    }
+    
     /**
     Creates a cold observable using the specified timestamped events.
      
@@ -53,6 +57,10 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
     */
     public func createColdObservable<Element>(_ events: [Recorded<Event<Element>>]) -> TestableObservable<Element> {
         return ColdObservable(testScheduler: self as AnyObject as! TestScheduler, recordedEvents: events)
+    }
+    
+    public func createColdObservable<Element>(@ArrayBuilder builder: () -> [Recorded<Event<Element>>]) -> TestableObservable<Element> {
+        createColdObservable(builder())
     }
 
     /**

--- a/Tests/RxSwiftTests/Observable+CombineLatestTests.swift
+++ b/Tests/RxSwiftTests/Observable+CombineLatestTests.swift
@@ -463,11 +463,11 @@ extension ObservableCombineLatestTest {
         for factory in factories {
             let scheduler = TestScheduler(initialClock: 0)
 
-            let e0 = scheduler.createHotObservable([
-                .next(150, 1),
-                .next(210, 2),
-                .error(220, testError1),
-                ])
+            let e0: TestableObservable<Int> = scheduler.createHotObservable {
+                Recorded.next(150, 1)
+                Recorded.next(210, 2)
+                Recorded.error(220, testError1)
+            }
             
             let e1 = scheduler.createHotObservable([
                 .next(150, 1),
@@ -675,14 +675,16 @@ extension ObservableCombineLatestTest {
                 factory(e0, e1)
             }
 
-            let messages = Recorded.events(
-                .next(220, 2 + 3),
-                .next(225, 3 + 4),
-                .next(230, 4 + 5),
-                .next(235, 4 + 6),
-                .next(240, 4 + 7),
-                .completed(250)
-            )
+            let messages: [Recorded<Event<Int>>] = Recorded.events {
+                // Sadly we can't ommit `Recorded` here
+                Recorded.next(220, 2 + 3)
+                // but we can use deprecated factory methods
+                next(225, 3 + 4)
+                Recorded.next(230, 4 + 5)
+                Recorded.next(235, 4 + 6)
+                Recorded.next(240, 4 + 7)
+                Recorded.completed(250)
+            }
             
             XCTAssertEqual(res.events, messages)
             


### PR DESCRIPTION
Inspired by https://github.com/ReactiveX/RxSwift/pull/2082/files
Just a proposal to use more Swift sugar (less commas).
Sadly we can't omit `Recorded` type, but we can use factory methods.