### PR TITLE
Support Xcode 12.5 on 5.x 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 * Nothing, yet.
 
+## [5.1.3](https://github.com/ReactiveX/RxSwift/releases/tag/5.1.3)
+
+fix: adjust method signatures for Xcode 12.5 compatibility (#2305)
+
 ## [5.1.2](https://github.com/ReactiveX/RxSwift/releases/tag/5.1.2)
 
 Remove invalid libswiftXCTest.dylib linking to support Xcode 12.5

--- a/RxBlocking.podspec
+++ b/RxBlocking.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxBlocking"
-  s.version          = "5.1.2"
+  s.version          = "5.1.3"
   s.summary          = "RxSwift Blocking operatos"
   s.description      = <<-DESC
 Set of blocking operators for RxSwift. These operators are mostly intended for unit/integration tests

--- a/RxBlocking/Info.plist
+++ b/RxBlocking/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.2</string>
+	<string>5.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RxCocoa.podspec
+++ b/RxCocoa.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxCocoa"
-  s.version          = "5.1.2"
+  s.version          = "5.1.3"
   s.summary          = "RxSwift Cocoa extensions"
   s.description      = <<-DESC
 * UI extensions

--- a/RxCocoa/Info.plist
+++ b/RxCocoa/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.2</string>
+	<string>5.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RxCocoa/Runtime/_RXObjCRuntime.m
+++ b/RxCocoa/Runtime/_RXObjCRuntime.m
@@ -987,7 +987,7 @@ replacementImplementationGenerator:(IMP (^)(IMP originalImplementation))replacem
 
 #if TRACE_RESOURCES
 
-NSInteger RX_number_of_dynamic_subclasses() {
+NSInteger RX_number_of_dynamic_subclasses(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.dynamicSubclassByRealClass.count;
@@ -996,7 +996,7 @@ NSInteger RX_number_of_dynamic_subclasses() {
     return count;
 }
 
-NSInteger RX_number_of_forwarding_enabled_classes() {
+NSInteger RX_number_of_forwarding_enabled_classes(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.classesThatSupportObservingByForwarding.count;
@@ -1005,7 +1005,7 @@ NSInteger RX_number_of_forwarding_enabled_classes() {
     return count;
 }
 
-NSInteger RX_number_of_intercepting_classes() {
+NSInteger RX_number_of_intercepting_classes(void) {
     __block NSInteger count = 0;
     [[RXObjCRuntime instance] performLocked:^(RXObjCRuntime * __nonnull self) {
         count = self.interceptorIMPbySelectorsByClass.count;
@@ -1014,11 +1014,11 @@ NSInteger RX_number_of_intercepting_classes() {
     return count;
 }
 
-NSInteger RX_number_of_forwarded_methods() {
+NSInteger RX_number_of_forwarded_methods(void) {
     return numberOfForwardedMethods;
 }
 
-NSInteger RX_number_of_swizzled_methods() {
+NSInteger RX_number_of_swizzled_methods(void) {
     return numberOInterceptedMethods;
 }
 

--- a/RxRelay.podspec
+++ b/RxRelay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxRelay"
-  s.version          = "5.1.2"
+  s.version          = "5.1.3"
   s.summary          = "Relays for RxSwift - PublishRelay and BehaviorRelay"
   s.description      = <<-DESC
 Relays for RxSwift - PublishRelay and BehaviorRelay

--- a/RxRelay/Info.plist
+++ b/RxRelay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.2</string>
+	<string>5.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxSwift"
-  s.version          = "5.1.2"
+  s.version          = "5.1.3"
   s.summary          = "RxSwift is a Swift implementation of Reactive Extensions"
   s.description      = <<-DESC
 This is a Swift port of [ReactiveX.io](https://github.com/ReactiveX)

--- a/RxSwift/Info.plist
+++ b/RxSwift/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.2</string>
+	<string>5.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RxTest.podspec
+++ b/RxTest.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RxTest"
-  s.version          = "5.1.2"
+  s.version          = "5.1.3"
   s.summary          = "RxSwift Testing extensions"
   s.description      = <<-DESC
 Unit testing extensions for RxSwift. This library contains mock schedulers, observables, and observers

--- a/RxTest/Info.plist
+++ b/RxTest/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>5.1.2</string>
+	<string>5.1.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/RxCocoaTests/RXObjCRuntime+Testing.m
+++ b/Tests/RxCocoaTests/RXObjCRuntime+Testing.m
@@ -306,8 +306,8 @@ static int32_t (^defaultImpl)(int32_t) = ^int32_t(int32_t a) {
                                        p15:(int8_t * __nullable)p15                                                                            \
                                        p16:(some_insanely_large_struct_t)p16 {                                                                 \
     [self.privateBaseMessages addObject:A(                                                                                                     \
-        p1 ?: [NSNull null],                                                                                                                   \
-        p2 ?: [NSNull null],                                                                                                                   \
+        p1,                                                                                                                   \
+        p2,                                                                                                                   \
         p3 ?: defaultImpl,                                                                                                                     \
         @(p4),                                                                                                                                 \
         @(p5),                                                                                                                                 \
@@ -562,9 +562,9 @@ baseClassContent                                                                
                                        p14:(const int8_t * __nullable)p14                                                                      \
                                        p15:(int8_t * __nullable)p15                                                                            \
                                        p16:(some_insanely_large_struct_t)p16 {                                                                 \
-    [self.privateMessages addObject:A(                                                                                                         \
-        p1 ?: [NSNull null],                                                                                                                   \
-        p2 ?: [NSNull null],                                                                                                                   \
+    [self.privateMessages addObject:A(                                                                                                             \
+        p1,                                                                                                                                    \
+        p2,                                                                                                                               \
         p3 ?: defaultImpl,                                                                                                                     \
         @(p4),                                                                                                                                 \
         @(p5),                                                                                                                                 \


### PR DESCRIPTION
Marked as a draft as it will not require a merge since the work will be released from the branch itself.

The changes are cherry picked from the work David did on adding support for Xcode 12.5 which can be seen on this commit: https://github.com/ReactiveX/RxSwift/commit/7fec9b5e63d46ac9d0a08149e9d4727a293c4651