### PR TITLE
Provide `Infallible` versions of `combineLatest` without `resultSelector` requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 * Use `AtomicInt` for `BooleanDisposable`s to prevent potential rase condition. #2419
 * Renames 'OSX' to 'macOS' in Availability Check.
 * Renames 'OSXApplicationExtension' to 'macOSApplicationExtension' in Availability Check.
+* Provides `Infallible` versions of `combineLatest` without `resultSelector` requirement.
 
 ## 6.5.0
 
@@ -84,7 +85,7 @@ Check out the [full documentation](https://github.com/ReactiveX/RxSwift/blob/mai
 * Make `NSTextView` not weak for Swift 5.2 and up.
 * Add `WKWebView` navigation delegate reactive extensions. #2144
 
-**Note**: We no longer guarantee support for Xcode 10.x. Maintaining these is counter-intuitive as they're over a year old and are ridden with bugs. 
+**Note**: We no longer guarantee support for Xcode 10.x. Maintaining these is counter-intuitive as they're over a year old and are ridden with bugs.
 
 ## [5.1.0](https://github.com/ReactiveX/RxSwift/releases/tag/5.1.0)
 
@@ -168,7 +169,7 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
 **Carthage users will probably need to include this framework manually.**
 
 * Updates deprecated `OSAtomic*` primitives to use C11 atomic primitives.
-* Adds `Event`, `SingleEvent`, `MaybeEvent` and `Recorded` conditional conformance to `Equatable` where their `Element` is equatable on `RXTest` for clients that are using Swift >= 4.1. 
+* Adds `Event`, `SingleEvent`, `MaybeEvent` and `Recorded` conditional conformance to `Equatable` where their `Element` is equatable on `RXTest` for clients that are using Swift >= 4.1.
 * Adds `string` to `NSTextView`.
 * Consolidates per platform frameworks to multi-platform frameworks.
 * Xcode 10.1 compatible.
@@ -176,7 +177,7 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
 #### Anomalies
 
 * Fixes problem with canceling events scheduled on serial scheduler through `observeOn` operator.  #1778
-* Fixes problem with `UISearchBar.text` property not triggering update when cancel button is tapped. #1714 
+* Fixes problem with `UISearchBar.text` property not triggering update when cancel button is tapped. #1714
 * Updates watchos minimum target to 3.0. #1752
 
 
@@ -327,7 +328,7 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
 
 ## [4.0.0-alpha.0](https://github.com/ReactiveX/RxSwift/releases/tag/4.0.0-alpha.0)
 * Swift 4.0 compatibility
-* Changes delegate proxy to use plugin architecture. 
+* Changes delegate proxy to use plugin architecture.
 
 #### Anomalies
 * Fixes public interface leakage of `NSKeyValueObservingOptions`. #1164
@@ -432,7 +433,7 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
 
 #### Anomalies
 
-* Fixes misspelled `Completeable` to `Completable`. #1134 
+* Fixes misspelled `Completeable` to `Completable`. #1134
 
 ## [3.3.0](https://github.com/ReactiveX/RxSwift/releases/tag/3.3.0) (Xcode 8 / Swift 3.0 compatible)
 
@@ -487,7 +488,7 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
 * Small performance optimizations for subjects.
 * Adaptations for Xcode 8.3 beta.
 * Adds `numberOfPages` to `UIPageControl`.
-* Adds additional resources cleanup unit tests for cases where operators are used without `DisposeBag`s. 
+* Adds additional resources cleanup unit tests for cases where operators are used without `DisposeBag`s.
 * Chroes:
     * Adds `final` keyword wherever applicable.
     * Remove unnecessary `import Foundation` statements.
@@ -510,8 +511,8 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
 * Improves `UIBindingObserver` by tolerating binding from non main dispatch queue. In case binding is attempted
   from non main dispatch queue it will be automagically dispathed async to main queue.
 * Makes control property naming consistent for `UIDatePicker`, `UISearchBar`, `UISegmentedControl`, `UISwitch`, `UITextField`, `UITextView` (`value` property + value alias name).
-* Adds missing extension to `UIScrollView`. 
-    * `didScroll` 
+* Adds missing extension to `UIScrollView`.
+    * `didScroll`
     * `didZoom`
     * `didEndDecelerating`
     * `didEndDragging`
@@ -524,7 +525,7 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
 * Adds `UITabBarController` extensions
     * `willBeginCustomizing`
     * `willEndCustomizing`
-    * `didEndCustomizing` 
+    * `didEndCustomizing`
     * `didSelect`
 * Adds `UIBarButtonItem` extensions
     * `title`
@@ -553,7 +554,7 @@ If you're using Xcode 10.1 and below, please use [RxSwift 4.5](https://github.co
     ...
     also ...
     * since `rx.text` has now type `String?` to be consistent with UIKit, in case `String` is needed
-    there is `rx.text.orEmpty` that has `String` type.   
+    there is `rx.text.orEmpty` that has `String` type.
 * Renames `title(controlState:)` on `UIButton` to `title(for:)`.
 * All data structures are now internal (`Bag`, `Queue`, `PriorityQueue` ...)
 * Improves performance of `Bag`.
@@ -599,7 +600,7 @@ let text: Observable<String> = Observable.just("")
 
 // Previously `map { $0 }` was needed because of mismatch between sequence `String` type and `String?` type
 // on binding `rx.text` observer.
-text.bindTo(label.rx.text)  
+text.bindTo(label.rx.text)
    .disposed(by: disposeBag)
 
 ...

--- a/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.swift
+++ b/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.swift
@@ -29,6 +29,24 @@ extension Infallible {
     }
 }
 
