### PR TITLE
Use AtomicInt for BooleanDisposable to prevent potential rase condition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ---
 
+## Unreleased
+
+Use `AtomicInt` for `BooleanDisposable`s to prevent potential rase condition. #2419
+
 ## 6.5.0
 
 You can now use `await` on `Observable`-conforming objects (as well as `Driver`, `Signal`, `Infallible`, `Single`, `Completable`) using the following syntax:

--- a/RxSwift/Disposables/BooleanDisposable.swift
+++ b/RxSwift/Disposables/BooleanDisposable.swift
@@ -10,24 +10,25 @@
 public final class BooleanDisposable : Cancelable {
 
     internal static let BooleanDisposableTrue = BooleanDisposable(isDisposed: true)
-    private var disposed = false
+    private let disposed: AtomicInt
     
     /// Initializes a new instance of the `BooleanDisposable` class
     public init() {
+        disposed = AtomicInt(0)
     }
     
     /// Initializes a new instance of the `BooleanDisposable` class with given value
     public init(isDisposed: Bool) {
-        self.disposed = isDisposed
+        self.disposed = AtomicInt(isDisposed ? 1 : 0)
     }
     
     /// - returns: Was resource disposed.
     public var isDisposed: Bool {
-        self.disposed
+        isFlagSet(self.disposed, 1)
     }
     
     /// Sets the status to disposed, which can be observer through the `isDisposed` property.
     public func dispose() {
-        self.disposed = true
+        fetchOr(self.disposed, 1)
     }
 }


### PR DESCRIPTION
`BooleanDisposable`s are typically used to create observables that check for disposal.

```swift
import Foundation
import RxSwift

let observable = Observable<Int>.create { observer in
  let disposable = BooleanDisposable()
  DispatchQueue.global().async {
    for i in 0..<10 {
      if disposable.isDisposed {
        break
      }
      sleep(1)
      observer.onNext(i)
    }
    observer.onCompleted()
  }
  return disposable
}
.debug()

let disposable = observable.subscribe(onNext: { val in
  print(val)
})

sleep(3)
disposable.dispose()

RunLoop.main.run()
```

Potential rase condition can occur in such use case that `BooleanDisposable.disposed` is written in one thread while concurrently checked in another.
<img width="1242" alt="Screen Shot 2022-04-30 at 14 12 31" src="https://user-images.githubusercontent.com/8158163/166094099-bd5529a9-5d04-4604-b479-1ac57b16e403.png">
<img width="1242" alt="Screen Shot 2022-04-30 at 14 12 26" src="https://user-images.githubusercontent.com/8158163/166094154-e0d25ceb-7941-46c2-a025-0b00631d00f3.png">

This PR adopts `AtomicInt` for `BooleanDisposable` (like all other disposables) to fix this issue.