### PR TITLE
Fix build failure on Xcode 12.5 beta 3

### DIFF
--- a/RxCocoa/Runtime/_RXObjCRuntime.m
+++ b/RxCocoa/Runtime/_RXObjCRuntime.m
@@ -1022,7 +1022,7 @@ replacementImplementationGenerator:(IMP (^)(IMP originalImplementation))replacem
 
 #if TRACE_RESOURCES
 
-NSInteger RX_number_of_dynamic_subclasses() {
+NSInteger RX_number_of_dynamic_subclasses(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.dynamicSubclassByRealClass.count;
@@ -1031,7 +1031,7 @@ NSInteger RX_number_of_dynamic_subclasses() {
     return count;
 }
 
-NSInteger RX_number_of_forwarding_enabled_classes() {
+NSInteger RX_number_of_forwarding_enabled_classes(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.classesThatSupportObservingByForwarding.count;
@@ -1040,7 +1040,7 @@ NSInteger RX_number_of_forwarding_enabled_classes() {
     return count;
 }
 
-NSInteger RX_number_of_intercepting_classes() {
+NSInteger RX_number_of_intercepting_classes(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.interceptorIMPbySelectorsByClass.count;
@@ -1049,11 +1049,11 @@ NSInteger RX_number_of_intercepting_classes() {
     return count;
 }
 
-NSInteger RX_number_of_forwarded_methods() {
+NSInteger RX_number_of_forwarded_methods(void) {
     return numberOfForwardedMethods;
 }
 
-NSInteger RX_number_of_swizzled_methods() {
+NSInteger RX_number_of_swizzled_methods(void) {
     return numberOInterceptedMethods;
 }
 

--- a/Tests/RxCocoaTests/RXObjCRuntime+Testing.m
+++ b/Tests/RxCocoaTests/RXObjCRuntime+Testing.m
@@ -307,7 +307,7 @@ static int32_t (^defaultImpl)(int32_t) = ^int32_t(int32_t a) {
                                        p16:(some_insanely_large_struct_t)p16 {                                                                 \
     [self.privateBaseMessages addObject:A(                                                                                                     \
         p1 ?: [NSNull null],                                                                                                                   \
-        p2 ?: [NSNull null],                                                                                                                   \
+        (id)p2 ?: [NSNull null],                                                                                                               \
         p3 ?: defaultImpl,                                                                                                                     \
         @(p4),                                                                                                                                 \
         @(p5),                                                                                                                                 \
@@ -564,7 +564,7 @@ baseClassContent                                                                
                                        p16:(some_insanely_large_struct_t)p16 {                                                                 \
     [self.privateMessages addObject:A(                                                                                                         \
         p1 ?: [NSNull null],                                                                                                                   \
-        p2 ?: [NSNull null],                                                                                                                   \
+        (id)p2 ?: [NSNull null],                                                                                                               \
         p3 ?: defaultImpl,                                                                                                                     \
         @(p4),                                                                                                                                 \
         @(p5),                                                                                                                                 \


### PR DESCRIPTION
When I tried building our app with Xcode 12.5 beta 3, it failed building RxCocoa.
Here are fixes for RxSwift and AllTests to build (and run) successfully on Xcode 12.5 (I also made sure I did not break Xcode 12.4).