### PR TITLE
OSX -> macOS, OSXApplicationExtension -> macOSApplicationExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-Use `AtomicInt` for `BooleanDisposable`s to prevent potential rase condition. #2419
+* Use `AtomicInt` for `BooleanDisposable`s to prevent potential rase condition. #2419
+* Renames 'OSX' to 'macOS' in Availability Check.
+* Renames 'OSXApplicationExtension' to 'macOSApplicationExtension' in Availability Check.
 
 ## 6.5.0
 

--- a/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxWKNavigationDelegateProxy.swift
@@ -11,7 +11,7 @@
 import RxSwift
 import WebKit
 
-@available(iOS 8.0, OSX 10.10, OSXApplicationExtension 10.10, *)
+@available(iOS 8.0, macOS 10.10, macOSApplicationExtension 10.10, *)
 open class RxWKNavigationDelegateProxy
     : DelegateProxy<WKWebView, WKNavigationDelegate>
     , DelegateProxyType {
@@ -39,7 +39,7 @@ open class RxWKNavigationDelegateProxy
     }
 }
 
-@available(iOS 8.0, OSX 10.10, OSXApplicationExtension 10.10, *)
+@available(iOS 8.0, macOS 10.10, macOSApplicationExtension 10.10, *)
 extension RxWKNavigationDelegateProxy: WKNavigationDelegate {}
 
 #endif

--- a/RxCocoa/iOS/WKWebView+Rx.swift
+++ b/RxCocoa/iOS/WKWebView+Rx.swift
@@ -11,7 +11,7 @@
 import RxSwift
 import WebKit
 
-@available(iOS 8.0, OSX 10.10, OSXApplicationExtension 10.10, *)
+@available(iOS 8.0, macOS 10.10, macOSApplicationExtension 10.10, *)
 extension Reactive where Base: WKWebView {
     
     /// Reactive wrapper for `navigationDelegate`.

--- a/RxExample/Extensions/CLLocationManager+Rx.swift
+++ b/RxExample/Extensions/CLLocationManager+Rx.swift
@@ -114,7 +114,7 @@ extension Reactive where Base: CLLocationManager {
     /**
     Reactive wrapper for `delegate` message.
     */
-    @available(OSX 10.10, *)
+    @available(macOS 10.10, *)
     public var didDetermineStateForRegion: Observable<(state: CLRegionState, region: CLRegion)> {
         return delegate.methodInvoked(#selector(CLLocationManagerDelegate.locationManager(_:didDetermineState:for:)))
             .map { a in

--- a/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest+WebKit.swift
@@ -13,14 +13,14 @@ import WebKit
 @testable import RxSwift
 import XCTest
 
-@available(iOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, macOSApplicationExtension 10.10, *)
 extension DelegateProxyTest {
     func test_WKNavigaionDelegateExtension() {
         performDelegateTest(WKNavigationWebViewSubclass(frame: CGRect.zero)) { ExtendWKNavigationDelegateProxy(webViewSubclass: $0) }
     }
 }
 
-@available(iOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, macOSApplicationExtension 10.10, *)
 final class ExtendWKNavigationDelegateProxy
     : RxWKNavigationDelegateProxy
     , TestDelegateProtocol {
@@ -29,7 +29,7 @@ final class ExtendWKNavigationDelegateProxy
     }
 }
 
-@available(iOS 8.0, OSX 10.10, OSXApplicationExtension 10.10, *)
+@available(iOS 8.0, macOS 10.10, macOSApplicationExtension 10.10, *)
 final class WKNavigationWebViewSubclass: WKWebView, TestDelegateControl {
     func doThatTest(_ value: Int) {
         (navigationDelegate as! TestDelegateProtocol).testEventHappened?(value)
@@ -48,7 +48,7 @@ final class WKNavigationWebViewSubclass: WKWebView, TestDelegateControl {
 
 // MARK: Mocks
 
-@available(iOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, macOSApplicationExtension 10.10, *)
 extension MockTestDelegateProtocol
     : WKNavigationDelegate
 {

--- a/Tests/RxCocoaTests/WKWebView+RxTests.swift
+++ b/Tests/RxCocoaTests/WKWebView+RxTests.swift
@@ -14,7 +14,7 @@ import RxSwift
 import RxBlocking
 import XCTest
 
-@available(iOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, macOSApplicationExtension 10.10, *)
 final class WKWebViewTests: RxTest {
     
     override func setUp() {
@@ -95,7 +95,7 @@ final class WKWebViewTests: RxTest {
 // MARK: - Test Helpers
 // Any WKNavigation object manually created on dealloc crashes the program.
 // This class overrides the deinit method of the WKNavition to avoid crashes.
-@available(iOS 10.0, OSXApplicationExtension 10.10, *)
+@available(iOS 10.0, macOSApplicationExtension 10.10, *)
 private class SafeWKNavigation: WKNavigation {
     static func toggleSafeDealloc() {
         guard let current_original = class_getInstanceMethod(SafeWKNavigation.self, NSSelectorFromString("dealloc")),


### PR DESCRIPTION
* Renames 'OSX' to 'macOS' in Availability Check.
* Renames 'OSXApplicationExtension' to 'macOSApplicationExtension' in Availability Check.