### PR TITLE
Bump arity from 8 to 9 in zip and combineLatest

### DIFF
--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
@@ -654,3 +654,111 @@ extension SharedSequenceConvertibleType where Element == Any {
 }
 
 
+
+// 9
+
+extension SharedSequence {
+    /**
+    Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType, O9: SharedSequenceConvertibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, _ source9: O9, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element) throws -> Element)
+        -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
+            SharingStrategy == O2.SharingStrategy,
+            SharingStrategy == O3.SharingStrategy,
+            SharingStrategy == O4.SharingStrategy,
+            SharingStrategy == O5.SharingStrategy,
+            SharingStrategy == O6.SharingStrategy,
+            SharingStrategy == O7.SharingStrategy,
+            SharingStrategy == O8.SharingStrategy,
+            SharingStrategy == O9.SharingStrategy {
+        let source = Observable.zip(
+            source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable(), source7.asSharedSequence().asObservable(), source8.asSharedSequence().asObservable(), source9.asSharedSequence().asObservable(),
+            resultSelector: resultSelector
+        )
+
+        return SharedSequence<SharingStrategy, Element>(source)
+    }
+}
+
+extension SharedSequenceConvertibleType where Element == Any {
+    /**
+    Merges the specified observable sequences into one observable sequence of element tuples whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType, O9: SharedSequenceConvertibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, _ source9: O9)
+        -> SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element)> where SharingStrategy == O1.SharingStrategy,
+            SharingStrategy == O2.SharingStrategy,
+            SharingStrategy == O3.SharingStrategy,
+            SharingStrategy == O4.SharingStrategy,
+            SharingStrategy == O5.SharingStrategy,
+            SharingStrategy == O6.SharingStrategy,
+            SharingStrategy == O7.SharingStrategy,
+            SharingStrategy == O8.SharingStrategy,
+            SharingStrategy == O9.SharingStrategy {
+        let source = Observable.zip(
+            source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable(), source7.asSharedSequence().asObservable(), source8.asSharedSequence().asObservable(), source9.asSharedSequence().asObservable()
+        )
+
+        return SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element)>(source)
+    }
+}
+
+extension SharedSequence {
+    /**
+    Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences produces an element.
+
+    - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType, O9: SharedSequenceConvertibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, _ source9: O9, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element) throws -> Element)
+        -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
+            SharingStrategy == O2.SharingStrategy,
+            SharingStrategy == O3.SharingStrategy,
+            SharingStrategy == O4.SharingStrategy,
+            SharingStrategy == O5.SharingStrategy,
+            SharingStrategy == O6.SharingStrategy,
+            SharingStrategy == O7.SharingStrategy,
+            SharingStrategy == O8.SharingStrategy,
+            SharingStrategy == O9.SharingStrategy {
+        let source = Observable.combineLatest(
+                source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable(), source7.asSharedSequence().asObservable(), source8.asSharedSequence().asObservable(), source9.asSharedSequence().asObservable(),
+                resultSelector: resultSelector
+            )
+
+        return SharedSequence<O1.SharingStrategy, Element>(source)
+    }
+}
+
+extension SharedSequenceConvertibleType where Element == Any {
+    /**
+    Merges the specified observable sequences into one observable sequence of element tuples whenever any of the observable sequences produces an element.
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType, O9: SharedSequenceConvertibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, _ source9: O9)
+        -> SharedSequence<SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element)> where SharingStrategy == O1.SharingStrategy,
+            SharingStrategy == O2.SharingStrategy,
+            SharingStrategy == O3.SharingStrategy,
+            SharingStrategy == O4.SharingStrategy,
+            SharingStrategy == O5.SharingStrategy,
+            SharingStrategy == O6.SharingStrategy,
+            SharingStrategy == O7.SharingStrategy,
+            SharingStrategy == O8.SharingStrategy,
+            SharingStrategy == O9.SharingStrategy {
+        let source = Observable.combineLatest(
+                source1.asSharedSequence().asObservable(), source2.asSharedSequence().asObservable(), source3.asSharedSequence().asObservable(), source4.asSharedSequence().asObservable(), source5.asSharedSequence().asObservable(), source6.asSharedSequence().asObservable(), source7.asSharedSequence().asObservable(), source8.asSharedSequence().asObservable(), source9.asSharedSequence().asObservable()
+            )
+
+        return SharedSequence<O1.SharingStrategy, (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element)>(source)
+    }
+}
+
+

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.tt
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.tt
@@ -8,7 +8,7 @@
 
 import RxSwift
 
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 
 // <%= i %>
 

--- a/RxSwift/Observables/CombineLatest+arity.swift
+++ b/RxSwift/Observables/CombineLatest+arity.swift
@@ -841,3 +841,150 @@ final class CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, Result> : Producer<Re
 }
 
 
+
+// 9
+
+extension ObservableType {
+    /**
+    Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType, O9: ObservableType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, _ source9: O9, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element) throws -> Element)
+            -> Observable<Element> {
+        return CombineLatest9(
+            source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(), source9: source9.asObservable(),
+            resultSelector: resultSelector
+        )
+    }
+}
+
+extension ObservableType where Element == Any {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType, O9: ObservableType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, _ source9: O9)
+            -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element)> {
+        return CombineLatest9(
+            source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(), source9: source9.asObservable(),
+            resultSelector: { ($0, $1, $2, $3, $4, $5, $6, $7, $8) }
+        )
+    }
+}
+
+final class CombineLatestSink9_<E1, E2, E3, E4, E5, E6, E7, E8, E9, Observer: ObserverType> : CombineLatestSink<Observer> {
+    typealias Result = Observer.Element
+    typealias Parent = CombineLatest9<E1, E2, E3, E4, E5, E6, E7, E8, E9, Result>
+
+    let parent: Parent
+
+    var latestElement1: E1! = nil
+    var latestElement2: E2! = nil
+    var latestElement3: E3! = nil
+    var latestElement4: E4! = nil
+    var latestElement5: E5! = nil
+    var latestElement6: E6! = nil
+    var latestElement7: E7! = nil
+    var latestElement8: E8! = nil
+    var latestElement9: E9! = nil
+
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
+        self.parent = parent
+        super.init(arity: 9, observer: observer, cancel: cancel)
+    }
+
+    func run() -> Disposable {
+        let subscription1 = SingleAssignmentDisposable()
+        let subscription2 = SingleAssignmentDisposable()
+        let subscription3 = SingleAssignmentDisposable()
+        let subscription4 = SingleAssignmentDisposable()
+        let subscription5 = SingleAssignmentDisposable()
+        let subscription6 = SingleAssignmentDisposable()
+        let subscription7 = SingleAssignmentDisposable()
+        let subscription8 = SingleAssignmentDisposable()
+        let subscription9 = SingleAssignmentDisposable()
+
+        let observer1 = CombineLatestObserver(lock: self.lock, parent: self, index: 0, setLatestValue: { (e: E1) -> Void in self.latestElement1 = e }, this: subscription1)
+        let observer2 = CombineLatestObserver(lock: self.lock, parent: self, index: 1, setLatestValue: { (e: E2) -> Void in self.latestElement2 = e }, this: subscription2)
+        let observer3 = CombineLatestObserver(lock: self.lock, parent: self, index: 2, setLatestValue: { (e: E3) -> Void in self.latestElement3 = e }, this: subscription3)
+        let observer4 = CombineLatestObserver(lock: self.lock, parent: self, index: 3, setLatestValue: { (e: E4) -> Void in self.latestElement4 = e }, this: subscription4)
+        let observer5 = CombineLatestObserver(lock: self.lock, parent: self, index: 4, setLatestValue: { (e: E5) -> Void in self.latestElement5 = e }, this: subscription5)
+        let observer6 = CombineLatestObserver(lock: self.lock, parent: self, index: 5, setLatestValue: { (e: E6) -> Void in self.latestElement6 = e }, this: subscription6)
+        let observer7 = CombineLatestObserver(lock: self.lock, parent: self, index: 6, setLatestValue: { (e: E7) -> Void in self.latestElement7 = e }, this: subscription7)
+        let observer8 = CombineLatestObserver(lock: self.lock, parent: self, index: 7, setLatestValue: { (e: E8) -> Void in self.latestElement8 = e }, this: subscription8)
+        let observer9 = CombineLatestObserver(lock: self.lock, parent: self, index: 8, setLatestValue: { (e: E9) -> Void in self.latestElement9 = e }, this: subscription9)
+
+         subscription1.setDisposable(self.parent.source1.subscribe(observer1))
+         subscription2.setDisposable(self.parent.source2.subscribe(observer2))
+         subscription3.setDisposable(self.parent.source3.subscribe(observer3))
+         subscription4.setDisposable(self.parent.source4.subscribe(observer4))
+         subscription5.setDisposable(self.parent.source5.subscribe(observer5))
+         subscription6.setDisposable(self.parent.source6.subscribe(observer6))
+         subscription7.setDisposable(self.parent.source7.subscribe(observer7))
+         subscription8.setDisposable(self.parent.source8.subscribe(observer8))
+         subscription9.setDisposable(self.parent.source9.subscribe(observer9))
+
+        return Disposables.create([
+                subscription1,
+                subscription2,
+                subscription3,
+                subscription4,
+                subscription5,
+                subscription6,
+                subscription7,
+                subscription8,
+                subscription9
+        ])
+    }
+
+    override func getResult() throws -> Result {
+        try self.parent.resultSelector(self.latestElement1, self.latestElement2, self.latestElement3, self.latestElement4, self.latestElement5, self.latestElement6, self.latestElement7, self.latestElement8, self.latestElement9)
+    }
+}
+
+final class CombineLatest9<E1, E2, E3, E4, E5, E6, E7, E8, E9, Result> : Producer<Result> {
+    typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7, E8, E9) throws -> Result
+
+    let source1: Observable<E1>
+    let source2: Observable<E2>
+    let source3: Observable<E3>
+    let source4: Observable<E4>
+    let source5: Observable<E5>
+    let source6: Observable<E6>
+    let source7: Observable<E7>
+    let source8: Observable<E8>
+    let source9: Observable<E9>
+
+    let resultSelector: ResultSelector
+
+    init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, source7: Observable<E7>, source8: Observable<E8>, source9: Observable<E9>, resultSelector: @escaping ResultSelector) {
+        self.source1 = source1
+        self.source2 = source2
+        self.source3 = source3
+        self.source4 = source4
+        self.source5 = source5
+        self.source6 = source6
+        self.source7 = source7
+        self.source8 = source8
+        self.source9 = source9
+
+        self.resultSelector = resultSelector
+    }
+
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
+        let sink = CombineLatestSink9_(parent: self, observer: observer, cancel: cancel)
+        let subscription = sink.run()
+        return (sink: sink, subscription: subscription)
+    }
+}
+
+

--- a/RxSwift/Observables/CombineLatest+arity.tt
+++ b/RxSwift/Observables/CombineLatest+arity.tt
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 
 // <%= i %>
 

--- a/RxSwift/Observables/Zip+arity.swift
+++ b/RxSwift/Observables/Zip+arity.swift
@@ -932,3 +932,167 @@ final class Zip8<E1, E2, E3, E4, E5, E6, E7, E8, Result> : Producer<Result> {
 }
 
 
+
+// 9
+
+extension ObservableType {
+    /**
+    Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+    - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType, O9: ObservableType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, _ source9: O9, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element) throws -> Element)
+        -> Observable<Element> {
+        return Zip9(
+            source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(), source9: source9.asObservable(),
+            resultSelector: resultSelector
+        )
+    }
+}
+
+extension ObservableType where Element == Any {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType, O9: ObservableType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, _ source9: O9)
+        -> Observable<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element, O9.Element)> {
+        return Zip9(
+            source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(), source9: source9.asObservable(),
+            resultSelector: { ($0, $1, $2, $3, $4, $5, $6, $7, $8) }
+        )
+    }
+}
+
+final class ZipSink9_<E1, E2, E3, E4, E5, E6, E7, E8, E9, Observer: ObserverType> : ZipSink<Observer> {
+    typealias Result = Observer.Element 
+    typealias Parent = Zip9<E1, E2, E3, E4, E5, E6, E7, E8, E9, Result>
+
+    let parent: Parent
+
+    var values1: Queue<E1> = Queue(capacity: 2)
+    var values2: Queue<E2> = Queue(capacity: 2)
+    var values3: Queue<E3> = Queue(capacity: 2)
+    var values4: Queue<E4> = Queue(capacity: 2)
+    var values5: Queue<E5> = Queue(capacity: 2)
+    var values6: Queue<E6> = Queue(capacity: 2)
+    var values7: Queue<E7> = Queue(capacity: 2)
+    var values8: Queue<E8> = Queue(capacity: 2)
+    var values9: Queue<E9> = Queue(capacity: 2)
+
+    init(parent: Parent, observer: Observer, cancel: Cancelable) {
+        self.parent = parent
+        super.init(arity: 9, observer: observer, cancel: cancel)
+    }
+
+    override func hasElements(_ index: Int) -> Bool {
+        switch index {
+        case 0: return !self.values1.isEmpty
+        case 1: return !self.values2.isEmpty
+        case 2: return !self.values3.isEmpty
+        case 3: return !self.values4.isEmpty
+        case 4: return !self.values5.isEmpty
+        case 5: return !self.values6.isEmpty
+        case 6: return !self.values7.isEmpty
+        case 7: return !self.values8.isEmpty
+        case 8: return !self.values9.isEmpty
+
+        default:
+            rxFatalError("Unhandled case (Function)")
+        }
+    }
+
+    func run() -> Disposable {
+        let subscription1 = SingleAssignmentDisposable()
+        let subscription2 = SingleAssignmentDisposable()
+        let subscription3 = SingleAssignmentDisposable()
+        let subscription4 = SingleAssignmentDisposable()
+        let subscription5 = SingleAssignmentDisposable()
+        let subscription6 = SingleAssignmentDisposable()
+        let subscription7 = SingleAssignmentDisposable()
+        let subscription8 = SingleAssignmentDisposable()
+        let subscription9 = SingleAssignmentDisposable()
+
+        let observer1 = ZipObserver(lock: self.lock, parent: self, index: 0, setNextValue: { self.values1.enqueue($0) }, this: subscription1)
+        let observer2 = ZipObserver(lock: self.lock, parent: self, index: 1, setNextValue: { self.values2.enqueue($0) }, this: subscription2)
+        let observer3 = ZipObserver(lock: self.lock, parent: self, index: 2, setNextValue: { self.values3.enqueue($0) }, this: subscription3)
+        let observer4 = ZipObserver(lock: self.lock, parent: self, index: 3, setNextValue: { self.values4.enqueue($0) }, this: subscription4)
+        let observer5 = ZipObserver(lock: self.lock, parent: self, index: 4, setNextValue: { self.values5.enqueue($0) }, this: subscription5)
+        let observer6 = ZipObserver(lock: self.lock, parent: self, index: 5, setNextValue: { self.values6.enqueue($0) }, this: subscription6)
+        let observer7 = ZipObserver(lock: self.lock, parent: self, index: 6, setNextValue: { self.values7.enqueue($0) }, this: subscription7)
+        let observer8 = ZipObserver(lock: self.lock, parent: self, index: 7, setNextValue: { self.values8.enqueue($0) }, this: subscription8)
+        let observer9 = ZipObserver(lock: self.lock, parent: self, index: 8, setNextValue: { self.values9.enqueue($0) }, this: subscription9)
+
+        subscription1.setDisposable(self.parent.source1.subscribe(observer1))
+        subscription2.setDisposable(self.parent.source2.subscribe(observer2))
+        subscription3.setDisposable(self.parent.source3.subscribe(observer3))
+        subscription4.setDisposable(self.parent.source4.subscribe(observer4))
+        subscription5.setDisposable(self.parent.source5.subscribe(observer5))
+        subscription6.setDisposable(self.parent.source6.subscribe(observer6))
+        subscription7.setDisposable(self.parent.source7.subscribe(observer7))
+        subscription8.setDisposable(self.parent.source8.subscribe(observer8))
+        subscription9.setDisposable(self.parent.source9.subscribe(observer9))
+
+        return Disposables.create([
+           subscription1,
+           subscription2,
+           subscription3,
+           subscription4,
+           subscription5,
+           subscription6,
+           subscription7,
+           subscription8,
+           subscription9
+        ])
+    }
+
+    override func getResult() throws -> Result {
+        try self.parent.resultSelector(self.values1.dequeue()!, self.values2.dequeue()!, self.values3.dequeue()!, self.values4.dequeue()!, self.values5.dequeue()!, self.values6.dequeue()!, self.values7.dequeue()!, self.values8.dequeue()!, self.values9.dequeue()!)
+    }
+}
+
+final class Zip9<E1, E2, E3, E4, E5, E6, E7, E8, E9, Result> : Producer<Result> {
+    typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7, E8, E9) throws -> Result
+
+    let source1: Observable<E1>
+    let source2: Observable<E2>
+    let source3: Observable<E3>
+    let source4: Observable<E4>
+    let source5: Observable<E5>
+    let source6: Observable<E6>
+    let source7: Observable<E7>
+    let source8: Observable<E8>
+    let source9: Observable<E9>
+
+    let resultSelector: ResultSelector
+
+    init(source1: Observable<E1>, source2: Observable<E2>, source3: Observable<E3>, source4: Observable<E4>, source5: Observable<E5>, source6: Observable<E6>, source7: Observable<E7>, source8: Observable<E8>, source9: Observable<E9>, resultSelector: @escaping ResultSelector) {
+        self.source1 = source1
+        self.source2 = source2
+        self.source3 = source3
+        self.source4 = source4
+        self.source5 = source5
+        self.source6 = source6
+        self.source7 = source7
+        self.source8 = source8
+        self.source9 = source9
+
+        self.resultSelector = resultSelector
+    }
+
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Result {
+        let sink = ZipSink9_(parent: self, observer: observer, cancel: cancel)
+        let subscription = sink.run()
+        return (sink: sink, subscription: subscription)
+    }
+}
+
+

--- a/RxSwift/Observables/Zip+arity.tt
+++ b/RxSwift/Observables/Zip+arity.tt
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 
 // <%= i %>
 

--- a/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.swift
+++ b/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.swift
@@ -149,3 +149,23 @@ extension Infallible {
     }
 }
 
+// 9
+extension Infallible {
+    /**
+    Merges the specified observable sequences into one observable sequence by using the selector function whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func combineLatest<I1: InfallibleType, I2: InfallibleType, I3: InfallibleType, I4: InfallibleType, I5: InfallibleType, I6: InfallibleType, I7: InfallibleType, I8: InfallibleType, I9: InfallibleType>
+        (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, _ source6: I6, _ source7: I7, _ source8: I8, _ source9: I9, resultSelector: @escaping (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element, I6.Element, I7.Element, I8.Element, I9.Element) throws -> Element)
+            -> Infallible<Element> {
+        Infallible(CombineLatest9(
+            source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(), source9: source9.asObservable(),
+            resultSelector: resultSelector
+        ))
+    }
+}
+

--- a/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.tt
+++ b/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.tt
@@ -7,7 +7,7 @@
 //
 
 // MARK: - Combine Latest
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 // <%= i %>
 extension Infallible {
     /**

--- a/RxSwift/Traits/Infallible/Infallible+Zip+arity.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Zip+arity.swift
@@ -136,3 +136,21 @@ extension InfallibleType {
     }
 }
 
+// 9
+extension InfallibleType {
+    /**
+    Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+    - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8, E9>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, _ source6: Infallible<E6>, _ source7: Infallible<E7>, _ source8: Infallible<E8>, _ source9: Infallible<E9>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8, E9) throws -> Element)
+        -> Infallible<Element> {
+        Infallible(
+            Observable.zip(source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(), source9.asObservable(), resultSelector: resultSelector)
+        )
+    }
+}
+

--- a/RxSwift/Traits/Infallible/Infallible+Zip+arity.tt
+++ b/RxSwift/Traits/Infallible/Infallible+Zip+arity.tt
@@ -8,7 +8,7 @@
 
 // MARK: - Zip
 
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 // <%= i %>
 extension InfallibleType {
     /**

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Zip+arity.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Zip+arity.swift
@@ -519,3 +519,76 @@ extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
 
 
 
+
+// 9
+
+extension PrimitiveSequenceType where Trait == SingleTrait {
+    /**
+    Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+    - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8, E9>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, _ source9: PrimitiveSequence<Trait, E9>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8, E9) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
+            return PrimitiveSequence(raw: Observable.zip(
+            source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(), source9.asObservable(),
+                resultSelector: resultSelector)
+            )
+    }
+}
+
+extension PrimitiveSequenceType where Element == Any, Trait == SingleTrait {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8, E9>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, _ source9: PrimitiveSequence<Trait, E9>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5, E6, E7, E8, E9)> {
+        return PrimitiveSequence(raw: Observable.zip(
+                source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(), source9.asObservable())
+            )
+    }
+}
+
+extension PrimitiveSequenceType where Trait == MaybeTrait {
+    /**
+    Merges the specified observable sequences into one observable sequence by using the selector function whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+    - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8, E9>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, _ source9: PrimitiveSequence<Trait, E9>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8, E9) throws -> Element)
+        -> PrimitiveSequence<Trait, Element> {
+            return PrimitiveSequence(raw: Observable.zip(
+            source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(), source9.asObservable(),
+                resultSelector: resultSelector)
+            )
+    }
+}
+
+extension PrimitiveSequenceType where Element == Any, Trait == MaybeTrait {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever all of the observable sequences have produced an element at a corresponding index.
+
+    - seealso: [zip operator on reactivex.io](http://reactivex.io/documentation/operators/zip.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
+    */
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8, E9>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, _ source9: PrimitiveSequence<Trait, E9>)
+        -> PrimitiveSequence<Trait, (E1, E2, E3, E4, E5, E6, E7, E8, E9)> {
+        return PrimitiveSequence(raw: Observable.zip(
+                source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(), source9.asObservable())
+            )
+    }
+}
+
+
+

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Zip+arity.tt
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Zip+arity.tt
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 
 // <%= i %>
 

