### PR TITLE
Add new subscribe/drive/emit with object, Deprecate withUnretained on Driver

### DIFF
--- a/.github/workflows/podspecs.yml
+++ b/.github/workflows/podspecs.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Select Xcode 12
-        run: sudo xcode-select -s /Applications/Xcode_12.app
+        run: sudo xcode-select -s /Applications/Xcode_12_4.app
       - name: Test Specs
         run: CI=1 TARGET=${{ matrix.target }} SWIFT_VERSION=5.1 ./scripts/validate-podspec.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Select Xcode 12
-        run: sudo xcode-select -s /Applications/Xcode_12.app
+      - name: Select Xcode 12.4
+        run: sudo xcode-select -s /Applications/Xcode_12.4.app
       - name: Run Tests
         run: CI=1 ./scripts/all-tests.sh "${{ matrix.environment }}"
 

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -61,7 +61,31 @@ extension ObservableType {
     public func bind<R1, R2>(to binder: (Self) -> (R1) -> R2, curriedArgument: R1) -> R2 {
         binder(self)(curriedArgument)
     }
+    
+    /**
+    Subscribes an element handler to an observable sequence.
+    In case error occurs in debug mode, `fatalError` will be raised.
+    In case error occurs in release mode, `error` will be logged.
 
+     - Note: If `object` can't be retained, none of the other closures will be invoked.
+     
+    - parameter object: The object to provide an unretained reference on.
+    - parameter onNext: Action to invoke for each element in the observable sequence.
+    - returns: Subscription object used to unsubscribe from the observable sequence.
+    */
+    public func bind<Object: AnyObject>(
+        with object: Object,
+        onNext: @escaping (Object, Element) -> Void
+    ) -> Disposable {
+        self.subscribe(onNext: { [weak object] in
+            guard let object = object else { return }
+            onNext(object, $0)
+        },
+        onError: { error in
+            rxFatalErrorInDebug("Binding error: \(error)")
+        })
+    }
+    
     /**
     Subscribes an element handler to an observable sequence.
     In case error occurs in debug mode, `fatalError` will be raised.

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -140,6 +140,34 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     /**
     Subscribes an element handler, a completion handler and disposed handler to an observable sequence.
     This method can be only called from `MainThread`.
+     
+    Also, take in an object and provide an unretained, safe to use (i.e. not implicitly unwrapped), reference to it along with the events emitted by the sequence.
+    
+    Error callback is not exposed because `Driver` can't error out.
+     
+     - Note: If `object` can't be retained, none of the other closures will be invoked.
+     
+    - parameter object: The object to provide an unretained reference on.
+    - parameter onNext: Action to invoke for each element in the observable sequence.
+    - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+    gracefully completed, errored, or if the generation is canceled by disposing subscription)
+    - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
+    gracefully completed, errored, or if the generation is canceled by disposing subscription)
+    - returns: Subscription object used to unsubscribe from the observable sequence.
+    */
+    public func drive<Object: AnyObject>(
+        with object: Object,
+        onNext: ((Object, Element) -> Void)? = nil,
+        onCompleted: ((Object) -> Void)? = nil,
+        onDisposed: ((Object) -> Void)? = nil
+    ) -> Disposable {
+        MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
+        return self.asObservable().subscribe(with: object, onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
+    }
+    
+    /**
+    Subscribes an element handler, a completion handler and disposed handler to an observable sequence.
+    This method can be only called from `MainThread`.
     
     Error callback is not exposed because `Driver` can't error out.
     
@@ -150,7 +178,11 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     gracefully completed, errored, or if the generation is canceled by disposing subscription)
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
-    public func drive(onNext: ((Element) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil) -> Disposable {
+    public func drive(
+        onNext: ((Element) -> Void)? = nil,
+        onCompleted: (() -> Void)? = nil,
+        onDisposed: (() -> Void)? = nil
+    ) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
     }

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -444,11 +444,13 @@ extension SharedSequence {
 }
 
 // MARK: - withUnretained
-extension SharedSequenceConvertibleType {
+extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingStrategy {
     /**
      Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the sequence.
      
      In the case the provided object cannot be retained successfully, the seqeunce will complete.
+     
+     - note: Be careful when using this operator in a sequence that has a buffer or replay, for example `share(replay: 1)`, as the sharing buffer will also include the provided object, which could potentially cause a retain cycle.
      
      - parameter obj: The object to provide an unretained reference on.
      - parameter resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
@@ -466,11 +468,28 @@ extension SharedSequenceConvertibleType {
      
      In the case the provided object cannot be retained successfully, the seqeunce will complete.
      
+     - note: Be careful when using this operator in a sequence that has a buffer or replay, for example `share(replay: 1)`, as the sharing buffer will also include the provided object, which could potentially cause a retain cycle.
+     
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.
      */
     public func withUnretained<Object: AnyObject>(_ obj: Object) -> SharedSequence<SharingStrategy, (Object, Element)> {
         withUnretained(obj) { ($0, $1) }
+    }
+}
+
+extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingStrategy {
+    @available(*, message: "withUnretained has been deprecated for Driver. Consider using `drive(with:onNext:)`, instead", unavailable)
+    public func withUnretained<Object: AnyObject, Out>(
+        _ obj: Object,
+        resultSelector: @escaping (Object, Element) -> Out
+    ) -> SharedSequence<SharingStrategy, Out> {
+        SharedSequence(self.asObservable().withUnretained(obj, resultSelector: resultSelector))
+    }
+    
+    @available(*, message: "withUnretained has been deprecated for Driver. Consider using `drive(with:onNext:)`, instead", unavailable)
+    public func withUnretained<Object: AnyObject>(_ obj: Object) -> SharedSequence<SharingStrategy, (Object, Element)> {
+        SharedSequence(self.asObservable().withUnretained(obj) { ($0, $1) })
     }
 }
 

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -479,7 +479,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
 }
 
 extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingStrategy {
-    @available(*, message: "withUnretained has been deprecated for Driver. Consider using `drive(with:onNext:)`, instead", unavailable)
+    @available(*, message: "withUnretained has been deprecated for Driver. Consider using `drive(with:onNext:onCompleted:onDisposed:)`, instead", unavailable)
     public func withUnretained<Object: AnyObject, Out>(
         _ obj: Object,
         resultSelector: @escaping (Object, Element) -> Out
@@ -487,7 +487,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
         SharedSequence(self.asObservable().withUnretained(obj, resultSelector: resultSelector))
     }
     
-    @available(*, message: "withUnretained has been deprecated for Driver. Consider using `drive(with:onNext:)`, instead", unavailable)
+    @available(*, message: "withUnretained has been deprecated for Driver. Consider using `drive(with:onNext:onCompleted:onDisposed:)`, instead", unavailable)
     public func withUnretained<Object: AnyObject>(_ obj: Object) -> SharedSequence<SharingStrategy, (Object, Element)> {
         SharedSequence(self.asObservable().withUnretained(obj) { ($0, $1) })
     }

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -112,12 +112,17 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
             relays.forEach { $0.accept(e) }
         })
     }
