### PR TITLE
Opt-out from RxNavigationControllerDelegateProxy being a @MainActor

### DIFF
--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourcePrefetchingProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourcePrefetchingProxy.swift
@@ -31,8 +31,7 @@ private final class CollectionViewPrefetchDataSourceNotSet
 @available(iOS 10.0, tvOS 10.0, *)
 open class RxCollectionViewDataSourcePrefetchingProxy
     : DelegateProxy<UICollectionView, UICollectionViewDataSourcePrefetching>
-    , DelegateProxyType
-    , UICollectionViewDataSourcePrefetching {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var collectionView: UICollectionView?
@@ -64,17 +63,6 @@ open class RxCollectionViewDataSourcePrefetchingProxy
 
     private weak var _requiredMethodsPrefetchDataSource: UICollectionViewDataSourcePrefetching? = collectionViewPrefetchDataSourceNotSet
 
-    // MARK: delegate
-
-    /// Required delegate method implementation.
-    public func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
-        if let subject = _prefetchItemsPublishSubject {
-            subject.on(.next(indexPaths))
-        }
-
-        (_requiredMethodsPrefetchDataSource ?? collectionViewPrefetchDataSourceNotSet).collectionView(collectionView, prefetchItemsAt: indexPaths)
-    }
-
     /// For more information take a look at `DelegateProxyType`.
     open override func setForwardToDelegate(_ forwardToDelegate: UICollectionViewDataSourcePrefetching?, retainDelegate: Bool) {
         _requiredMethodsPrefetchDataSource = forwardToDelegate ?? collectionViewPrefetchDataSourceNotSet
@@ -87,6 +75,18 @@ open class RxCollectionViewDataSourcePrefetchingProxy
         }
     }
 
+}
+
+@available(iOS 10.0, tvOS 10.0, *)
+extension RxCollectionViewDataSourcePrefetchingProxy: UICollectionViewDataSourcePrefetching {
+    /// Required delegate method implementation.
+    public func collectionView(_ collectionView: UICollectionView, prefetchItemsAt indexPaths: [IndexPath]) {
+        if let subject = _prefetchItemsPublishSubject {
+            subject.on(.next(indexPaths))
+        }
+
+        (_requiredMethodsPrefetchDataSource ?? collectionViewPrefetchDataSourceNotSet).collectionView(collectionView, prefetchItemsAt: indexPaths)
+    }
 }
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDataSourceProxy.swift
@@ -35,8 +35,7 @@ private final class CollectionViewDataSourceNotSet
 /// For more information take a look at `DelegateProxyType`.
 open class RxCollectionViewDataSourceProxy
     : DelegateProxy<UICollectionView, UICollectionViewDataSource>
-    , DelegateProxyType 
-    , UICollectionViewDataSource {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var collectionView: UICollectionView?
@@ -54,22 +53,22 @@ open class RxCollectionViewDataSourceProxy
 
     private weak var _requiredMethodsDataSource: UICollectionViewDataSource? = collectionViewDataSourceNotSet
 
-    // MARK: delegate
-
-    /// Required delegate method implementation.
-    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        (_requiredMethodsDataSource ?? collectionViewDataSourceNotSet).collectionView(collectionView, numberOfItemsInSection: section)
-    }
-    
-    /// Required delegate method implementation.
-    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        (_requiredMethodsDataSource ?? collectionViewDataSourceNotSet).collectionView(collectionView, cellForItemAt: indexPath)
-    }
-
     /// For more information take a look at `DelegateProxyType`.
     open override func setForwardToDelegate(_ forwardToDelegate: UICollectionViewDataSource?, retainDelegate: Bool) {
         _requiredMethodsDataSource = forwardToDelegate ?? collectionViewDataSourceNotSet
         super.setForwardToDelegate(forwardToDelegate, retainDelegate: retainDelegate)
+    }
+}
+
+extension RxCollectionViewDataSourceProxy: UICollectionViewDataSource {
+    /// Required delegate method implementation.
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        (_requiredMethodsDataSource ?? collectionViewDataSourceNotSet).collectionView(collectionView, numberOfItemsInSection: section)
+    }
+
+    /// Required delegate method implementation.
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        (_requiredMethodsDataSource ?? collectionViewDataSourceNotSet).collectionView(collectionView, cellForItemAt: indexPath)
     }
 }
 

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift
@@ -13,9 +13,7 @@ import RxSwift
 
 /// For more information take a look at `DelegateProxyType`.
 open class RxCollectionViewDelegateProxy