--- a/Tests/RxSwiftTests/Observable+CombineLatestTests+arity.swift
+++ b/Tests/RxSwiftTests/Observable+CombineLatestTests+arity.swift
@@ -2339,4 +2339,484 @@ extension ObservableCombineLatestTest {
 
 
 
+    // 9
+
+    func testCombineLatest_Never9() {
+        let factories: [(TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8) { _, _, _, _, _, _, _, _, _ -> Int in
+                        return (42)
+                    }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { _, _, _, _, _, _, _, _, _ -> Int in
+                        return (42)
+                    }
+                },
+            ]
+        for factory in factories {
+            let scheduler = TestScheduler(initialClock: 0)
+
+
+            let e0 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+            let e1 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+            let e2 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+            let e3 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+            let e4 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+            let e5 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+            let e6 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+            let e7 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+            let e8 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+
+
+            let res = scheduler.start { () -> Observable<Int> in
+                factory(e0, e1, e2, e3, e4, e5, e6, e7, e8)
+            }
+            
+            XCTAssertEqual(res.events, [])
+            
+            let subscriptions = [Subscription(200, 1000)]
+            
+
+            XCTAssertEqual(e0.subscriptions, subscriptions)
+            XCTAssertEqual(e1.subscriptions, subscriptions)
+            XCTAssertEqual(e2.subscriptions, subscriptions)
+            XCTAssertEqual(e3.subscriptions, subscriptions)
+            XCTAssertEqual(e4.subscriptions, subscriptions)
+            XCTAssertEqual(e5.subscriptions, subscriptions)
+            XCTAssertEqual(e6.subscriptions, subscriptions)
+            XCTAssertEqual(e7.subscriptions, subscriptions)
+            XCTAssertEqual(e8.subscriptions, subscriptions)
+        }
+    }
+
+    func testCombineLatest_Empty9() {
+        let factories: [(TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8) { _, _, _, _, _, _, _, _, _ -> Int in
+                        return (42)
+                    }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { _, _, _, _, _, _, _, _, _ -> Int in
+                        return (42)
+                    }
+                },
+            ]
+
+        for factory in factories {
+            let scheduler = TestScheduler(initialClock: 0)
+
+
+            let e0 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(210)
+            ])
+
+            let e1 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(220)
+            ])
+
+            let e2 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(230)
+            ])
+
+            let e3 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(240)
+            ])
+
+            let e4 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(250)
+            ])
+
+            let e5 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(260)
+            ])
+
+            let e6 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(270)
+            ])
+
+            let e7 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(280)
+            ])
+
+            let e8 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(290)
+            ])
+
+
+            let res = scheduler.start { () -> Observable<Int> in
+                factory(e0, e1, e2, e3, e4, e5, e6, e7, e8)
+            }
+
+            XCTAssertEqual(res.events, [.completed(290)])
+
+
+            XCTAssertEqual(e0.subscriptions, [Subscription(200, 210)])
+
+            XCTAssertEqual(e1.subscriptions, [Subscription(200, 220)])
+
+            XCTAssertEqual(e2.subscriptions, [Subscription(200, 230)])
+
+            XCTAssertEqual(e3.subscriptions, [Subscription(200, 240)])
+
+            XCTAssertEqual(e4.subscriptions, [Subscription(200, 250)])
+
+            XCTAssertEqual(e5.subscriptions, [Subscription(200, 260)])
+
+            XCTAssertEqual(e6.subscriptions, [Subscription(200, 270)])
+
+            XCTAssertEqual(e7.subscriptions, [Subscription(200, 280)])
+
+            XCTAssertEqual(e8.subscriptions, [Subscription(200, 290)])
+
+        }
+    }
+
+    func testCombineLatest_SelectorThrows9() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+
+        let e0 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .completed(400)
+        ])
+
+        let e1 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(220, 2),
+            .completed(400)
+        ])
+
+        let e2 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(230, 3),
+            .completed(400)
+        ])
+
+        let e3 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(240, 4),
+            .completed(400)
+        ])
+
+        let e4 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(250, 5),
+            .completed(400)
+        ])
+
+        let e5 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(260, 6),
+            .completed(400)
+        ])
+
+        let e6 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(270, 7),
+            .completed(400)
+        ])
+
+        let e7 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(280, 8),
+            .completed(400)
+        ])
+
+        let e8 = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(290, 9),
+            .completed(400)
+        ])
+
+
+        let res = scheduler.start { () -> Observable<Int> in
+            Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8) { _, _, _, _, _, _, _, _, _ throws -> Int in
+                throw testError
+            }
+        }
+
+        XCTAssertEqual(res.events, [
+            .error(290, testError)
+        ])
+
+
+        XCTAssertEqual(e0.subscriptions, [Subscription(200, 290)])
+
+        XCTAssertEqual(e1.subscriptions, [Subscription(200, 290)])
+
+        XCTAssertEqual(e2.subscriptions, [Subscription(200, 290)])
+
+        XCTAssertEqual(e3.subscriptions, [Subscription(200, 290)])
+
+        XCTAssertEqual(e4.subscriptions, [Subscription(200, 290)])
+
+        XCTAssertEqual(e5.subscriptions, [Subscription(200, 290)])
+
+        XCTAssertEqual(e6.subscriptions, [Subscription(200, 290)])
+
+        XCTAssertEqual(e7.subscriptions, [Subscription(200, 290)])
+
+        XCTAssertEqual(e8.subscriptions, [Subscription(200, 290)])
+
+    }
+
+    func testCombineLatest_WillNeverBeAbleToCombine9() {
+        let factories: [(TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8) { _, _, _, _, _, _, _, _, _ -> Int in
+                        return (42)
+                    }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { _, _, _, _, _, _, _, _, _ -> Int in
+                        return (42)
+                    }
+                },
+            ]
+        for factory in factories {
+            let scheduler = TestScheduler(initialClock: 0)
+        
+
+            let e0 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(250)
+            ])
+
+            let e1 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(260)
+            ])
+
+            let e2 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(270)
+            ])
+
+            let e3 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(280)
+            ])
+
+            let e4 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(290)
+            ])
+
+            let e5 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(300)
+            ])
+
+            let e6 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(310)
+            ])
+
+            let e7 = scheduler.createHotObservable([
+                .next(150, 1),
+                .completed(320)
+            ])
+
+            let e8 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(500, 2),
+                .completed(800)
+            ])
+
+            let res = scheduler.start { () -> Observable<Int> in
+                factory(e0, e1, e2, e3, e4, e5, e6, e7, e8)
+            }
+
+            XCTAssertEqual(res.events, [
+                .completed(500)
+            ])
+
+
+            XCTAssertEqual(e0.subscriptions, [Subscription(200, 250)])
+
+            XCTAssertEqual(e1.subscriptions, [Subscription(200, 260)])
+
+            XCTAssertEqual(e2.subscriptions, [Subscription(200, 270)])
+
+            XCTAssertEqual(e3.subscriptions, [Subscription(200, 280)])
+
+            XCTAssertEqual(e4.subscriptions, [Subscription(200, 290)])
+
+            XCTAssertEqual(e5.subscriptions, [Subscription(200, 300)])
+
+            XCTAssertEqual(e6.subscriptions, [Subscription(200, 310)])
+
+            XCTAssertEqual(e7.subscriptions, [Subscription(200, 320)])
+
+            XCTAssertEqual(e8.subscriptions, [Subscription(200, 500)])
+        }
+    }
+    
+    func testCombineLatest_Typical9() {
+        let factories: [(TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8) { (e0: Int, e1: Int, e2: Int, e3: Int, e4: Int, e5: Int, e6: Int, e7: Int, e8: Int) -> Int in
+                        return (e0 + e1 + e2 + e3 + e4 + e5 + e6 + e7 + e8)
+                    }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.combineLatest(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { (e0: Int, e1: Int, e2: Int, e3: Int, e4: Int, e5: Int, e6: Int, e7: Int, e8: Int) -> Int in
+                        return (e0 + e1 + e2 + e3 + e4 + e5 + e6 + e7 + e8)
+                    }
+                },
+            ]
+        for factory in factories {
+            let scheduler = TestScheduler(initialClock: 0)
+
+
+            let e0 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(210, 1),
+                .next(410, 10),
+                .completed(800)
+            ])
+
+            let e1 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(220, 2),
+                .next(420, 11),
+                .completed(800)
+            ])
+
+            let e2 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(230, 3),
+                .next(430, 12),
+                .completed(800)
+            ])
+
+            let e3 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(240, 4),
+                .next(440, 13),
+                .completed(800)
+            ])
+
+            let e4 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(250, 5),
+                .next(450, 14),
+                .completed(800)
+            ])
+
+            let e5 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(260, 6),
+                .next(460, 15),
+                .completed(800)
+            ])
+
+            let e6 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(270, 7),
+                .next(470, 16),
+                .completed(800)
+            ])
+
+            let e7 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(280, 8),
+                .next(480, 17),
+                .completed(800)
+            ])
+
+            let e8 = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(290, 9),
+                .next(490, 18),
+                .completed(800)
+            ])
+
+            let res = scheduler.start { () -> Observable<Int> in
+                factory(e0, e1, e2, e3, e4, e5, e6, e7, e8)
+            }
+
+            XCTAssertEqual(res.events, [
+                
+                .next(290, 45),
+
+                .next(410, 54),
+                .next(420, 63),
+                .next(430, 72),
+                .next(440, 81),
+                .next(450, 90),
+                .next(460, 99),
+                .next(470, 108),
+                .next(480, 117),
+                .next(490, 126),
+                .completed(800)
+                ])
+
+
+            XCTAssertEqual(e0.subscriptions, [Subscription(200, 800)])
+
+            XCTAssertEqual(e1.subscriptions, [Subscription(200, 800)])
+
+            XCTAssertEqual(e2.subscriptions, [Subscription(200, 800)])
+
+            XCTAssertEqual(e3.subscriptions, [Subscription(200, 800)])
+
+            XCTAssertEqual(e4.subscriptions, [Subscription(200, 800)])
+
+            XCTAssertEqual(e5.subscriptions, [Subscription(200, 800)])
+
+            XCTAssertEqual(e6.subscriptions, [Subscription(200, 800)])
+
+            XCTAssertEqual(e7.subscriptions, [Subscription(200, 800)])
+
+            XCTAssertEqual(e8.subscriptions, [Subscription(200, 800)])
+
+        }
+    }
+
+
+
+
 }

