### PR TITLE
Add the possibility to convert an observable to driver ignoring error

### DIFF
--- a/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
+++ b/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
@@ -54,4 +54,19 @@ extension ObservableConvertibleType {
             }
         return Driver(source)
     }
+
+    /**
+    Converts observable sequence to `Driver` trait. Ignoring Errors
+    - returns: Driver trait.
+    */
+    public func asDriverIgnoringError() -> Driver<Element> {
+        let source = self
+            .asObservable()
+            .map(Optional.init)
+            .observeOn(DriverSharingStrategy.scheduler)
+            .catchErrorJustReturn(nil)
+            .filterNil()
+        
+        return Driver(source)
+    }
 }

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -132,3 +132,28 @@ extension Hooks {
     }
 }
 
+public protocol OptionalType {
+    associatedtype Wrapped
+    var value: Wrapped? { get }
+}
+
+extension Optional: OptionalType {
+    public var value: Wrapped? {
+        return self
+    }
+}
+
+extension ObservableType where Element: OptionalType {
+    /**
+     Unwraps and filters out `nil` elements.
+     - returns: `Observable` of source `Observable`'s elements, with `nil` elements filtered out.
+     */
+    public func filterNil() -> Observable<Element.Wrapped> {
+        return self.flatMap { element -> Observable<Element.Wrapped> in
+            guard let value = element.value else {
+                return .empty()
+            }
+            return .just(value)
+        }
+    }
+}


### PR DESCRIPTION
## Description
This PR exposes a new method for all observables that allow to convert directly to driver ignoring the error event

## Motivation
We have had enough problems in our team to convert some subject to driver that, apart from never failing, many times we do not have or do not know what error value to send in the conversion

## Example

```swift
let someSubject = PublishSubject<String>()
let asDriver = someSubject.asDriverIgnoringError()
```