### PR TITLE
add recorded operator 

### DIFF
--- a/RxBlocking/ObservableType+Record.swift
+++ b/RxBlocking/ObservableType+Record.swift
@@ -1,0 +1,21 @@
+//
+//  ObservableType+Record.swift
+//  
+//
+//  Created by Booung on 2022/03/19.
+//
+
+import RxSwift
+import Foundation
+
+extension ObservableType {
+    /// Converts an `Observable` that records last `N` events
+    ///
+    /// - parameter bufferSize: Number of recent recordable events
+    /// - returns: `Observable<Element>` version of `self`
+    func recorded(_ bufferSize: Int = 10) -> Observable<Element> {
+        let replaySubject = ReplaySubject<Element>.create(bufferSize: bufferSize)
+        _ = self.subscribe(replaySubject)
+        return replaySubject.asObservable()
+    }
+}

--- a/RxBlocking/ObservableType+Record.swift
+++ b/RxBlocking/ObservableType+Record.swift
@@ -2,7 +2,7 @@
 //  ObservableType+Record.swift
 //  
 //
-//  Created by Booung on 2022/03/19.
+//  Created by dongyoung.lee on 2022/03/19.
 //
 
 import RxSwift


### PR DESCRIPTION
added operators to make testing hot observables easier

ASIS
```swift
func testHotObservable() {
    // given
    let hotObservable = PublishSubject<Int>()
    
    // when
    hotObservable.onNext(1)
    
    // then
    let event = try! hotObservable.toBlocking(timeout: 1).first() // ❌ Sequence timeout.
    XCTAssertEqual(event, 1)
  }
```

TOBE
```swift
func testHotObservable() {
    // given
    let hotObservable = PublishSubject<Int>()
    let recorded = hotObservable.recorded()
    
    // when
    hotObservable.onNext(1)
    
    // then
    let event = try! recorded.toBlocking(timeout: 1).first() 
    XCTAssertEqual(event, 1) // ✅ 
  }  
```