### PR TITLE
Add primary associated type Element to ObservableConvertibleType

### DIFF
--- a/RxSwift/ObservableConvertibleType.swift
+++ b/RxSwift/ObservableConvertibleType.swift
@@ -7,7 +7,7 @@
 //
 
 /// Type that can be converted to observable sequence (`Observable<Element>`).
-public protocol ObservableConvertibleType {
+public protocol ObservableConvertibleType<Element> {
     /// Type of elements in sequence.
     associatedtype Element
 


### PR DESCRIPTION
This allows us to pass this around while ensuring matching types, such as when writing generic methods around ObservableConvertibleTypes

(just want to see if this builds without anything else changing in the repo, so ignore if needed)