### PR TITLE
Table/CollectionViewDelegateProxy crash workaround

### DIFF
--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		4C8DE0E220D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E320D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
 		4C8DE0E420D54545003E2D8A /* DisposeBagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */; };
+		5039386128CB6479003A0ACC /* RxDelegateProxyCrashFix.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5039386028CB6479003A0ACC /* RxDelegateProxyCrashFix.swift */; };
 		504540C924196D960098665F /* WKWebView+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540C824196D960098665F /* WKWebView+Rx.swift */; };
 		504540CB24196EB10098665F /* WKWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CA24196EB10098665F /* WKWebView+RxTests.swift */; };
 		504540CC24196EB10098665F /* WKWebView+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504540CA24196EB10098665F /* WKWebView+RxTests.swift */; };
@@ -968,6 +969,7 @@
 		4C5213A9225D41E60079FC77 /* CompactMap.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompactMap.swift; sourceTree = "<group>"; };
 		4C5213AB225E20350079FC77 /* Observable+CompactMapTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+CompactMapTests.swift"; sourceTree = "<group>"; };
 		4C8DE0E120D54545003E2D8A /* DisposeBagTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisposeBagTest.swift; sourceTree = "<group>"; };
+		5039386028CB6479003A0ACC /* RxDelegateProxyCrashFix.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RxDelegateProxyCrashFix.swift; sourceTree = "<group>"; };
 		504540C824196D960098665F /* WKWebView+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+Rx.swift"; sourceTree = "<group>"; };
 		504540CA24196EB10098665F /* WKWebView+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WKWebView+RxTests.swift"; sourceTree = "<group>"; };
 		504540CD2419701D0098665F /* RxWKNavigationDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxWKNavigationDelegateProxy.swift; sourceTree = "<group>"; };
@@ -2312,6 +2314,7 @@
 				D9080ACD1EA05A16002B433B /* RxNavigationControllerDelegateProxy.swift */,
 				504540CD2419701D0098665F /* RxWKNavigationDelegateProxy.swift */,
 				A520FFFB1F0D291500573734 /* RxPickerViewDataSourceProxy.swift */,
+				5039386028CB6479003A0ACC /* RxDelegateProxyCrashFix.swift */,
 			);
 			path = Proxies;
 			sourceTree = "<group>";
@@ -3108,6 +3111,7 @@
 				504540C924196D960098665F /* WKWebView+Rx.swift in Sources */,
 				DB08833726FB0637005805BE /* SharedSequence+Concurrency.swift in Sources */,
 				C89AB1731DAAC1680065FBE6 /* ControlTarget.swift in Sources */,
+				5039386128CB6479003A0ACC /* RxDelegateProxyCrashFix.swift in Sources */,
 				C882541B1B8A752B00B02D69 /* RxTableViewDataSourceType.swift in Sources */,
 				B5624794203532F500D3EE75 /* RxTableViewDataSourcePrefetchingProxy.swift in Sources */,
 			);

--- a/RxCocoa/iOS/Proxies/RxDelegateProxyCrashFix.swift
+++ b/RxCocoa/iOS/Proxies/RxDelegateProxyCrashFix.swift
@@ -1,0 +1,30 @@
+//
+//  RxDelegateProxyCrashFix.swift
+//  RxCocoa
+//
+//  Created by SlashDevSlashGnoll (SlashDevSlashGnoll@users.noreply.github.com) on 9/9/22.
+//  Copyright © 2022 Krunoslav Zaher. All rights reserved.
+//
+
+import Foundation
+
+
+// This extension exists solely to get around a crash found on iOS 15.4+ where a `text`
+// method invocation is being sent to the RxCollectionViewDelegateProxy which doesn't implement it.
+// This is tracked at this bug: https://github.com/ReactiveX/RxSwift/issues/2428 This can be
+// removed if/when the actual source of the problem is found
+@objc extension RxCollectionViewDelegateProxy {
+    var text: String {
+        return String()
+    }
+}
+
+// This extension exists solely to get around a crash found on iOS 15.4+ where a `text`
+// method invocation is being sent to the RxTableViewDelegateProxy which doesn't implement it.
+// This is tracked at this bug: https://github.com/ReactiveX/RxSwift/issues/2428 This can be
+//removed if/when the actual source of the problem is found
+@objc extension RxTableViewDelegateProxy {
+    var text: String {
+        return String()
+    }
+}


### PR DESCRIPTION
This PR implements the workaround for the crash discussed at https://github.com/ReactiveX/RxSwift/issues/2428 as requested by @freak4pc 

I put the extensions in a separate file to make later removal simple as this isn't expected to stay permanently.   I didn't add any tests as we do not know the actual source of the problem/bug at this time however existing tests passed without issue.