### PR TITLE
removed the 'return' as it was not necessary.

### DIFF
--- a/RxExample/RxExample/Example.swift
+++ b/RxExample/RxExample/Example.swift
@@ -19,7 +19,7 @@
 let MB = 1024 * 1024
 
 func exampleError(_ error: String, location: String = "\(#file):\(#line)") -> NSError {
-    return NSError(domain: "ExampleError", code: -1, userInfo: [NSLocalizedDescriptionKey: "\(location): \(error)"])
+    NSError(domain: "ExampleError", code: -1, userInfo: [NSLocalizedDescriptionKey: "\(location): \(error)"])
 }
 
 extension String {

--- a/RxExample/RxExample/String+URL.swift
+++ b/RxExample/RxExample/String+URL.swift
@@ -9,6 +9,6 @@
 
 extension String {
     var URLEscaped: String {
-       return self.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? ""
+       self.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? ""
     }
 }


### PR DESCRIPTION
# Overview

I removed unnecessary code.

In accordance with `Swift` language specifications, having no `return` is acceptable and, in fact, recommended as it makes the code less verbose."

Example bellow code

```swift
func exampleError(_ error: String, location: String = "\(#file):\(#line)") -> NSError {
    return NSError(domain: "ExampleError", code: -1, userInfo: [NSLocalizedDescriptionKey: "\(location): \(error)"])
->    NSError(domain: "ExampleError", code: -1, userInfo: [NSLocalizedDescriptionKey: "\(location): \(error)"])
}

```