### PR TITLE
Rename "Github" to "GitHub" (lowercase -> uppercase)

### DIFF
--- a/RxExample/RxExample-iOSTests/RxExample_iOSTests.swift
+++ b/RxExample/RxExample-iOSTests/RxExample_iOSTests.swift
@@ -56,7 +56,7 @@ class RxExample_iOSTests
         let scheduler = TestScheduler(initialClock: 0, resolution: resolution, simulateProcessingDelay: false)
 
         // mock the universe
-        let mockAPI = mockGithubAPI(scheduler: scheduler)
+        let mockAPI = mockGitHubAPI(scheduler: scheduler)
 
         // expected events and test data
         let (
@@ -80,7 +80,7 @@ class RxExample_iOSTests
         let wireframe = MockWireframe()
         let validationService = GitHubDefaultValidationService(API: mockAPI)
 
-        let viewModel = GithubSignupViewModel1(
+        let viewModel = GitHubSignupViewModel1(
             input: (
                 username: scheduler.createHotObservable(usernameEvents).asObservable(),
                 password: scheduler.createHotObservable(passwordEvents).asObservable(),
@@ -109,7 +109,7 @@ class RxExample_iOSTests
         let scheduler = TestScheduler(initialClock: 0, resolution: resolution, simulateProcessingDelay: false)
 
         // mock the universe
-        let mockAPI = mockGithubAPI(scheduler: scheduler)
+        let mockAPI = mockGitHubAPI(scheduler: scheduler)
 
         // expected events and test data
         let (
@@ -142,7 +142,7 @@ class RxExample_iOSTests
         */
         SharingScheduler.mock(scheduler: scheduler) {
             
-            let viewModel = GithubSignupViewModel2(
+            let viewModel = GitHubSignupViewModel2(
                 input: (
                     username: scheduler.createHotObservable(usernameEvents).asDriver(onErrorJustReturn: ""),
                     password: scheduler.createHotObservable(passwordEvents).asDriver(onErrorJustReturn: ""),
@@ -172,7 +172,7 @@ class RxExample_iOSTests
 // MARK: Mocks
 
 extension RxExample_iOSTests {
-    func mockGithubAPI(scheduler: TestScheduler) -> GitHubAPI {
+    func mockGitHubAPI(scheduler: TestScheduler) -> GitHubAPI {
         return MockGitHubAPI(
             usernameAvailable: scheduler.mock(values: booleans, errors: errors) { (username) -> String in
                 if username == "secretusername" {

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -89,13 +89,13 @@
 		C843A0931C1CE58700CBA4BD /* UINavigationController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C843A0921C1CE58700CBA4BD /* UINavigationController+Extensions.swift */; };
 		C849EF641C3190360048AC4A /* RxExample_iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF631C3190360048AC4A /* RxExample_iOSTests.swift */; };
 		C849EF801C3193B10048AC4A /* GitHubSignupViewController1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF7E1C3193B10048AC4A /* GitHubSignupViewController1.swift */; };
-		C849EF821C3193B10048AC4A /* GithubSignupViewModel1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF7F1C3193B10048AC4A /* GithubSignupViewModel1.swift */; };
+		C849EF821C3193B10048AC4A /* GitHubSignupViewModel1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF7F1C3193B10048AC4A /* GitHubSignupViewModel1.swift */; };
 		C849EF861C3195180048AC4A /* GitHubSignupViewController2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF841C3195180048AC4A /* GitHubSignupViewController2.swift */; };
-		C849EF881C3195180048AC4A /* GithubSignupViewModel2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF851C3195180048AC4A /* GithubSignupViewModel2.swift */; };
-		C849EF901C319E9A0048AC4A /* GithubSignupViewModel1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF7F1C3193B10048AC4A /* GithubSignupViewModel1.swift */; };
+		C849EF881C3195180048AC4A /* GitHubSignupViewModel2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF851C3195180048AC4A /* GitHubSignupViewModel2.swift */; };
+		C849EF901C319E9A0048AC4A /* GitHubSignupViewModel1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF7F1C3193B10048AC4A /* GitHubSignupViewModel1.swift */; };
 		C849EF911C319E9A0048AC4A /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = C822B1D81C14CBEA0088A01A /* Protocols.swift */; };
 		C849EF921C319E9A0048AC4A /* DefaultImplementations.swift in Sources */ = {isa = PBXBuildFile; fileRef = C822B1DB1C14CD1C0088A01A /* DefaultImplementations.swift */; };
-		C849EF951C319E9D0048AC4A /* GithubSignupViewModel2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF851C3195180048AC4A /* GithubSignupViewModel2.swift */; };
+		C849EF951C319E9D0048AC4A /* GitHubSignupViewModel2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C849EF851C3195180048AC4A /* GitHubSignupViewModel2.swift */; };
 		C849EF981C31A3340048AC4A /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C8864C5A1C275A200073016D /* RxTest.framework */; };
 		C849EF991C31A63C0048AC4A /* Wireframe.swift in Sources */ = {isa = PBXBuildFile; fileRef = C809E9791BE6841C0058D948 /* Wireframe.swift */; };
 		C849EF9A1C31A7680048AC4A /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C80397391BD3E17D009D8B26 /* ActivityIndicator.swift */; };
