### PR TITLE
Re-enable thread sanitizer for all framework test schemes.

### DIFF
--- a/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-iOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-iOS.xcscheme
@@ -11,6 +11,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
       codeCoverageEnabled = "YES">
       <Testables>

--- a/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-macOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-macOS.xcscheme
@@ -11,6 +11,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES">
       <Testables>
          <TestableReference

--- a/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-tvOS.xcscheme
+++ b/Rx.xcodeproj/xcshareddata/xcschemes/AllTests-tvOS.xcscheme
@@ -11,6 +11,7 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES">
       <Testables>
          <TestableReference


### PR DESCRIPTION
This PR re-enable thread sanitizer for all framework test schemes, as discussed in #2420.

macOS and iOS tests sould run well with thread sanitizers enabled with the latest SDK bundled with Xcode 14.3.

I'm getting problems to compile tvOS tests with the 16.4 SDK locally and if this change causes tvOS tests to fail, feel free to revert that.