### PR TITLE
Introduce Weakify and weakTargetMap

### DIFF
--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -21,6 +21,24 @@ extension ObservableType {
         -> Observable<Result> {
         return Map(source: self.asObservable(), transform: transform)
     }
+
+    /**
+     Projects each element of an observable sequence into a new form.
+
+     - seealso: [map operator on reactivex.io](http://reactivex.io/documentation/operators/map.html)
+
+     - parameters:
+       - target: The target the transform function lives on. Will be held weakly.
+       - transform: A transform function to apply to each source element.
+     - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source. 
+                An error is returned if the target is nil.
+     */
+    public func weakTargetMap<ClassType: AnyObject, Result>(
+        _ target: ClassType,
+        _ transform: @escaping (ClassType) -> (Self.Element) throws -> Result
+    ) -> RxSwift.Observable<Result> {
+        map(weakifyTarget(target, function: transform))
+    }
 }
 
 final private class MapSink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType {

--- a/RxSwift/Weakify/Weakify.swift
+++ b/RxSwift/Weakify/Weakify.swift
@@ -1,0 +1,25 @@
+public func weakifyTarget<ClassType: AnyObject, InputType, OutputType>(
+    _ target: ClassType,
+    function: @escaping (ClassType) -> (InputType) throws -> OutputType
+) -> (InputType) throws -> OutputType {
+    let weakExecuter = WeakExecutor<ClassType, InputType, OutputType>(target, function: function)
+    return weakExecuter.execute
+}
+
+
+private struct WeakExecutor<ClassType: AnyObject, InputType, OutputType> {
+    enum NonRetainError: Error { case weakSelfError }
+
+    weak var target: ClassType?
+    let function: (ClassType) -> (InputType) throws -> OutputType
+
+    init(_ target: ClassType, function: @escaping (ClassType) -> (InputType) throws -> OutputType) {
+        self.target = target
+        self.function = function
+    }
+
+    func execute(_ input: InputType) throws -> OutputType {
+        guard let target = target else { throw NonRetainError.weakSelfError }
+        return try function(target)(input)
+    }
+}

--- a/Weakify/Weakify.swift
+++ b/Weakify/Weakify.swift
@@ -1,0 +1,33 @@
+//
+//  Weakify.swift
+//  RxSwift
+//
+//  Created by Jeffrey Adler on 10/3/19.
+//  Copyright © 2019 Jeffrey Adler. All rights reserved.
+//
+
+public func weakifyTarget<ClassType: AnyObject, InputType, OutputType>(
+    _ target: ClassType,
+    function: @escaping (ClassType) -> (InputType) throws -> OutputType
+) -> (InputType) throws -> OutputType {
+    let weakExecuter = WeakExecutor<ClassType, InputType, OutputType>(target, function: function)
+    return weakExecuter.execute
+}
+
+
+private struct WeakExecutor<ClassType: AnyObject, InputType, OutputType> {
+    enum NonRetainError: Error { case weakSelfError }
+
+    weak var target: ClassType?
+    let function: (ClassType) -> (InputType) throws -> OutputType
+
+    init(_ target: ClassType, function: @escaping (ClassType) -> (InputType) throws -> OutputType) {
+        self.target = target
+        self.function = function
+    }
+
+    func execute(_ input: InputType) throws -> OutputType {
+        guard let target = target else { throw NonRetainError.weakSelfError }
+        return try function(target)(input)
+    }
+}


### PR DESCRIPTION
Since instance functions are curried with the instances that they are called on the below code creates a retain cycle on `self` when `transform(_:)` is passed into the `map()` function.

```
class BadVC: UIViewController {
    let disposeBag = DisposeBag()

    init(with stream: Observable<Int>) {
        super.init(nibName: nil, bundle: nil)

        Observable<Int>
            .of(1, 2, 3)
            .concat(stream)
            .map(transform(_:)) // Captures self
            .subscribe(onNext: { (value) in
                print(value)
            })
            .disposed(by: disposeBag)
    }
    
    func transform(_ number: Int) -> String {
        return "\(number)"
    }
}
```

This issue exists due to `MapSink` retaining the transformation function until the stream is disposed. In cases where we have a `disposeBag` bag living on self we end up with a retain cycle.

This solution allows for targets to be weak before there is an attempt to curry the target with a given function:

```
Observable<Int>
    .of(1, 2, 3)
    .concat(stream)
    .map(weakifyTarget(self, function: BadVC.transform(_:)))
    .subscribe(onNext: { (value) in
        print(value)
    })
    .disposed(by: disposeBag)
```

Even shorter hand wrappers can be introduced:
```
    Observable<Int>
            .of(1, 2, 3)
            .concat(stream)
            .weakTargetMap(self, BadVC.transform(_:))
            .subscribe(onNext: { (value) in
                print(value)
            })
            .disposed(by: disposeBag)
```

Note: I recognize that if `func transform(_ number: Int)` is implemented as a class function than this issue wouldn't exist. However there are cases where access to self is needed.
