### PR TITLE
Fix parameter names in method Documentation Comments

### DIFF
--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -200,7 +200,7 @@
         /// Sets reference of normal delegate that receives all forwarded messages
         /// through `self`.
         ///
-        /// - parameter forwardToDelegate: Reference of delegate that receives all messages through `self`.
+        /// - parameter delegate: Reference of delegate that receives all messages through `self`.
         /// - parameter retainDelegate: Should `self` retain `forwardToDelegate`.
         open func setForwardToDelegate(_ delegate: Delegate?, retainDelegate: Bool) {
             #if DEBUG // 4.0 all configurations

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -98,8 +98,8 @@ public protocol DelegateProxyType: AnyObject {
     ///
     /// It's abstract method.
     ///
-    /// - parameter toObject: Object that has delegate property.
     /// - parameter delegate: Delegate value.
+    /// - parameter object: Object that has delegate property.
     static func setCurrentDelegate(_ delegate: Delegate?, to object: ParentObject)
 
     /// Returns reference of normal delegate that receives all forwarded messages

--- a/RxCocoa/Common/Infallible+Bind.swift
+++ b/RxCocoa/Common/Infallible+Bind.swift
@@ -13,7 +13,7 @@ extension InfallibleType {
      Creates new subscription and sends elements to observer(s).
      In this form, it's equivalent to the `subscribe` method, but it better conveys intent, and enables
      writing more consistent binding code.
-     - parameter to: Observers to receives events.
+     - parameter observers: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
     public func bind<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element {
@@ -26,7 +26,7 @@ extension InfallibleType {
      Creates new subscription and sends elements to observer(s).
      In this form, it's equivalent to the `subscribe` method, but it better conveys intent, and enables
      writing more consistent binding code.
-     - parameter to: Observers to receives events.
+     - parameter observers: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
     public func bind<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element? {
@@ -39,7 +39,7 @@ extension InfallibleType {
     /**
     Subscribes to observable sequence using custom binder function.
 
-    - parameter to: Function used to bind elements from `self`.
+    - parameter binder: Function used to bind elements from `self`.
     - returns: Object representing subscription.
     */
     public func bind<Result>(to binder: (Self) -> Result) -> Result {
@@ -54,7 +54,7 @@ extension InfallibleType {
             return binder(self)(curriedArgument)
         }
 
-    - parameter to: Function used to bind elements from `self`.
+    - parameter binder: Function used to bind elements from `self`.
     - parameter curriedArgument: Final argument passed to `binder` to finish binding process.
     - returns: Object representing subscription.
     */
@@ -77,7 +77,7 @@ extension InfallibleType {
     /**
     Creates new subscription and sends elements to `BehaviorRelay`.
 
-    - parameter relay: Target relay for sequence elements.
+    - parameter relays: Target relay for sequence elements.
     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
     */
     public func bind(to relays: BehaviorRelay<Element>...) -> Disposable {
@@ -89,7 +89,7 @@ extension InfallibleType {
     /**
      Creates new subscription and sends elements to `BehaviorRelay`.
 
-     - parameter relay: Target relay for sequence elements.
+     - parameter relays: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func bind(to relays: BehaviorRelay<Element?>...) -> Disposable {
@@ -101,7 +101,7 @@ extension InfallibleType {
     /**
     Creates new subscription and sends elements to `PublishRelay`.
 
-    - parameter relay: Target relay for sequence elements.
+    - parameter relays: Target relay for sequence elements.
     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
     */
     public func bind(to relays: PublishRelay<Element>...) -> Disposable {
@@ -113,7 +113,7 @@ extension InfallibleType {
     /**
      Creates new subscription and sends elements to `PublishRelay`.
 
-     - parameter relay: Target relay for sequence elements.
+     - parameter relays: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func bind(to relays: PublishRelay<Element?>...) -> Disposable {
@@ -125,7 +125,7 @@ extension InfallibleType {
     /**
     Creates new subscription and sends elements to `ReplayRelay`.
 
-    - parameter relay: Target relay for sequence elements.
+    - parameter relays: Target relay for sequence elements.
     - returns: Disposable object that can be used to unsubscribe the observer from the relay.
     */
     public func bind(to relays: ReplayRelay<Element>...) -> Disposable {
@@ -137,7 +137,7 @@ extension InfallibleType {
     /**
      Creates new subscription and sends elements to `ReplayRelay`.
 
-     - parameter relay: Target relay for sequence elements.
+     - parameter relays: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func bind(to relays: ReplayRelay<Element?>...) -> Disposable {

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -13,7 +13,7 @@ extension ObservableType {
      Creates new subscription and sends elements to observer(s).
      In this form, it's equivalent to the `subscribe` method, but it better conveys intent, and enables
      writing more consistent binding code.
-     - parameter to: Observers to receives events.
+     - parameter observers: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
     public func bind<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element {
@@ -26,7 +26,7 @@ extension ObservableType {
      Creates new subscription and sends elements to observer(s).
      In this form, it's equivalent to the `subscribe` method, but it better conveys intent, and enables
      writing more consistent binding code.
-     - parameter to: Observers to receives events.
+     - parameter observers: Observers to receives events.
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
     public func bind<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element? {
@@ -39,7 +39,7 @@ extension ObservableType {
     /**
     Subscribes to observable sequence using custom binder function.
 
-    - parameter to: Function used to bind elements from `self`.
+    - parameter binder: Function used to bind elements from `self`.
     - returns: Object representing subscription.
     */
     public func bind<Result>(to binder: (Self) -> Result) -> Result {
@@ -54,7 +54,7 @@ extension ObservableType {
             return binder(self)(curriedArgument)
         }
 
-    - parameter to: Function used to bind elements from `self`.
+    - parameter binder: Function used to bind elements from `self`.
     - parameter curriedArgument: Final argument passed to `binder` to finish binding process.
     - returns: Object representing subscription.
     */

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -57,7 +57,7 @@ extension Reactive where Base: NSObject {
 
      If support for weak properties is needed or observing arbitrary or unknown relationships in the
      ownership tree, `observeWeakly` is the preferred option.
-
+     - parameter type: Optional type hint of the observed sequence elements.
      - parameter keyPath: Key path of property names to observe.
      - parameter options: KVO mechanism notification options.
      - parameter retainSelf: Retains self during observation if set `true`.
@@ -107,7 +107,7 @@ extension Reactive where Base: NSObject {
      * it can be used to observe `weak` properties
 
      **Since it needs to intercept object deallocation process it needs to perform swizzling of `dealloc` method on observed object.**
-
+     - parameter type: Optional type hint of the observed sequence elements.
      - parameter keyPath: Key path of property names to observe.
      - parameter options: KVO mechanism notification options.
      - returns: Observable sequence of objects on `keyPath`.

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -110,7 +110,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     Subscribes to observable sequence using custom binder function.
     This method can be only called from `MainThread`.
 
-    - parameter with: Function used to bind elements from `self`.
+    - parameter transformation: Function used to bind elements from `self`.
     - returns: Object representing subscription.
     */
     public func drive<Result>(_ transformation: (Observable<Element>) -> Result) -> Result {

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -31,7 +31,7 @@ extension SharedSequenceConvertibleType {
     /**
      Projects each element of an observable sequence into an optional form and filters all optional results.
      
-     - parameter transform: A transform function to apply to each source element and which returns an element or nil.
+     - parameter selector: A transform function to apply to each source element and which returns an element or nil.
      - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
      
      */
@@ -572,7 +572,6 @@ extension SharedSequenceConvertibleType {
      - seealso: [delay operator on reactivex.io](http://reactivex.io/documentation/operators/delay.html)
 
      - parameter dueTime: Relative time shift of the source by.
-     - parameter scheduler: Scheduler to run the subscription delay timer on.
      - returns: the source Observable shifted in time by the specified delay.
      */
     public func delay(_ dueTime: RxTimeInterval)

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -15,7 +15,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
 
      In this form it's equivalent to `subscribe` method, but it communicates intent better.
 
-     - parameter to: Observers that receives events.
+     - parameter observers: Observers that receives events.
      - returns: Disposable object that can be used to unsubscribe the observer from the subject.
      */
     public func emit<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element {
@@ -31,7 +31,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
 
      In this form it's equivalent to `subscribe` method, but it communicates intent better.
 
-     - parameter to: Observers that receives events.
+     - parameter observers: Observers that receives events.
      - returns: Disposable object that can be used to unsubscribe the observer from the subject.
      */
     public func emit<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element? {
@@ -45,7 +45,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
 
     /**
      Creates new subscription and sends elements to `BehaviorRelay`.
-     - parameter to: Target relays for sequence elements.
+     - parameter relays: Target relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func emit(to relays: BehaviorRelay<Element>...) -> Disposable {
@@ -56,7 +56,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     
     /**
      Creates new subscription and sends elements to `BehaviorRelay`.
-     - parameter to: Target relays for sequence elements.
+     - parameter relays: Target relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func emit(to relays: BehaviorRelay<Element?>...) -> Disposable {
@@ -68,7 +68,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     /**
      Creates new subscription and sends elements to `PublishRelay`.
 
-     - parameter to: Target relays for sequence elements.
+     - parameter relays: Target relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func emit(to relays: PublishRelay<Element>...) -> Disposable {
@@ -80,7 +80,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     /**
      Creates new subscription and sends elements to `PublishRelay`.
 
-     - parameter to: Target relay for sequence elements.
+     - parameter relays: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func emit(to relays: PublishRelay<Element?>...) -> Disposable {
@@ -92,7 +92,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     /**
      Creates new subscription and sends elements to `ReplayRelay`.
 
-     - parameter to: Target relays for sequence elements.
+     - parameter relays: Target relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func emit(to relays: ReplayRelay<Element>...) -> Disposable {
@@ -104,7 +104,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
     /**
      Creates new subscription and sends elements to `ReplayRelay`.
 
-     - parameter to: Target relay for sequence elements.
+     - parameter relays: Target relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer from the relay.
      */
     public func emit(to relays: ReplayRelay<Element?>...) -> Disposable {

--- a/RxExample/RxExample/Observable+Extensions.swift
+++ b/RxExample/RxExample/Observable+Extensions.swift
@@ -23,8 +23,9 @@ extension ObservableType where Element == Any {
      Events are represented by `Event` parameter.
 
      - parameter initialState: Initial state of the system.
-     - parameter accumulator: Calculates new system state from existing state and a transition event (system integrator, reducer).
-     - parameter feedback: Feedback loops that produce events depending on current system state.
+     - parameter reduce: Calculates new system state from existing state and a transition event (system integrator, reducer).
+     - parameter scheduler: Scheduler on which observable sequence receives elements
+     - parameter scheduledFeedback: Feedback loops that produce events depending on current system state.
      - returns: Current state of the system.
      */
     public static func system<State, Event>(
@@ -79,7 +80,7 @@ extension SharedSequenceConvertibleType where Element == Any, SharingStrategy ==
      Events are represented by `Event` parameter.
 
      - parameter initialState: Initial state of the system.
-     - parameter accumulator: Calculates new system state from existing state and a transition event (system integrator, reducer).
+     - parameter reduce: Calculates new system state from existing state and a transition event (system integrator, reducer).
      - parameter feedback: Feedback loops that produce events depending on current system state.
      - returns: Current state of the system.
      */

--- a/RxRelay/Observable+Bind.swift
+++ b/RxRelay/Observable+Bind.swift
@@ -13,7 +13,7 @@ extension ObservableType {
      Creates new subscription and sends elements to publish relay(s).
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target publish relays for sequence elements.
+     - parameter relays: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     public func bind(to relays: PublishRelay<Element>...) -> Disposable {
@@ -26,7 +26,7 @@ extension ObservableType {
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
 
-     - parameter to: Target publish relays for sequence elements.
+     - parameter relays: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     public func bind(to relays: PublishRelay<Element?>...) -> Disposable {
@@ -37,7 +37,7 @@ extension ObservableType {
      Creates new subscription and sends elements to publish relay(s).
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target publish relays for sequence elements.
+     - parameter relays: Target publish relays for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     private func bind(to relays: [PublishRelay<Element>]) -> Disposable {
@@ -59,7 +59,7 @@ extension ObservableType {
      Creates new subscription and sends elements to behavior relay(s).
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target behavior relay for sequence elements.
+     - parameter relays: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     public func bind(to relays: BehaviorRelay<Element>...) -> Disposable {
@@ -72,7 +72,7 @@ extension ObservableType {
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
 
-     - parameter to: Target behavior relay for sequence elements.
+     - parameter relays: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     public func bind(to relays: BehaviorRelay<Element?>...) -> Disposable {
@@ -83,7 +83,7 @@ extension ObservableType {
      Creates new subscription and sends elements to behavior relay(s).
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target behavior relay for sequence elements.
+     - parameter relays: Target behavior relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     private func bind(to relays: [BehaviorRelay<Element>]) -> Disposable {
@@ -105,7 +105,7 @@ extension ObservableType {
      Creates new subscription and sends elements to replay relay(s).
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target replay relay for sequence elements.
+     - parameter relays: Target replay relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     public func bind(to relays: ReplayRelay<Element>...) -> Disposable {
@@ -118,7 +118,7 @@ extension ObservableType {
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
 
-     - parameter to: Target replay relay for sequence elements.
+     - parameter relays: Target replay relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     public func bind(to relays: ReplayRelay<Element?>...) -> Disposable {
@@ -129,7 +129,7 @@ extension ObservableType {
      Creates new subscription and sends elements to replay relay(s).
      In case error occurs in debug mode, `fatalError` will be raised.
      In case error occurs in release mode, `error` will be logged.
-     - parameter to: Target replay relay for sequence elements.
+     - parameter relays: Target replay relay for sequence elements.
      - returns: Disposable object that can be used to unsubscribe the observer.
      */
     private func bind(to relays: [ReplayRelay<Element>]) -> Disposable {

--- a/RxSwift/Observables/SwitchIfEmpty.swift
+++ b/RxSwift/Observables/SwitchIfEmpty.swift
@@ -12,7 +12,7 @@ extension ObservableType {
 
      - seealso: [DefaultIfEmpty operator on reactivex.io](http://reactivex.io/documentation/operators/defaultifempty.html)
 
-     - parameter switchTo: Observable sequence being returned when source sequence is empty.
+     - parameter other: Observable sequence being returned when source sequence is empty.
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
     public func ifEmpty(switchTo other: Observable<Element>) -> Observable<Element> {

--- a/RxSwift/Traits/Infallible/ObservableConvertibleType+Infallible.swift
+++ b/RxSwift/Traits/Infallible/ObservableConvertibleType+Infallible.swift
@@ -16,7 +16,7 @@ public extension ObservableConvertibleType {
 
     /// Convert to an `Infallible`
     ///
-    /// - parameter onErrorFallbackTo: Fall back to this provided infallible on error
+    /// - parameter infallible: Fall back to this provided infallible on error
     ///
     ///
     /// - returns: `Infallible<Element>`

--- a/RxSwift/Traits/PrimitiveSequence/Maybe.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Maybe.swift
@@ -335,11 +335,11 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     }
 
     /**
-     Returns the elements of the specified sequence or `switchTo` sequence if the sequence is empty.
+     Returns the elements of the specified sequence or `other` sequence if the sequence is empty.
 
      - seealso: [DefaultIfEmpty operator on reactivex.io](http://reactivex.io/documentation/operators/defaultifempty.html)
 
-     - parameter switchTo: Observable sequence being returned when source sequence is empty.
+     - parameter other: Observable sequence being returned when source sequence is empty.
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
     public func ifEmpty(switchTo other: Maybe<Element>) -> Maybe<Element> {
@@ -347,11 +347,11 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     }
 
     /**
-     Returns the elements of the specified sequence or `switchTo` sequence if the sequence is empty.
+     Returns the elements of the specified sequence or `other` sequence if the sequence is empty.
 
      - seealso: [DefaultIfEmpty operator on reactivex.io](http://reactivex.io/documentation/operators/defaultifempty.html)
 
-     - parameter switchTo: Observable sequence being returned when source sequence is empty.
+     - parameter other: Observable sequence being returned when source sequence is empty.
      - returns: Observable sequence that contains elements from switchTo sequence if source is empty, otherwise returns source sequence elements.
      */
     public func ifEmpty(switchTo other: Single<Element>) -> Single<Element> {

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -87,10 +87,10 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
     /**
     Starts the test scheduler and uses the specified virtual times to invoke the factory function, subscribe to the resulting sequence, and dispose the subscription.
     
-    - parameter create: Factory method to create an observable convertible sequence.
     - parameter created: Virtual time at which to invoke the factory to create an observable sequence.
     - parameter subscribed: Virtual time at which to subscribe to the created observable sequence.
     - parameter disposed: Virtual time at which to dispose the subscription.
+    - parameter create: Factory method to create an observable convertible sequence.
     - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
     */
     public func start<Element, OutputSequence: ObservableConvertibleType>(created: TestTime, subscribed: TestTime, disposed: TestTime, create: @escaping () -> OutputSequence)
@@ -126,8 +126,8 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
      * created at virtual time `Defaults.created`           -> 100
      * subscribed to at virtual time `Defaults.subscribed`  -> 200
 
-     - parameter create: Factory method to create an observable convertible sequence.
      - parameter disposed: Virtual time at which to dispose the subscription.
+     - parameter create: Factory method to create an observable convertible sequence.
      - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
      */
     public func start<Element, OutputSequence: ObservableConvertibleType>(disposed: TestTime, create: @escaping () -> OutputSequence)

--- a/RxTest/XCTest+Rx.swift
+++ b/RxTest/XCTest+Rx.swift
@@ -18,7 +18,9 @@ Event is considered equal if:
 * `Completed` events are always equal.
 
 - parameter lhs: first set of events.
-- parameter lhs: second set of events.
+- parameter rhs: second set of events.
+- parameter file: The path to the file in which it appears.
+- parameter line: The line number on which it appears.
 */
 public func XCTAssertEqual<Element: Equatable>(_ lhs: [Event<Element>], _ rhs: [Event<Element>], file: StaticString = #file, line: UInt = #line) {
     let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }
@@ -44,7 +46,9 @@ public func XCTAssertEqual<Element: Equatable>(_ lhs: [Event<Element>], _ rhs: [
  * `Completed` events are always equal.
 
  - parameter lhs: first set of events.
- - parameter lhs: second set of events.
+ - parameter rhs: second set of events.
+ - parameter file: The path to the file in which it appears.
+ - parameter line: The line number on which it appears.
  */
 public func XCTAssertEqual<Element: Equatable>(_ lhs: [SingleEvent<Element>], _ rhs: [SingleEvent<Element>], file: StaticString = #file, line: UInt = #line) {
     let leftEquatable = lhs.map { AnyEquatable(target: try? $0.get(), comparer: ==) }
@@ -70,7 +74,9 @@ public func XCTAssertEqual<Element: Equatable>(_ lhs: [SingleEvent<Element>], _ 
  * `Completed` events are always equal.
 
  - parameter lhs: first set of events.
- - parameter lhs: second set of events.
+ - parameter rhs: second set of events.
+ - parameter file: The path to the file in which it appears.
+ - parameter line: The line number on which it appears.
  */
 public func XCTAssertEqual<Element: Equatable>(_ lhs: [MaybeEvent<Element>], _ rhs: [MaybeEvent<Element>], file: StaticString = #file, line: UInt = #line) {
     let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }
@@ -96,7 +102,9 @@ public func XCTAssertEqual<Element: Equatable>(_ lhs: [MaybeEvent<Element>], _ r
  * `Completed` events are always equal.
 
  - parameter lhs: first set of events.
- - parameter lhs: second set of events.
+ - parameter rhs: second set of events.
+ - parameter file: The path to the file in which it appears.
+ - parameter line: The line number on which it appears.
  */
 public func XCTAssertEqual(_ lhs: [CompletableEvent], _ rhs: [CompletableEvent], file: StaticString = #file, line: UInt = #line) {
     let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }
@@ -124,7 +132,9 @@ Event is considered equal if:
 * `Completed` events are always equal.
 
 - parameter lhs: first set of events.
-- parameter lhs: second set of events.
+- parameter rhs: second set of events.
+- parameter file: The path to the file in which it appears.
+- parameter line: The line number on which it appears.
 */
 public func XCTAssertEqual<Element: Equatable>(_ lhs: [Recorded<Event<Element>>], _ rhs: [Recorded<Event<Element>>], file: StaticString = #file, line: UInt = #line) {
     let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }
@@ -153,7 +163,9 @@ public func XCTAssertEqual<Element: Equatable>(_ lhs: [Recorded<Event<Element>>]
  * `Completed` events are always equal.
  
  - parameter lhs: first set of events.
- - parameter lhs: second set of events.
+ - parameter rhs: second set of events.
+ - parameter file: The path to the file in which it appears.
+ - parameter line: The line number on which it appears.
  */
 public func XCTAssertEqual<Element: Equatable>(_ lhs: [Recorded<Event<Element?>>], _ rhs: [Recorded<Event<Element?>>], file: StaticString = #file, line: UInt = #line) {
     let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: ==) }


### PR DESCRIPTION
This PR is to fix parameter names in method Documentation Comments.

The following is the revised content:

- Fix difference between actual parameter names and those in comments
- Replace argument labels with actual parameter names
- Add missing parameter names.