-    : RxScrollViewDelegateProxy
-    , UICollectionViewDelegate
-    , UICollectionViewDelegateFlowLayout {
+    : RxScrollViewDelegateProxy {
 
     /// Typed parent object.
     public weak private(set) var collectionView: UICollectionView?
@@ -28,5 +26,7 @@ open class RxCollectionViewDelegateProxy
         super.init(scrollView: collectionView)
     }
 }
+
+extension RxCollectionViewDelegateProxy: UICollectionViewDelegateFlowLayout {}
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift
@@ -18,8 +18,7 @@
     /// For more information take a look at `DelegateProxyType`.
     open class RxNavigationControllerDelegateProxy
         : DelegateProxy<UINavigationController, UINavigationControllerDelegate>
-        , DelegateProxyType 
-        , UINavigationControllerDelegate {
+        , DelegateProxyType {
 
         /// Typed parent object.
         public weak private(set) var navigationController: UINavigationController?
@@ -35,4 +34,6 @@
             self.register { RxNavigationControllerDelegateProxy(navigationController: $0) }
         }
     }
+
+    extension RxNavigationControllerDelegateProxy: UINavigationControllerDelegate {}
 #endif

--- a/RxCocoa/iOS/Proxies/RxPickerViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDataSourceProxy.swift
@@ -30,8 +30,7 @@ final private class PickerViewDataSourceNotSet: NSObject, UIPickerViewDataSource
 /// For more information take a look at `DelegateProxyType`.
 public class RxPickerViewDataSourceProxy
     : DelegateProxy<UIPickerView, UIPickerViewDataSource>
-    , DelegateProxyType
-    , UIPickerViewDataSource {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var pickerView: UIPickerView?
@@ -49,8 +48,16 @@ public class RxPickerViewDataSourceProxy
 
     private weak var _requiredMethodsDataSource: UIPickerViewDataSource? = pickerViewDataSourceNotSet
 
-    // MARK: UIPickerViewDataSource
+    /// For more information take a look at `DelegateProxyType`.
+    public override func setForwardToDelegate(_ forwardToDelegate: UIPickerViewDataSource?, retainDelegate: Bool) {
+        _requiredMethodsDataSource = forwardToDelegate ?? pickerViewDataSourceNotSet
+        super.setForwardToDelegate(forwardToDelegate, retainDelegate: retainDelegate)
+    }
+}
 
+// MARK: UIPickerViewDataSource
+
+extension RxPickerViewDataSourceProxy: UIPickerViewDataSource {
     /// Required delegate method implementation.
     public func numberOfComponents(in pickerView: UIPickerView) -> Int {
         (_requiredMethodsDataSource ?? pickerViewDataSourceNotSet).numberOfComponents(in: pickerView)
@@ -59,12 +66,6 @@ public class RxPickerViewDataSourceProxy
     /// Required delegate method implementation.
     public func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
         (_requiredMethodsDataSource ?? pickerViewDataSourceNotSet).pickerView(pickerView, numberOfRowsInComponent: component)
-    }
-    
-    /// For more information take a look at `DelegateProxyType`.
-    public override func setForwardToDelegate(_ forwardToDelegate: UIPickerViewDataSource?, retainDelegate: Bool) {
-        _requiredMethodsDataSource = forwardToDelegate ?? pickerViewDataSourceNotSet
-        super.setForwardToDelegate(forwardToDelegate, retainDelegate: retainDelegate)
     }
 }
 

