### PR TITLE
Fixed print statements in GettingStarted.md

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -443,18 +443,27 @@ let subscription1 = counter
     .subscribe(onNext: { n in
         print("First \(n)")
     })
+    
+print("Subscribed")
+
 let subscription2 = counter
     .subscribe(onNext: { n in
         print("Second \(n)")
     })
+    
+print("Subscribed")
 
 Thread.sleep(forTimeInterval: 0.5)
 
 subscription1.dispose()
 
+print("Disposed")
+
 Thread.sleep(forTimeInterval: 0.5)
 
 subscription2.dispose()
+
+print("Disposed")
 
 print("Ended ----")
 ```


### PR DESCRIPTION
A couple of print statements were missing. The print output should line up correctly with the code now.