-
+    
     /**
      Subscribes an element handler, a completion handler and disposed handler to an observable sequence.
 
+     Also, take in an object and provide an unretained, safe to use (i.e. not implicitly unwrapped), reference to it along with the events emitted by the sequence.
+
      Error callback is not exposed because `Signal` can't error out.
 
+     - Note: If `object` can't be retained, none of the other closures will be invoked.
+     
+     - parameter object: The object to provide an unretained reference on.
      - parameter onNext: Action to invoke for each element in the observable sequence.
      - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
      gracefully completed, errored, or if the generation is canceled by disposing subscription)
@@ -125,7 +130,37 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      gracefully completed, errored, or if the generation is canceled by disposing subscription)
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func emit(onNext: ((Element) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil) -> Disposable {
+    public func emit<Object: AnyObject>(
+        with object: Object,
+        onNext: ((Object, Element) -> Void)? = nil,
+        onCompleted: ((Object) -> Void)? = nil,
+        onDisposed: ((Object) -> Void)? = nil
+    ) -> Disposable {
+        self.asObservable().subscribe(
+            with: object,
+            onNext: onNext,
+            onCompleted: onCompleted,
+            onDisposed: onDisposed
+        )
+    }
+
+    /**
+     Subscribes an element handler, a completion handler and disposed handler to an observable sequence.
+
+     Error callback is not exposed because `Signal` can't error out.
+     
+     - parameter onNext: Action to invoke for each element in the observable sequence.
+     - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+     gracefully completed, errored, or if the generation is canceled by disposing subscription)
+     - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
+     gracefully completed, errored, or if the generation is canceled by disposing subscription)
+     - returns: Subscription object used to unsubscribe from the observable sequence.
+     */
+    public func emit(
+        onNext: ((Element) -> Void)? = nil,
+        onCompleted: (() -> Void)? = nil,
+        onDisposed: (() -> Void)? = nil
+    ) -> Disposable {
         self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
     }
 

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -24,6 +24,47 @@ extension ObservableType {
         return self.asObservable().subscribe(observer)
     }
     
