### PR TITLE
@frozen MaybeEvent ☃️

### DIFF
--- a/RxSwift/Traits/PrimitiveSequence/Maybe.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Maybe.swift
@@ -15,7 +15,7 @@ public enum MaybeTrait { }
 /// Represents a push style sequence containing 0 or 1 element.
 public typealias Maybe<Element> = PrimitiveSequence<MaybeTrait, Element>
 
-public enum MaybeEvent<Element> {
+@frozen public enum MaybeEvent<Element> {
     /// One and only sequence element is produced. (underlying observable sequence emits: `.next(Element)`, `.completed`)
     case success(Element)
     


### PR DESCRIPTION
Similar to https://github.com/ReactiveX/RxSwift/issues/2238, but for the `MaybeEvent` enum.

This fixes the requirement of handling `@unknown default` that was introduced in Swift 6.