### PR TITLE
Reactive extension WKWebView navigation delegate

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -100,6 +100,7 @@ custom_categories:
   - UITextView+Rx
   - UIView+Rx
   - UIViewController+Rx
+  - WKWebView+Rx
 - name: RxCocoa/iOS/Protocols
   children:
   - RxCollectionViewDataSourceType
@@ -123,6 +124,7 @@ custom_categories:
   - RxTableViewDelegateProxy
   - RxTextStorageDelegateProxy
   - RxTextViewDelegateProxy
+  - RxWKNavigationDelegateProxy
 - name: RxCocoa/macOS
   children:
   - NSButton+Rx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ---
+## Unreleased
+
+* Add `WKWebView` navigation delegate reactive extensions. #2144
+
 ## [5.1.0](https://github.com/ReactiveX/RxSwift/releases/tag/5.1.0)
 
 * Remove UIWebView Reactive Extensions due to [Apple's hard deprecation, starting April 2020](https://developer.apple.com/news/?id=12232019b). #2062

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		4C8DE0E320D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E420D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		504540C924196D960098665F /* WKWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540C824196D960098665F /* WKWebView+Rx.swift */; };
+		504540CB24196EB10098665F /* WKWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CA24196EB10098665F /* WKWebView+RxTests.swift */; };
+		504540CC24196EB10098665F /* WKWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CA24196EB10098665F /* WKWebView+RxTests.swift */; };
 		54700CA01CE37E1800EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54700CA11CE37E1900EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54D2138E1CE0824E0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
@@ -952,6 +954,7 @@
 		4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+CompactMapTests.swift"; sourceTree = "<group>"; };
 		4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBagTest.swift; sourceTree = "<group>"; };
 		504540C824196D960098665F /* WKWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+Rx.swift"; sourceTree = "<group>"; };
+		504540CA24196EB10098665F /* WKWebView+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+RxTests.swift"; sourceTree = "<group>"; };
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
@@ -1870,6 +1873,7 @@
 				C83508DD1C38706D0027C24C /* ControlEventTests.swift */,
 				C83508DE1C38706D0027C24C /* ControlPropertyTests.swift */,
 				C83508E11C38706D0027C24C /* DelegateProxyTest.swift */,
+				504540CA24196EB10098665F /* WKWebView+RxTests.swift */,
 				C83508DF1C38706D0027C24C /* DelegateProxyTest+Cocoa.swift */,
 				C83508E01C38706D0027C24C /* DelegateProxyTest+UIKit.swift */,
 				C83508E41C38706D0027C24C /* KVOObservableTests.swift */,
@@ -3208,6 +3212,7 @@
 				C820A9A61EB5056C00D431BC /* Observable+SkipUntilTests.swift in Sources */,
 				88718D011CE5DE2600D88D60 /* UITabBar+RxTests.swift in Sources */,
 				C8D970EC1F532FD30058F2FE /* SectionedViewDataSourceMock.swift in Sources */,
+				504540CB24196EB10098665F /* WKWebView+RxTests.swift in Sources */,
 				C822BACE1DB424EC00F98810 /* Reactive+Tests.swift in Sources */,
 				C820A9BE1EB509B500D431BC /* Observable+TakeLastTests.swift in Sources */,
 				C8165AD521891DBF00494BEF /* AtomicInt.swift in Sources */,
@@ -3555,6 +3560,7 @@
 				C820A96C1EB4F64800D431BC /* Observable+JustTests.swift in Sources */,
 				C801DE401F6EAD57008DB060 /* CompletableTest.swift in Sources */,
 				C820A9741EB4F84000D431BC /* Observable+OptionalTests.swift in Sources */,
