### PR TITLE
use present() instead of show() with UIAlertController

### DIFF
--- a/RxExample/RxExample/Examples/SimpleValidation/SimpleValidationViewController.swift
+++ b/RxExample/RxExample/Examples/SimpleValidation/SimpleValidationViewController.swift
@@ -67,7 +67,10 @@ class SimpleValidationViewController : ViewController {
             message: "This is wonderful",
             preferredStyle: .alert
         )
-
-        show(alert, sender: nil)
+        let defaultAction = UIAlertAction(title: "Ok",
+                                          style: .default,
+                                          handler: nil)
+        alert.addAction(defaultAction)
+        present(alert, animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
In current iOS versions `show()` does not work as expected with UIAlertController. So that newcomers may confuse with the sample projects. I change it to the correct one.