### PR TITLE
Fix constraints warnings

### DIFF
--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -326,7 +326,9 @@ extension DelegateProxyType where ParentObject: HasPrefetchDataSource, Self.Dele
                 let proxy = DelegateProxy.proxy(for: object)
                 let unregisterDelegate = DelegateProxy.installForwardDelegate(dataSource, retainDelegate: retainDataSource, onProxyForObject: object)
                 // this is needed to flush any delayed old state (https://github.com/RxSwiftCommunity/RxDataSources/pull/75)
-                object.layoutIfNeeded()
+                  if object.window != nil {
+                    object.layoutIfNeeded()
+                  }
 
                 let subscription = self.asObservable()
                     .observeOn(MainScheduler())
@@ -358,7 +360,9 @@ extension DelegateProxyType where ParentObject: HasPrefetchDataSource, Self.Dele
                     
                 return Disposables.create { [weak object] in
                     subscription.dispose()
-                    object?.layoutIfNeeded()
+                    if object?.window != nil {
+                      object?.layoutIfNeeded()
+                    }
                     unregisterDelegate.dispose()
                 }
             }


### PR DESCRIPTION
I'm facing a problem when I'm binding the view with the data in the view did load or when I'm removing a custom view from the window. The view is trying to update the constraint but there is as I understand some internal UIKit constraints which will be zero when the view is not attached to a window.

`_UITemporaryLayoutWidth`
`_UITemporaryLayoutHeight`
```
 "<NSLayoutConstraint:0x283e26b70 '_UITemporaryLayoutWidth' App.StringsActionSheet:0x1171c0a60.width == 0   (active)>"
```
