### PR TITLE
Tidied up some code using optional map

### DIFF
--- a/RxSwift/Traits/PrimitiveSequence/Completable.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Completable.swift
@@ -123,12 +123,7 @@ extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Swif
                 let callStack = [String]()
         #endif
 
-        let disposable: Disposable
-        if let onDisposed = onDisposed {
-            disposable = Disposables.create(with: onDisposed)
-        } else {
-            disposable = Disposables.create()
-        }
+        let disposable: Disposable = onDisposed.map({ Disposables.create(with: $0) }) ?? Disposables.create()
 
         let observer: CompletableObserver = { event in
             switch event {

--- a/RxSwift/Traits/PrimitiveSequence/Completable.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Completable.swift
@@ -123,7 +123,7 @@ extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Swif
                 let callStack = [String]()
         #endif
 
-        let disposable: Disposable = onDisposed.map({ Disposables.create(with: $0) }) ?? Disposables.create()
+        let disposable: Disposable = onDisposed.map(Disposables.create(with:)) ?? Disposables.create()
 
         let observer: CompletableObserver = { event in
             switch event {

--- a/RxSwift/Traits/PrimitiveSequence/Maybe.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Maybe.swift
@@ -138,7 +138,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
         #else
             let callStack = [String]()
         #endif
-        let disposable: Disposable = onDisposed.map({ Disposables.create(with: $0) }) ?? Disposables.create()
+        let disposable: Disposable = onDisposed.map(Disposables.create(with:)) ?? Disposables.create()
 
         let observer: MaybeObserver = { event in
             switch event {

--- a/RxSwift/Traits/PrimitiveSequence/Maybe.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Maybe.swift
@@ -138,12 +138,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
         #else
             let callStack = [String]()
         #endif
-        let disposable: Disposable
-        if let onDisposed = onDisposed {
-            disposable = Disposables.create(with: onDisposed)
-        } else {
-            disposable = Disposables.create()
-        }
+        let disposable: Disposable = onDisposed.map({ Disposables.create(with: $0) }) ?? Disposables.create()
 
         let observer: MaybeObserver = { event in
             switch event {

--- a/RxSwift/Traits/PrimitiveSequence/Single.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Single.swift
@@ -135,12 +135,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
             let callStack = [String]()
         #endif
 
-        let disposable: Disposable
-        if let onDisposed = onDisposed {
-            disposable = Disposables.create(with: onDisposed)
-        } else {
-            disposable = Disposables.create()
-        }
+        let disposable: Disposable = onDisposed.map({ Disposables.create(with: $0) }) ?? Disposables.create()
 
         let observer: SingleObserver = { event in
             switch event {

--- a/RxSwift/Traits/PrimitiveSequence/Single.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Single.swift
@@ -135,7 +135,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
             let callStack = [String]()
         #endif
 
-        let disposable: Disposable = onDisposed.map({ Disposables.create(with: $0) }) ?? Disposables.create()
+        let disposable: Disposable = onDisposed.map(Disposables.create(with:)) ?? Disposables.create()
 
         let observer: SingleObserver = { event in
             switch event {


### PR DESCRIPTION
Simply shortens/tidies up a few places of code, each of which were 3 lines, but could be written with just one using Optional's map function.

This feels like too small of change to mention in the changelog. If you disagree, let me know and I can make a mention.

I was also thinking of further condensing this code to the existing extension on `Disposables` in `AnonymousDisposable.swift`:
```
extension Disposables {
.....
    /// Constructs a new disposable with the given action used for disposal. Provides an optional `dispose` param for convenience
    ///
    /// - parameter dispose: Optional disposal action which would be run upon calling `dispose`.
    public static func create(with dispose: (() -> Void)?) -> Disposable {
        return dispose.map({ create(with: $0) }) ?? create()
    }

}
```

That way, the three places I cleaned up wouldn't each be repeating the same logic. Let me know if that's something you'd want.