--- a/Tests/RxSwiftTests/Observable+CombineLatestTests+arity.tt
+++ b/Tests/RxSwiftTests/Observable+CombineLatestTests+arity.tt
@@ -12,7 +12,7 @@ import RxTest
 
 // combine latest
 extension ObservableCombineLatestTest {
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 
     // <%= i %>
 

--- a/Tests/RxSwiftTests/Observable+ZipTests+arity.swift
+++ b/Tests/RxSwiftTests/Observable+ZipTests+arity.swift
@@ -2003,6 +2003,418 @@ extension ObservableZipTest {
 
     
 
+    // 9
+
+    func testZip_ImmediateSchedule9() {
+        let factories: [(Observable<Int>, Observable<Int>, Observable<Int>, Observable<Int>, Observable<Int>, Observable<Int>, Observable<Int>, Observable<Int>, Observable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { (a0: Int, a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int) -> Int in a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8) { (a0: Int, a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int) -> Int in a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 }
+                },
+            ]
+
+        for factory in factories {
+            
+            let v0: Observable<Int> = Observable.just(1)
+            let v1: Observable<Int> = Observable.just(2)
+            let v2: Observable<Int> = Observable.just(3)
+            let v3: Observable<Int> = Observable.just(4)
+            let v4: Observable<Int> = Observable.just(5)
+            let v5: Observable<Int> = Observable.just(6)
+            let v6: Observable<Int> = Observable.just(7)
+            let v7: Observable<Int> = Observable.just(8)
+            let v8: Observable<Int> = Observable.just(9)
+
+            var result: Int! = nil
+
+            _ = factory(v0, v1, v2, v3, v4, v5, v6, v7, v8)
+                .subscribe(onNext: { (x: Int) -> Void in result = x })
+
+            XCTAssertEqual(result, 45)
+        }
+    }
+
+    func testZip_Never9() {
+        let factories: [(TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { (_: Int, _: Int, _: Int, _: Int, _: Int, _: Int, _: Int, _: Int, _: Int) -> Int in 42 }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8) { (_: Int, _: Int, _: Int, _: Int, _: Int, _: Int, _: Int, _: Int, _: Int) -> Int in 42 }
+                },
+            ]
+
+        for factory in factories {
+            let scheduler = TestScheduler(initialClock: 0)
+
+            
+            let e0 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+            let e1 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+            let e2 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+            let e3 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+            let e4 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+            let e5 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+            let e6 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+            let e7 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+            let e8 = scheduler.createHotObservable([
+                .next(150, 1)
+            ])
+            
+
+            let res = scheduler.start { () -> Observable<Int> in
+                factory(e0, e1, e2, e3, e4, e5, e6, e7, e8)
+            }
+
+            XCTAssertEqual(res.events, [])
+
+            let subscriptions = [Subscription(200, 1000)]
+
+
+            XCTAssertEqual(e0.subscriptions, subscriptions)
+            XCTAssertEqual(e1.subscriptions, subscriptions)
+            XCTAssertEqual(e2.subscriptions, subscriptions)
+            XCTAssertEqual(e3.subscriptions, subscriptions)
+            XCTAssertEqual(e4.subscriptions, subscriptions)
+            XCTAssertEqual(e5.subscriptions, subscriptions)
+            XCTAssertEqual(e6.subscriptions, subscriptions)
+            XCTAssertEqual(e7.subscriptions, subscriptions)
+            XCTAssertEqual(e8.subscriptions, subscriptions)
+        }
+    }
+
+    func testZip_Empty9() {
+        let factories: [(TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { (a0: Int, a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int) -> Int in a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8) { (a0: Int, a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int) -> Int in a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 }
+                },
+            ]
+        for factory in factories {
+            let scheduler = TestScheduler(initialClock: 0)
+
+            
+            let e0: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(210)
+            ])
+            
+            let e1: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(220)
+            ])
+            
+            let e2: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(230)
+            ])
+            
+            let e3: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(240)
+            ])
+            
+            let e4: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(250)
+            ])
+            
+            let e5: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(260)
+            ])
+            
+            let e6: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(270)
+            ])
+            
+            let e7: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(280)
+            ])
+            
+            let e8: TestableObservable<Int> = scheduler.createHotObservable([
+                .completed(290)
+            ])
+            
+
+            let res = scheduler.start { () -> Observable<Int> in
+                factory(e0, e1, e2, e3, e4, e5, e6, e7, e8)
+            }
+
+            XCTAssertEqual(res.events, [
+                .completed(290)
+            ])
+
+
+            XCTAssertEqual(e0.subscriptions, [Subscription(200, 210)])
+            XCTAssertEqual(e1.subscriptions, [Subscription(200, 220)])
+            XCTAssertEqual(e2.subscriptions, [Subscription(200, 230)])
+            XCTAssertEqual(e3.subscriptions, [Subscription(200, 240)])
+            XCTAssertEqual(e4.subscriptions, [Subscription(200, 250)])
+            XCTAssertEqual(e5.subscriptions, [Subscription(200, 260)])
+            XCTAssertEqual(e6.subscriptions, [Subscription(200, 270)])
+            XCTAssertEqual(e7.subscriptions, [Subscription(200, 280)])
+            XCTAssertEqual(e8.subscriptions, [Subscription(200, 290)])
+        }
+    }
+
+    func testZip_SymmetricReturn9() {
+        let factories: [(TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { (a0: Int, a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int) -> Int in a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8) { (a0: Int, a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int) -> Int in a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 }
+                },
+            ]
+
+        for factory in factories {
+            let scheduler = TestScheduler(initialClock: 0)
+
+            
+            let e0: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(210, 1),
+                .completed(400)
+            ])
+            
+            let e1: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(220, 2),
+                .completed(400)
+            ])
+            
+            let e2: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(230, 3),
+                .completed(400)
+            ])
+            
+            let e3: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(240, 4),
+                .completed(400)
+            ])
+            
+            let e4: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(250, 5),
+                .completed(400)
+            ])
+            
+            let e5: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(260, 6),
+                .completed(400)
+            ])
+            
+            let e6: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(270, 7),
+                .completed(400)
+            ])
+            
+            let e7: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(280, 8),
+                .completed(400)
+            ])
+            
+            let e8: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+                .next(290, 9),
+                .completed(400)
+            ])
+            
+
+            let res = scheduler.start { () -> Observable<Int> in
+                factory(e0, e1, e2, e3, e4, e5, e6, e7, e8)
+            }
+
+            XCTAssertEqual(res.events, [
+                .next(290, 45),
+                .completed(400)
+            ])
+
+
+            XCTAssertEqual(e0.subscriptions, [Subscription(200, 400)])
+            XCTAssertEqual(e1.subscriptions, [Subscription(200, 400)])
+            XCTAssertEqual(e2.subscriptions, [Subscription(200, 400)])
+            XCTAssertEqual(e3.subscriptions, [Subscription(200, 400)])
+            XCTAssertEqual(e4.subscriptions, [Subscription(200, 400)])
+            XCTAssertEqual(e5.subscriptions, [Subscription(200, 400)])
+            XCTAssertEqual(e6.subscriptions, [Subscription(200, 400)])
+            XCTAssertEqual(e7.subscriptions, [Subscription(200, 400)])
+            XCTAssertEqual(e8.subscriptions, [Subscription(200, 400)])
+        }
+    }
+
+    func testZip_AllCompleted9() {
+        let factories: [(TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>, TestableObservable<Int>) -> Observable<Int>] =
+            [
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8).map { (a0: Int, a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int) -> Int in a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 }
+                },
+                { e0, e1, e2, e3, e4, e5, e6, e7, e8 in
+                    Observable.zip(e0, e1, e2, e3, e4, e5, e6, e7, e8) { (a0: Int, a1: Int, a2: Int, a3: Int, a4: Int, a5: Int, a6: Int, a7: Int, a8: Int) -> Int in a0 + a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 }
+                },
+            ]
+
+        for factory in factories {
+            let scheduler = TestScheduler(initialClock: 0)
+
+            
+            let e0: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5),
+                .completed(220)
+            ])
+            
+            let e1: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5), 
+                .next(220, 6),
+                .completed(230)
+            ])
+            
+            let e2: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5), 
+                .next(220, 6), 
+                .next(230, 7),
+                .completed(240)
+            ])
+            
+            let e3: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5), 
+                .next(220, 6), 
+                .next(230, 7), 
+                .next(240, 8),
+                .completed(250)
+            ])
+            
+            let e4: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5), 
+                .next(220, 6), 
+                .next(230, 7), 
+                .next(240, 8), 
+                .next(250, 9),
+                .completed(260)
+            ])
+            
+            let e5: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5), 
+                .next(220, 6), 
+                .next(230, 7), 
+                .next(240, 8), 
+                .next(250, 9), 
+                .next(260, 10),
+                .completed(270)
+            ])
+            
+            let e6: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5), 
+                .next(220, 6), 
+                .next(230, 7), 
+                .next(240, 8), 
+                .next(250, 9), 
+                .next(260, 10), 
+                .next(270, 11),
+                .completed(280)
+            ])
+            
+            let e7: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5), 
+                .next(220, 6), 
+                .next(230, 7), 
+                .next(240, 8), 
+                .next(250, 9), 
+                .next(260, 10), 
+                .next(270, 11), 
+                .next(280, 12),
+                .completed(290)
+            ])
+            
+            let e8: TestableObservable<Int> = scheduler.createHotObservable([
+                .next(150, 1),
+     
+                .next(210, 5), 
+                .next(220, 6), 
+                .next(230, 7), 
+                .next(240, 8), 
+                .next(250, 9), 
+                .next(260, 10), 
+                .next(270, 11), 
+                .next(280, 12), 
+                .next(290, 13),
+                .completed(300)
+            ])
+            
+
+            let res = scheduler.start { () -> Observable<Int> in
+                factory(e0, e1, e2, e3, e4, e5, e6, e7, e8) 
+            }
+
+            XCTAssertEqual(res.events, [
+                .next(210, 45),
+                .completed(300)
+            ])
+
+    
+            XCTAssertEqual(e0.subscriptions, [Subscription(200, 220)])
+            XCTAssertEqual(e1.subscriptions, [Subscription(200, 230)])
+            XCTAssertEqual(e2.subscriptions, [Subscription(200, 240)])
+            XCTAssertEqual(e3.subscriptions, [Subscription(200, 250)])
+            XCTAssertEqual(e4.subscriptions, [Subscription(200, 260)])
+            XCTAssertEqual(e5.subscriptions, [Subscription(200, 270)])
+            XCTAssertEqual(e6.subscriptions, [Subscription(200, 280)])
+            XCTAssertEqual(e7.subscriptions, [Subscription(200, 290)])
+            XCTAssertEqual(e8.subscriptions, [Subscription(200, 300)])
+        }
+    }
+
+
+
+    
+
 
 
 