+    /**
+     Subscribes an element handler, an error handler, a completion handler and disposed handler to an observable sequence.
+     
+     Also, take in an object and provide an unretained, safe to use (i.e. not implicitly unwrapped), reference to it along with the events emitted by the sequence.
+     
+     - Note: If `object` can't be retained, none of the other closures will be invoked.
+     
+     - parameter object: The object to provide an unretained reference on.
+     - parameter onNext: Action to invoke for each element in the observable sequence.
+     - parameter onError: Action to invoke upon errored termination of the observable sequence.
+     - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+     - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
+     gracefully completed, errored, or if the generation is canceled by disposing subscription).
+     - returns: Subscription object used to unsubscribe from the observable sequence.
+     */
+    public func subscribe<Object: AnyObject>(
+        with object: Object,
+        onNext: ((Object, Element) -> Void)? = nil,
+        onError: ((Object, Swift.Error) -> Void)? = nil,
+        onCompleted: ((Object) -> Void)? = nil,
+        onDisposed: ((Object) -> Void)? = nil
+    ) -> Disposable {
+        subscribe(
+            onNext: { [weak object] in
+                guard let object = object else { return }
+                onNext?(object, $0)
+            },
+            onError: { [weak object] in
+                guard let object = object else { return }
+                onError?(object, $0)
+            },
+            onCompleted: { [weak object] in
+                guard let object = object else { return }
+                onCompleted?(object)
+            },
+            onDisposed: { [weak object] in
+                guard let object = object else { return }
+                onDisposed?(object)
+            }
+        )
+    }
     
     /**
      Subscribes an element handler, an error handler, a completion handler and disposed handler to an observable sequence.
@@ -35,8 +76,12 @@ extension ObservableType {
      gracefully completed, errored, or if the generation is canceled by disposing subscription).
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(onNext: ((Element) -> Void)? = nil, onError: ((Swift.Error) -> Void)? = nil, onCompleted: (() -> Void)? = nil, onDisposed: (() -> Void)? = nil)
-        -> Disposable {
+    public func subscribe(
+        onNext: ((Element) -> Void)? = nil,
+        onError: ((Swift.Error) -> Void)? = nil,
+        onCompleted: (() -> Void)? = nil,
+        onDisposed: (() -> Void)? = nil
+    ) -> Disposable {
             let disposable: Disposable
             
             if let disposed = onDisposed {

--- a/RxSwift/Observables/WithUnretained.swift
+++ b/RxSwift/Observables/WithUnretained.swift
@@ -12,6 +12,8 @@ extension ObservableType {
      
      In the case the provided object cannot be retained successfully, the seqeunce will complete.
      
+     - note: Be careful when using this operator in a sequence that has a buffer or replay, for example `share(replay: 1)`, as the sharing buffer will also include the provided object, which could potentially cause a retain cycle.
+     
      - parameter obj: The object to provide an unretained reference on.
      - parameter resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
@@ -40,6 +42,8 @@ extension ObservableType {
      Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the sequence.
      
      In the case the provided object cannot be retained successfully, the seqeunce will complete.
+     
+     - note: Be careful when using this operator in a sequence that has a buffer or replay, for example `share(replay: 1)`, as the sharing buffer will also include the provided object, which could potentially cause a retain cycle.
      
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.

--- a/RxSwift/Traits/Infallible/Infallible+Operators.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Operators.swift
@@ -652,6 +652,8 @@ extension InfallibleType {
      
      In the case the provided object cannot be retained successfully, the seqeunce will complete.
      
+     - note: Be careful when using this operator in a sequence that has a buffer or replay, for example `share(replay: 1)`, as the sharing buffer will also include the provided object, which could potentially cause a retain cycle.
+     
      - parameter obj: The object to provide an unretained reference on.
      - parameter resultSelector: A function to combine the unretained referenced on `obj` and the value of the observable sequence.
      - returns: An observable sequence that contains the result of `resultSelector` being called with an unretained reference on `obj` and the values of the original sequence.
@@ -667,6 +669,8 @@ extension InfallibleType {
      Provides an unretained, safe to use (i.e. not implicitly unwrapped), reference to an object along with the events emitted by the sequence.
      
      In the case the provided object cannot be retained successfully, the seqeunce will complete.
+     
+     - note: Be careful when using this operator in a sequence that has a buffer or replay, for example `share(replay: 1)`, as the sharing buffer will also include the provided object, which could potentially cause a retain cycle.
      
      - parameter obj: The object to provide an unretained reference on.
      - returns: An observable sequence of tuples that contains both an unretained reference on `obj` and the values of the original sequence.

--- a/RxSwift/Traits/Infallible/Infallible.swift
+++ b/RxSwift/Traits/Infallible/Infallible.swift
@@ -30,16 +30,47 @@ public struct Infallible<Element>: InfallibleType {
 
 extension InfallibleType {
     /**
-    Subscribes an element handler, a completion handler and disposed handler to an observable sequence.
-
-    Error callback is not exposed because `Infallible` can't error out.
-
-    - parameter onNext: Action to invoke for each element in the observable sequence.
-    - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
-    gracefully completed, errored, or if the generation is canceled by disposing subscription)
-    - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
-    gracefully completed, errored, or if the generation is canceled by disposing subscription)
-    - returns: Subscription object used to unsubscribe from the observable sequence.
+     Subscribes an element handler, a completion handler and disposed handler to an observable sequence.
+     
+     Error callback is not exposed because `Infallible` can't error out.
+     
+     Also, take in an object and provide an unretained, safe to use (i.e. not implicitly unwrapped), reference to it along with the events emitted by the sequence.
+     
+     - Note: If `object` can't be retained, none of the other closures will be invoked.
+     
+     - parameter object: The object to provide an unretained reference on.
+     - parameter onNext: Action to invoke for each element in the observable sequence.
+     - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+     gracefully completed, errored, or if the generation is canceled by disposing subscription)
+     - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
+     gracefully completed, errored, or if the generation is canceled by disposing subscription)
+     - returns: Subscription object used to unsubscribe from the observable sequence.
+     */
+    public func subscribe<Object: AnyObject>(
+        with object: Object,
+        onNext: ((Object, Element) -> Void)? = nil,
+        onCompleted: ((Object) -> Void)? = nil,
+        onDisposed: ((Object) -> Void)? = nil
+    ) -> Disposable {
+        self.asObservable().subscribe(
+            with: object,
+            onNext: onNext,
+            onCompleted: onCompleted,
+            onDisposed: onDisposed
+        )
+    }
+    
+    /**
+     Subscribes an element handler, a completion handler and disposed handler to an observable sequence.
+     
+     Error callback is not exposed because `Infallible` can't error out.
+     
+     - parameter onNext: Action to invoke for each element in the observable sequence.
+     - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+     gracefully completed, errored, or if the generation is canceled by disposing subscription)
+     - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
+     gracefully completed, errored, or if the generation is canceled by disposing subscription)
+     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
     public func subscribe(onNext: ((Element) -> Void)? = nil,
                           onCompleted: (() -> Void)? = nil,
@@ -51,7 +82,7 @@ extension InfallibleType {
 
     /**
      Subscribes an event handler to an observable sequence.
-
+     
      - parameter on: Action to invoke for each event in the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */

