### PR TITLE
Use SwiftPM default minimum deployment targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 *.o
+.swiftpm/
 
 timeline.xctimeline
 .vscode

--- a/Package.swift
+++ b/Package.swift
@@ -42,9 +42,6 @@ extension Target {
 
 let package = Package(
   name: "RxSwift",
-  platforms: [
-    .macOS(.v10_10), .iOS(.v8), .tvOS(.v9), .watchOS(.v3)
-  ],
   products: ([
     [
       .library(name: "RxSwift", targets: ["RxSwift"]),

--- a/RxTest/XCTest+Rx.swift
+++ b/RxTest/XCTest+Rx.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+#if !os(watchOS)
 import RxSwift
 import XCTest
 /**
@@ -230,3 +231,4 @@ func printSequenceDifferences<Element>(_ lhs: [Element], _ rhs: [Element], _ equ
         print("rhs[\(index + shortest)]:\n    \(element)")
     }
 }
+#endif


### PR DESCRIPTION
Xcode 12 raises the minimum known iOS deployment target from iOS 8.0 to iOS 9.0, resulting in a warning when using RxSwift via SwiftPM. Instead of explicitly specifying minimum deployment targets, we can use SwiftPM's default values which will stay up-to-date whenever the toolchain in use changes the valid deployment target range.

**Update:** Here's a citation for my claim about the default values for minimum deployment targets, in [SE-0236: Package Manager Platform Deployment Settings](https://github.com/apple/swift-evolution/blob/master/proposals/0236-package-manager-platform-deployment-settings.md#proposed-solution):

> A package will be assumed to support all platforms using a predefined minimum deployment version.