--- a/Tests/RxSwiftTests/Observable+ZipTests+arity.tt
+++ b/Tests/RxSwiftTests/Observable+ZipTests+arity.tt
@@ -12,7 +12,7 @@ import RxTest
 
 // combine latest
 extension ObservableZipTest {
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 
     // <%= i %>
 

--- a/Tests/RxSwiftTests/PrimitiveSequenceTest+zip+arity.swift
+++ b/Tests/RxSwiftTests/PrimitiveSequenceTest+zip+arity.swift
@@ -185,8 +185,7 @@ extension SingleTest {
     }
 
     func testZip6_tuple() {
-        let singleZip = Single.zip(Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1))
-        let singleResult = singleZip.map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) -> Int in a + b + c + d + e + f }
+        let singleResult: Single<Int> = Single.zip(Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1)).map { $0 + $1 + $2 + $3 + $4 + $5 }
 
         let result = try! singleResult
             .toBlocking().first()!
@@ -204,8 +203,7 @@ extension MaybeTest {
     }
 
     func testZip6_tuple() {
-        let singleZip = Maybe.zip(Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1))
-        let singleResult = singleZip.map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) -> Int in a + b + c + d + e + f }
+        let singleResult: Maybe<Int> = Maybe.zip(Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1)).map { $0 + $1 + $2 + $3 + $4 + $5 }
 
         let result = try! singleResult
             .toBlocking().first()!
