### PR TITLE
Remove link to dead video

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ $ git submodule add git@github.com:ReactiveX/RxSwift.git
 * [Boxue.io RxSwift Online Course](https://boxueio.com/series/rxswift-101) (Chinese 🇨🇳)
 * [Erik Meijer (Wikipedia)](http://en.wikipedia.org/wiki/Erik_Meijer_%28computer_scientist%29)
 * [Expert to Expert: Brian Beckman and Erik Meijer - Inside the .NET Reactive Framework (Rx) (video)](https://youtu.be/looJcaeboBY)
-* [Reactive Programming Overview (Jafar Husain from Netflix)](https://www.youtube.com/watch?v=dwP1TNXE6fc)
 * [Subject/Observer is Dual to Iterator (paper)](http://csl.stanford.edu/~christos/pldi2010.fit/meijer.duality.pdf)
 * [Rx standard sequence operators visualized (visualization tool)](http://rxmarbles.com/)
 * [Haskell](https://www.haskell.org/)


### PR DESCRIPTION
This YouTube video is now set to private. This change removes the link to the private video.