### PR TITLE
Check that aSelector is not nil before passing it on...

### DIFF
--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -225,9 +225,10 @@
         }
 
         override open func responds(to aSelector: Selector!) -> Bool {
-            return aSelector != nil && (super.responds(to: aSelector)
+            guard let aSelector = aSelector else { return false }
+            return super.responds(to: aSelector)
                 || (self._forwardToDelegate?.responds(to: aSelector) ?? false)
-                || (self.voidDelegateMethodsContain(aSelector) && self.hasObservers(selector: aSelector)))
+                || (self.voidDelegateMethodsContain(aSelector) && self.hasObservers(selector: aSelector))
         }
 
         fileprivate func reset() {

--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -225,9 +225,9 @@
         }
 
         override open func responds(to aSelector: Selector!) -> Bool {
-            return super.responds(to: aSelector)
+            return aSelector != nil && (super.responds(to: aSelector)
                 || (self._forwardToDelegate?.responds(to: aSelector) ?? false)
-                || (self.voidDelegateMethodsContain(aSelector) && self.hasObservers(selector: aSelector))
+                || (self.voidDelegateMethodsContain(aSelector) && self.hasObservers(selector: aSelector)))
         }
 
         fileprivate func reset() {


### PR DESCRIPTION
Both `voidDelegateMethodsContain(_ :)` and `hasObservers(selector:)` require that `aSelector` is not nil. The `responds(to:)` method assumes it isn't nil but doesn't check. Some older objective-c libraries (eg, FSCalendar) check to see if the delegate responds to a `nil` selector.

This change adds code to return false if the selector is nil.