### PR TITLE
If URLRequest has httpBody, ensure that it's show in the curl text.

### DIFF
--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -51,7 +51,7 @@ private func convertURLRequestToCurlCommand(_ request: URLRequest) -> String {
     let method = request.httpMethod ?? "GET"
     var returnValue = "curl -X \(method) "
 
-    if let httpBody = request.httpBody, request.httpMethod == "POST" || request.httpMethod == "PUT" {
+    if let httpBody = request.httpBody {
         let maybeBody = String(data: httpBody, encoding: String.Encoding.utf8)
         if let body = maybeBody {
             returnValue += "-d \"\(escapeTerminalString(body))\" "


### PR DESCRIPTION
Fix for issue #2282 