### PR TITLE
fix: adjust method signatures for Xcode 12.5 compatibility

### DIFF
--- a/RxCocoa/Runtime/_RXObjCRuntime.m
+++ b/RxCocoa/Runtime/_RXObjCRuntime.m
@@ -1022,7 +1022,7 @@ replacementImplementationGenerator:(IMP (^)(IMP originalImplementation))replacem
 
 #if TRACE_RESOURCES
 
-NSInteger RX_number_of_dynamic_subclasses() {
+NSInteger RX_number_of_dynamic_subclasses(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.dynamicSubclassByRealClass.count;
@@ -1031,7 +1031,7 @@ NSInteger RX_number_of_dynamic_subclasses() {
     return count;
 }
 
-NSInteger RX_number_of_forwarding_enabled_classes() {
+NSInteger RX_number_of_forwarding_enabled_classes(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.classesThatSupportObservingByForwarding.count;
@@ -1040,7 +1040,7 @@ NSInteger RX_number_of_forwarding_enabled_classes() {
     return count;
 }
 
-NSInteger RX_number_of_intercepting_classes() {
+NSInteger RX_number_of_intercepting_classes(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.interceptorIMPbySelectorsByClass.count;
@@ -1049,11 +1049,11 @@ NSInteger RX_number_of_intercepting_classes() {
     return count;
 }
 
-NSInteger RX_number_of_forwarded_methods() {
+NSInteger RX_number_of_forwarded_methods(void) {
     return numberOfForwardedMethods;
 }
 
-NSInteger RX_number_of_swizzled_methods() {
+NSInteger RX_number_of_swizzled_methods(void) {
     return numberOInterceptedMethods;
 }
 

--- a/Tests/RxCocoaTests/RXObjCRuntime+Testing.m
+++ b/Tests/RxCocoaTests/RXObjCRuntime+Testing.m
@@ -306,8 +306,8 @@ static int32_t (^defaultImpl)(int32_t) = ^int32_t(int32_t a) {
                                        p15:(int8_t * __nullable)p15                                                                            \
                                        p16:(some_insanely_large_struct_t)p16 {                                                                 \
     [self.privateBaseMessages addObject:A(                                                                                                     \
-        p1 ?: [NSNull null],                                                                                                                   \
-        p2 ?: [NSNull null],                                                                                                                   \
+        p1,                                                                                                                   \
+        p2,                                                                                                                   \
         p3 ?: defaultImpl,                                                                                                                     \
         @(p4),                                                                                                                                 \
         @(p5),                                                                                                                                 \
@@ -562,9 +562,9 @@ baseClassContent                                                                
                                        p14:(const int8_t * __nullable)p14                                                                      \
                                        p15:(int8_t * __nullable)p15                                                                            \
                                        p16:(some_insanely_large_struct_t)p16 {                                                                 \
-    [self.privateMessages addObject:A(                                                                                                         \
-        p1 ?: [NSNull null],                                                                                                                   \
-        p2 ?: [NSNull null],                                                                                                                   \
+    [self.privateMessages addObject:A(                                                                                                             \
+        p1,                                                                                                                                    \
+        p2,                                                                                                                               \
         p3 ?: defaultImpl,                                                                                                                     \
         @(p4),                                                                                                                                 \
         @(p5),                                                                                                                                 \


### PR DESCRIPTION
Xcode gives errors now around these function declarations starting in Xcode 12.5, tested in b3 and this properly adds the declarations as well as gets rid of what seems to be a now-unneeded ternary if. 

This is needed for the new Xcode versions, as well as anything depending on those.