+				504540CC24196EB10098665F /* WKWebView+RxTests.swift in Sources */,
 				C820A9C41EB509FC00D431BC /* Observable+SkipTests.swift in Sources */,
 				C820A9701EB4F7AC00D431BC /* Observable+SequenceTests.swift in Sources */,
 				C8B0F70F1F530A1700548EBE /* SharingSchedulerTests.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		4C8DE0E220D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E320D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E420D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
+		504540C924196D960098665F /* WKWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540C824196D960098665F /* WKWebView+Rx.swift */; };
 		54700CA01CE37E1800EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54700CA11CE37E1900EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54D2138E1CE0824E0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
@@ -950,6 +951,7 @@
 		4C5213A9225D41E60079FC77 /* CompactMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompactMap.swift; sourceTree = "<group>"; };
 		4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+CompactMapTests.swift"; sourceTree = "<group>"; };
 		4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBagTest.swift; sourceTree = "<group>"; };
+		504540C824196D960098665F /* WKWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+Rx.swift"; sourceTree = "<group>"; };
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
@@ -2199,6 +2201,7 @@
 				54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */,
 				844BC8B31CE4FD7500F5C7CB /* UIPickerView+Rx.swift */,
 				46307D4D1CDE77D800E47A1C /* UIAlertAction+Rx.swift */,
+				504540C824196D960098665F /* WKWebView+Rx.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -3054,6 +3057,7 @@
 				C88254301B8A752B00B02D69 /* UISearchBar+Rx.swift in Sources */,
 				C89AB2121DAAC3350065FBE6 /* NotificationCenter+Rx.swift in Sources */,
 				C88254181B8A752B00B02D69 /* ItemEvents.swift in Sources */,
+				504540C924196D960098665F /* WKWebView+Rx.swift in Sources */,
 				C89AB1731DAAC1680065FBE6 /* ControlTarget.swift in Sources */,
 				C882541B1B8A752B00B02D69 /* RxTableViewDataSourceType.swift in Sources */,
 				B5624794203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift in Sources */,

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -42,6 +42,9 @@
 		504540C924196D960098665F /* WKWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540C824196D960098665F /* WKWebView+Rx.swift */; };
 		504540CB24196EB10098665F /* WKWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CA24196EB10098665F /* WKWebView+RxTests.swift */; };
 		504540CC24196EB10098665F /* WKWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CA24196EB10098665F /* WKWebView+RxTests.swift */; };
+		504540CE2419701D0098665F /* RxWKNavigationDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CD2419701D0098665F /* RxWKNavigationDelegateProxy.swift */; };
+		504540D0241971E80098665F /* DelegateProxyTest+WebKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CF241971E70098665F /* DelegateProxyTest+WebKit.swift */; };
+		504540D1241971E80098665F /* DelegateProxyTest+WebKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CF241971E70098665F /* DelegateProxyTest+WebKit.swift */; };
 		54700CA01CE37E1800EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54700CA11CE37E1900EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54D2138E1CE0824E0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
@@ -955,6 +958,8 @@
 		4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBagTest.swift; sourceTree = "<group>"; };
 		504540C824196D960098665F /* WKWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+Rx.swift"; sourceTree = "<group>"; };
 		504540CA24196EB10098665F /* WKWebView+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+RxTests.swift"; sourceTree = "<group>"; };
+		504540CD2419701D0098665F /* RxWKNavigationDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxWKNavigationDelegateProxy.swift; sourceTree = "<group>"; };
+		504540CF241971E70098665F /* DelegateProxyTest+WebKit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DelegateProxyTest+WebKit.swift"; sourceTree = "<group>"; };
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
@@ -1876,6 +1881,7 @@
 				504540CA24196EB10098665F /* WKWebView+RxTests.swift */,
 				C83508DF1C38706D0027C24C /* DelegateProxyTest+Cocoa.swift */,
 				C83508E01C38706D0027C24C /* DelegateProxyTest+UIKit.swift */,
+				504540CF241971E70098665F /* DelegateProxyTest+WebKit.swift */,
 				C83508E41C38706D0027C24C /* KVOObservableTests.swift */,
 				C8C4F1761DE9D84900003FA7 /* NSButton+RxTests.swift */,
 				C834F6C51DB3950600C29244 /* NSControl+RxTests.swift */,
