### PR TITLE
Resolves issue 2554 (Missing imports warn 'this is an error in Swift 6')

### DIFF
--- a/RxSwift/Observables/Buffer.swift
+++ b/RxSwift/Observables/Buffer.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Debounce.swift
+++ b/RxSwift/Observables/Debounce.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/DelaySubscription.swift
+++ b/RxSwift/Observables/DelaySubscription.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Skip.swift
+++ b/RxSwift/Observables/Skip.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Take.swift
+++ b/RxSwift/Observables/Take.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Timeout.swift
+++ b/RxSwift/Observables/Timeout.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Observables/Window.swift
+++ b/RxSwift/Observables/Window.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 extension ObservableType {
 
     /**

--- a/RxSwift/Schedulers/VirtualTimeScheduler.swift
+++ b/RxSwift/Schedulers/VirtualTimeScheduler.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 /// Base class for virtual time schedulers using a priority queue for scheduled items.
 open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
     : SchedulerType {

--- a/RxSwift/Traits/Infallible/Infallible+Operators.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Operators.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2020 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 // MARK: - Static allocation
 extension InfallibleType {
     /**

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
+import Foundation
+
 /// Observable sequences containing 0 or 1 element.
 public struct PrimitiveSequence<Trait, Element> {
     let source: Observable<Element>


### PR DESCRIPTION
## Summary
This commit resolves issue 2554, where Release builds of RxSwift (and other targets) emit many warnings that various references to Foundation types, such as `Foundation.Date` and `Dispatch.DispatchTimeInterval`, cannot be used because their definition was never imported, and that this warning will be a hard error in Swift 6.

## Implementation detail
These are resolved by simply adding "import Foundation" to the files generating the warnings.

## Other thoughts
If those files weren't importing Foundation on purpose, for some reason, the individual types needed could be imported instead.