### PR TITLE
Make object of withUnretained optional

### DIFF
--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -455,7 +455,7 @@ extension SharedSequenceConvertibleType {
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
      */
     public func withUnretained<Object: AnyObject, Out>(
-        _ obj: Object,
+        _ obj: Object?,
         resultSelector: @escaping (Object, Element) -> Out
     ) -> SharedSequence<SharingStrategy, Out> {
         SharedSequence(self.asObservable().withUnretained(obj, resultSelector: resultSelector))
@@ -469,7 +469,7 @@ extension SharedSequenceConvertibleType {
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.
      */
-    public func withUnretained<Object: AnyObject>(_ obj: Object) -> SharedSequence<SharingStrategy, (Object, Element)> {
+    public func withUnretained<Object: AnyObject>(_ obj: Object?) -> SharedSequence<SharingStrategy, (Object, Element)> {
         withUnretained(obj) { ($0, $1) }
     }
 }

--- a/RxSwift/Observables/WithUnretained.swift
+++ b/RxSwift/Observables/WithUnretained.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
      */
     public func withUnretained<Object: AnyObject, Out>(
-        _ obj: Object,
+        _ obj: Object?,
         resultSelector: @escaping (Object, Element) -> Out
     ) -> Observable<Out> {
         map { [weak obj] element -> Out in
@@ -44,7 +44,7 @@ extension ObservableType {
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.
      */
-    public func withUnretained<Object: AnyObject>(_ obj: Object) -> Observable<(Object, Element)> {
+    public func withUnretained<Object: AnyObject>(_ obj: Object?) -> Observable<(Object, Element)> {
         return withUnretained(obj) { ($0, $1) }
     }
 }

--- a/RxSwift/Traits/Infallible/Infallible+Operators.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Operators.swift
@@ -657,7 +657,7 @@ extension InfallibleType {
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
      */
     public func withUnretained<Object: AnyObject, Out>(
-        _ obj: Object,
+        _ obj: Object?,
         resultSelector: @escaping (Object, Element) -> Out
     ) -> Infallible<Out> {
         Infallible(self.asObservable().withUnretained(obj, resultSelector: resultSelector))
@@ -671,7 +671,7 @@ extension InfallibleType {
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.
      */
-    public func withUnretained<Object: AnyObject>(_ obj: Object) -> Infallible<(Object, Element)> {
+    public func withUnretained<Object: AnyObject>(_ obj: Object?) -> Infallible<(Object, Element)> {
         withUnretained(obj) { ($0, $1) }
     }
 }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -2159,6 +2159,7 @@ final class WithUnretainedTests_ : WithUnretainedTests, RxTestCase {
     ("testObjectDeallocates", WithUnretainedTests.testObjectDeallocates),
     ("testObjectDeallocatesSequenceCompletes", WithUnretainedTests.testObjectDeallocatesSequenceCompletes),
     ("testResultsSelector", WithUnretainedTests.testResultsSelector),
+    ("testObjectDeallocatesBeforeSequenceStarts", WithUnretainedTests.testObjectDeallocatesBeforeSequenceStarts),
     ] }
 }
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)


### PR DESCRIPTION
Seems to me there is no reason that the object passed in to `withUnretained` cannot be optional. By making it optional it allows rewriting the following:

```
class MyView: UIView {

    let subview: UIView? = UIView()

    let observable = UIButton().rx.tap
    let disposeBag = DisposeBag()

    func setup() {
        observable
            .withUnretained(self)
            .subscribe(onNext: { owner, _ in
                guard let subview = owner.subview else { return }
                print("My subview: \(subview)")
            })
            .disposed(by: disposeBag)
    }

}
```

to this:

```
class MyView: UIView {

    let subview: UIView? = UIView()

    let observable = UIButton().rx.tap
    let disposeBag = DisposeBag()

    func setup() {
        observable
            .withUnretained(self.subview)
            .subscribe(onNext: { subview, _ in
                print("My subview: \(subview)")
            })
            .disposed(by: disposeBag)
    }

}
```
