### PR TITLE
Fix for value leaks its continuation

### DIFF
--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
@@ -41,8 +41,7 @@ public extension PrimitiveSequenceType where Trait == SingleTrait {
                                     continuation.resume(throwing: $0)
                                 },
                                 onDisposed: {
-                                    // Check if continuation was resumed.
-                                    // Otherwise fatal error could be thrown:
+                                    // Check if continuation was resumed otherwise fatal error could be thrown:
                                     //  - Fatal error: SWIFT TASK CONTINUATION MISUSE: value tried to resume its continuation more than once, throwing CancellationError()!
                                     guard !didResume else { return }
                                     continuation.resume(throwing: CancellationError())
@@ -96,13 +95,12 @@ public extension PrimitiveSequenceType where Trait == MaybeTrait {
                                     continuation.resume(throwing: error)
                                 },
                                 onCompleted: {
-                                    didResume = true
                                     guard !didEmit else { return }
+                                    didResume = true
                                     continuation.resume(returning: nil)
                                 },
                                 onDisposed: {
-                                    // Check if continuation was resumed.
-                                    // Otherwise fatal error could be thrown:
+                                    // Check if continuation was resumed otherwise fatal error could be thrown:
                                     //  - Fatal error: SWIFT TASK CONTINUATION MISUSE: value tried to resume its continuation more than once, throwing CancellationError()!
                                     guard !didResume else { return }
                                     continuation.resume(throwing: CancellationError())

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
@@ -41,8 +41,6 @@ public extension PrimitiveSequenceType where Trait == SingleTrait {
                                     continuation.resume(throwing: $0)
                                 },
                                 onDisposed: {
-                                    // Check if continuation was resumed otherwise fatal error could be thrown:
-                                    //  - Fatal error: SWIFT TASK CONTINUATION MISUSE: value tried to resume its continuation more than once, throwing CancellationError()!
                                     guard !didResume else { return }
                                     continuation.resume(throwing: CancellationError())
                                 }
@@ -100,8 +98,6 @@ public extension PrimitiveSequenceType where Trait == MaybeTrait {
                                     continuation.resume(returning: nil)
                                 },
                                 onDisposed: {
-                                    // Check if continuation was resumed otherwise fatal error could be thrown:
-                                    //  - Fatal error: SWIFT TASK CONTINUATION MISUSE: value tried to resume its continuation more than once, throwing CancellationError()!
                                     guard !didResume else { return }
                                     continuation.resume(throwing: CancellationError())
                                 }
@@ -151,9 +147,6 @@ public extension PrimitiveSequenceType where Trait == CompletableTrait, Element 
                                     continuation.resume(throwing: error)
                                 },
                                 onDisposed: {
-                                    // Check if continuation was resumed.
-                                    // Otherwise fatal error could be thrown:
-                                    //  - Fatal error: SWIFT TASK CONTINUATION MISUSE: value tried to resume its continuation more than once, throwing CancellationError()!
                                     guard !didResume else { return }
                                     continuation.resume(throwing: CancellationError())
                                 }

--- a/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
@@ -50,6 +50,7 @@ extension PrimitiveSequenceConcurrencyTests {
                 try await single.value
                 XCTFail("Should not proceed beyond try")
             } catch {
+                XCTAssertTrue(Task.isCancelled)
                 XCTAssertTrue(error is CancellationError)
             }
         }.cancel()
@@ -118,6 +119,7 @@ extension PrimitiveSequenceConcurrencyTests {
                 try await maybe.value
                 XCTFail("Should not proceed beyond try")
             } catch {
+                XCTAssertTrue(Task.isCancelled)
                 XCTAssertTrue(error is CancellationError)
             }
         }.cancel()
@@ -186,6 +188,7 @@ extension PrimitiveSequenceConcurrencyTests {
                 try await completable.value
                 XCTFail()
             } catch {
+                XCTAssertTrue(Task.isCancelled)
                 XCTAssertTrue(error is CancellationError)
             }
         }.cancel()

--- a/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
@@ -42,7 +42,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }
     }
 
