### PR TITLE
SharingScheduler.mock(scheduler:action:) can be throwing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 * Add `distinctUntilChanged(at:)` for Key Paths.
 * Fix `DelegateProxy` call to `layoutIfNeeded` for an object without a window. #2076
 * Add `ControlEvent` wrappers to `UIApplication` Notifications. #2116
+* `SharingScheduler.mock(scheduler:action:)` can use throwing function for `action`. #2150
 
 ## [5.1.1](https://github.com/ReactiveX/RxSwift/releases/tag/5.1.1)
 

--- a/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
@@ -18,8 +18,8 @@ public enum SharingScheduler {
 
      **This shouldn't be used in normal release builds.**
     */
-    static public func mock(scheduler: SchedulerType, action: () -> Void) {
-        return mock(makeScheduler: { scheduler }, action: action)
+    static public func mock(scheduler: SchedulerType, action: () throws -> Void) rethrows {
+        return try mock(makeScheduler: { scheduler }, action: action)
     }
 
     /**
@@ -28,17 +28,18 @@ public enum SharingScheduler {
 
      **This shouldn't be used in normal release builds.**
      */
-    static public func mock(makeScheduler: @escaping () -> SchedulerType, action: () -> Void) {
+    static public func mock(makeScheduler: @escaping () -> SchedulerType, action: () throws  -> Void) rethrows {
         let originalMake = make
         make = makeScheduler
+        defer {
+            make = originalMake
+        }
 
-        action()
+        try action()
 
         // If you remove this line , compiler buggy optimizations will change behavior of this code
         _forceCompilerToStopDoingInsaneOptimizationsThatBreakCode(makeScheduler)
         // Scary, I know
-
-        make = originalMake
     }
 }
 

--- a/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
@@ -28,7 +28,7 @@ public enum SharingScheduler {
 
      **This shouldn't be used in normal release builds.**
      */
-    static public func mock(makeScheduler: @escaping () -> SchedulerType, action: () throws  -> Void) rethrows {
+    static public func mock(makeScheduler: @escaping () -> SchedulerType, action: () throws -> Void) rethrows {
         let originalMake = make
         make = makeScheduler
         defer {

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -1910,6 +1910,7 @@ final class SharingSchedulerTest_ : SharingSchedulerTest, RxTestCase {
     static var allTests: [(String, (SharingSchedulerTest_) -> () -> Void)] { return [
     ("testSharingSchedulerMockMake", SharingSchedulerTest.testSharingSchedulerMockMake),
     ("testSharingSchedulerMockInstance", SharingSchedulerTest.testSharingSchedulerMockInstance),
+    ("testSharingSchedulerMockThrows", SharingSchedulerTest.testSharingSchedulerMockThrows),
     ] }
 }
 

--- a/Tests/RxSwiftTests/SharingSchedulerTests.swift
+++ b/Tests/RxSwiftTests/SharingSchedulerTests.swift
@@ -45,6 +45,23 @@ extension SharingSchedulerTest {
             XCTAssertTrue(SharingScheduler.make() is Scheduler1)
         }
     }
+
+    func testSharingSchedulerMockThrows() {
+        XCTAssertTrue(SharingScheduler.make() is MainScheduler)
+
+        do {
+            try SharingScheduler.mock(makeScheduler: { Scheduler1() }) {
+                XCTAssertTrue(SharingScheduler.make() is Scheduler1)
+                throw TestError.dummyError
+            }
+            XCTFail()
+        } catch {
+            XCTAssertTrue(error is TestError)
+            XCTAssertTrue(SharingScheduler.make() is MainScheduler)
+            return
+        }
+        XCTFail()
+    }
 }
 
 class Scheduler1: SchedulerType {


### PR DESCRIPTION
On Xcode 11.0, it's itroduced a throwing XCTFunction like `XCTUnwrap` ( https://developer.apple.com/documentation/xctest/3380195-xctunwrap ).  On Xcode 11.4 Beta, `XCTSkipIf` ( https://developer.apple.com/documentation/xctest/3521325-xctskipif ) is implemented.
These functions throw some `XCTCustomErrorHandling` or `XCTSkip`, and it needs to be handled by XCTestCase.

`SharingScheduler.mock(scheduler:action:)` is not marked `throws`, so it can't throw such error in `action` clusure. 

ex:

```swift
func callFoo() -> Bool? { ... }

func testFoo() throws {
	try SharingScheduler.mock(makeScheduler: { MyScheduler() }) {
		let fooResult = try XCTUnwrap(callFoo()) // compile error
		XCTAssertTrue(fooResult)
	}
}
```

This PR make it possible.