### PR TITLE
Display bind call location when binding error to relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 * Fix `DelegateProxy` call to `layoutIfNeeded` for an object without a window. #2076
 * Add `ControlEvent` wrappers to `UIApplication` Notifications. #2116
 * `SharingScheduler.mock(scheduler:action:)` can use throwing function for `action`. #2150
+* Display bind call location when binding error to relay.
 
 ## [5.1.1](https://github.com/ReactiveX/RxSwift/releases/tag/5.1.1)
 

--- a/RxRelay/Observable+Bind.swift
+++ b/RxRelay/Observable+Bind.swift
@@ -16,8 +16,8 @@ extension ObservableType {
      - parameter to: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: PublishRelay<Element>...) -> Disposable {
-        return bind(to: relays)
+    public func bind(to relays: PublishRelay<Element>..., file: StaticString = #file, line: UInt = #line) -> Disposable {
+        return bind(to: relays, file: file, line: line)
     }
 
     /**
@@ -29,8 +29,8 @@ extension ObservableType {
      - parameter to: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: PublishRelay<Element?>...) -> Disposable {
-        return self.map { $0 as Element? }.bind(to: relays)
+    public func bind(to relays: PublishRelay<Element?>..., file: StaticString = #file, line: UInt = #line) -> Disposable {
+        return self.map { $0 as Element? }.bind(to: relays, file: file, line: line)
     }
 
     /**
@@ -40,7 +40,7 @@ extension ObservableType {
      - parameter to: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    private func bind(to relays: [PublishRelay<Element>]) -> Disposable {
+    private func bind(to relays: [PublishRelay<Element>], file: StaticString = #file, line: UInt = #line) -> Disposable {
         return subscribe { e in
             switch e {
             case let .next(element):
@@ -48,7 +48,7 @@ extension ObservableType {
                     $0.accept(element)
                 }
             case let .error(error):
-                rxFatalErrorInDebug("Binding error to publish relay: \(error)")
+                rxFatalErrorInDebug("Binding error to publish relay: \(error)", file: file, line: line)
             case .completed:
                 break
             }
@@ -62,8 +62,8 @@ extension ObservableType {
      - parameter to: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: BehaviorRelay<Element>...) -> Disposable {
-        return self.bind(to: relays)
+    public func bind(to relays: BehaviorRelay<Element>..., file: StaticString = #file, line: UInt = #line) -> Disposable {
+        return self.bind(to: relays, file: file, line: line)
     }
 
     /**
@@ -75,8 +75,8 @@ extension ObservableType {
      - parameter to: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    public func bind(to relays: BehaviorRelay<Element?>...) -> Disposable {
-        return self.map { $0 as Element? }.bind(to: relays)
+    public func bind(to relays: BehaviorRelay<Element?>..., file: StaticString = #file, line: UInt = #line) -> Disposable {
+        return self.map { $0 as Element? }.bind(to: relays, file: file, line: line)
     }
 
     /**
@@ -86,7 +86,7 @@ extension ObservableType {
      - parameter to: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
-    private func bind(to relays: [BehaviorRelay<Element>]) -> Disposable {
+    private func bind(to relays: [BehaviorRelay<Element>], file: StaticString = #file, line: UInt = #line) -> Disposable {
         return subscribe { e in
             switch e {
             case let .next(element):
@@ -94,7 +94,7 @@ extension ObservableType {
                     $0.accept(element)
                 }
             case let .error(error):
-                rxFatalErrorInDebug("Binding error to behavior relay: \(error)")
+                rxFatalErrorInDebug("Binding error to behavior relay: \(error)", file: file, line: line)
             case .completed:
                 break
             }


### PR DESCRIPTION
This PR is about making it easier to debug when an error gets bound to a `PublishRelay` or a `BehaviorRelay`.
Should this happen, `rxFatalErrorInDebug` gets called, which incorporates the caller's file name and line number into its error message. But since `ObservableType.bind(to relays: ...)` doesn't take `file` and `line` arguments, this error message always just displays `Observable+Bind.swift`, with no clue as to where to find the real issue.
The stack doesn't help either, since we're in the `bind` operation's code, so all the frames in the stack trace refer to RxSwift project code locations.
With this change, it immediately points to the relevant `bind` operation call in the project code.