### PR TITLE
Fixes issues of AsyncStream wrapper of Observables and related tests.

### DIFF
--- a/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-macOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-macOS.xcscheme
@@ -11,7 +11,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES">
       <Testables>
          <TestableReference

--- a/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-tvOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-tvOS.xcscheme
@@ -11,7 +11,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES">
       <Testables>
          <TestableReference

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Concurrency.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Concurrency.swift
@@ -29,12 +29,12 @@ public extension SharedSequence {
             let disposable = self.asObservable()
                 .subscribe(
                     onNext: { value in continuation.yield(value) },
-                    onCompleted: { continuation.finish() },
-                    onDisposed: { continuation.onTermination?(.cancelled) }
+                    onCompleted: { continuation.finish() }
                 )
-
-            continuation.onTermination = { @Sendable _ in
-                disposable.dispose()
+            continuation.onTermination = { @Sendable termination in
+                if termination == .cancelled {
+                    disposable.dispose()
+                }
             }
         }
     }

--- a/RxSwift/Traits/Infallible/Infallible+Concurrency.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Concurrency.swift
@@ -24,12 +24,12 @@ public extension InfallibleType {
         AsyncStream<Element> { continuation in
             let disposable = subscribe(
                 onNext: { value in continuation.yield(value) },
-                onCompleted: { continuation.finish() },
-                onDisposed: { continuation.onTermination?(.cancelled) }
+                onCompleted: { continuation.finish() }
             )
-
-            continuation.onTermination = { @Sendable _ in
-                disposable.dispose()
+            continuation.onTermination = { @Sendable termination in
+                if termination == .cancelled {
+                    disposable.dispose()
+                }
             }
         }
     }

--- a/Tests/RxCocoaTests/SharedSequence+ConcurrencyTests.swift
+++ b/Tests/RxCocoaTests/SharedSequence+ConcurrencyTests.swift
@@ -20,18 +20,26 @@ class SharedSequenceConcurrencyTests: RxTest {
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension SharedSequenceConcurrencyTests {
-    @MainActor func testAwaitsValuesAndFinishes() {
+    func testAwaitsValuesAndFinishes() async {
         let driver = Driver.from(1...10)
 
-        Task {
-            var values = [Int]()
+        var values = [Int]()
 
-            for await value in driver.values {
-                values.append(value)
-            }
-
-            XCTAssertEqual(values, Array(1...10))
+        for await value in await driver.values {
+            values.append(value)
         }
+
+        XCTAssertEqual(values, Array(1...10))
+    }
+    
+    func testCancellationWithoutEvents() async {
+        let driver = Driver<Void>.never()
+        Task {
+            for await _ in await driver.values {
+                //
+            }
+            XCTAssertTrue(Task.isCancelled)
+        }.cancel()
     }
 }
 #endif

--- a/Tests/RxSwiftTests/Infallible+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/Infallible+ConcurrencyTests.swift
@@ -19,21 +19,17 @@ class InfallibleConcurrencyTests: RxTest {
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension InfallibleConcurrencyTests {
-    func testAwaitsValuesAndFinishes() {
+    func testAwaitsValuesAndFinishes() async {
         let infallible = Infallible
             .from(1...10)
 
-        Task {
-            var values = [Int]()
+        var values = [Int]()
 
-            do {
-                for await value in infallible.values {
-                    values.append(value)
-                }
-
-                XCTAssertEqual(values, Array(1...10))
-            }
+        for await value in infallible.values {
+            values.append(value)
         }
+
+        XCTAssertEqual(values, Array(1...10))
     }
 }
 #endif

--- a/Tests/RxSwiftTests/Observable+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/Observable+ConcurrencyTests.swift
@@ -19,26 +19,24 @@ class ObservableConcurrencyTests: RxTest {
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension ObservableConcurrencyTests {
-    func testAwaitsValuesAndFinishes() {
+    func testAwaitsValuesAndFinishes() async {
         let observable = Observable
             .from(1...10)
 
-        Task {
-            var values = [Int]()
+        var values = [Int]()
 
-            do {
-                for try await value in observable.values {
-                    values.append(value)
-                }
-
-                XCTAssertEqual(values, Array(1...10))
-            } catch {
-                XCTFail("Expected to not emit failure")
+        do {
+            for try await value in observable.values {
+                values.append(value)
             }
+
+            XCTAssertEqual(values, Array(1...10))
+        } catch {
+            XCTFail("Expected to not emit failure")
         }
     }
 
-    func testAwaitsValuesAndErrors() {
+    func testAwaitsValuesAndErrors() async {
         let driver = Observable
             .from(1...10)
             .map { n -> Int in
@@ -49,17 +47,48 @@ extension ObservableConcurrencyTests {
                 return n
             }
 
-        Task {
-            var values = [Int]()
+        var values = [Int]()
 
-            do {
-                for try await value in driver.values {
-                    values.append(value)
-                }
-            } catch {
-                XCTAssertEqual(values, Array(1...5), "Expected to emit familure after 5 items")
+        do {
+            for try await value in driver.values {
+                values.append(value)
             }
+        } catch {
+            XCTAssertEqual(values, Array(1...5), "Expected to emit familure after 5 items")
         }
     }
+    
+    func testThrowsCancellationErrorWithoutEvents() async throws {
+        let observable = Observable<Void>.never()
+        Task {
+            do {
+                for try await _ in observable.values {
+                    //
+                }
+                XCTFail("Should not proceed beyond try")
+            } catch {
+                XCTAssertTrue(Task.isCancelled)
+                XCTAssertTrue(error is CancellationError)
+            }
+        }.cancel()
+    }
+
+    func testNotThrowingCancellation() async throws {
+        let observable = Observable.from(1...10)
+        let task = Task {
+            do {
+                var values = [Int]()
+                for try await value in observable.values {
+                    values.append(value)
+                }
+                XCTAssertTrue(values == Array(1...10))
+            } catch {
+                XCTFail("Should not throw CancellationError")
+            }
+        }
+        try await Task.sleep(nanoseconds: 1_000_000)
+        task.cancel()
+    }
+
 }
 #endif


### PR DESCRIPTION
I'm using `observable.values` to bridge `Observable`s into `AsyncStream`s in my app, but I found some issues in the related code and tests. This PR aims to adjust the following issues:

## 1. Tests wrapping `Task` return before firing the assertions.
```swift
func testAwaitsValuesAndFinishes() {
    Task {
		let observable = Observable
        	.from(1...10)
        var values = [Int]()
        do {
            for try await value in observable.values {
                values.append(value)
            }
            XCTAssertEqual(values, Array(1...10))
        } catch {
            XCTFail("Expected to not emit failure")
        }
    }
}
```

`Task.init` schedules a concurrent job and returns immediately. Tests wrapping `Task` are likely to have no chance to fire the assertions inside the operation closures before the functions return.

This PR modifies these tests to use [Asynchronous Tests](https://developer.apple.com/documentation/xctest/asynchronous_tests_and_expectations) as recommended by Apple.

Thread sanitizer on **framework test targets** seems to be problematic and reports false positives on Swift Concurrency 
 code, especially when actors being used.

For example, the following obviously correct tests can trigger false positives with thread sanitizer turned on:
(Target platform: macOS, Xcode: 13.2.1/13.3.1)
```swift
import XCTest

class TestFrameworkTests: XCTestCase {

  @MainActor func testEample() async {
    // Do nothing here...
  }

}
```

```swift
import XCTest

actor MyActor {
  var values = [Int]()
  func append(_ value: Int) {
    values.append(value)
  }
}

class TestFrameworkTests: XCTestCase {

  func testEample() async {
    let myActor = MyActor()
    await withTaskGroup(of: Void.self) { group in
      group.addTask {
        for i in 0..<10 {
          await myActor.append(i)
        }
      }
    }
    let value = await myActor.values
    XCTAssertEqual(value, [Int](0..<10))
  }

}
```

This PR turns off the thread sanitizer to ensure tests pass. It's a compromised solution and I'm wondering if it's better to move Swift Concurrency related code to separate targets with the TSan off.

## 2. Subscriptions inside `AsyncStream`s block the cooperative queue.
`AsyncStream`s doesn't by default establish a `Task` environment. Long-running work can block the cooperative queue and  
 `continuation.yield(_:)` has no chance to switch to awaiting thread. Async results have to be queued until the entire observable is disposed.
```swift
import Foundation
import RxSwift

let observable = Observable<Int>.create { observer in
  let disposable = Disposables.create()
  for i in 0..<5 {
    sleep(1)
    observer.onNext(i)
  }
  observer.onCompleted()
  return disposable
}
.debug()

let task = Task {
  do {
    for try await val in observable.values {
      print(val)
    }
  } catch {
    print(error)
  }
}

RunLoop.main.run()
```
<details>
<summary>Output</summary>
<pre>
2022-05-04 15:01:27.736: main.swift:17 (TestRxSwift) -> subscribed
2022-05-04 15:01:28.746: main.swift:17 (TestRxSwift) -> Event next(0)
2022-05-04 15:01:29.752: main.swift:17 (TestRxSwift) -> Event next(1)
2022-05-04 15:01:30.758: main.swift:17 (TestRxSwift) -> Event next(2)
2022-05-04 15:01:31.763: main.swift:17 (TestRxSwift) -> Event next(3)
2022-05-04 15:01:32.767: main.swift:17 (TestRxSwift) -> Event next(4)
2022-05-04 15:01:32.767: main.swift:17 (TestRxSwift) -> Event completed
2022-05-04 15:01:32.767: main.swift:17 (TestRxSwift) -> isDisposed
0
1
2
3
4
</pre>
</details>
<img width="1373" alt="Screen Shot 2022-05-04 at 15 06 42" src="https://user-images.githubusercontent.com/8158163/166642918-27f4b854-d25a-4e03-8c3f-080e6396ae63.png">

It's reasonable for `AsyncStream`s to start a new `Task` inside its continuation to prevent blocking the cooperative queue. This PR wraps subscriptions inside `AsyncStream`s with a `Task`.
<details>
<summary>Output</summary>
<pre>
2022-05-04 15:24:20.040: main.swift:17 (TestRxSwift) -> subscribed
2022-05-04 15:24:21.050: main.swift:17 (TestRxSwift) -> Event next(0)
0
2022-05-04 15:24:22.053: main.swift:17 (TestRxSwift) -> Event next(1)
1
2022-05-04 15:24:23.058: main.swift:17 (TestRxSwift) -> Event next(2)
2
2022-05-04 15:24:24.061: main.swift:17 (TestRxSwift) -> Event next(3)
3
2022-05-04 15:24:25.067: main.swift:17 (TestRxSwift) -> Event next(4)
2022-05-04 15:24:25.067: main.swift:17 (TestRxSwift) -> Event completed
2022-05-04 15:24:25.067: main.swift:17 (TestRxSwift) -> isDisposed
4
</pre>
</details>

## 3. Reentrancy of `disposable.dispose()` and `continuation.onTermination` on subscription disposal.
AsyncStream calls `continuation.onTermination` **both on completion and cancellation**. The current subscription in `Observable.values` might call `disposable.dispose()` and `continuation.onTermination` twice.

This PR removes `onDisposed` on the subscriptions inside `AsyncStream`s and add extra checks for `AsyncStream.Continuation.Termination` to only dispose the disposable on cancellation. This ensures `disposable.dispose()` and `continuation.onTermination` are only invoked once.