--- a/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxPickerViewDelegateProxy.swift
@@ -17,8 +17,7 @@
 
     open class RxPickerViewDelegateProxy
         : DelegateProxy<UIPickerView, UIPickerViewDelegate>
-        , DelegateProxyType 
-        , UIPickerViewDelegate {
+        , DelegateProxyType {
 
         /// Typed parent object.
         public weak private(set) var pickerView: UIPickerView?
@@ -34,4 +33,6 @@
             self.register { RxPickerViewDelegateProxy(pickerView: $0) }
         }
     }
+
+    extension RxPickerViewDelegateProxy: UIPickerViewDelegate {}
 #endif

--- a/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift
@@ -18,8 +18,7 @@ extension UIScrollView: HasDelegate {
 /// For more information take a look at `DelegateProxyType`.
 open class RxScrollViewDelegateProxy
     : DelegateProxy<UIScrollView, UIScrollViewDelegate>
-    , DelegateProxyType 
-    , UIScrollViewDelegate {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var scrollView: UIScrollView?
@@ -65,8 +64,18 @@ open class RxScrollViewDelegateProxy
         return subject
     }
     
-    // MARK: delegate methods
+    deinit {
+        if let subject = _contentOffsetBehaviorSubject {
+            subject.on(.completed)
+        }
 
+        if let subject = _contentOffsetPublishSubject {
+            subject.on(.completed)
+        }
+    }
+}
+
+extension RxScrollViewDelegateProxy: UIScrollViewDelegate {
     /// For more information take a look at `DelegateProxyType`.
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if let subject = _contentOffsetBehaviorSubject {
@@ -76,16 +85,6 @@ open class RxScrollViewDelegateProxy
             subject.on(.next(()))
         }
         self._forwardToDelegate?.scrollViewDidScroll?(scrollView)
-    }
-    
-    deinit {
-        if let subject = _contentOffsetBehaviorSubject {
-            subject.on(.completed)
-        }
-
-        if let subject = _contentOffsetPublishSubject {
-            subject.on(.completed)
-        }
     }
 }
 

--- a/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchBarDelegateProxy.swift
@@ -18,8 +18,7 @@ extension UISearchBar: HasDelegate {
 /// For more information take a look at `DelegateProxyType`.
 open class RxSearchBarDelegateProxy
     : DelegateProxy<UISearchBar, UISearchBarDelegate>
-    , DelegateProxyType 
-    , UISearchBarDelegate {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var searchBar: UISearchBar?
@@ -35,5 +34,7 @@ open class RxSearchBarDelegateProxy
         self.register { RxSearchBarDelegateProxy(searchBar: $0) }
     }
 }
+
+extension RxSearchBarDelegateProxy: UISearchBarDelegate {}
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxSearchControllerDelegateProxy.swift
@@ -18,8 +18,7 @@ extension UISearchController: HasDelegate {
 /// For more information take a look at `DelegateProxyType`.
 open class RxSearchControllerDelegateProxy
     : DelegateProxy<UISearchController, UISearchControllerDelegate>
-    , DelegateProxyType 
-    , UISearchControllerDelegate {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var searchController: UISearchController?
@@ -35,5 +34,7 @@ open class RxSearchControllerDelegateProxy
         self.register { RxSearchControllerDelegateProxy(searchController: $0) }
     }
 }
+
+extension RxSearchControllerDelegateProxy: UISearchControllerDelegate {}
    
 #endif

--- a/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarControllerDelegateProxy.swift
@@ -18,8 +18,7 @@ extension UITabBarController: HasDelegate {
 /// For more information take a look at `DelegateProxyType`.
 open class RxTabBarControllerDelegateProxy
     : DelegateProxy<UITabBarController, UITabBarControllerDelegate>
-    , DelegateProxyType 
-    , UITabBarControllerDelegate {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var tabBar: UITabBarController?
@@ -35,5 +34,7 @@ open class RxTabBarControllerDelegateProxy
         self.register { RxTabBarControllerDelegateProxy(tabBar: $0) }
     }
 }
