### PR TITLE
fix: restore Xcode 12.4 functionality due to resultBuilder rename

### DIFF
--- a/RxSwift/Disposables/DisposeBag.swift
+++ b/RxSwift/Disposables/DisposeBag.swift
@@ -125,10 +125,20 @@ extension DisposeBag {
     }
 
     /// A function builder accepting a list of Disposables and returning them as an array.
+    #if swift(>=5.4)
     @resultBuilder
     public struct DisposableBuilder {
       public static func buildBlock(_ disposables: Disposable...) -> [Disposable] {
         return disposables
       }
     }
+    #else
+    @_functionBuilder
+    public struct DisposableBuilder {
+      public static func buildBlock(_ disposables: Disposable...) -> [Disposable] {
+        return disposables
+      }
+    }
+    #endif
+    
 }


### PR DESCRIPTION
Annoyingly there's no way to fix this warning, but `@resultBuilder` doesn't exist for Swift versions prior to 5.4. 