@@ -2256,6 +2262,7 @@
 				846436E11C9AF64C0035B40D /* RxSearchControllerDelegateProxy.swift */,
 				844BC8AA1CE4FA5600F5C7CB /* RxPickerViewDelegateProxy.swift */,
 				D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */,
+				504540CD2419701D0098665F /* RxWKNavigationDelegateProxy.swift */,
 				A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */,
 			);
 			path = Proxies;
@@ -2983,6 +2990,7 @@
 				A520FFFC1F0D291500573734 /* RxPickerViewDataSourceProxy.swift in Sources */,
 				C882542A1B8A752B00B02D69 /* UIControl+Rx.swift in Sources */,
 				C8E65EFB1F6E91D1004478C3 /* Binder.swift in Sources */,
+				504540CE2419701D0098665F /* RxWKNavigationDelegateProxy.swift in Sources */,
 				C8D132441C42D15E00B59FFF /* SectionedViewDataSourceType.swift in Sources */,
 				B562478F203515DD00D3EE75 /* RxCollectionViewDataSourcePrefetchingProxy.swift in Sources */,
 				84E4D3921C9AFD3400ADFDC9 /* UISearchController+Rx.swift in Sources */,
@@ -3103,6 +3111,7 @@
 				C835092E1C38706E0027C24C /* ControlEventTests.swift in Sources */,
 				844BC8BB1CE5024500F5C7CB /* UIPickerView+RxTests.swift in Sources */,
 				C801DE361F6EAD3C008DB060 /* SingleTest.swift in Sources */,
+				504540D0241971E80098665F /* DelegateProxyTest+WebKit.swift in Sources */,
 				C896A68B1E6B7DC60073A3A8 /* Observable+CombineLatestTests.swift in Sources */,
 				4C8DE0E220D54545003E2D8A /* DisposeBagTest.swift in Sources */,
 				C820A9AA1EB505A800D431BC /* Observable+WithLatestFromTests.swift in Sources */,
@@ -3555,6 +3564,7 @@
 				C8350A041C38755E0027C24C /* CurrentThreadSchedulerTest.swift in Sources */,
 				C8353CE81DA19BC500BE3F5C /* Recorded+Timeless.swift in Sources */,
 				C8A9B6F61DAD752200C9B027 /* Observable+BindTests.swift in Sources */,
+				504540D1241971E80098665F /* DelegateProxyTest+WebKit.swift in Sources */,
 				C820A99C1EB5001C00D431BC /* Observable+MergeTests.swift in Sources */,
 				C8350A051C38755E0027C24C /* DisposableTest.swift in Sources */,
 				C820A96C1EB4F64800D431BC /* Observable+JustTests.swift in Sources */,

--- a/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
@@ -1,5 +1,5 @@
 //
-//  RxWKWebViewDelegateProxy.swift
+//  RxWKNavigationDelegateProxy.swift
 //  RxCocoa
 //
 //  Created by Giuseppe Lanza on 14/02/2020.

--- a/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
@@ -1,0 +1,43 @@
+//
+//  RxWKWebViewDelegateProxy.swift
+//  RxCocoa
+//
+//  Created by Giuseppe Lanza on 14/02/2020.
+//  Copyright © 2020 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS) || os(macOS) || os(tvOS)
+
+import RxSwift
+import WebKit
+
+@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+open class RxWKNavigationDelegateProxy
+    : DelegateProxy<WKWebView, WKNavigationDelegate>
+    , DelegateProxyType
+, WKNavigationDelegate {
+
+    /// Typed parent object.
+    public weak private(set) var webView: WKWebView?
+
+    /// - parameter webView: Parent object for delegate proxy.
+    public init(webView: ParentObject) {
+        self.webView = webView
+        super.init(parentObject: webView, delegateProxy: RxWKNavigationDelegateProxy.self)
+    }
+
+    // Register known implementations
+    public static func registerKnownImplementations() {
+        self.register { RxWKNavigationDelegateProxy(webView: $0) }
+    }
+    
+    public static func currentDelegate(for object: WKWebView) -> WKNavigationDelegate? {
+        object.navigationDelegate
+    }
+    
+    public static func setCurrentDelegate(_ delegate: WKNavigationDelegate?, to object: WKWebView) {
+        object.navigationDelegate = delegate
+    }
+}
+
+#endif

