### PR TITLE
Fix Infallible CombineLatest arity helpers

### DIFF
--- a/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.swift
+++ b/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.swift
@@ -29,7 +29,7 @@ extension Infallible {
     }
 }
 
-extension InfallibleType {
+extension InfallibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -67,7 +67,7 @@ extension Infallible {
     }
 }
 
-extension InfallibleType {
+extension InfallibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -105,7 +105,7 @@ extension Infallible {
     }
 }
 
-extension InfallibleType {
+extension InfallibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -143,7 +143,7 @@ extension Infallible {
     }
 }
 
-extension InfallibleType {
+extension InfallibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -181,7 +181,7 @@ extension Infallible {
     }
 }
 
-extension InfallibleType {
+extension InfallibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -219,7 +219,7 @@ extension Infallible {
     }
 }
 
-extension InfallibleType {
+extension InfallibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 
@@ -257,7 +257,7 @@ extension Infallible {
     }
 }
 
-extension InfallibleType {
+extension InfallibleType where Element == Any {
     /**
     Merges the specified observable sequences into one observable sequence of tuples whenever any of the observable sequences produces an element.
 

--- a/Sources/AllTestz/Infallible+CombineLatestTests+arity.swift
+++ b/Sources/AllTestz/Infallible+CombineLatestTests+arity.swift
@@ -1,0 +1,1 @@
+../../Tests/RxSwiftTests/Infallible+CombineLatestTests+arity.swift

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -315,6 +315,24 @@ final class HistoricalSchedulerTest_ : HistoricalSchedulerTest, RxTestCase {
     ] }
 }
 
+final class InfallibleCombineLatestTest_ : InfallibleCombineLatestTest, RxTestCase {
+    #if os(macOS)
+    required override init() {
+        super.init()
+    }
+    #endif
+
+    static var allTests: [(String, (InfallibleCombineLatestTest_) -> () -> Void)] { return [
+    ("testCombineLatest_Arity", InfallibleCombineLatestTest.testCombineLatest_Arity),
+    ("testCombineLatest_3_Arity", InfallibleCombineLatestTest.testCombineLatest_3_Arity),
+    ("testCombineLatest_4_Arity", InfallibleCombineLatestTest.testCombineLatest_4_Arity),
+    ("testCombineLatest_5_Arity", InfallibleCombineLatestTest.testCombineLatest_5_Arity),
+    ("testCombineLatest_6_Arity", InfallibleCombineLatestTest.testCombineLatest_6_Arity),
+    ("testCombineLatest_7_Arity", InfallibleCombineLatestTest.testCombineLatest_7_Arity),
+    ("testCombineLatest_8_Arity", InfallibleCombineLatestTest.testCombineLatest_8_Arity),
+    ] }
+}
+
 final class InfallibleTest_ : InfallibleTest, RxTestCase {
     #if os(macOS)
     required override init() {
@@ -2217,6 +2235,7 @@ func XCTMain(_ tests: [() -> Void]) {
         testCase(DriverTest_.allTests),
         testCase(EventTests_.allTests),
         testCase(HistoricalSchedulerTest_.allTests),
+        testCase(InfallibleCombineLatestTest_.allTests),
         testCase(InfallibleTest_.allTests),
         testCase(MainSchedulerTest_.allTests),
         testCase(MaybeTest_.allTests),

--- a/Tests/RxSwiftTests/Infallible+CombineLatestTests+arity.swift
+++ b/Tests/RxSwiftTests/Infallible+CombineLatestTests+arity.swift
@@ -1,0 +1,246 @@
+//
+//  Infallible+CombineLatestTests+arity.swift
+//  Tests
+//
+//  Created by Hal Lee on 5/11/23.
+//  Copyright © 2023 Krunoslav Zaher. All rights reserved.
+//
+
+import XCTest
+import RxSwift
+import RxTest
+
+class InfallibleCombineLatestTest: RxTest {
+
+    func testCombineLatest_Arity() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let firstStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let secondStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let observer = scheduler.start(created: 0, subscribed: 0, disposed: 100) {
+            return Infallible
+                .combineLatest(firstStream, secondStream)
+                .map { $0 + $1 }
+        }
+
+        XCTAssertEqual(observer.events, [
+            .next(1, 2),
+        ])
+    }
+
+    func testCombineLatest_3_Arity() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let firstStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let secondStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let thirdStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let observer = scheduler.start(created: 0, subscribed: 0, disposed: 100) {
+            return Infallible
+                .combineLatest(firstStream, secondStream, thirdStream)
+                .map { $0 + $1 + $2 }
+        }
+
+        XCTAssertEqual(observer.events, [
+            .next(1, 3),
+        ])
+    }
+
+    func testCombineLatest_4_Arity() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let firstStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let secondStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let thirdStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fourthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let observer = scheduler.start(created: 0, subscribed: 0, disposed: 100) {
+            return Infallible
+                .combineLatest(firstStream, secondStream, thirdStream, fourthStream)
+                .map { (a: Int, b: Int, c: Int, d: Int) -> Int in a + b + c + d }
+        }
+
+        XCTAssertEqual(observer.events, [
+            .next(1, 4),
+        ])
+    }
+
+    func testCombineLatest_5_Arity() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let firstStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let secondStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let thirdStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fourthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fifthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let observer = scheduler.start(created: 0, subscribed: 0, disposed: 100) {
+            return Infallible
+                .combineLatest(firstStream, secondStream, thirdStream, fourthStream, fifthStream)
+                .map { (a: Int, b: Int, c: Int, d: Int, e: Int) -> Int in a + b + c + d + e }
+        }
+
+        XCTAssertEqual(observer.events, [
+            .next(1, 5),
+        ])
+    }
+
+    func testCombineLatest_6_Arity() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let firstStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let secondStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let thirdStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fourthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fifthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let sixthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let observer = scheduler.start(created: 0, subscribed: 0, disposed: 100) {
+            return Infallible
+                .combineLatest(firstStream, secondStream, thirdStream, fourthStream, fifthStream, sixthStream)
+                .map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int) -> Int in a + b + c + d + e + f }
+        }
+
+        XCTAssertEqual(observer.events, [
+            .next(1, 6),
+        ])
+    }
+
+    func testCombineLatest_7_Arity() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let firstStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let secondStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let thirdStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fourthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fifthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let sixthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let seventhStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let observer = scheduler.start(created: 0, subscribed: 0, disposed: 100) {
+            return Infallible
+                .combineLatest(firstStream, secondStream, thirdStream, fourthStream, fifthStream, sixthStream, seventhStream)
+                .map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int) -> Int in a + b + c + d + e + f + g }
+        }
+
+        XCTAssertEqual(observer.events, [
+            .next(1, 7),
+        ])
+    }
+
+    func testCombineLatest_8_Arity() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let firstStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let secondStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let thirdStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fourthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let fifthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let sixthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let seventhStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let eighthStream = scheduler.createColdObservable([
+            .next(1, 1)
+        ]).asInfallible(onErrorFallbackTo: .never())
+
+        let observer = scheduler.start(created: 0, subscribed: 0, disposed: 100) {
+            return Infallible
+                .combineLatest(firstStream, secondStream, thirdStream, fourthStream, fifthStream, sixthStream, seventhStream, eighthStream)
+                .map { (a: Int, b: Int, c: Int, d: Int, e: Int, f: Int, g: Int, h: Int) -> Int in a + b + c + d + e + f + g + h }
+        }
+
+        XCTAssertEqual(observer.events, [
+            .next(1, 8),
+        ])
+    }
+
+}


### PR DESCRIPTION
From https://github.com/ReactiveX/RxSwift/pull/2508#discussion_r1181269601, I was wrong; the `where Element == Any` constraint is required to help the type system automatically infer the element type of the tuple. Without that constraint, combineLatest has this issue: 


<img width="743" alt="Screenshot 2023-05-11 at 4 48 13 PM" src="https://github.com/ReactiveX/RxSwift/assets/784999/09677c92-0f07-4a87-af86-20bca597ee94">


Added back the constraint and also added tests to verify.