-    func testSingleThrowsCancellationErrorWhenParentTaskIsCancelledButNoEventIsProduced() async throws {
+    func testSingleThrowsCancellationWithoutEvents() async throws {
         let single = Single<Void>.never()
 
         Task {
@@ -56,7 +56,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }.cancel()
     }
 
-    func testSingleDoesntThrowCancellationErrorWhenParentTaskIsCancelled() async throws {
+    func testSingleNotThrowingCancellation() async throws {
         let single = Single.just(())
 
         let task = Task {
@@ -111,7 +111,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }
     }
 
-    func testMaybeThrowsCancellationErrorWhenParentTaskIsCancelledButNoEventIsProduced() async throws {
+    func testMaybeThrowsCancellationWithoutEvents() async throws {
         let maybe = Maybe<Void>.never()
 
         Task {
@@ -125,7 +125,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }.cancel()
     }
 
-    func testMaybeDoesntThrowCancellationErrorWhenParentTaskIsCancelledButMaybeCompleted() async throws {
+    func testMaybeNotThrowingCancellationWhenCompleted() async throws {
         let maybe = Maybe<Int>.empty()
 
         Task {
@@ -138,7 +138,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }.cancel()
     }
 
-    func testMaybeDoesntThrowCancellationErrorWhenParentTaskIsCancelled() async throws {
+    func testMaybeNotThrowingCancellation() async throws {
         let maybe = Maybe.just(())
 
         let task = Task {
@@ -180,7 +180,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }
     }
 
-    func testCompletableThrowsCancellationErrorWhenParentTaskIsCancelledButCompletableDidNotComplete() async throws {
+    func testCompletableThrowsCancellationWithoutEvents() async throws {
         let completable = Completable.never()
 
         Task {
@@ -194,7 +194,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }.cancel()
     }
 
-    func testCompletableDoesntThrowCancellationErrorWhenParentTaskIsCancelledButCompletableCompleted() async throws {
+    func testCompletableNotThrowingCancellation() async throws {
         let completable = Completable.empty()
 
         Task {

--- a/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
@@ -41,6 +41,36 @@ extension PrimitiveSequenceConcurrencyTests {
             XCTAssertTrue(true)
         }
     }
+
+    func testSingleThrowCancellationErrorWhenParentTaskIsCancelledButNoEventIsProduced() async throws {
+        let single = Single<Void>.never()
+
+        Task {
+            do {
+                try await single.value
+                XCTFail("Should not proceed beyond try")
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+            }
+        }.cancel()
+    }
+
+    func testSingleDoesntThrowCancellationErrorWhenParentTaskIsCancelled() async throws {
+        let single = Single.just(())
+
+        let task = Task {
+            do {
+                try await single.value
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail()
+            }
+        }
+
+        try await Task.sleep(nanoseconds: 1_000_000)
+        task.cancel()
+    }
+
 }
 
 // MARK: - Maybe
@@ -79,6 +109,48 @@ extension PrimitiveSequenceConcurrencyTests {
             XCTAssertTrue(true)
         }
     }
+
+    func testMaybeThrowCancellationErrorWhenParentTaskIsCancelledButNoEventIsProduced() async throws {
+        let maybe = Maybe<Void>.never()
+
+        Task {
+            do {
+                try await maybe.value
+                XCTFail("Should not proceed beyond try")
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+            }
+        }.cancel()
+    }
+
+    func testMaybeDoesntThrowCancellationErrorWhenParentTaskIsCancelledButMaybeCompleted() async throws {
+        let maybe = Maybe<Int>.empty()
+
+        Task {
+            do {
+                let value = try await maybe.value
+                XCTAssertNil(value)
+            } catch {
+                XCTFail("Should not throw an error")
+            }
+        }.cancel()
+    }
+
+    func testMaybeDoesntThrowCancellationErrorWhenParentTaskIsCancelled() async throws {
+        let maybe = Maybe.just(())
+
+        let task = Task {
+            do {
+                try await maybe.value
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail("Should not throw an error")
+            }
+        }
+
+        try await Task.sleep(nanoseconds: 1_000_000)
+        task.cancel()
+    }
 }
 
 // MARK: - Completable
@@ -104,6 +176,32 @@ extension PrimitiveSequenceConcurrencyTests {
         } catch {
             XCTAssertTrue(true)
         }
+    }
+
+    func testCompletableThrowsCancellationErrorWhenParentTaskIsCancelledButCompletableDidNotComplete() async throws {
+        let completable = Completable.never()
+
+        Task {
+            do {
+                try await completable.value
+                XCTFail()
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+            }
+        }.cancel()
+    }
+
+    func testCompletableDoesntThrowCancellationErrorWhenParentTaskIsCancelledButCompletableCompleted() async throws {
+        let completable = Completable.empty()
+
+        Task {
+            do {
+                try await completable.value
+                XCTAssertTrue(true)
+            } catch {
+                XCTFail("Should not throw an error")
+            }
+        }.cancel()
     }
 }
 #endif

--- a/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
@@ -42,7 +42,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }
     }
 
-    func testSingleThrowCancellationErrorWhenParentTaskIsCancelledButNoEventIsProduced() async throws {
+    func testSingleThrowsCancellationErrorWhenParentTaskIsCancelledButNoEventIsProduced() async throws {
         let single = Single<Void>.never()
 
         Task {
@@ -111,7 +111,7 @@ extension PrimitiveSequenceConcurrencyTests {
         }
     }
 
-    func testMaybeThrowCancellationErrorWhenParentTaskIsCancelledButNoEventIsProduced() async throws {
+    func testMaybeThrowsCancellationErrorWhenParentTaskIsCancelledButNoEventIsProduced() async throws {
         let maybe = Maybe<Void>.never()
 
         Task {


### PR DESCRIPTION
This PR contains a fix for Swift task continuation misuse where value leaks its continuation. #2426 