--- a/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.
 //
 
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS)
 
 import RxSwift
 import WebKit
 
-@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
 open class RxWKNavigationDelegateProxy
     : DelegateProxy<WKWebView, WKNavigationDelegate>
     , DelegateProxyType

--- a/RxCocoa/iOS/WKWebView+Rx.swift
+++ b/RxCocoa/iOS/WKWebView+Rx.swift
@@ -25,7 +25,6 @@ extension Reactive where Base: WKWebView {
         navigationDelegate
             .methodInvoked(#selector(WKNavigationDelegate.webView(_:didCommit:)))
             .map { a in try castOrThrow(WKNavigation.self, a[1]) }
-
     }
     
     /// Reactive wrapper for `navigationDelegate` message.
@@ -51,7 +50,7 @@ extension Reactive where Base: WKWebView {
                     try castOrThrow(WKNavigation.self, a[1]),
                     try castOrThrow(Error.self, a[2])
                 )
-        }
+            }
     }
 }
 

--- a/RxCocoa/iOS/WKWebView+Rx.swift
+++ b/RxCocoa/iOS/WKWebView+Rx.swift
@@ -1,0 +1,58 @@
+//
+//  WKWebView+Rx.swift
+//  RxCocoa
+//
+//  Created by Giuseppe Lanza on 14/02/2020.
+//  Copyright © 2020 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS) || os(macOS) || os(tvOS)
+
+import RxSwift
+import WebKit
+
+@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+extension Reactive where Base: WKWebView {
+    
+    /// Reactive wrapper for `navigationDelegate`.
+    /// For more information take a look at `DelegateProxyType` protocol documentation.
+    public var navigationDelegate: DelegateProxy<WKWebView, WKNavigationDelegate> {
+        RxWKNavigationDelegateProxy.proxy(for: base)
+    }
+    
+    /// Reactive wrapper for `navigationDelegate` message.
+    public var didCommit: Observable<WKNavigation> {
+        navigationDelegate
+            .methodInvoked(#selector(WKNavigationDelegate.webView(_:didCommit:)))
+            .map { a in try castOrThrow(WKNavigation.self, a[1]) }
+
+    }
+    
+    /// Reactive wrapper for `navigationDelegate` message.
+    public var didStartLoad: Observable<WKNavigation> {
+        navigationDelegate
+            .methodInvoked(#selector(WKNavigationDelegate.webView(_:didStartProvisionalNavigation:)))
+            .map { a in try castOrThrow(WKNavigation.self, a[1]) }
+    }
+
+    /// Reactive wrapper for `navigationDelegate` message.
+    public var didFinishLoad: Observable<WKNavigation> {
+        navigationDelegate
+            .methodInvoked(#selector(WKNavigationDelegate.webView(_:didFinish:)))
+            .map { a in try castOrThrow(WKNavigation.self, a[1]) }
+    }
+
+    /// Reactive wrapper for `navigationDelegate` message.
+    public var didFailLoad: Observable<(WKNavigation, Error)> {
+        navigationDelegate
+            .methodInvoked(#selector(WKNavigationDelegate.webView(_:didFail:withError:)))
+            .map { a in
+                (
+                    try castOrThrow(WKNavigation.self, a[1]),
+                    try castOrThrow(Error.self, a[2])
+                )
+        }
+    }
+}
+
+#endif

--- a/RxCocoa/iOS/WKWebView+Rx.swift
+++ b/RxCocoa/iOS/WKWebView+Rx.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.
 //
 
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS)
 
 import RxSwift
 import WebKit
 
-@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
 extension Reactive where Base: WKWebView {
     
     /// Reactive wrapper for `navigationDelegate`.

--- a/Sources/RxCocoa/RxWKNavigationDelegateProxy.swift
+++ b/Sources/RxCocoa/RxWKNavigationDelegateProxy.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift

--- a/Sources/RxCocoa/WKWebView+Rx.swift
+++ b/Sources/RxCocoa/WKWebView+Rx.swift
@@ -1,0 +1,1 @@
+../../RxCocoa/iOS/WKWebView+Rx.swift

--- a/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
@@ -6,21 +6,21 @@
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.
 //
 
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS)
 
 import WebKit
 @testable import RxCocoa
 @testable import RxSwift
 import XCTest
 
-@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
 extension DelegateProxyTest {
     func test_WKNavigaionDelegateExtension() {
         performDelegateTest(WKNavigationWebViewSubclass(frame: CGRect.zero)) { ExtendWKNavigationDelegateProxy(webViewSubclass: $0) }
     }
 }
 
-@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
 final class ExtendWKNavigationDelegateProxy
     : RxWKNavigationDelegateProxy
     , TestDelegateProtocol {
@@ -29,7 +29,7 @@ final class ExtendWKNavigationDelegateProxy
     }
 }
 
-@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
 final class WKNavigationWebViewSubclass: WKWebView, TestDelegateControl {
     func doThatTest(_ value: Int) {
         (navigationDelegate as! TestDelegateProtocol).testEventHappened?(value)

--- a/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
@@ -1,6 +1,6 @@
 //
 //  DelegateProxyTest+WebKit.swift
-//  Rx
+//  Tests
 //
 //  Created by Giuseppe Lanza on 14/02/2020.
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.

--- a/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
@@ -1,0 +1,49 @@
+//
+//  DelegateProxyTest+WebKit.swift
+//  Rx
+//
+//  Created by Giuseppe Lanza on 14/02/2020.
+//  Copyright © 2020 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS) || os(macOS) || os(tvOS)
+
+import WebKit
+@testable import RxCocoa
+@testable import RxSwift
+import XCTest
+
+@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+extension DelegateProxyTest {
+    func test_WKNavigaionDelegateExtension() {
+        performDelegateTest(WKNavigationWebViewSubclass(frame: CGRect.zero)) { ExtendWKNavigationDelegateProxy(webViewSubclass: $0) }
+    }
+}
+
+@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+final class ExtendWKNavigationDelegateProxy
+    : RxWKNavigationDelegateProxy
+    , TestDelegateProtocol {
+    init(webViewSubclass: WKNavigationWebViewSubclass) {
+        super.init(webView: webViewSubclass)
+    }
+}
+
+@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+final class WKNavigationWebViewSubclass: WKWebView, TestDelegateControl {
+    func doThatTest(_ value: Int) {
+        (navigationDelegate as! TestDelegateProtocol).testEventHappened?(value)
+    }
+
+    var delegateProxy: DelegateProxy<WKWebView, WKNavigationDelegate> {
+        return self.rx.navigationDelegate
+    }
+
+    func setMineForwardDelegate(_ testDelegate: WKNavigationDelegate) -> Disposable {
+        return RxWKNavigationDelegateProxy.installForwardDelegate(testDelegate,
+                                                             retainDelegate: false,
+                                                             onProxyForObject: self)
+    }
+}
+
+#endif

--- a/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
@@ -46,4 +46,12 @@ final class WKNavigationWebViewSubclass: WKWebView, TestDelegateControl {
     }
 }
 
+// MARK: Mocks
+
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
+extension MockTestDelegateProtocol
+    : WKNavigationDelegate
+{
+}
+
 #endif

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -397,7 +397,7 @@ extension DelegateProxyTest {
         var completedMethodInvoked = false
         var deallocated = false
         var stages: [MessageProcessingStage] = []
-
+        let expectation = self.expectation(description: "dealloc")
         autoreleasepool {
             _ = control.testSentMessage.subscribe(onNext: { value in
                 receivedValueSentMessage = value
@@ -415,6 +415,7 @@ extension DelegateProxyTest {
 
             _ = (control as! NSObject).rx.deallocated.subscribe(onNext: { _ in
                 deallocated = true
+                expectation.fulfill()
             })
         }
 
@@ -446,6 +447,9 @@ extension DelegateProxyTest {
         autoreleasepool {
             control = nil
         }
+        
+        wait(for: [expectation], timeout: 1)
+        
         XCTAssertTrue(deallocated)
         XCTAssertTrue(completedSentMessage)
         XCTAssertTrue(completedMethodInvoked)
@@ -767,6 +771,14 @@ extension MockTestDelegateProtocol
 #if os(iOS)
 extension MockTestDelegateProtocol
     : UIPickerViewDelegate
+{
+}
+#endif
+
+#if os(iOS) || os(macOS) || os(tvOS)
+import WebKit
+extension MockTestDelegateProtocol
+    : WKNavigationDelegate
 {
 }
 #endif

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -774,13 +774,3 @@ extension MockTestDelegateProtocol
 {
 }
 #endif
-
-#if os(iOS) || os(macOS)
-import WebKit
-
-@available(iOS 10.0, OSXApplicationExtension 10.10, *)
-extension MockTestDelegateProtocol
-    : WKNavigationDelegate
-{
-}
-#endif

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -775,8 +775,10 @@ extension MockTestDelegateProtocol
 }
 #endif
 
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS)
 import WebKit
+
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
 extension MockTestDelegateProtocol
     : WKNavigationDelegate
 {

--- a/Tests/RxCocoaTests/WKWebView+RxTests.swift
+++ b/Tests/RxCocoaTests/WKWebView+RxTests.swift
@@ -1,0 +1,109 @@
+//
+//  WKWebView+RxTests.swift
+//  Rx
+//
+//  Created by Giuseppe Lanza on 14/02/2020.
+//  Copyright © 2020 Krunoslav Zaher. All rights reserved.
+//
+
+#if os(iOS) || os(macOS) || os(tvOS)
+
+import WebKit
+import RxCocoa
+import RxSwift
+import RxBlocking
+import XCTest
+
+// Any WKNavigation object manually created on dealloc crashes the program.
+// This class overrides the deinit method of the WKNavition to avoid crashes.
+class SafeWKNavigation: WKNavigation {
+    static func toggleSwizzleDealloc() {
+        guard let current_original = class_getInstanceMethod(SafeWKNavigation.self, NSSelectorFromString("dealloc")),
+            let current_swizzled = class_getInstanceMethod(SafeWKNavigation.self, #selector(nonCrashingDealloc)) else { return }
+        method_exchangeImplementations(current_original, current_swizzled)
+    }
+    
+    @objc func nonCrashingDealloc() { }
+}
+
+extension String: Error {}
+
+@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+final class WKWebViewTests: RxTest {
+    
+    override func setUp() {
+        super.setUp()
+        SafeWKNavigation.toggleSwizzleDealloc()
+    }
+    
+    override func tearDown() {
+        SafeWKNavigation.toggleSwizzleDealloc()
+        super.tearDown()
+    }
+    
+    func testDidCommit() {
+        let expectedNavigation = SafeWKNavigation()
+        let webView = WKWebView(frame: .zero)
+        var navigation: WKNavigation?
+        
+        let subscription = webView.rx.didCommit.subscribe(onNext: { nav in
+            navigation = nav
+        })
+
+        webView.navigationDelegate!.webView?(webView, didCommit: expectedNavigation)
+
+        XCTAssertEqual(expectedNavigation, navigation)
+        subscription.dispose()
+    }
+    
+    func testDidStartLoad() {
+        let expectedNavigation = SafeWKNavigation()
+        let webView = WKWebView(frame: .zero)
+        var navigation: WKNavigation?
+        
+        let subscription = webView.rx.didStartLoad.subscribe(onNext: { nav in
+            navigation = nav
+        })
+
+        webView.navigationDelegate!.webView?(webView, didStartProvisionalNavigation: expectedNavigation)
+
+        XCTAssertEqual(expectedNavigation, navigation)
+        subscription.dispose()
+    }
+    
+    func testDidFinishLoad() {
+        let expectedNavigation = SafeWKNavigation()
+        let webView = WKWebView(frame: .zero)
+        var navigation: WKNavigation?
+        
+        let subscription = webView.rx.didFinishLoad.subscribe(onNext: { nav in
+            navigation = nav
+        })
+
+        webView.navigationDelegate!.webView?(webView, didFinish: expectedNavigation)
+
+        XCTAssertEqual(expectedNavigation, navigation)
+        subscription.dispose()
+    }
+    
+    func testDidFail() {
+        let expectedNavigation = SafeWKNavigation()
+        let expectedError = "Something horrible just happened"
+        let webView = WKWebView(frame: .zero)
+        var navigation: WKNavigation?
+        var error: Error?
+        
+        let subscription = webView.rx.didFailLoad.subscribe(onNext: { nav, err in
+            navigation = nav
+            error = err
+        })
+
+        webView.navigationDelegate!.webView?(webView, didFail: expectedNavigation, withError: expectedError)
+
+        XCTAssertEqual(expectedNavigation, navigation)
+        XCTAssertEqual(expectedError, error as? String)
+        subscription.dispose()
+    }
+}
+
+#endif

--- a/Tests/RxCocoaTests/WKWebView+RxTests.swift
+++ b/Tests/RxCocoaTests/WKWebView+RxTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.
 //
 
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS)
 
 import WebKit
 import RxCocoa
@@ -16,8 +16,9 @@ import XCTest
 
 // Any WKNavigation object manually created on dealloc crashes the program.
 // This class overrides the deinit method of the WKNavition to avoid crashes.
-class SafeWKNavigation: WKNavigation {
-    static func toggleSwizzleDealloc() {
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
+private class SafeWKNavigation: WKNavigation {
+    static func toggleSafeDealloc() {
         guard let current_original = class_getInstanceMethod(SafeWKNavigation.self, NSSelectorFromString("dealloc")),
             let current_swizzled = class_getInstanceMethod(SafeWKNavigation.self, #selector(nonCrashingDealloc)) else { return }
         method_exchangeImplementations(current_original, current_swizzled)
@@ -28,7 +29,7 @@ class SafeWKNavigation: WKNavigation {
 
 extension String: Error {}
 
-@available(iOS 10.0, tvOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, OSXApplicationExtension 10.10, *)
 final class WKWebViewTests: RxTest {
     
     override func setUp() {

--- a/Tests/RxCocoaTests/WKWebView+RxTests.swift
+++ b/Tests/RxCocoaTests/WKWebView+RxTests.swift
@@ -1,6 +1,6 @@
 //
 //  WKWebView+RxTests.swift
-//  Rx
+//  Tests
 //
 //  Created by Giuseppe Lanza on 14/02/2020.
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.

--- a/Tests/RxCocoaTests/WKWebView+RxTests.swift
+++ b/Tests/RxCocoaTests/WKWebView+RxTests.swift
@@ -34,11 +34,11 @@ final class WKWebViewTests: RxTest {
     
     override func setUp() {
         super.setUp()
-        SafeWKNavigation.toggleSwizzleDealloc()
+        SafeWKNavigation.toggleSafeDealloc()
     }
     
     override func tearDown() {
-        SafeWKNavigation.toggleSwizzleDealloc()
+        SafeWKNavigation.toggleSafeDealloc()
         super.tearDown()
     }
     


### PR DESCRIPTION
This PR add a new delegate proxy for WKNavigationDelegate for WKWebView.
Losing UIWebView delegate proxy, this PR now offers a replacement.

Please note that WKWebView has multiple delegates. This PR offers a proxy just for the WKNavigationDelegate. Other delegates will be subject of future PRs