--- a/RxSwift/Traits/PrimitiveSequence/Completable.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Completable.swift
@@ -74,6 +74,40 @@ extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Swif
     /**
      Subscribes a completion handler and an error handler for this sequence.
      
+     Also, take in an object and provide an unretained, safe to use (i.e. not implicitly unwrapped), reference to it along with the events emitted by the sequence.
+     
+     - Note: If `object` can't be retained, none of the other closures will be invoked.
+     
+     - parameter object: The object to provide an unretained reference on.
+     - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+     - parameter onError: Action to invoke upon errored termination of the observable sequence.
+     - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
+     gracefully completed, errored, or if the generation is canceled by disposing subscription).
+     - returns: Subscription object used to unsubscribe from the observable sequence.
+     */
+    public func subscribe<Object: AnyObject>(
+        with object: Object,
+        onCompleted: ((Object) -> Void)? = nil,
+        onError: ((Object, Swift.Error) -> Void)? = nil,
+        onDisposed: ((Object) -> Void)? = nil
+    ) -> Disposable {
+        subscribe(
+            onCompleted: { [weak object] in
+                guard let object = object else { return }
+                onCompleted?(object)
+            }, onError: { [weak object] in
+                guard let object = object else { return }
+                onError?(object, $0)
+            }, onDisposed: { [weak object] in
+                guard let object = object else { return }
+                onDisposed?(object)
+            }
+        )
+    }
+    
+    /**
+     Subscribes a completion handler and an error handler for this sequence.
+     
      - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
      - parameter onError: Action to invoke upon errored termination of the observable sequence.
      - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has

--- a/RxSwift/Traits/PrimitiveSequence/Maybe.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Maybe.swift
@@ -80,6 +80,48 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     /**
      Subscribes a success handler, an error handler, and a completion handler for this sequence.
      
+     Also, take in an object and provide an unretained, safe to use (i.e. not implicitly unwrapped), reference to it along with the events emitted by the sequence.
+     
+     - Note: If `object` can't be retained, none of the other closures will be invoked.
+     
+     - parameter object: The object to provide an unretained reference on.
+     - parameter onSuccess: Action to invoke for each element in the observable sequence.
+     - parameter onError: Action to invoke upon errored termination of the observable sequence.
+     - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.
+     - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
+     gracefully completed, errored, or if the generation is canceled by disposing subscription).
+     - returns: Subscription object used to unsubscribe from the observable sequence.
+     */
+    public func subscribe<Object: AnyObject>(
+        with object: Object,
+        onSuccess: ((Object, Element) -> Void)? = nil,
+        onError: ((Object, Swift.Error) -> Void)? = nil,
+        onCompleted: ((Object) -> Void)? = nil,
+        onDisposed: ((Object) -> Void)? = nil
+    ) -> Disposable {
+        subscribe(
+            onSuccess: { [weak object] in
+                guard let object = object else { return }
+                onSuccess?(object, $0)
+            },
+            onError: { [weak object] in
+                guard let object = object else { return }
+                onError?(object, $0)
+            },
+            onCompleted: { [weak object] in
+                guard let object = object else { return }
+                onCompleted?(object)
+            },
+            onDisposed: { [weak object] in
+                guard let object = object else { return }
+                onDisposed?(object)
+            }
+        )
+    }
+    
+    /**
+     Subscribes a success handler, an error handler, and a completion handler for this sequence.
+     
      - parameter onSuccess: Action to invoke for each element in the observable sequence.
      - parameter onError: Action to invoke upon errored termination of the observable sequence.
      - parameter onCompleted: Action to invoke upon graceful termination of the observable sequence.

--- a/RxSwift/Traits/PrimitiveSequence/Single.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Single.swift
@@ -84,6 +84,42 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
     /**
      Subscribes a success handler, and an error handler for this sequence.
      
+     Also, take in an object and provide an unretained, safe to use (i.e. not implicitly unwrapped), reference to it along with the events emitted by the sequence.
+     
+     - Note: If `object` can't be retained, none of the other closures will be invoked.
+     
+     - parameter object: The object to provide an unretained reference on.
+     - parameter onSuccess: Action to invoke for each element in the observable sequence.
+     - parameter onFailure: Action to invoke upon errored termination of the observable sequence.
+     - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has
+     gracefully completed, errored, or if the generation is canceled by disposing subscription).
+     - returns: Subscription object used to unsubscribe from the observable sequence.
+     */
+    public func subscribe<Object: AnyObject>(
+        with object: Object,
+        onSuccess: ((Object, Element) -> Void)? = nil,
+        onFailure: ((Object, Swift.Error) -> Void)? = nil,
+        onDisposed: ((Object) -> Void)? = nil
+    ) -> Disposable {
+        subscribe(
+            onSuccess: { [weak object] in
+                guard let object = object else { return }
+                onSuccess?(object, $0)
+            },
+            onFailure: { [weak object] in
+                guard let object = object else { return }
+                onFailure?(object, $0)
+            },
+            onDisposed: { [weak object] in
+                guard let object = object else { return }
+                onDisposed?(object)
+            }
+        )
+    }
+    
+    /**
+     Subscribes a success handler, and an error handler for this sequence.
+     
      - parameter onSuccess: Action to invoke for each element in the observable sequence.
      - parameter onFailure: Action to invoke upon errored termination of the observable sequence.
      - parameter onDisposed: Action to invoke upon any type of termination of sequence (if the sequence has

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -274,6 +274,9 @@ final class DriverTest_ : DriverTest, RxTestCase {
     ("testDriveOptionalReplayRelay2", DriverTest.testDriveOptionalReplayRelay2),
     ("testDriveReplayRelays2", DriverTest.testDriveReplayRelays2),
     ("testDriveReplayRelayNoAmbiguity", DriverTest.testDriveReplayRelayNoAmbiguity),
+    ("testDriveWithNext", DriverTest.testDriveWithNext),
+    ("testDriveWithError", DriverTest.testDriveWithError),
+    ("testDriveWithCompleted", DriverTest.testDriveWithCompleted),
     ] }
 }
 
@@ -2052,6 +2055,9 @@ final class SignalTests_ : SignalTests, RxTestCase {
     ("testEmitOptionalReplayRelay2", SignalTests.testEmitOptionalReplayRelay2),
     ("testEmitReplayRelays2", SignalTests.testEmitReplayRelays2),
     ("testEmitReplayRelayNoAmbiguity", SignalTests.testEmitReplayRelayNoAmbiguity),
+    ("testEmitWithNext", SignalTests.testEmitWithNext),
+    ("testEmitWithError", SignalTests.testEmitWithError),
+    ("testEmitWithCompleted", SignalTests.testEmitWithCompleted),
     ] }
 }
 

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -328,6 +328,8 @@ final class InfallibleTest_ : InfallibleTest, RxTestCase {
     ("testAnonymousInfallible_detachesOnDispose", InfallibleTest.testAnonymousInfallible_detachesOnDispose),
     ("testAnonymousInfallible_detachesOnComplete", InfallibleTest.testAnonymousInfallible_detachesOnComplete),
     ("testAsInfallible_never", InfallibleTest.testAsInfallible_never),
+    ("testSubscribeWithNext", InfallibleTest.testSubscribeWithNext),
+    ("testSubscribeWithError", InfallibleTest.testSubscribeWithError),
     ] }
 }
 
@@ -1632,6 +1634,8 @@ final class ObservableTest_ : ObservableTest, RxTestCase {
     ("testAsObservable_asObservable", ObservableTest.testAsObservable_asObservable),
     ("testAsObservable_hides", ObservableTest.testAsObservable_hides),
     ("testAsObservable_never", ObservableTest.testAsObservable_never),
+    ("testSubscribeWithNext", ObservableTest.testSubscribeWithNext),
+    ("testSubscribeWithError", ObservableTest.testSubscribeWithError),
     ] }
 }
 

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -13,13 +13,7 @@ import RxRelay
 import XCTest
 import RxTest
 
-class DriverTest: SharedSequenceTest {
-    fileprivate var testObject: TestObject!
-    
-    override func setUp() {
-        testObject = TestObject()
-    }
-}
+class DriverTest: SharedSequenceTest { }
 
 // MARK: properties
 extension DriverTest {
@@ -590,6 +584,7 @@ extension DriverTest {
 // MARK: - Drive with object
 extension DriverTest {
     func testDriveWithNext() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?
@@ -628,6 +623,7 @@ extension DriverTest {
     }
     
     func testDriveWithError() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?
@@ -666,6 +662,7 @@ extension DriverTest {
     }
     
     func testDriveWithCompleted() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -13,7 +13,13 @@ import RxRelay
 import XCTest
 import RxTest
 
-class DriverTest: SharedSequenceTest { }
+class DriverTest: SharedSequenceTest {
+    fileprivate var testObject: TestObject!
+    
+    override func setUp() {
+        testObject = TestObject()
+    }
+}
 
 // MARK: properties
 extension DriverTest {
@@ -579,4 +585,127 @@ extension DriverTest {
 
         XCTAssertEqual(latest, 1)
     }
+}
+
+// MARK: - Drive with object
+extension DriverTest {
+    func testDriveWithNext() {
+        let scheduler = TestScheduler(initialClock: 0)
+        var values = [String]()
+        var disposed: UUID?
+        let coldObservable = scheduler.createColdObservable([
+            .next(10, 0),
+            .next(20, 1),
+            .next(30, 2),
+            .next(40, 3),
+            .completed(50)
+        ])
+        
+        let driver = coldObservable.asDriver(onErrorJustReturn: -1)
+        
+        _ = driver
+            .drive(
+                with: testObject,
+                onNext: { object, value in values.append(object.id.uuidString + "\(value)") },
+                onDisposed: { disposed = $0.id }
+            )
+        
+        scheduler.start()
+        
+        let uuid = testObject.id
+        XCTAssertEqual(values, [
+            uuid.uuidString + "0",
+            uuid.uuidString + "1",
+            uuid.uuidString + "2",
+            uuid.uuidString + "3"
+        ])
+        
+        XCTAssertEqual(disposed, uuid)
+        
+        XCTAssertNotNil(testObject)
+        testObject = nil
+        XCTAssertNil(testObject)
+    }
+    
+    func testDriveWithError() {
+        let scheduler = TestScheduler(initialClock: 0)
+        var values = [String]()
+        var disposed: UUID?
+        let coldObservable = scheduler.createColdObservable([
+            .next(10, 0),
+            .next(20, 1),
+            .next(30, 2),
+            .error(40, testError),
+            .next(50, 3)
+        ])
+        
+        let driver = coldObservable.asDriver(onErrorJustReturn: -1)
+        
+        _ = driver
+            .drive(
+                with: testObject,
+                onNext: { object, value in values.append(object.id.uuidString + "\(value)") },
+                onDisposed: { disposed = $0.id }
+            )
+        
+        scheduler.start()
+        
+        let uuid = testObject.id
+        XCTAssertEqual(values, [
+            uuid.uuidString + "0",
+            uuid.uuidString + "1",
+            uuid.uuidString + "2",
+            uuid.uuidString + "-1"
+        ])
+        
+        XCTAssertEqual(disposed, uuid)
+        
+        XCTAssertNotNil(testObject)
+        testObject = nil
+        XCTAssertNil(testObject)
+    }
+    
+    func testDriveWithCompleted() {
+        let scheduler = TestScheduler(initialClock: 0)
+        var values = [String]()
+        var disposed: UUID?
+        var completed: UUID?
+        
+        let coldObservable = scheduler.createColdObservable([
+            .next(10, 0),
+            .next(20, 1),
+            .next(30, 2),
+            .completed(40)
+        ])
+        
+        let driver = coldObservable.asDriver(onErrorJustReturn: -1)
+        
+        _ = driver
+            .drive(
+                with: testObject,
+                onNext: { object, value in values.append(object.id.uuidString + "\(value)") },
+                onCompleted: { completed = $0.id },
+                onDisposed: { disposed = $0.id  }
+            )
+        
+        scheduler.start()
+        
+        let uuid = testObject.id
+        XCTAssertEqual(values, [
+            uuid.uuidString + "0",
+            uuid.uuidString + "1",
+            uuid.uuidString + "2"
+        ])
+        
+        XCTAssertEqual(disposed, uuid)
+        XCTAssertEqual(completed, uuid)
+        
+        XCTAssertNotNil(testObject)
+        testObject = nil
+        XCTAssertNil(testObject)
+    }
+}
+
+private class TestObject: NSObject {
+    var id = UUID()
 }

--- a/Tests/RxCocoaTests/Signal+Test.swift
+++ b/Tests/RxCocoaTests/Signal+Test.swift
@@ -654,7 +654,7 @@ extension SignalTests {
     }
 }
 
-// MARK: - Drive with object
+// MARK: - Emit with object
 extension SignalTests {
     func testEmitWithNext() {
         let scheduler = TestScheduler(initialClock: 0)

--- a/Tests/RxCocoaTests/Signal+Test.swift
+++ b/Tests/RxCocoaTests/Signal+Test.swift
@@ -13,13 +13,7 @@ import RxRelay
 import XCTest
 import RxTest
 
-class SignalTests: SharedSequenceTest {
-    fileprivate var testObject: TestObject!
-    
-    override func setUp() {
-        testObject = TestObject()
-    }
-}
+class SignalTests: SharedSequenceTest { }
 
 extension SignalTests {
     func testSignalSharing_WhenErroring() {
@@ -657,6 +651,7 @@ extension SignalTests {
 // MARK: - Emit with object
 extension SignalTests {
     func testEmitWithNext() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?
@@ -695,6 +690,7 @@ extension SignalTests {
     }
     
     func testEmitWithError() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?
@@ -733,6 +729,7 @@ extension SignalTests {
     }
     
     func testEmitWithCompleted() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?

--- a/Tests/RxSwiftTests/Infallible+Tests.swift
+++ b/Tests/RxSwiftTests/Infallible+Tests.swift
@@ -11,13 +11,7 @@ import RxCocoa
 import RxTest
 import XCTest
 
-class InfallibleTest: RxTest {
-    fileprivate var testObject: TestObject!
-    
-    override func setUp() {
-        testObject = TestObject()
-    }
-}
+class InfallibleTest: RxTest { }
 
 extension InfallibleTest {
     func testAsInfallible_OnErrorJustReturn() {
@@ -182,6 +176,7 @@ extension InfallibleTest {
 // MARK: - Subscribe with object
 extension InfallibleTest {
     func testSubscribeWithNext() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?
@@ -224,6 +219,7 @@ extension InfallibleTest {
     }
     
     func testSubscribeWithError() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?

--- a/Tests/RxSwiftTests/Observable+Tests.swift
+++ b/Tests/RxSwiftTests/Observable+Tests.swift
@@ -11,13 +11,7 @@ import RxCocoa
 import RxTest
 import XCTest
 
-class ObservableTest: RxTest {
-    fileprivate var testObject: TestObject!
-    
-    override func setUp() {
-        testObject = TestObject()
-    }
-}
+class ObservableTest: RxTest { }
 
 extension ObservableTest {
     func testAnonymousObservable_detachesOnDispose() {
@@ -193,6 +187,7 @@ extension ObservableTest {
 // MARK: - Subscribe with object
 extension ObservableTest {
     func testSubscribeWithNext() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?
@@ -233,6 +228,7 @@ extension ObservableTest {
     }
     
     func testSubscribeWithError() {
+        var testObject: TestObject! = TestObject()
         let scheduler = TestScheduler(initialClock: 0)
         var values = [String]()
         var disposed: UUID?

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -23,7 +23,7 @@ BOLDWHITE="\033[1m\033[37m"
 
 if [[ `uname` == "Darwin" ]]; then
     if [ `xcrun simctl list runtimes | grep com.apple.CoreSimulator.SimRuntime.iOS-14- | wc -l` -ge 1 ]; then
-        DEFAULT_IOS_SIMULATOR=RxSwiftTest/iPhone-11/iOS/14.0
+        DEFAULT_IOS_SIMULATOR=RxSwiftTest/iPhone-11/iOS/14.4
     else
 		echo "No iOS 14.* Simulator found, available runtimes are:"
 		xcrun simctl list runtimes
@@ -31,7 +31,7 @@ if [[ `uname` == "Darwin" ]]; then
     fi
 
     if [ `xcrun simctl list runtimes | grep com.apple.CoreSimulator.SimRuntime.watchOS-7- | wc -l` -ge 1 ]; then
-        DEFAULT_WATCHOS_SIMULATOR=RxSwiftTest/Apple-Watch-Series-5-44mm/watchOS/7.0
+        DEFAULT_WATCHOS_SIMULATOR=RxSwiftTest/Apple-Watch-Series-5-44mm/watchOS/7.2
     else
 		echo "No watchOS 7.* Simulator found, available runtimes are:"
 		xcrun simctl list runtimes
@@ -39,7 +39,7 @@ if [[ `uname` == "Darwin" ]]; then
     fi
 
     if [ `xcrun simctl list runtimes | grep com.apple.CoreSimulator.SimRuntime.tvOS-14- | wc -l` -ge 1 ]; then
-        DEFAULT_TVOS_SIMULATOR=RxSwiftTest/Apple-TV-1080p/tvOS/14.0
+        DEFAULT_TVOS_SIMULATOR=RxSwiftTest/Apple-TV-1080p/tvOS/14.3
     else
 		echo "No tvOS 14.* Simulator found, available runtimes are:"
 		xcrun simctl list runtimes


### PR DESCRIPTION
# tl;dr

This PR will:

1. Hard deprecate withUnretained for Driver specifically
2. Update documentation for the other implementations of withUnretained so it’s obvious to look out for replaying behavior
3. Add new subscribe(with:onNext:etc:) operators for all items: Observable, Driver, Signal, Infallible, Completable, Single, Maybe.


# Why are we doing this?

RxSwift 6.0 added a new `withUnretained` operator that creates a weak reference and then retains it within the next emission, so you could do `observable.withUnretained(self)` and get `self` with the element in parity. 

Unfortunately there is a small side-effect we didn't consider. If the stream you're working with has `share(replay: 1)`, the replay buffer would buffer `self` along with the value, which might create a retain cycle in some scenarios. 

This in itself isn't an issue (just a documentation change), but for `Driver` specifically, the default is to replay the latest value, so we are forced to **immediately deprecated `withUnretained` on `Driver`, specifically**. It is still available on all other traits, `Observable` and `Signal`. 

This is a very rare decision, to deprecate something in a patch release, but given this is a very new API, we prefer to deprecate it ASAP, before any widespread adoption. 

Along with this deprecate, we're adding a new set of APIs to have a similar action for different pieces. For `Driver`, this looks like this:

```swift
driver
  .drive(with: self,
         onNext: { object, value in ... 
           // object is self, value is the emission from `driver`
         })
```

This API is more concise and is available for all pieces in RxSwift and RxCocoa: Observable, Infallible, Driver, Signal, Completable, Single, and Maybe.