@@ -227,8 +225,7 @@ extension SingleTest {
     }
 
     func testZip7_tuple() {
-        let singleZip = Single.zip(Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1))
-        let singleResult = singleZip.map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) -> Int in a + b + c + d + e + f + g }
+        let singleResult: Single<Int> = Single.zip(Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1)).map { $0 + $1 + $2 + $3 + $4 + $5 + $6 }
 
         let result = try! singleResult
             .toBlocking().first()!
@@ -246,8 +243,7 @@ extension MaybeTest {
     }
 
     func testZip7_tuple() {
-        let singleZip = Maybe.zip(Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1))
-        let singleResult = singleZip.map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) -> Int in a + b + c + d + e + f + g }
+        let singleResult: Maybe<Int> = Maybe.zip(Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1)).map { $0 + $1 + $2 + $3 + $4 + $5 + $6 }
 
         let result = try! singleResult
             .toBlocking().first()!
@@ -269,8 +265,7 @@ extension SingleTest {
     }
 
     func testZip8_tuple() {
-        let singleZip = Single.zip(Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1))
-        let singleResult = singleZip.map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) -> Int in a + b + c + d + e + f + g + h }
+        let singleResult: Single<Int> = Single.zip(Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1)).map { $0 + $1 + $2 + $3 + $4 + $5 + $6 + $7 }
 
         let result = try! singleResult
             .toBlocking().first()!