+
+extension RxTabBarControllerDelegateProxy: UITabBarControllerDelegate {}
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTabBarDelegateProxy.swift
@@ -18,8 +18,7 @@ extension UITabBar: HasDelegate {
 /// For more information take a look at `DelegateProxyType`.
 open class RxTabBarDelegateProxy
     : DelegateProxy<UITabBar, UITabBarDelegate>
-    , DelegateProxyType 
-    , UITabBarDelegate {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var tabBar: UITabBar?
@@ -45,5 +44,7 @@ open class RxTabBarDelegateProxy
         object.delegate = delegate
     }
 }
+
+extension RxTabBarDelegateProxy: UITabBarDelegate {}
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourcePrefetchingProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourcePrefetchingProxy.swift
@@ -31,8 +31,7 @@ private final class TableViewPrefetchDataSourceNotSet
 @available(iOS 10.0, tvOS 10.0, *)
 open class RxTableViewDataSourcePrefetchingProxy
     : DelegateProxy<UITableView, UITableViewDataSourcePrefetching>
-    , DelegateProxyType
-    , UITableViewDataSourcePrefetching {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var tableView: UITableView?
@@ -64,17 +63,6 @@ open class RxTableViewDataSourcePrefetchingProxy
 
     private weak var _requiredMethodsPrefetchDataSource: UITableViewDataSourcePrefetching? = tableViewPrefetchDataSourceNotSet
 
-    // MARK: delegate
-
-    /// Required delegate method implementation.
-    public func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
-        if let subject = _prefetchRowsPublishSubject {
-            subject.on(.next(indexPaths))
-        }
-
-        (_requiredMethodsPrefetchDataSource ?? tableViewPrefetchDataSourceNotSet).tableView(tableView, prefetchRowsAt: indexPaths)
-    }
-
     /// For more information take a look at `DelegateProxyType`.
     open override func setForwardToDelegate(_ forwardToDelegate: UITableViewDataSourcePrefetching?, retainDelegate: Bool) {
         _requiredMethodsPrefetchDataSource = forwardToDelegate ?? tableViewPrefetchDataSourceNotSet
@@ -87,6 +75,18 @@ open class RxTableViewDataSourcePrefetchingProxy
         }
     }
 
+}
+
+@available(iOS 10.0, tvOS 10.0, *)
+extension RxTableViewDataSourcePrefetchingProxy: UITableViewDataSourcePrefetching {
+    /// Required delegate method implementation.
+    public func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+        if let subject = _prefetchRowsPublishSubject {
+            subject.on(.next(indexPaths))
+        }
+
+        (_requiredMethodsPrefetchDataSource ?? tableViewPrefetchDataSourceNotSet).tableView(tableView, prefetchRowsAt: indexPaths)
+    }
 }
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDataSourceProxy.swift
@@ -33,8 +33,7 @@ private final class TableViewDataSourceNotSet
 /// For more information take a look at `DelegateProxyType`.
 open class RxTableViewDataSourceProxy
     : DelegateProxy<UITableView, UITableViewDataSource>
-    , DelegateProxyType 
-    , UITableViewDataSource {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var tableView: UITableView?
@@ -52,8 +51,14 @@ open class RxTableViewDataSourceProxy
 
     private weak var _requiredMethodsDataSource: UITableViewDataSource? = tableViewDataSourceNotSet
 
-    // MARK: delegate
+    /// For more information take a look at `DelegateProxyType`.
+    open override func setForwardToDelegate(_ forwardToDelegate: UITableViewDataSource?, retainDelegate: Bool) {
+        _requiredMethodsDataSource = forwardToDelegate  ?? tableViewDataSourceNotSet
+        super.setForwardToDelegate(forwardToDelegate, retainDelegate: retainDelegate)
+    }
+}
 
+extension RxTableViewDataSourceProxy: UITableViewDataSource {
     /// Required delegate method implementation.
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         (_requiredMethodsDataSource ?? tableViewDataSourceNotSet).tableView(tableView, numberOfRowsInSection: section)
@@ -63,13 +68,6 @@ open class RxTableViewDataSourceProxy
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         (_requiredMethodsDataSource ?? tableViewDataSourceNotSet).tableView(tableView, cellForRowAt: indexPath)
     }
