### PR TITLE
fix: Changing system time affects Throttle/Delay. (#2316)

### DIFF
--- a/Tests/RxSwiftTests/Observable+ThrottleTests.swift
+++ b/Tests/RxSwiftTests/Observable+ThrottleTests.swift
@@ -16,6 +16,35 @@ class ObservableThrottleTest : RxTest {
 }
 
 extension ObservableThrottleTest {
+    
+    func asyncAfter(timeMS: Int, block: @escaping (() -> Void)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double(timeMS) / 1000 , execute: block)
+    }
+    
+    func test_ThrottleTimeSpan_NotLatest_Completed() {
+        let subject: PublishSubject<Int> = PublishSubject()
+        var results: [Int] = []
+        _ = subject
+            .throttle(.milliseconds(20), latest: false, scheduler: MainScheduler.instance)
+            .subscribe(onNext: { (value) in
+            results.append(value)
+        })
+        
+        asyncAfter(timeMS: 15) { subject.onNext(1) }
+        asyncAfter(timeMS: 21) { subject.onNext(2) }
+        asyncAfter(timeMS: 25) { subject.onNext(3) }
+        asyncAfter(timeMS: 31) { subject.onNext(4) }
+        asyncAfter(timeMS: 35) { subject.onNext(5) }
+        asyncAfter(timeMS: 41) { subject.onNext(6) }
+        asyncAfter(timeMS: 45) { subject.onNext(7) }
+        asyncAfter(timeMS: 46) { subject.onCompleted() }
+        
+        asyncAfter(timeMS: 100) {
+            let correct = [1, 6]
+            XCTAssertEqual(results, correct)
+        }
+    }
+    
     func test_ThrottleTimeSpan_NotLatest_Completed() {
         let scheduler = TestScheduler(initialClock: 0)
 


### PR DESCRIPTION
As title. And I'd like to share my use case. My app is used on the iPad in the meeting room to initiate and operate online meetings. The app will basically remain running and will not exit. Sometimes users will return to the background to modify the system time zone during the opening of the app (in order to keep the time consistent with overseas customers). If the time is adjusted forward, the button event using the throttle operator will become invalid.