@@ -288,12 +283,51 @@ extension MaybeTest {
     }
 
     func testZip8_tuple() {
-        let singleZip = Maybe.zip(Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1))
-        let singleResult = singleZip.map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) -> Int in a + b + c + d + e + f + g + h }
+        let singleResult: Maybe<Int> = Maybe.zip(Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1)).map { $0 + $1 + $2 + $3 + $4 + $5 + $6 + $7 }
 
         let result = try! singleResult
             .toBlocking().first()!
         XCTAssertEqual(result, 8)
+    }
+}
+
+
+
+// 9
+
+extension SingleTest {
+    func testZip9_selector() {
+        let singleResult: Single<Int> = Single.zip(Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1)) { $0 + $1 + $2 + $3 + $4 + $5 + $6 + $7 + $8 }
+
+        let result = try! singleResult
+            .toBlocking().first()!
+        XCTAssertEqual(result, 9)
+    }
+
+    func testZip9_tuple() {
+        let singleResult: Single<Int> = Single.zip(Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1), Single.just(1)).map { $0 + $1 + $2 + $3 + $4 + $5 + $6 + $7 + $8 }
+
+        let result = try! singleResult
+            .toBlocking().first()!
+        XCTAssertEqual(result, 9)
+    }
+}
+
+extension MaybeTest {
+    func testZip9_selector() {
+        let singleResult: Maybe<Int> = Maybe.zip(Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1)) { $0 + $1 + $2 + $3 + $4 + $5 + $6 + $7 + $8 }
+
+        let result = try! singleResult
+            .toBlocking().first()!
+        XCTAssertEqual(result, 9)
+    }
+
+    func testZip9_tuple() {
+        let singleResult: Maybe<Int> = Maybe.zip(Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1), Maybe.just(1)).map { $0 + $1 + $2 + $3 + $4 + $5 + $6 + $7 + $8 }
+
+        let result = try! singleResult
+            .toBlocking().first()!
+        XCTAssertEqual(result, 9)
     }
 }
 

--- a/Tests/RxSwiftTests/PrimitiveSequenceTest+zip+arity.tt
+++ b/Tests/RxSwiftTests/PrimitiveSequenceTest+zip+arity.tt
@@ -10,7 +10,7 @@ import XCTest
 import RxSwift
 import RxTest
 
-<% for i in 2 ... 8 { %>
+<% for i in 2 ... 9 { %>
 
 // <%= i %>
 


### PR DESCRIPTION
I made this suggestion because in some case we need to combine or zip 9 observables and see that the change is easy to do with the templates but is hard to implement in an extension.

Thanks in advice! 