@@ -378,9 +378,9 @@
 		C849EF631C3190360048AC4A /* RxExample_iOSTests.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = RxExample_iOSTests.swift; sourceTree = "<group>"; tabWidth = 4; };
 		C849EF651C3190360048AC4A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C849EF7E1C3193B10048AC4A /* GitHubSignupViewController1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSignupViewController1.swift; sourceTree = "<group>"; };
-		C849EF7F1C3193B10048AC4A /* GithubSignupViewModel1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubSignupViewModel1.swift; sourceTree = "<group>"; };
+		C849EF7F1C3193B10048AC4A /* GitHubSignupViewModel1.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSignupViewModel1.swift; sourceTree = "<group>"; };
 		C849EF841C3195180048AC4A /* GitHubSignupViewController2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSignupViewController2.swift; sourceTree = "<group>"; };
-		C849EF851C3195180048AC4A /* GithubSignupViewModel2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubSignupViewModel2.swift; sourceTree = "<group>"; };
+		C849EF851C3195180048AC4A /* GitHubSignupViewModel2.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitHubSignupViewModel2.swift; sourceTree = "<group>"; };
 		C849EF9B1C31A8750048AC4A /* String+URL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+URL.swift"; sourceTree = "<group>"; };
 		C84E5BA51E7893A4001F659A /* Observable+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+Extensions.swift"; sourceTree = "<group>"; };
 		C864BAD11C3332F10083833C /* DetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
@@ -737,7 +737,7 @@
 			isa = PBXGroup;
 			children = (
 				C849EF841C3195180048AC4A /* GitHubSignupViewController2.swift */,
-				C849EF851C3195180048AC4A /* GithubSignupViewModel2.swift */,
+				C849EF851C3195180048AC4A /* GitHubSignupViewModel2.swift */,
 			);
 			name = "UsingDriver > 2";
 			path = UsingDriver;
@@ -747,7 +747,7 @@
 			isa = PBXGroup;
 			children = (
 				C849EF7E1C3193B10048AC4A /* GitHubSignupViewController1.swift */,
-				C849EF7F1C3193B10048AC4A /* GithubSignupViewModel1.swift */,
+				C849EF7F1C3193B10048AC4A /* GitHubSignupViewModel1.swift */,
 			);
 			name = "UsingVanillaObservables > 1";
 			path = UsingVanillaObservables;
@@ -1297,12 +1297,12 @@
 				C82FF1241F93E84600BDB34D /* IdentifiableType.swift in Sources */,
 				C82FF13E1F93E84600BDB34D /* RxTableViewSectionedReloadDataSource.swift in Sources */,
 				C8CDF0C11D688DF700C18F99 /* UITableView+Extensions.swift in Sources */,
-				C849EF821C3193B10048AC4A /* GithubSignupViewModel1.swift in Sources */,
+				C849EF821C3193B10048AC4A /* GitHubSignupViewModel1.swift in Sources */,
 				C82FF13A1F93E84600BDB34D /* IntegerType+IdentifiableType.swift in Sources */,
 				C864BADD1C3332F10083833C /* TableViewWithEditingCommandsViewController.swift in Sources */,
 				C822B1D91C14CBEA0088A01A /* Protocols.swift in Sources */,
 				C8BCD3E61C14A95E005F1280 /* NumbersViewController.swift in Sources */,
-				C849EF881C3195180048AC4A /* GithubSignupViewModel2.swift in Sources */,
+				C849EF881C3195180048AC4A /* GitHubSignupViewModel2.swift in Sources */,
 				C809E97A1BE6841C0058D948 /* Wireframe.swift in Sources */,
 				C843A0931C1CE58700CBA4BD /* UINavigationController+Extensions.swift in Sources */,
 				C82FF1321F93E84600BDB34D /* RxTableViewSectionedAnimatedDataSource.swift in Sources */,
