### PR TITLE
fix "'RxCocoaRuntime.h' file not found" compile error

### DIFF
--- a/RxCocoa.podspec
+++ b/RxCocoa.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target = '9.0'
 
+  s.header_dir            = "RxCocoa"
   s.source_files          = 'RxCocoa/**/*.{swift,h,m}', 'Platform/**/*.swift'
   s.exclude_files         = 'RxCocoa/Platform/**/*.swift', 'Platform/AtomicInt.swift'
 


### PR DESCRIPTION
fix `'RxCocoaRuntime.h' file not found` error when not open the `use_frameworks!` configuration  in `podfile`.

generally occurs in the scene of mixed `Swift` and `Objective-C` project with `multiple_pod_projects`.

Add this configuration to enable it to be compiled as a static library in mixed project.

![iShot2021-01-29 20.28.47.png](https://i.loli.net/2021/01/29/ONuL5twYjGHMRI3.png)