### PR TITLE
Add DisposeMap: replacement for DisposeBag

### DIFF
--- a/.jazzy.yml
+++ b/.jazzy.yml
@@ -178,6 +178,7 @@ custom_categories:
   - Disposables
   - DisposeBag
   - DisposeBase
+  - DisposeMap
   - NopDisposable
   - RefCountDisposable
   - ScheduledDisposable

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		54700CA11CE37E1900EF3A8F /* UINavigationItem+RxTests.swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */; };
 		54D2138E1CE0824E0028D5B4 /* UINavigationItem+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */; };
 		601AE3DA1EE24E4F00617386 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601AE3D91EE24E4F00617386 /* SwiftSupport.swift */; };
+		647442482440A3B3001CC108 /* DisposeMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647442472440A3B3001CC108 /* DisposeMap.swift */; };
 		6B9CA56B202A1F44002C2D11 /* KeyPathBinder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */; };
 		6B9CA56E202A206A002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
 		6B9CA56F202A206B002C2D11 /* KeyPathBinder+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */; };
@@ -963,6 +964,7 @@
 		54700C9E1CE37D1000EF3A8F /* UINavigationItem+RxTests.swift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+RxTests.swift.swift"; sourceTree = "<group>"; };
 		54D2138C1CE081890028D5B4 /* UINavigationItem+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+Rx.swift"; sourceTree = "<group>"; };
 		601AE3D91EE24E4F00617386 /* SwiftSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftSupport.swift; sourceTree = "<group>"; };
+		647442472440A3B3001CC108 /* DisposeMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeMap.swift; sourceTree = "<group>"; };
 		6B9CA568202A1F43002C2D11 /* KeyPathBinder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPathBinder.swift; sourceTree = "<group>"; };
 		6B9CA56D202A1F96002C2D11 /* KeyPathBinder+RxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyPathBinder+RxTests.swift"; sourceTree = "<group>"; };
 		7EDBAEAB1C89B1A5006CBE67 /* UITabBarItem+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+RxTests.swift"; sourceTree = "<group>"; };
@@ -1634,6 +1636,7 @@
 				C8093C5F1B8A72BE0088E94D /* SerialDisposable.swift */,
 				C8093C601B8A72BE0088E94D /* SingleAssignmentDisposable.swift */,
 				CDDEF1691D4FB40000CA8546 /* Disposables.swift */,
+				647442472440A3B3001CC108 /* DisposeMap.swift */,
 			);
 			path = Disposables;
 			sourceTree = "<group>";
@@ -3629,6 +3632,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C820A8BC1EB4DA5A00D431BC /* SwitchIfEmpty.swift in Sources */,
+				647442482440A3B3001CC108 /* DisposeMap.swift in Sources */,
 				C8093CCB1B8A72BE0088E94D /* ConnectableObservableType.swift in Sources */,
 				C820A8801EB4DA5A00D431BC /* Filter.swift in Sources */,
 				C820A86C1EB4DA5A00D431BC /* ElementAt.swift in Sources */,

--- a/RxSwift/Disposables/DisposeMap.swift
+++ b/RxSwift/Disposables/DisposeMap.swift
@@ -1,0 +1,82 @@
+//
+//  DisposeMap.swift
+//  RxSwift
+//
+//  Created by Anatoly Shcherbinin on 4/10/20.
+//  Copyright © 2020 Krunoslav Zaher. All rights reserved.
+//
+
+extension Disposable {
+    /// Adds `self` to `bag`
+    ///
+    /// - parameter map: `DisposeMap` to add `self` to.
+    public func disposed<T>(by map: DisposeMap<T>, key: T) {
+        map.insert(self, forKey: key)
+    }
+
+    public func disposed(by map: DisposeMap<Int>, key: Int = #line) {
+        map.insert(self, forKey: key)
+    }
+
+}
+
+/**
+ Thread safe map, that disposes duplicating disposables
+ */
+public final class DisposeMap<T:Hashable>: DisposeBase {
+
+    private let _lock = SpinLock()
+
+    // state
+    private var _disposables = [T:Disposable]()
+    private var _isDisposed = false
+
+    /// Constructs new empty dispose map.
+    public override init() {
+        super.init()
+    }
+
+    /// Adds `disposable` to be disposed when dispose bag is being deinited
+    /// or when other disposable with same key is added
+    ///
+    /// - parameter disposable: Disposable to add.
+    /// - parameter key: comparison key
+    public func insert(_ disposable: Disposable, forKey key: T) {
+        self._insert(disposable, forKey: key)?.dispose()
+    }
+
+    private func _insert(_ disposable: Disposable, forKey key: T) -> Disposable? {
+        self._lock.lock(); defer { self._lock.unlock() }
+        if self._isDisposed {
+            return disposable
+        }
+
+        let oldDisposable = _disposables[key]
+        _disposables[key] = disposable
+        return oldDisposable
+    }
+
+    /// This is internal on purpose, take a look at `CompositeDisposable` instead.
+    private func dispose() {
+        let oldDisposables = self._dispose()
+
+        for disposable in oldDisposables {
+            disposable.dispose()
+        }
+    }
+
+    private func _dispose() -> [Disposable] {
+        self._lock.lock(); defer { self._lock.unlock() }
+
+        let disposables = self._disposables.values
+
+        self._disposables.removeAll(keepingCapacity: false)
+        self._isDisposed = true
+
+        return [Disposable](disposables)
+    }
+
+    deinit {
+        self.dispose()
+    }
+}


### PR DESCRIPTION
Subscriptions is identified by the key,
previous subscriptions with the same key are disposed

For convenience you can use DisposeMap<Int>:
It have sampe interface like DisposeBag and uses file #line as the key