### PR TITLE
Delete unused code in Map.swift

### DIFF
--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -27,7 +27,6 @@ final private class MapSink<SourceType, Observer: ObserverType>: Sink<Observer>,
     typealias Transform = (SourceType) throws -> ResultType
 
     typealias ResultType = Observer.Element 
-    typealias Element = SourceType
 
     private let transform: Transform
 


### PR DESCRIPTION
`typealias Element` is no need anymore