### PR TITLE
Remove print("Subscription") not supposed to exist in Getting Started document

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -444,15 +444,11 @@ let subscription1 = counter
     .subscribe(onNext: { n in
         print("First \(n)")
     })
-    
-print("Subscribed")
 
 let subscription2 = counter
     .subscribe(onNext: { n in
         print("Second \(n)")
     })
-    
-print("Subscribed")
 
 Thread.sleep(forTimeInterval: 0.5)
 


### PR DESCRIPTION
in [Getting Started document's creating-an-observable-that-performs-work](https://github.com/Neph3779/RxSwift/blob/main/Documentation/GettingStarted.md#creating-an-observable-that-performs-work)



448 line and 455 line is calling print("Subscribed")
so print log should print "Subscribed" 4 times
(2 times for calling MyInterval, 2 time for 448 line and 455 line)

I think you forgot to remove 448, 455 line when wrote this document

It might be confusing for beginners like me, so can you remove 448, 455 line or fix print log?

### in conclusion

```swift
let counter = myInterval(.milliseconds(100))

print("Started ----")

let subscription1 = counter
    .subscribe(onNext: { n in
        print("First \(n)")
    })
    
print("Subscribed")

let subscription2 = counter
    .subscribe(onNext: { n in
        print("Second \(n)")
    })
    
print("Subscribed")

Thread.sleep(forTimeInterval: 0.5)

subscription1.dispose()

print("Disposed")

Thread.sleep(forTimeInterval: 0.5)

subscription2.dispose()

print("Disposed")

print("Ended ----")
```

output of this code should be

```
Started ----
Subscribed
Subscribed
Subscribed
Subscribed
First 0
Second 0
First 1
Second 1
First 2
Second 2
First 3
Second 3
First 4
Second 4
Disposed
Second 5
Second 6
Second 7
Second 8
Second 9
Disposed
Ended ----
```

so I recommend to change code like this

```swift
let counter = myInterval(.milliseconds(100))

print("Started ----")

let subscription1 = counter
    .subscribe(onNext: { n in
        print("First \(n)")
    })
    
// remove this line

let subscription2 = counter
    .subscribe(onNext: { n in
        print("Second \(n)")
    })
    
// remove this line

Thread.sleep(forTimeInterval: 0.5)

subscription1.dispose()

print("Disposed")

Thread.sleep(forTimeInterval: 0.5)

subscription2.dispose()

print("Disposed")

print("Ended ----")
```
