### PR TITLE
Change SingleEvent to Result<Element, Swift.Error>

### DIFF
--- a/Documentation/Traits.md
+++ b/Documentation/Traits.md
@@ -69,14 +69,14 @@ func getRepo(_ repo: String) -> Single<[String: Any]> {
     return Single<[String: Any]>.create { single in
         let task = URLSession.shared.dataTask(with: URL(string: "https://api.github.com/repos/\(repo)")!) { data, _, error in
             if let error = error {
-                single(.error(error))
+                single(.failure(error))
                 return
             }
 
             guard let data = data,
                   let json = try? JSONSerialization.jsonObject(with: data, options: .mutableLeaves),
                   let result = json as? [String: Any] else {
-                single(.error(DataError.cantParseJSON))
+                single(.failure(DataError.cantParseJSON))
                 return
             }
 
@@ -98,7 +98,7 @@ getRepo("ReactiveX/RxSwift")
         switch event {
             case .success(let json):
                 print("JSON: ", json)
-            case .error(let error):
+            case .failure(let error):
                 print("Error: ", error)
         }
     }
@@ -117,7 +117,7 @@ getRepo("ReactiveX/RxSwift")
     .disposed(by: disposeBag)
 ```
 
-The subscription provides a `SingleEvent` enumeration which could be either `.success` containing a element of the Single's type, or `.error`. No further events would be emitted beyond the first one.
+The subscription uses Swift `Result` enumeration which could be either `.success` containing an element of the Single's type, or `.failure` containing an error. No further events would be emitted beyond the first one.
 
 It's also possible using `.asSingle()` on a raw Observable sequence to transform it into a Single.
 


### PR DESCRIPTION
Change SingleEvent to Result<Element, Swift.Error> to match the changes in RxSwift v6