### PR TITLE
Remove new line

### DIFF
--- a/RxTest/Subscription.swift
+++ b/RxTest/Subscription.swift
@@ -7,8 +7,7 @@
 //
 
 /// Records information about subscriptions to and unsubscriptions from observable sequences.
-public struct Subscription
-    {
+public struct Subscription {
 
     /// Subscription virtual time.
     public let subscribe : Int

--- a/RxTest/Subscription.swift
+++ b/RxTest/Subscription.swift
@@ -8,7 +8,6 @@
 
 /// Records information about subscriptions to and unsubscriptions from observable sequences.
 public struct Subscription {
-
     /// Subscription virtual time.
     public let subscribe : Int
     /// Unsubscription virtual time.


### PR DESCRIPTION
Subscription is not adopt any protocol in struct declaration, so there's no need new line.

like BlockingObservable


https://github.com/ReactiveX/RxSwift/blob/177ab4272f06ee8c14f23cff55021d0468ff2812/RxBlocking/BlockingObservable.swift#L20-L23
