### PR TITLE
withLatestFrom note and playground example

### DIFF
--- a/Rx.playground/Pages/Combining_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Combining_Operators.xcplaygroundpage/Contents.swift
@@ -155,6 +155,36 @@ example("switchLatest") {
 }
 /*:
  > In this example, adding ⚾️ onto `subject1` after adding `subject2` to `subjectsSubject` has no effect, because only the most recent inner `Observable` sequence (`subject2`) will emit elements.
+
+ ----
+ ## `withLatestFrom`
+ Merges two observable sequences into one observable sequence by combining each element from the first source with the latest element from the second source, if any.
+ */
+example("withLatestFrom") {
+    let disposeBag = DisposeBag()
+    
+    let foodSubject = PublishSubject<String>()
+    let drinksSubject = PublishSubject<String>()
+    
+    foodSubject.asObservable()
+        .withLatestFrom(drinksSubject) { "\($0) + \($1)" }
+        .subscribe(onNext: { print($0) })
+        .disposed(by: disposeBag)
+    
+    foodSubject.onNext("🥗")
+    
+    drinksSubject.onNext("☕️")
+    foodSubject.onNext("🥐")
+    
+    drinksSubject.onNext("🍷")
+    foodSubject.onNext("🍔")
+    
+    foodSubject.onNext("🍟")
+    
+    drinksSubject.onNext("🍾")
+}
+/*:
+ > In this example 🥗 is not printed because `drinksSubject` did not emit any values before 🥗 was received. The last drink (🍾) will be printed whenever `foodSubject` will emit another event.
  */
 
 //: [Next](@next) - [Table of Contents](Table_of_Contents)

--- a/RxSwift/Observables/WithLatestFrom.swift
+++ b/RxSwift/Observables/WithLatestFrom.swift
@@ -12,6 +12,7 @@ extension ObservableType {
      Merges two observable sequences into one observable sequence by combining each element from self with the latest element from the second source, if any.
 
      - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+     - note: Elements emitted by self before the second source has emitted any values will be omitted.
 
      - parameter second: Second observable source.
      - parameter resultSelector: Function to invoke for each element from the self combined with the latest element from the second source, if any.
@@ -25,6 +26,7 @@ extension ObservableType {
      Merges two observable sequences into one observable sequence by using latest element from the second sequence every time when `self` emits an element.
 
      - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+     - note: Elements emitted by self before the second source has emitted any values will be omitted.
 
      - parameter second: Second observable source.
      - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.


### PR DESCRIPTION
I struggled a bit with withLatestFrom today. After 2 hours of debugging I found out ([thanks @danielt1263](https://stackoverflow.com/a/52727077/672989)) doesn't "wait" for the second observable to emit an value like `combineLatest` 

This PR clarifies that behaviour and also adds a playground example for withLatestFrom since there was none yet. 