### PR TITLE
Fix missing typealiased import warnings

### DIFF
--- a/RxSwift/Observables/Buffer.swift
+++ b/RxSwift/Observables/Buffer.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Debounce.swift
+++ b/RxSwift/Observables/Debounce.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/DelaySubscription.swift
+++ b/RxSwift/Observables/DelaySubscription.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Skip.swift
+++ b/RxSwift/Observables/Skip.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Take.swift
+++ b/RxSwift/Observables/Take.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Timeout.swift
+++ b/RxSwift/Observables/Timeout.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Window.swift
+++ b/RxSwift/Observables/Window.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Schedulers/VirtualTimeScheduler.swift
+++ b/RxSwift/Schedulers/VirtualTimeScheduler.swift
@@ -6,6 +6,9 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+import Foundation
+
 /// Base class for virtual time schedulers using a priority queue for scheduled items.
 open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
     : SchedulerType {

--- a/RxSwift/Traits/Infallible/Infallible+Operators.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Operators.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 // MARK: - Static allocation
 extension InfallibleType {
     /**

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
+import Dispatch
+
 /// Observable sequences containing 0 or 1 element.
 public struct PrimitiveSequence<Trait, Element> {
     let source: Observable<Element>


### PR DESCRIPTION
With Swift 5.8 a warning is produced unless you import all the modules that contain types you use typealises of. This adds the missing imports to fix the warnings.

<img width="238" alt="Screenshot 2023-02-17 at 19 49 32" src="https://user-images.githubusercontent.com/283886/219830321-c6d6a761-532d-4fc6-88d5-a47c792a0ffe.png">