@@ -1361,7 +1361,7 @@
 			files = (
 				C89C2BD61C321DA200EBC99C /* TestScheduler+MarbleTests.swift in Sources */,
 				C886A6951D85AEA300653EE4 /* RxTest.swift in Sources */,
-				C849EF901C319E9A0048AC4A /* GithubSignupViewModel1.swift in Sources */,
+				C849EF901C319E9A0048AC4A /* GitHubSignupViewModel1.swift in Sources */,
 				C849EF641C3190360048AC4A /* RxExample_iOSTests.swift in Sources */,
 				C886A6911D85AD7E00653EE4 /* CLLocationManager+RxTests.swift in Sources */,
 				C849EF921C319E9A0048AC4A /* DefaultImplementations.swift in Sources */,
@@ -1369,7 +1369,7 @@
 				C89C2BDC1C32231A00EBC99C /* MockGitHubAPI.swift in Sources */,
 				C89C2BDE1C32231A00EBC99C /* NotImplementedStubs.swift in Sources */,
 				C849EF9A1C31A7680048AC4A /* ActivityIndicator.swift in Sources */,
-				C849EF951C319E9D0048AC4A /* GithubSignupViewModel2.swift in Sources */,
+				C849EF951C319E9D0048AC4A /* GitHubSignupViewModel2.swift in Sources */,
 				C886A6931D85ADA100653EE4 /* UIImagePickerController+RxTests.swift in Sources */,
 				C89C2BDD1C32231A00EBC99C /* MockWireframe.swift in Sources */,
 				C89C2BDF1C32231A00EBC99C /* ValidationResult+Equatable.swift in Sources */,

--- a/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
+++ b/RxExample/RxExample/Examples/GitHubSearchRepositories/GitHubSearchRepositories.swift
@@ -61,7 +61,7 @@ extension GitHubSearchRepositoriesState {
 import RxSwift
 import RxCocoa
 
-struct GithubQuery: Equatable {
+struct GitHubQuery: Equatable {
     let searchText: String;
     let shouldLoadNextPage: Bool;
     let nextURL: URL?
@@ -81,7 +81,7 @@ func githubSearchRepositories(
 
     let searchPerformerFeedback: (Driver<GitHubSearchRepositoriesState>) -> Signal<GitHubCommand> = react(
         query: { (state) in
-            GithubQuery(searchText: state.searchText, shouldLoadNextPage: state.shouldLoadNextPage, nextURL: state.nextURL)
+            GitHubQuery(searchText: state.searchText, shouldLoadNextPage: state.shouldLoadNextPage, nextURL: state.nextURL)
         },
         effects: { query -> Signal<GitHubCommand> in
                 if !query.shouldLoadNextPage {

--- a/RxExample/RxExample/Examples/GitHubSignup/UsingDriver/GitHubSignupViewController2.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/UsingDriver/GitHubSignupViewController2.swift
@@ -26,7 +26,7 @@ class GitHubSignupViewController2 : ViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let viewModel = GithubSignupViewModel2(
+        let viewModel = GitHubSignupViewModel2(
             input: (
                 username: usernameOutlet.rx.text.orEmpty.asDriver(),
                 password: passwordOutlet.rx.text.orEmpty.asDriver(),

--- a/RxExample/RxExample/Examples/GitHubSignup/UsingVanillaObservables/GitHubSignupViewController1.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/UsingVanillaObservables/GitHubSignupViewController1.swift
@@ -26,7 +26,7 @@ class GitHubSignupViewController1 : ViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let viewModel = GithubSignupViewModel1(
+        let viewModel = GitHubSignupViewModel1(
             input: (
                 username: usernameOutlet.rx.text.orEmpty.asObservable(),
                 password: passwordOutlet.rx.text.orEmpty.asObservable(),

--- a/RxExample/RxExample/Examples/GitHubSignup/UsingVanillaObservables/GitHubSignupViewModel1.swift
+++ b/RxExample/RxExample/Examples/GitHubSignup/UsingVanillaObservables/GitHubSignupViewModel1.swift
@@ -1,5 +1,5 @@
 //
-//  GithubSignupViewModel2.swift
+//  GitHubSignupViewModel1.swift
 //  RxExample
 //
 //  Created by Krunoslav Zaher on 12/6/15.
@@ -16,36 +16,34 @@ This is example where view model is mutable. Some consider this to be MVVM, some
  
  If you want to take a look at example using "immutable VMs", take a look at `TableViewWithEditingCommands` example.
  
- This uses Driver builder for sequences.
+ This uses vanilla rx observable sequences.
  
  Please note that there is no explicit state, outputs are defined using inputs and dependencies.
  Please note that there is no dispose bag, because no subscription is being made.
 */
-class GithubSignupViewModel2 {
+class GitHubSignupViewModel1 {
     // outputs {
 
-    //
-    let validatedUsername: Driver<ValidationResult>
-    let validatedPassword: Driver<ValidationResult>
-    let validatedPasswordRepeated: Driver<ValidationResult>
+    let validatedUsername: Observable<ValidationResult>
+    let validatedPassword: Observable<ValidationResult>
+    let validatedPasswordRepeated: Observable<ValidationResult>
 
     // Is signup button enabled
-    let signupEnabled: Driver<Bool>
+    let signupEnabled: Observable<Bool>
 
     // Has user signed in
-    let signedIn: Driver<Bool>
+    let signedIn: Observable<Bool>
 
     // Is signing process in progress
-    let signingIn: Driver<Bool>
+    let signingIn: Observable<Bool>
 
     // }
 
-    init(
-        input: (
-            username: Driver<String>,
-            password: Driver<String>,
-            repeatedPassword: Driver<String>,
-            loginTaps: Signal<()>
+    init(input: (
+            username: Observable<String>,
+            password: Observable<String>,
+            repeatedPassword: Observable<String>,
+            loginTaps: Observable<Void>
         ),
         dependency: (
             API: GitHubAPI,
@@ -62,56 +60,52 @@ class GithubSignupViewModel2 {
          Everything is just a definition.
 
          Pure transformation of input sequences to output sequences.
-         
-         When using `Driver`, underlying observable sequence elements are shared because
-         driver automagically adds "shareReplay(1)" under the hood.
-         
-             .observeOn(MainScheduler.instance)
-             .catchErrorJustReturn(.Failed(message: "Error contacting server"))
-         
-         ... are squashed into single `.asDriver(onErrorJustReturn: .Failed(message: "Error contacting server"))`
         */
 
         validatedUsername = input.username
             .flatMapLatest { username in
                 return validationService.validateUsername(username)
-                    .asDriver(onErrorJustReturn: .failed(message: "Error contacting server"))
+                    .observeOn(MainScheduler.instance)
+                    .catchErrorJustReturn(.failed(message: "Error contacting server"))
             }
+            .share(replay: 1)
 
         validatedPassword = input.password
             .map { password in
                 return validationService.validatePassword(password)
             }
+            .share(replay: 1)
 
-        validatedPasswordRepeated = Driver.combineLatest(input.password, input.repeatedPassword, resultSelector: validationService.validateRepeatedPassword)
+        validatedPasswordRepeated = Observable.combineLatest(input.password, input.repeatedPassword, resultSelector: validationService.validateRepeatedPassword)
+            .share(replay: 1)
 
         let signingIn = ActivityIndicator()
-        self.signingIn = signingIn.asDriver()
+        self.signingIn = signingIn.asObservable()
 
-        let usernameAndPassword = Driver.combineLatest(input.username, input.password) { (username: $0, password: $1) }
+        let usernameAndPassword = Observable.combineLatest(input.username, input.password) { (username: $0, password: $1) }
 
         signedIn = input.loginTaps.withLatestFrom(usernameAndPassword)
             .flatMapLatest { pair in
                 return API.signup(pair.username, password: pair.password)
+                    .observeOn(MainScheduler.instance)
+                    .catchErrorJustReturn(false)
                     .trackActivity(signingIn)
-                    .asDriver(onErrorJustReturn: false)
             }
-            .flatMapLatest { loggedIn -> Driver<Bool> in
+            .flatMapLatest { loggedIn -> Observable<Bool> in
                 let message = loggedIn ? "Mock: Signed in to GitHub." : "Mock: Sign in to GitHub failed"
                 return wireframe.promptFor(message, cancelAction: "OK", actions: [])
                     // propagate original value
                     .map { _ in
                         loggedIn
                     }
-                    .asDriver(onErrorJustReturn: false)
             }
-
-
-        signupEnabled = Driver.combineLatest(
+            .share(replay: 1)
+        
+        signupEnabled = Observable.combineLatest(
             validatedUsername,
             validatedPassword,
             validatedPasswordRepeated,
-            signingIn
+            signingIn.asObservable()
         )   { username, password, repeatPassword, signingIn in
                 username.isValid &&
                 password.isValid &&
@@ -119,5 +113,6 @@ class GithubSignupViewModel2 {
                 !signingIn
             }
             .distinctUntilChanged()
+            .share(replay: 1)
     }
 }


### PR DESCRIPTION
## Summary

- Rename (Fix) class names, struct name and file names which contain "Github" to "GitHub".
  - "h" was lowercase
- The scope of this PR is inside of `RxExample/RxExample/Examples/GitHubSignup`.

## Changes

- Class names:
  - `GithubSignupViewModel1` -> `GitHubSignupViewModel1`
  - `GithubSignupViewModel2` -> `GitHubSignupViewModel2`
    - reason: ViewControllers are named `GitHub*`, but ViewModels are not.
  - `mockGithubAPI` -> `mockGitHubAPI`
    - reason: `GitHubAPI` class exists
- Struct names:
  - `GithubQuery` -> `GitHubQuery`
- File names:
  - `GithubSignupViewModel1.swift` -> `GitHubSignupViewModel1.swift`
  - `GithubSignupViewModel2.swift` -> `GitHubSignupViewModel2.swift`

## Notes

- I didn't change `CHANGELOG.md` because these changes are very small.
- This PR targets `develop` branch. Please make sure this is right.