### PR TITLE
Adding shareUntilDisposed to the Single

### DIFF
--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -156,6 +156,29 @@ extension ObservableType {
     }
 }
 
+/// Single replay count
+public enum SingleReplayCount: Int {
+    case zero, one
+}
+
+extension PrimitiveSequenceType where Trait == SingleTrait {
+    /**
+     Returns an observable sequence that **shares a single subscription to the underlying sequence**, and immediately upon subscription replays  elements in buffer.
+
+     - parameter replay: Maximum element count (up to one) of the replay buffer. For more information see `SingleReplayCount` enum.
+     - parameter ignoreTerminate: Ignore terminate for preventing immediate disconnect on completion
+
+     - seealso: [shareReplay operator on reactivex.io](http://reactivex.io/documentation/operators/replay.html)
+     - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence.
+     */
+
+    public func shareUntilDisposed(_ replay: SingleReplayCount = .zero, ignoreTerminate: Bool = true) -> Observable<Element> {
+        return ignoreTerminate
+            ? self.primitiveSequence.source.concat(Observable<Element>.never()).share(replay: replay.rawValue)
+            : self.primitiveSequence.source.share(replay: replay.rawValue)
+    }
+}
+
 private final class ShareReplay1WhileConnectedConnection<Element>
     : ObserverType
     , SynchronizedUnsubscribeType {


### PR DESCRIPTION
Usually whileConnected attribute/option is recommended to be applied when using share method.

But there is a problem when applying share-whileConnected to the Single. The problem is, in Single, the complete attribute is set automatically after the connection succeeds, that means the connection is off.

I think the simplest way to solve this problem is converting Single to Observable which ignores Single's terminated options and returns that converted Observable. The returned Observable can share until that Observable has been disposed.

This PR might useful for applying share-whileConnected in Single.