### PR TITLE
fix manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ $ git submodule add git@github.com:ReactiveX/RxSwift.git
 ```
 
 * Drag `Rx.xcodeproj` into Project Navigator
-* Go to `Project > Targets > Build Phases > Link Binary With Libraries`, click `+` and select `RxSwift-[Platform]` and `RxCocoa-[Platform]` targets
+* Go to `Project > Targets > Build Phases > Link Binary With Libraries`, click `+` and select `RxSwift`, `RxCocoa` and `RxRelay` targets
 
 ## References
 


### PR DESCRIPTION
RxCocoa has RxRelay dependency. So when manually adding Rx using submodules, RxRelay should be added too, otherwise App Store Connect will not accept build with 'ITMS-90562: Invalid Bundle - One or more dynamic libraries that are referenced by your app are not present in the dylib search path.' error.