### PR TITLE
RxTest: Comparing failure case in XCTAssertEqual for SingleEvent

### DIFF
--- a/RxTest/XCTest+Rx.swift
+++ b/RxTest/XCTest+Rx.swift
@@ -62,7 +62,7 @@ public func XCTAssertEqual<Element: Equatable>(_ lhs: [SingleEvent<Element>], _ 
         return
     }
 
-    printSequenceDifferences(lhs.map { try? $0.get() }, rhs.map { try? $0.get() }, ==)
+    printSequenceDifferences(lhs, rhs, equals)
 }
 
 /**

--- a/RxTest/XCTest+Rx.swift
+++ b/RxTest/XCTest+Rx.swift
@@ -51,8 +51,8 @@ public func XCTAssertEqual<Element: Equatable>(_ lhs: [Event<Element>], _ rhs: [
  - parameter line: The line number on which it appears.
  */
 public func XCTAssertEqual<Element: Equatable>(_ lhs: [SingleEvent<Element>], _ rhs: [SingleEvent<Element>], file: StaticString = #file, line: UInt = #line) {
-    let leftEquatable = lhs.map { AnyEquatable(target: try? $0.get(), comparer: ==) }
-    let rightEquatable = rhs.map { AnyEquatable(target: try? $0.get(), comparer: ==) }
+    let leftEquatable = lhs.map { AnyEquatable(target: $0, comparer: equals) }
+    let rightEquatable = rhs.map { AnyEquatable(target: $0, comparer: equals) }
     #if os(Linux)
         XCTAssertEqual(leftEquatable, rightEquatable)
     #else


### PR DESCRIPTION
This PR fixes a small issue where the `XCTAssertEqual` implementation for `[SingleEvent<Element>]` streams wouldn't compare `.failure` cases correctly.

Since comparison was being done using `try? event.get()`, any errors thrown by both events would be matched against each other, therefore one could write the following test and it would give us a false positive (i.e. pass, even though it shouldn't):

```swift
enum SomeError: Error {
    case failed
    case invalid
}

let stream = Single<Int>.error(SomeError.failed)
var events: [SingleEvent<Int>] = []

_ = stream.subscribe { event in
    events.append(event)
}

XCTAssertEqual(events, [.failure(SomeError.invalid)]) // this passes, even though the errors are different
```

Whereas a similar test but using `Event<Element>` instead would correctly raise an error on the tests:
```swift
enum SomeError: Error {
    case failed
    case invalid
}

let stream = Observable<Int>.error(SomeError.failed)
var events: [Event<Int>] = []

_ = stream.subscribe { event in
    events.append(event)
}

XCTAssertEqual(events, [.error(SomeError.invalid)]) // this fails as expected
```

To fix this issue is fairly trivial, instead of comparing `try? event.result()` we can just compare the `event` directly but using the `equals` method as `comparer`.