### PR TITLE
fix: ControlEvent Type Standardization

### DIFF
--- a/RxCocoa/iOS/UIBarButtonItem+Rx.swift
+++ b/RxCocoa/iOS/UIBarButtonItem+Rx.swift
@@ -15,7 +15,7 @@ private var rx_tap_key: UInt8 = 0
 
 extension Reactive where Base: UIBarButtonItem {
     /// Reactive wrapper for target action pattern on `self`.
-    public var tap: ControlEvent<()> {
+    public var tap: ControlEvent<Void> {
         let source = lazyInstanceObservable(&rx_tap_key) { () -> Observable<()> in
             Observable.create { [weak control = self.base] observer in
                 guard let control = control else {

--- a/RxCocoa/iOS/UIControl+Rx.swift
+++ b/RxCocoa/iOS/UIControl+Rx.swift
@@ -15,7 +15,7 @@ extension Reactive where Base: UIControl {
     /// Reactive wrapper for target action pattern.
     ///
     /// - parameter controlEvents: Filter for observed event types.
-    public func controlEvent(_ controlEvents: UIControl.Event) -> ControlEvent<()> {
+    public func controlEvent(_ controlEvents: UIControl.Event) -> ControlEvent<Void> {
         let source: Observable<Void> = Observable.create { [weak control = self.base] observer in
                 MainScheduler.ensureRunningOnMainThread()
 

--- a/RxCocoa/iOS/UITextView+Rx.swift
+++ b/RxCocoa/iOS/UITextView+Rx.swift
@@ -89,7 +89,7 @@ extension Reactive where Base: UITextView {
     }
 
     /// Reactive wrapper for `delegate` message.
-    public var didBeginEditing: ControlEvent<()> {
+    public var didBeginEditing: ControlEvent<Void> {
        return ControlEvent<()>(events: self.delegate.methodInvoked(#selector(UITextViewDelegate.textViewDidBeginEditing(_:)))
             .map { _ in
                 return ()
@@ -97,7 +97,7 @@ extension Reactive where Base: UITextView {
     }
 
     /// Reactive wrapper for `delegate` message.
-    public var didEndEditing: ControlEvent<()> {
+    public var didEndEditing: ControlEvent<Void> {
         return ControlEvent<()>(events: self.delegate.methodInvoked(#selector(UITextViewDelegate.textViewDidEndEditing(_:)))
             .map { _ in
                 return ()
@@ -105,7 +105,7 @@ extension Reactive where Base: UITextView {
     }
 
     /// Reactive wrapper for `delegate` message.
-    public var didChange: ControlEvent<()> {
+    public var didChange: ControlEvent<Void> {
         return ControlEvent<()>(events: self.delegate.methodInvoked(#selector(UITextViewDelegate.textViewDidChange(_:)))
             .map { _ in
                 return ()
@@ -113,7 +113,7 @@ extension Reactive where Base: UITextView {
     }
 
     /// Reactive wrapper for `delegate` message.
-    public var didChangeSelection: ControlEvent<()> {
+    public var didChangeSelection: ControlEvent<Void> {
         return ControlEvent<()>(events: self.delegate.methodInvoked(#selector(UITextViewDelegate.textViewDidChangeSelection(_:)))
             .map { _ in
                 return ()

--- a/RxCocoa/macOS/NSControl+Rx.swift
+++ b/RxCocoa/macOS/NSControl+Rx.swift
@@ -17,7 +17,7 @@ private var rx_control_events_key: UInt8 = 0
 extension Reactive where Base: NSControl {
 
     /// Reactive wrapper for control event.
-    public var controlEvent: ControlEvent<()> {
+    public var controlEvent: ControlEvent<Void> {
         MainScheduler.ensureRunningOnMainThread()
 
         let source = self.lazyInstanceObservable(&rx_control_events_key) { () -> Observable<Void> in


### PR DESCRIPTION
`ControlEvent` type of `UIButton`'s `tap` is `Void`
`ControlEvent` type of `UIBarButtonItem`'s `tap` is `()`

For unity, I changed the `ControlEvent` type to `Void`.

## Before
```swift
extension Reactive where Base : UIBarButtonItem {
    /// Reactive wrapper for target action pattern on `self`.
    public var tap: RxCocoa.ControlEvent<()> { get } // <<
}

extension Reactive where Base : UIButton {
    /// Reactive wrapper for `TouchUpInside` control event.
    public var tap: RxCocoa.ControlEvent<Void> { get }
}
```

## After

```swift
extension Reactive where Base : UIBarButtonItem {
    /// Reactive wrapper for target action pattern on `self`.
    public var tap: RxCocoa.ControlEvent<Void> { get } // <<
}

...
```

Other `ControlEvent` types for `NSControl`, `UIControl`, and `UITextView` have been changed.