### PR TITLE
Remove scoped imports for library evolution

### DIFF
--- a/Platform/AtomicInt.swift
+++ b/Platform/AtomicInt.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSLock
+import Foundation
 
 final class AtomicInt: NSLock {
     fileprivate var value: Int32

--- a/Platform/Platform.Darwin.swift
+++ b/Platform/Platform.Darwin.swift
@@ -9,8 +9,7 @@
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
     import Darwin
-    import class Foundation.Thread
-    import protocol Foundation.NSCopying
+    import Foundation
 
     extension Thread {
         static func setThreadLocalStorageValue<T: AnyObject>(_ value: T?, forKey key: NSCopying) {

--- a/Platform/Platform.Linux.swift
+++ b/Platform/Platform.Linux.swift
@@ -8,7 +8,7 @@
 
 #if os(Linux)
 
-    import class Foundation.Thread
+    import Foundation
 
     extension Thread {
 

--- a/Platform/RecursiveLock.swift
+++ b/Platform/RecursiveLock.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSRecursiveLock
+import Foundation
 
 #if TRACE_RESOURCES
     class RecursiveLock: NSRecursiveLock {

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -8,9 +8,7 @@
 
 #if !os(Linux)
 
-    import func Foundation.objc_getAssociatedObject
-    import func Foundation.objc_setAssociatedObject
-
+    import Foundation
     import RxSwift
 
 /**

--- a/RxCocoa/Common/RxTarget.swift
+++ b/RxCocoa/Common/RxTarget.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSObject
+import Foundation
 
 import RxSwift
 

--- a/RxCocoa/Common/SectionedViewDataSourceType.swift
+++ b/RxCocoa/Common/SectionedViewDataSourceType.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.IndexPath
+import Foundation
 
 /// Data source with access to underlying sectioned model.
 public protocol SectionedViewDataSourceType {

--- a/RxCocoa/Foundation/KVORepresentable+CoreGraphics.swift
+++ b/RxCocoa/Foundation/KVORepresentable+CoreGraphics.swift
@@ -11,7 +11,7 @@
 import RxSwift
 import CoreGraphics
 
-import class Foundation.NSValue
+import Foundation
 
 #if arch(x86_64) || arch(arm64)
 	let CGRectType = "{CGRect={CGPoint=dd}{CGSize=dd}}"

--- a/RxCocoa/Foundation/KVORepresentable+Swift.swift
+++ b/RxCocoa/Foundation/KVORepresentable+Swift.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSNumber
+import Foundation
 
 extension Int : KVORepresentable {
     public typealias KVOType = NSNumber

--- a/RxCocoa/Foundation/Logging.swift
+++ b/RxCocoa/Foundation/Logging.swift
@@ -6,10 +6,10 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 #if canImport(FoundationNetworking)
-import struct FoundationNetworking.URLRequest
-#else
-import struct Foundation.URLRequest
+import FoundationNetworking
 #endif
 
 /// Simple logging settings for RxCocoa library.

--- a/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
@@ -8,7 +8,7 @@
 
 #if !os(Linux)
 
-import Foundation.NSObject
+import Foundation
 import RxSwift
 
 /// Key value observing options

--- a/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
@@ -10,7 +10,7 @@
 
 import RxSwift
 
-import Foundation.NSObject
+import Foundation
 
 extension Reactive where Base: NSObject {
     /**

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -8,7 +8,7 @@
 
 #if !os(Linux)
 
-import Foundation.NSObject
+import Foundation
 import RxSwift
 #if SWIFT_PACKAGE && !DISABLE_SWIZZLING && !os(Linux)
     import RxCocoaRuntime

--- a/RxCocoa/Foundation/NotificationCenter+Rx.swift
+++ b/RxCocoa/Foundation/NotificationCenter+Rx.swift
@@ -6,9 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NotificationCenter
-import struct Foundation.Notification
-
+import Foundation
 import RxSwift
 
 extension Reactive where Base: NotificationCenter {

--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -6,33 +6,12 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.URL
-import struct Foundation.Data
-import struct Foundation.Date
-import struct Foundation.TimeInterval
-import class Foundation.JSONSerialization
-import class Foundation.NSError
-import var Foundation.NSURLErrorCancelled
-import var Foundation.NSURLErrorDomain
+import Foundation
+import RxSwift
 
 #if canImport(FoundationNetworking)
-import struct FoundationNetworking.URLRequest
-import class FoundationNetworking.HTTPURLResponse
-import class FoundationNetworking.URLSession
-import class FoundationNetworking.URLResponse
-#else
-import struct Foundation.URLRequest
-import class Foundation.HTTPURLResponse
-import class Foundation.URLSession
-import class Foundation.URLResponse
+import FoundationNetworking
 #endif
-
-#if os(Linux)
-    // don't know why
-    import Foundation
-#endif
-
-import RxSwift
 
 /// RxCocoa URL errors.
 public enum RxCocoaURLError

--- a/RxCocoa/RxCocoa.swift
+++ b/RxCocoa/RxCocoa.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSNull
+import Foundation
 
 // Importing RxCocoa also imports RxRelay
 @_exported import RxRelay

--- a/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
@@ -45,7 +45,7 @@ public enum SharingScheduler {
 #if os(Linux)
     import Glibc
 #else
-    import func Foundation.arc4random
+    import Foundation
 #endif
 
 func _forceCompilerToStopDoingInsaneOptimizationsThatBreakCode(_ scheduler: () -> SchedulerType) {

--- a/RxExample/RxExample-iOSTests/Mocks/MockWireframe.swift
+++ b/RxExample/RxExample-iOSTests/Mocks/MockWireframe.swift
@@ -7,7 +7,7 @@
 //
 
 import RxSwift
-import struct Foundation.URL
+import Foundation
 
 class MockWireframe: Wireframe {
     let _openURL: (URL) -> Void

--- a/RxExample/RxExample-iOSTests/Mocks/NotImplementedStubs.swift
+++ b/RxExample/RxExample-iOSTests/Mocks/NotImplementedStubs.swift
@@ -9,7 +9,7 @@
 import RxSwift
 import RxTest
 
-import func Foundation.arc4random
+import Foundation
 
 func genericFatal<T>(_ message: String) -> T {
     if -1 == Int(arc4random() % 4) {

--- a/RxExample/RxExample/Examples/Dependencies.swift
+++ b/RxExample/RxExample/Examples/Dependencies.swift
@@ -7,10 +7,7 @@
 //
 
 import RxSwift
-
-import class Foundation.URLSession
-import class Foundation.OperationQueue
-import enum Foundation.QualityOfService
+import Foundation
 
 class Dependencies {
 

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesAPI.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositoriesAPI.swift
@@ -7,16 +7,7 @@
 //
 
 import RxSwift
-
-import struct Foundation.URL
-import struct Foundation.Data
-import struct Foundation.NSRange
-import struct Foundation.URLRequest
-import class Foundation.HTTPURLResponse
-import class Foundation.URLSession
-import class Foundation.NSRegularExpression
-import class Foundation.JSONSerialization
-import class Foundation.NSString
+import Foundation
 
 /**
  Parsed GitHub repository.

--- a/RxExample/RxExample/Examples/GitHubSignup/DefaultImplementations.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/DefaultImplementations.swift
@@ -7,13 +7,7 @@
 //
 
 import RxSwift
-
-import struct Foundation.CharacterSet
-import struct Foundation.URL
-import struct Foundation.URLRequest
-import struct Foundation.NSRange
-import class Foundation.URLSession
-import func Foundation.arc4random
+import Foundation
 
 class GitHubDefaultValidationService: GitHubValidationService {
     let API: GitHubAPI

--- a/RxExample/RxExample/Examples/TableViewWithEditingCommands/RandomUserAPI.swift
+++ b/RxExample/RxExample/Examples/TableViewWithEditingCommands/RandomUserAPI.swift
@@ -7,9 +7,7 @@
 //
 
 import RxSwift
-
-import struct Foundation.URL
-import class Foundation.URLSession
+import Foundation
 
 class RandomUserAPI {
     

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaPage.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaPage.swift
@@ -8,7 +8,7 @@
 
 import RxSwift
 
-import class Foundation.NSDictionary
+import Foundation
 
 struct WikipediaPage {
     let title: String

--- a/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaSearchResult.swift
+++ b/RxExample/RxExample/Examples/WikipediaImageSearch/WikipediaAPI/WikipediaSearchResult.swift
@@ -8,7 +8,7 @@
 
 import RxSwift
 
-import struct Foundation.URL
+import Foundation
 
 struct WikipediaSearchResult: CustomDebugStringConvertible {
     let title: String

--- a/RxExample/RxExample/Services/HtmlParsing.swift
+++ b/RxExample/RxExample/Services/HtmlParsing.swift
@@ -6,10 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSString
-import class Foundation.NSRegularExpression
-import func Foundation.NSMakeRange
-import struct Foundation.URL
+import Foundation
 
 func parseImageURLsfromHTML(_ html: NSString) throws -> [URL]  {
     let regularExpression = try NSRegularExpression(pattern: "<img[^>]*src=\"([^\"]+)\"[^>]*>", options: [])

--- a/RxExample/RxExample/Services/Reachability.swift
+++ b/RxExample/RxExample/Services/Reachability.swift
@@ -26,8 +26,7 @@ POSSIBILITY OF SUCH DAMAGE.
 */
 
 import SystemConfiguration
-import struct Foundation.Notification
-import class Foundation.NotificationCenter
+import Foundation
 
 public enum ReachabilityError: Error {
     case failedToCreateWithAddress(sockaddr_in)

--- a/RxExample/RxExample/Services/ReachabilityService.swift
+++ b/RxExample/RxExample/Services/ReachabilityService.swift
@@ -7,8 +7,7 @@
 //
 
 import RxSwift
-
-import class Dispatch.DispatchQueue
+import Dispatch
 
 public enum ReachabilityStatus {
     case reachable(viaWiFi: Bool)

--- a/RxExample/RxExample/Version.swift
+++ b/RxExample/RxExample/Version.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSObject
+import Foundation
 
 class Unique: NSObject {
 }

--- a/RxSwift/Date+Dispatch.swift
+++ b/RxSwift/Date+Dispatch.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2019 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.Date
-import struct Foundation.TimeInterval
-import enum Dispatch.DispatchTimeInterval
+import Dispatch
+import Foundation
 
 extension DispatchTimeInterval {
     var convertToSecondsFactor: Double {

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -83,7 +83,7 @@ extension ObservableType {
     }
 }
 
-import class Foundation.NSRecursiveLock
+import Foundation
 
 extension Hooks {
     public typealias DefaultErrorHandler = (_ subscriptionCallStack: [String], _ error: Error) -> Void

--- a/RxSwift/Observables/Debug.swift
+++ b/RxSwift/Observables/Debug.swift
@@ -6,8 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.Date
-import class Foundation.DateFormatter
+import Foundation
 
 extension ObservableType {
 

--- a/RxSwift/Observables/Delay.swift
+++ b/RxSwift/Observables/Delay.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.Date
+import Foundation
 
 extension ObservableType {
 

--- a/RxSwift/Observables/Throttle.swift
+++ b/RxSwift/Observables/Throttle.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.Date
+import Foundation
 
 extension ObservableType {
 

--- a/RxSwift/Reactive.swift
+++ b/RxSwift/Reactive.swift
@@ -73,7 +73,7 @@ extension ReactiveCompatible {
     }
 }
 
-import class Foundation.NSObject
+import Foundation
 
 /// Extend NSObject with `rx` proxy.
 extension NSObject: ReactiveCompatible { }

--- a/RxSwift/Rx.swift
+++ b/RxSwift/Rx.swift
@@ -66,7 +66,7 @@ func decrementChecked(_ i: inout Int) throws -> Int {
 }
 
 #if DEBUG
-    import class Foundation.Thread
+    import Foundation
     final class SynchronizationTracker {
         private let _lock = RecursiveLock()
 

--- a/RxSwift/RxMutableBox.swift
+++ b/RxSwift/RxMutableBox.swift
@@ -16,7 +16,7 @@
 ///
 /// For more information, read the discussion at:
 /// https://github.com/ReactiveX/RxSwift/issues/1911#issuecomment-479723298
-import class Foundation.NSObject
+import Foundation
 
 /// Creates mutable reference wrapper for any type.
 final class RxMutableBox<T>: NSObject {

--- a/RxSwift/SchedulerType.swift
+++ b/RxSwift/SchedulerType.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import enum Dispatch.DispatchTimeInterval
-import struct Foundation.Date
+import Dispatch
+import Foundation
 
 // Type that represents time interval in the context of RxSwift.
 public typealias RxTimeInterval = DispatchTimeInterval

--- a/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.Date
-import struct Foundation.TimeInterval
 import Dispatch
+import Foundation
 
 /// Abstracts the work that needs to be performed on a specific `dispatch_queue_t`. You can also pass a serial dispatch queue, it shouldn't cause any problems.
 ///

--- a/RxSwift/Schedulers/ConcurrentMainScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentMainScheduler.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.Date
-import struct Foundation.TimeInterval
 import Dispatch
+import Foundation
 
 /**
 Abstracts work that needs to be performed on `MainThread`. In case `schedule` methods are called from main thread, it will perform action immediately without scheduling.

--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -10,11 +10,6 @@ import Dispatch
 import Foundation
 
 #if os(Linux)
-    import struct Foundation.pthread_key_t
-    import func Foundation.pthread_setspecific
-    import func Foundation.pthread_getspecific
-    import func Foundation.pthread_key_create
-    
     fileprivate enum CurrentThreadSchedulerQueueKey {
         fileprivate static let instance = "RxSwift.CurrentThreadScheduler.Queue"
     }

--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -6,10 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.NSObject
-import protocol Foundation.NSCopying
-import class Foundation.Thread
 import Dispatch
+import Foundation
 
 #if os(Linux)
     import struct Foundation.pthread_key_t

--- a/RxSwift/Schedulers/HistoricalScheduler.swift
+++ b/RxSwift/Schedulers/HistoricalScheduler.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.Date
+import Foundation
 
 /// Provides a virtual time scheduler that uses `Date` for absolute time and `NSTimeInterval` for relative time.
 public class HistoricalScheduler : VirtualTimeScheduler<HistoricalSchedulerTimeConverter> {

--- a/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
+++ b/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
@@ -7,7 +7,7 @@
 //
 
 import Dispatch
-import struct Foundation.TimeInterval
+import Foundation
 
 struct DispatchQueueConfiguration {
     let queue: DispatchQueue

--- a/RxSwift/Schedulers/OperationQueueScheduler.swift
+++ b/RxSwift/Schedulers/OperationQueueScheduler.swift
@@ -6,10 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import class Foundation.Operation
-import class Foundation.OperationQueue
-import class Foundation.BlockOperation
 import Dispatch
+import Foundation
 
 /// Abstracts the work that needs to be performed on a specific `NSOperationQueue`.
 ///

--- a/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
@@ -6,9 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-import struct Foundation.TimeInterval
-import struct Foundation.Date
 import Dispatch
+import Foundation
 
 /**
 Abstracts the work that needs to be performed on a specific `dispatch_queue_t`. It will make sure 

--- a/RxTest/Event+Equatable.swift
+++ b/RxTest/Event+Equatable.swift
@@ -7,7 +7,7 @@
 //
 
 import RxSwift
-import class Foundation.NSError
+import Foundation
 
 internal func equals<Element: Equatable>(lhs: Event<Element>, rhs: Event<Element>) -> Bool {
     switch (lhs, rhs) {

--- a/Tests/RxCocoaTests/NSObject+RxTests.swift
+++ b/Tests/RxCocoaTests/NSObject+RxTests.swift
@@ -10,7 +10,7 @@ import RxSwift
 import RxCocoa
 import XCTest
 
-import Foundation.NSObject
+import Foundation
 
 final class NSObjectTests: RxTest {
     

--- a/Tests/RxCocoaTests/NotificationCenterTests.swift
+++ b/Tests/RxCocoaTests/NotificationCenterTests.swift
@@ -9,10 +9,7 @@
 import XCTest
 import RxSwift
 import RxCocoa
-
-import class Foundation.NotificationCenter
-import class Foundation.NSObject
-import struct Foundation.Notification
+import Foundation
 
 class NSNotificationCenterTests : RxTest {
     func testNotificationCenterWithoutObject() {

--- a/Tests/RxSwiftTests/Anomalies.swift
+++ b/Tests/RxSwiftTests/Anomalies.swift
@@ -12,7 +12,7 @@ import RxTest
 import XCTest
 import Dispatch
 
-import class Foundation.Thread
+import Foundation
 
 /**
  Makes sure github anomalies and edge cases don't surface up again.

--- a/Tests/RxSwiftTests/AssumptionsTest.swift
+++ b/Tests/RxSwiftTests/AssumptionsTest.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 import RxSwift
-import class Foundation.NSNull
+import Foundation
 
 final class AssumptionsTest : RxTest {
     

--- a/Tests/RxSwiftTests/DisposableTest.swift
+++ b/Tests/RxSwiftTests/DisposableTest.swift
@@ -9,13 +9,12 @@
 import XCTest
 import RxSwift
 import RxTest
+import Dispatch
 
-import class Dispatch.DispatchQueue
-import class Dispatch.DispatchSpecificKey
 #if os(Linux)
-    import func Glibc.random
+    import Glibc
 #else
-    import func Foundation.arc4random_uniform
+    import Foundation
 #endif
 
 class DisposableTest : RxTest {

--- a/Tests/RxSwiftTests/HistoricalSchedulerTest.swift
+++ b/Tests/RxSwiftTests/HistoricalSchedulerTest.swift
@@ -8,7 +8,7 @@
 
 import RxSwift
 import XCTest
-import struct Foundation.Date
+import Foundation
 
 class HistoricalSchedulerTest : RxTest {
 

--- a/Tests/RxSwiftTests/Observable+GroupByTests.swift
+++ b/Tests/RxSwiftTests/Observable+GroupByTests.swift
@@ -1123,7 +1123,7 @@ extension ObservableGroupByTest {
     #endif
 }
 
-import struct Foundation.CharacterSet
+import Foundation
 
 extension String {
     fileprivate func trimWhitespace() -> String {

--- a/Tests/RxSwiftTests/Observable+ObserveOnTests.swift
+++ b/Tests/RxSwiftTests/Observable+ObserveOnTests.swift
@@ -10,12 +10,7 @@ import XCTest
 import RxSwift
 import RxBlocking
 import RxTest
-
-import class Foundation.NSLock
-import class Foundation.NSError
-import class Foundation.NSCondition
-import class Foundation.OperationQueue
-import class Foundation.Thread
+import Foundation
 
 class ObservableObserveOnTestBase : RxTest {
     var lock = NSLock()

--- a/Tests/RxSwiftTests/Observable+RetryWhenTests.swift
+++ b/Tests/RxSwiftTests/Observable+RetryWhenTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import RxSwift
 import RxTest
 
-import class Foundation.NSError
+import Foundation
 
 class ObservableRetryWhenTest : RxTest {
 }

--- a/Tests/RxSwiftTests/Observable+ThrottleTests.swift
+++ b/Tests/RxSwiftTests/Observable+ThrottleTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import RxSwift
 import RxTest
 
-import struct Foundation.Date
+import Foundation
 
 class ObservableThrottleTest : RxTest {
 }

--- a/Tests/RxSwiftTests/Observable+TimerTests.swift
+++ b/Tests/RxSwiftTests/Observable+TimerTests.swift
@@ -10,7 +10,7 @@ import XCTest
 import RxSwift
 import RxTest
 
-import struct Foundation.Date
+import Foundation
 
 class ObservableTimerTest : RxTest {
 }

--- a/Tests/RxSwiftTests/RecursiveLockTest.swift
+++ b/Tests/RxSwiftTests/RecursiveLockTest.swift
@@ -12,7 +12,7 @@ import XCTest
     import Glibc
     import Foundation
 #else
-    import Darwin.C
+    import Darwin
 #endif
 
 private class StrandClosure {

--- a/Tests/RxSwiftTests/SchedulerTests.swift
+++ b/Tests/RxSwiftTests/SchedulerTests.swift
@@ -13,7 +13,7 @@ import Glibc
 import Dispatch
 #endif
 
-import struct Foundation.Date
+import Foundation
 
 class ConcurrentDispatchQueueSchedulerTests: RxTest {
     func createScheduler() -> SchedulerType {

--- a/Tests/RxSwiftTests/SharingSchedulerTests.swift
+++ b/Tests/RxSwiftTests/SharingSchedulerTests.swift
@@ -13,7 +13,7 @@ import XCTest
     import Glibc
 #endif
 
-import struct Foundation.Date
+import Foundation
 
 class SharingSchedulerTest : RxTest {
 

--- a/Tests/RxSwiftTests/VirtualSchedulerTest.swift
+++ b/Tests/RxSwiftTests/VirtualSchedulerTest.swift
@@ -12,7 +12,7 @@ import XCTest
     import Glibc
 #endif
 
-import struct Foundation.Date
+import Foundation
 
 class VirtualSchedulerTest : RxTest {
 

--- a/Tests/RxTest.swift
+++ b/Tests/RxTest.swift
@@ -9,15 +9,7 @@
 import XCTest
 import RxSwift
 import RxTest
-
-import struct Foundation.TimeInterval
-import struct Foundation.Date
-
-import class Foundation.RunLoop
-
-#if os(Linux)
-    import Foundation
-#endif
+import Foundation
 
 #if TRACE_RESOURCES
 #elseif RELEASE

--- a/Tests/XCTest+AllTests.swift
+++ b/Tests/XCTest+AllTests.swift
@@ -10,10 +10,7 @@ import RxSwift
 import RxTest
 import XCTest
 import Dispatch
-
-import class Foundation.NSValue
-import class Foundation.NSObject
-import struct Foundation.Date
+import Foundation
 
 func XCTAssertErrorEqual(_ lhs: Swift.Error, _ rhs: Swift.Error, file: StaticString = #file, line: UInt = #line) {
     let lhsEvent: Event<Int> = .error(lhs)


### PR DESCRIPTION
In order to support `-enable-library-evolution` and `swiftinteface`
files, we have to use non-scoped imports. I've filed an upstream bug to
track this https://bugs.swift.org/browse/SR-11782

This is a step towards https://github.com/ReactiveX/RxSwift/issues/2026