-
-    /// For more information take a look at `DelegateProxyType`.
-    open override func setForwardToDelegate(_ forwardToDelegate: UITableViewDataSource?, retainDelegate: Bool) {
-        _requiredMethodsDataSource = forwardToDelegate  ?? tableViewDataSourceNotSet
-        super.setForwardToDelegate(forwardToDelegate, retainDelegate: retainDelegate)
-    }
-
 }
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift
@@ -13,8 +13,7 @@ import RxSwift
 
 /// For more information take a look at `DelegateProxyType`.
 open class RxTableViewDelegateProxy
-    : RxScrollViewDelegateProxy
-    , UITableViewDelegate {
+    : RxScrollViewDelegateProxy {
 
     /// Typed parent object.
     public weak private(set) var tableView: UITableView?
@@ -26,5 +25,7 @@ open class RxTableViewDelegateProxy
     }
 
 }
+
+extension RxTableViewDelegateProxy: UITableViewDelegate {}
 
 #endif

--- a/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextStorageDelegateProxy.swift
@@ -17,8 +17,7 @@
 
     open class RxTextStorageDelegateProxy
         : DelegateProxy<NSTextStorage, NSTextStorageDelegate>
-        , DelegateProxyType 
-        , NSTextStorageDelegate {
+        , DelegateProxyType {
 
         /// Typed parent object.
         public weak private(set) var textStorage: NSTextStorage?
@@ -34,4 +33,6 @@
             self.register { RxTextStorageDelegateProxy(textStorage: $0) }
         }
     }
+
+    extension RxTextStorageDelegateProxy: NSTextStorageDelegate {}
 #endif

--- a/RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift
@@ -13,8 +13,7 @@ import RxSwift
 
 /// For more information take a look at `DelegateProxyType`.
 open class RxTextViewDelegateProxy
-    : RxScrollViewDelegateProxy
-    , UITextViewDelegate {
+    : RxScrollViewDelegateProxy {
 
     /// Typed parent object.
     public weak private(set) var textView: UITextView?
@@ -24,13 +23,13 @@ open class RxTextViewDelegateProxy
         self.textView = textView
         super.init(scrollView: textView)
     }
+}
 
-    // MARK: delegate methods
-
+extension RxTextViewDelegateProxy: UITextViewDelegate {
     /// For more information take a look at `DelegateProxyType`.
     @objc open func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         /**
-         We've had some issues with observing text changes. This is here just in case we need the same hack in future and that 
+         We've had some issues with observing text changes. This is here just in case we need the same hack in future and that
          we wouldn't need to change the public interface.
         */
         let forwardToDelegate = self.forwardToDelegate() as? UITextViewDelegate

--- a/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
@@ -14,8 +14,7 @@ import WebKit
 @available(iOS 8.0, OSX 10.10, OSXApplicationExtension 10.10, *)
 open class RxWKNavigationDelegateProxy
     : DelegateProxy<WKWebView, WKNavigationDelegate>
-    , DelegateProxyType
-, WKNavigationDelegate {
+    , DelegateProxyType {
 
     /// Typed parent object.
     public weak private(set) var webView: WKWebView?
@@ -39,5 +38,8 @@ open class RxWKNavigationDelegateProxy
         object.navigationDelegate = delegate
     }
 }
+
+@available(iOS 8.0, OSX 10.10, OSXApplicationExtension 10.10, *)
+extension RxWKNavigationDelegateProxy: WKNavigationDelegate {}
 
 #endif


### PR DESCRIPTION
Apparently, moving the `UINavigationControllerDelegate` conformance to an extension makes it so `RxNavigationControllerDelegateProxy` is not recognized as `@MainActor`, avoiding compilation errors when using RxCocoa.

Fixes https://github.com/ReactiveX/RxSwift/issues/2347