### PR TITLE
Relax constraint for convenient distinctUntilChanged operator on InfallibleType

### DIFF
--- a/RxSwift/Traits/Infallible/Infallible+Operators.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Operators.swift
@@ -158,7 +158,7 @@ extension InfallibleType {
 
 // MARK: - Distinct
 
-extension InfallibleType where Element: Comparable {
+extension InfallibleType where Element: Equatable {
     /**
      Returns an observable sequence that contains only distinct contiguous elements according to equality operator.
 


### PR DESCRIPTION
Please correct me if this is wrong to do. But at first sight looks like a typo, because all other `distinctUntilChanged()` are available on types that only conform to `Equatable`