### PR TITLE
Add fatal synchronization error hook

### DIFF
--- a/RxSwift/Rx.swift
+++ b/RxSwift/Rx.swift
@@ -81,7 +81,11 @@ func decrementChecked(_ i: inout Int) throws -> Int {
             #if FATAL_SYNCHRONIZATION
                 rxFatalError(message)
             #else
-                print(message)
+                if Hooks.fatalSynchronizationError {
+                    rxFatalError(message)
+                } else {
+                    print(message)
+                }
             #endif
         }
         
@@ -139,4 +143,6 @@ public enum Hooks {
     // Should capture call stack
     public static var recordCallStackOnError: Bool = false
 
+    // Should trigger a fatal error when a synchronization error is detected
+    public static var fatalSynchronizationError: Bool = false
 }


### PR DESCRIPTION
This change introduces a setting to trigger a fatal error when a synchronization error is detected. The `FATAL_SYNCHRONIZATION` flag has precedence over this setting and it does not change the current default behavior.

Reasoning: We're trying to work through many synchronization errors in our app, but this process is going to take a while. In the meantime, we want to prevent new errors from being added to places that don't have them already. Our approach is to enable this setting for tests and provide a way to disable it for specific tests that currently have synchronization issues. One of the things we need for this to be possible is a way to turn this feature on or off easily.