### PR TITLE
Generic type parameter <T> to <Element>

### DIFF
--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -1062,7 +1062,6 @@
 					};
 					C83366DC1AD0293800C668A7 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = TG22ZHQ59G;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};

--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -1643,7 +1643,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = TG22ZHQ59G;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "RxExample/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1660,7 +1660,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = TG22ZHQ59G;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "RxExample/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1874,7 +1874,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = TG22ZHQ59G;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "RxExample/Info-iOS.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/RxSwift/Concurrency/Lock.swift
+++ b/RxSwift/Concurrency/Lock.swift
@@ -16,7 +16,7 @@ typealias SpinLock = RecursiveLock
 
 extension RecursiveLock : Lock {
     @inline(__always)
-    final func performLocked<Element>(_ action: () -> Element) -> Element {
+    final func performLocked<T>(_ action: () -> T) -> T {
         self.lock(); defer { self.unlock() }
         return action()
     }

--- a/RxSwift/Concurrency/Lock.swift
+++ b/RxSwift/Concurrency/Lock.swift
@@ -16,7 +16,7 @@ typealias SpinLock = RecursiveLock
 
 extension RecursiveLock : Lock {
     @inline(__always)
-    final func performLocked<T>(_ action: () -> T) -> T {
+    final func performLocked<Element>(_ action: () -> Element) -> Element {
         self.lock(); defer { self.unlock() }
         return action()
     }

--- a/RxSwift/Observables/Dematerialize.swift
+++ b/RxSwift/Observables/Dematerialize.swift
@@ -18,8 +18,8 @@ extension ObservableType where Element: EventConvertible {
 
 }
 
-private final class DematerializeSink<T: EventConvertible, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == T.Element {
-    fileprivate func on(_ event: Event<T>) {
+private final class DematerializeSink<Element: EventConvertible, Observer: ObserverType>: Sink<Observer>, ObserverType where Observer.Element == Element.Element {
+    fileprivate func on(_ event: Event<Element>) {
         switch event {
         case .next(let element):
             self.forwardOn(element.event)
@@ -36,15 +36,15 @@ private final class DematerializeSink<T: EventConvertible, Observer: ObserverTyp
     }
 }
 
-final private class Dematerialize<T: EventConvertible>: Producer<T.Element> {
-    private let source: Observable<T>
+final private class Dematerialize<Element: EventConvertible>: Producer<Element.Element> {
+    private let source: Observable<Element>
 
-    init(source: Observable<T>) {
+    init(source: Observable<Element>) {
         self.source = source
     }
 
-    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == T.Element {
-        let sink = DematerializeSink<T, Observer>(observer: observer, cancel: cancel)
+    override func run<Observer: ObserverType>(_ observer: Observer, cancel: Cancelable) -> (sink: Disposable, subscription: Disposable) where Observer.Element == Element.Element {
+        let sink = DematerializeSink<Element, Observer>(observer: observer, cancel: cancel)
         let subscription = self.source.subscribe(sink)
         return (sink: sink, subscription: subscription)
     }

--- a/RxSwift/RxMutableBox.swift
+++ b/RxSwift/RxMutableBox.swift
@@ -19,27 +19,27 @@
 import Foundation
 
 /// Creates mutable reference wrapper for any type.
-final class RxMutableBox<T>: NSObject {
+final class RxMutableBox<Value>: NSObject {
     /// Wrapped value
-    var value: T
+    var value: Value
 
     /// Creates reference wrapper for `value`.
     ///
     /// - parameter value: Value to wrap.
-    init (_ value: T) {
+    init (_ value: Value) {
         self.value = value
     }
 }
 #else
 /// Creates mutable reference wrapper for any type.
-final class RxMutableBox<T>: CustomDebugStringConvertible {
+final class RxMutableBox<Value>: CustomDebugStringConvertible {
     /// Wrapped value
-    var value: T
+    var value: Value
     
     /// Creates reference wrapper for `value`.
     ///
     /// - parameter value: Value to wrap.
-    init (_ value: T) {
+    init (_ value: Value) {
         self.value = value
     }
 }

--- a/RxSwift/Schedulers/Internal/ScheduledItem.swift
+++ b/RxSwift/Schedulers/Internal/ScheduledItem.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-struct ScheduledItem<T>
+struct ScheduledItem<Element>
     : ScheduledItemType
     , InvocableType {
-    typealias Action = (T) -> Disposable
+    typealias Action = (Element) -> Disposable
     
     private let action: Action
-    private let state: T
+    private let state: Element
 
     private let disposable = SingleAssignmentDisposable()
 
@@ -20,7 +20,7 @@ struct ScheduledItem<T>
         self.disposable.isDisposed
     }
     
-    init(action: @escaping Action, state: T) {
+    init(action: @escaping Action, state: Element) {
         self.action = action
         self.state = state
     }

--- a/RxSwift/Schedulers/Internal/ScheduledItem.swift
+++ b/RxSwift/Schedulers/Internal/ScheduledItem.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-struct ScheduledItem<Element>
+struct ScheduledItem<State>
     : ScheduledItemType
     , InvocableType {
-    typealias Action = (Element) -> Disposable
+    typealias Action = (State) -> Disposable
     
     private let action: Action
-    private let state: Element
+    private let state: State
 
     private let disposable = SingleAssignmentDisposable()
 
@@ -20,7 +20,7 @@ struct ScheduledItem<Element>
         self.disposable.isDisposed
     }
     
-    init(action: @escaping Action, state: Element) {
+    init(action: @escaping Action, state: State) {
         self.action = action
         self.state = state
     }


### PR DESCRIPTION
In most of `RxSwift` source, and in `Apple's offical documentation`, most of generic type parameters are named as `<Element>` which is descriptive with upper camel case. 

I Found some generic type parameter names still using as `<T>` rather than `<Element>`. It would be better if matching generic type parameter under same standarization. For example, in 'RxMutableBox.swift' file,

`Before`
```
final class RxMutableBox<T>: NSObject {
    /// Wrapped value
    var value: T

    /// Creates reference wrapper for `value`.
    ///
    /// - parameter value: Value to wrap.
    init (_ value: T) {
        self.value = value
    }
}
```
`After`
```
final class RxMutableBox<Element>: NSObject {
    /// Wrapped value
    var value: Element

    /// Creates reference wrapper for `value`.
    ///
    /// - parameter value: Value to wrap.
    init (_ value: Element) {
        self.value = value
    }
}
```