### PR TITLE
fix:Pass as a parenthesized argument to remove confusion with trailing closure

### DIFF
--- a/scripts/package-spm.swift
+++ b/scripts/package-spm.swift
@@ -93,7 +93,7 @@ func packageRelativePath(_ paths: [String], targetDirName: String, excluded: [St
 
     print("Checking " + targetPath)
 
-    for file in try fileManager.contentsOfDirectory(atPath: targetPath).sorted { $0 < $1 }  {
+    for file in try fileManager.contentsOfDirectory(atPath: targetPath).sorted(by: { $0 < $1 })  {
         if file != "include" && file != ".DS_Store" {
             print("Checking extension \(file)")
             try checkExtension(file)
@@ -150,7 +150,7 @@ func buildAllTestsTarget(_ testsPath: String) throws {
 
     var reducedMethods: [String: [String]] = [:]
 
-    for file in try fileManager.contentsOfDirectory(atPath: testsPath).sorted { $0 < $1 } {
+    for file in try fileManager.contentsOfDirectory(atPath: testsPath).sorted(by: { $0 < $1 }) {
         if !file.hasSuffix(".swift") || file == "main.swift" {
             continue
         }


### PR DESCRIPTION
Remove the warning `trailing closure in this context is confusable with the body of the statement; pass as a parenthesized argument to silence this warning` that is issued when `package-spm` scripts is executed.