### PR TITLE
Adding XCTAssertEqual methods for Void streams

### DIFF
--- a/RxTest/Event+Equatable.swift
+++ b/RxTest/Event+Equatable.swift
@@ -47,6 +47,25 @@ internal func equals<Element: Equatable>(lhs: Event<Element?>, rhs: Event<Elemen
     }
 }
 
+internal func equals(lhs: Event<Void>, rhs: Event<Void>) -> Bool {
+    switch (lhs, rhs) {
+    case (.completed, .completed): return true
+    case let (.error(e1), .error(e2)):
+        #if os(Linux)
+        return  "\(e1)" == "\(e2)"
+        #else
+        let error1 = e1 as NSError
+        let error2 = e2 as NSError
+
+        return error1.domain == error2.domain
+            && error1.code == error2.code
+            && "\(e1)" == "\(e2)"
+        #endif
+    case (.next, .next): return true
+    default: return false
+    }
+}
+
 internal func equals<Element: Equatable>(lhs: SingleEvent<Element>, rhs: SingleEvent<Element>) -> Bool {
     switch (lhs, rhs) {
     case let (.failure(e1), .failure(e2)):
@@ -84,6 +103,25 @@ internal func equals<Element: Equatable>(lhs: MaybeEvent<Element>, rhs: MaybeEve
     }
 }
 
+internal func equals(lhs: MaybeEvent<Void>, rhs: MaybeEvent<Void>) -> Bool {
+    switch (lhs, rhs) {
+    case (.completed, .completed): return true
+    case let (.error(e1), .error(e2)):
+        #if os(Linux)
+        return  "\(e1)" == "\(e2)"
+        #else
+        let error1 = e1 as NSError
+        let error2 = e2 as NSError
+
+        return error1.domain == error2.domain
+            && error1.code == error2.code
+            && "\(e1)" == "\(e2)"
+        #endif
+    case (.success, .success): return true
+    default: return false
+    }
+}
+
 /// Compares two `CompletableEvent` events.
 ///
 /// In case `Error` events are being compared, they are equal in case their `NSError` representations are equal (domain and code)
@@ -114,8 +152,20 @@ extension Event: Equatable where Element: Equatable {
     }
 }
 
+public extension Event where Element == Void {
+    static func == (lhs: Event<Element>, rhs: Event<Element>) -> Bool {
+        equals(lhs: lhs, rhs: rhs)
+    }
+}
+
 extension MaybeEvent: Equatable where Element: Equatable {
     public static func == (lhs: MaybeEvent<Element>, rhs: MaybeEvent<Element>) -> Bool {
+        equals(lhs: lhs, rhs: rhs)
+    }
+}
+
+public extension MaybeEvent where Element == Void {
+    static func == (lhs: MaybeEvent<Element>, rhs: MaybeEvent<Element>) -> Bool {
         equals(lhs: lhs, rhs: rhs)
     }
 }

--- a/RxTest/Recorded+Event.swift
+++ b/RxTest/Recorded+Event.swift
@@ -20,6 +20,15 @@ extension Recorded {
     public static func next<T>(_ time: TestTime, _ element: T) -> Recorded<Event<T>> where Value == Event<T> {
         Recorded(time: time, value: .next(element))
     }
+
+    /**
+     Factory method for a `.next` event recorded at a given time.
+     - parameter time: Recorded virtual time the `.next` event occurs.
+     - returns: Recorded event in time.
+     */
+    public static func next(_ time: TestTime) -> Recorded<Value> where Value == Event<Void> {
+        return Recorded<Value>(time: time, value: .next(()))
+    }
     
     /**
      Factory method for an `.completed` event recorded at a given time.

--- a/RxTest/Recorded.swift
+++ b/RxTest/Recorded.swift
@@ -37,3 +37,15 @@ extension Recorded: Equatable where Value: Equatable {
         lhs.time == rhs.time && lhs.value == rhs.value
     }
 }
+
+public extension Recorded where Value == Event<Void> {
+    static func == (lhs: Recorded<Value>, rhs: Recorded<Value>) -> Bool {
+        lhs.time == rhs.time && lhs.value == rhs.value
+    }
+}
+
+public extension Recorded where Value == MaybeEvent<Void> {
+    static func == (lhs: Recorded<Value>, rhs: Recorded<Value>) -> Bool {
+        lhs.time == rhs.time && lhs.value == rhs.value
+    }
+}


### PR DESCRIPTION
This addresses https://github.com/ReactiveX/RxSwift/issues/1552.

It basically treats `next` events on streams with `Void` as element as if they were the same.

I am aware there was [another PR addressing this](https://github.com/ReactiveX/RxSwift/pull/1747) which got closed, however I do think it is worth raising the discussion again and updating the PR to include `Maybe` and `Single` streams as well.

The reasons I believe it is worth revisiting the original stance on this is twofold:
- There's been somewhat a trend in the Swift community (or even the Developer community for that matter) to use Tests as documentation, having that in mind using the [current workarounds](https://github.com/ReactiveX/RxSwift/pull/1747#issuecomment-501105465) might not be as readable as if we treated `Void` as if they were `Equatable`, e.g:
```swift
// less readable, might raise confusion to other developers/new joiners of why mapping values

let observer = scheduler.createObserver(Bool.self)

anyVoidOutputs
    .map { true }
    .bind(to: observer)

let expected: [Recorded<Event<Bool>>] = [
    .next(TestScheduler.Defaults.subscribed, true)
]

XCTAssertEqual(observer.events, expected)

// more readable (IMHO)
let observer = scheduler.start { anyVoidOutputs }
let expected: [Recorded<Event<Void>>] = [
    .next(TestScheduler.Defaults.subscribed)
]

XCTAssertEqual(observer.events, expected)
```
- As mentioned, there might be a day where the Core Swift team might decide to implement `Equatable` conformance to `Void`, however that will probably be limited to whatever Swift version that is introduced and won't be backwards compatible so we would lock-out library consumers of this nicer API until they are able to update to the latest Swift version. If we go ahead with merging this PR, we can then add `#if swift()` macros around these `Void` stream implementations so they do not clash with the `Equatable` implementations.

With that said, it might not be much of an issue to most people that use this library, but that might be due to the fact that tests are usually neglected (don't usually follow the same strict guidelines as "production" code, or worst, not implemented at all), at least that has been my previous experience, so any opportunity to make testing a bit easier might contribute to a future with more reliable software (one can hope 😂).