### PR TITLE
Fix carthage setting of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Officially supported: Carthage 0.33 and up.
 Add this to `Cartfile`
 
 ```
-github "ReactiveX/RxSwift" '6.0.0-rc.1'
+github "ReactiveX/RxSwift" "6.0.0-rc.1"
 ```
 
 ```bash


### PR DESCRIPTION
`Cartfile` version specification must be done in double quotes.

```
$ carthage update --use-ssh --platform ios RxSwift
Parse error: unexpected trailing characters in line: github "ReactiveX/RxSwift" '6.0.0-rc.1'
```
```
$ carthage version
0.36.0
```