### PR TITLE
Modify the closure argument of subscribe to InfallibleEvent

### DIFF
--- a/RxCocoa/Common/Infallible+Bind.swift
+++ b/RxCocoa/Common/Infallible+Bind.swift
@@ -17,8 +17,8 @@ extension InfallibleType {
      - returns: Disposable object that can be used to unsubscribe the observers.
      */
     public func bind<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element {
-        self.subscribe { event in
-            observers.forEach { $0.on(event) }
+        self.subscribe { infallibleEvent in
+            observers.forEach { $0.on(infallibleEvent.event) }
         }
     }
 
@@ -31,8 +31,8 @@ extension InfallibleType {
      */
     public func bind<Observer: ObserverType>(to observers: Observer...) -> Disposable where Observer.Element == Element? {
         self.map { $0 as Element? }
-            .subscribe { event in
-                observers.forEach { $0.on(event) }
+            .subscribe { infallibleEvent in
+                observers.forEach { $0.on(infallibleEvent.event) }
             }
     }
 

--- a/RxSwift/Traits/Infallible/Infallible+Create.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Create.swift
@@ -42,3 +42,14 @@ extension Infallible {
         return Infallible(source)
     }
 }
+
+extension InfallibleEvent: EventConvertible {
+    public var event: Event<Element> {
+        switch self {
+        case let .next(element):
+            return .next(element)
+        case .completed:
+            return .completed
+        }
+    }
+}

--- a/RxSwift/Traits/Infallible/Infallible.swift
+++ b/RxSwift/Traits/Infallible/Infallible.swift
@@ -86,7 +86,17 @@ extension InfallibleType {
      - parameter on: Action to invoke for each event in the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(_ on: @escaping (Event<Element>) -> Void) -> Disposable {
-        self.asObservable().subscribe(on)
+    public func subscribe(_ on: @escaping (InfallibleEvent<Element>) -> Void) -> Disposable {
+        let eventHandler: ((Event<Element>) -> Void) = { event in
+            switch event {
+            case .next(let element):
+                on(.next(element))
+            case .completed:
+                on(.completed)
+            case .error(let error):
+                rxFatalErrorInDebug("Infallible must never emit a error event. error: \(error)")
+            }
+        }
+        return self.asObservable().subscribe(eventHandler)
     }
 }


### PR DESCRIPTION
`Infallible` ensures that it does not fail, but `Event` in the `subscribe` method have an error case.
This is not in line with `Infallible`'s implementation intentions.

Modified the closure argument of `subscribe` to `InfallibleEvent` and modified the associated logics as well.