### PR TITLE
Removed ReactiveCompatible & Reactive conformance to objects

### DIFF
--- a/RxSwift/Reactive.swift
+++ b/RxSwift/Reactive.swift
@@ -24,7 +24,7 @@
  */
 
 @dynamicMemberLookup
-public struct Reactive<Base: AnyObject> {
+public struct Reactive<Base: Any> {
     /// Base object to extend.
     public let base: Base
 
@@ -37,7 +37,7 @@ public struct Reactive<Base: AnyObject> {
 
     /// Automatically synthesized binder for a key path between the reactive
     /// base and one of its properties
-    public subscript<Property>(dynamicMember keyPath: ReferenceWritableKeyPath<Base, Property>) -> Binder<Property> {
+    public subscript<Property>(dynamicMember keyPath: ReferenceWritableKeyPath<Base, Property>) -> Binder<Property> where Base: AnyObject {
         Binder(self.base) { base, value in
             base[keyPath: keyPath] = value
         }
@@ -45,9 +45,9 @@ public struct Reactive<Base: AnyObject> {
 }
 
 /// A type that has reactive extensions.
-public protocol ReactiveCompatible: AnyObject {
+public protocol ReactiveCompatible: Any {
     /// Extended type
-    associatedtype ReactiveBase: AnyObject
+    associatedtype ReactiveBase: Any
 
     /// Reactive extensions.
     static var rx: Reactive<ReactiveBase>.Type { get set }

--- a/RxSwift/Reactive.swift
+++ b/RxSwift/Reactive.swift
@@ -24,7 +24,7 @@
  */
 
 @dynamicMemberLookup
-public struct Reactive<Base: Any> {
+public struct Reactive<Base> {
     /// Base object to extend.
     public let base: Base
 
@@ -45,9 +45,9 @@ public struct Reactive<Base: Any> {
 }
 
 /// A type that has reactive extensions.
-public protocol ReactiveCompatible: Any {
+public protocol ReactiveCompatible {
     /// Extended type
-    associatedtype ReactiveBase: Any
+    associatedtype ReactiveBase
 
     /// Reactive extensions.
     static var rx: Reactive<ReactiveBase>.Type { get set }

--- a/Tests/RxSwiftTests/Reactive+Tests.swift
+++ b/Tests/RxSwiftTests/Reactive+Tests.swift
@@ -33,7 +33,7 @@ extension Reactive where Base: MyObject {
 
 extension ReactiveTests {
     func testEnablesMutations() {
-        let object = MyObject()
+        var object = MyObject()
         object.rx.somethingPublic = "Aha"
 
         XCTAssertEqual(object._something, "Aha")


### PR DESCRIPTION
As explained in the issue #2270, ReactiveCompatible & Reactive protocols are from RxSwift 6 only class protocols due to the @dynamicMemberLookup approach.

With this pull request, I removed the limit of the class protocols without removing the @dynamicMemberLookup approach.