+extension InfallibleType {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: InfallibleType, O2: InfallibleType>
+        (_ source1: O1, _ source2: O2)
+            -> Infallible<(O1.Element, O2.Element)> {
+        Infallible.combineLatest(
+            source1, source2,
+            resultSelector: { ($0, $1) }
+        )
+    }
+}
+
 // 3
 extension Infallible {
     /**
@@ -46,6 +64,24 @@ extension Infallible {
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(),
             resultSelector: resultSelector
         ))
+    }
+}
+
+extension InfallibleType {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: InfallibleType, O2: InfallibleType, O3: InfallibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3)
+            -> Infallible<(O1.Element, O2.Element, O3.Element)> {
+        Infallible.combineLatest(
+            source1, source2, source3,
+            resultSelector: { ($0, $1, $2) }
+        )
     }
 }
 
@@ -69,6 +105,24 @@ extension Infallible {
     }
 }
 
+extension InfallibleType {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: InfallibleType, O2: InfallibleType, O3: InfallibleType, O4: InfallibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4)
+            -> Infallible<(O1.Element, O2.Element, O3.Element, O4.Element)> {
+        Infallible.combineLatest(
+            source1, source2, source3, source4,
+            resultSelector: { ($0, $1, $2, $3) }
+        )
+    }
+}
+
 // 5
 extension Infallible {
     /**
@@ -86,6 +140,24 @@ extension Infallible {
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(),
             resultSelector: resultSelector
         ))
+    }
+}
+
+extension InfallibleType {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: InfallibleType, O2: InfallibleType, O3: InfallibleType, O4: InfallibleType, O5: InfallibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5)
+            -> Infallible<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element)> {
+        Infallible.combineLatest(
+            source1, source2, source3, source4, source5,
+            resultSelector: { ($0, $1, $2, $3, $4) }
+        )
     }
 }
 
@@ -109,6 +181,24 @@ extension Infallible {
     }
 }
 
+extension InfallibleType {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: InfallibleType, O2: InfallibleType, O3: InfallibleType, O4: InfallibleType, O5: InfallibleType, O6: InfallibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6)
+            -> Infallible<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element)> {
+        Infallible.combineLatest(
+            source1, source2, source3, source4, source5, source6,
+            resultSelector: { ($0, $1, $2, $3, $4, $5) }
+        )
+    }
+}
+
 // 7
 extension Infallible {
     /**
@@ -126,6 +216,24 @@ extension Infallible {
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(),
             resultSelector: resultSelector
         ))
+    }
+}
+
+extension InfallibleType {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: InfallibleType, O2: InfallibleType, O3: InfallibleType, O4: InfallibleType, O5: InfallibleType, O6: InfallibleType, O7: InfallibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7)
+            -> Infallible<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element)> {
+        Infallible.combineLatest(
+            source1, source2, source3, source4, source5, source6, source7,
+            resultSelector: { ($0, $1, $2, $3, $4, $5, $6) }
+        )
     }
 }
 
@@ -149,3 +257,20 @@ extension Infallible {
     }
 }
 
+extension InfallibleType {
+    /**
+    Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
+
+    - seealso: [combineLatest operator on reactivex.io](http://reactivex.io/documentation/operators/combinelatest.html)
+
+    - returns: An observable sequence containing the result of combining elements of the sources.
+    */
+    public static func combineLatest<O1: InfallibleType, O2: InfallibleType, O3: InfallibleType, O4: InfallibleType, O5: InfallibleType, O6: InfallibleType, O7: InfallibleType, O8: InfallibleType>
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8)
+            -> Infallible<(O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element)> {
+        Infallible.combineLatest(
+            source1, source2, source3, source4, source5, source6, source7, source8,
+            resultSelector: { ($0, $1, $2, $3, $4, $5, $6, $7) }
+        )
+    }
+}


### PR DESCRIPTION
`Observable` has helper extensions for `combineLatest` that implement a basic default `resultSelector` which makes `combineLatest` much more ergonomic to work with. 

This PR implements `Infallible` versions of these helpers.