### PR TITLE
Fixes issue #2548, Cannot call value of non-function type RxExample-iOS and RxExample-macOS fail build

### DIFF
--- a/RxExample/RxExample/Feedbacks.swift
+++ b/RxExample/RxExample/Feedbacks.swift
@@ -363,7 +363,7 @@ private func bindingsStrongify<Event, O, WeakOwner>(_ owner: WeakOwner, _ bindin
     -> (O) -> (Bindings<Event>) where WeakOwner: AnyObject {
         return { [weak owner] state -> Bindings<Event> in
             guard let strongOwner = owner else {
-                return Bindings(subscriptions: [], events: [Observable<Event>]())
+                return Bindings(subscriptions: [], events: [RxSwift.Observable<Event>]())
             }
             return bindings(strongOwner, state)
         }


### PR DESCRIPTION
## Summary

Building RxExample-iOS or RxExample-macOS from Xcode both fail with the warning, `Cannot call value of non-function type '[Observable<Event>.Type]'`.

This is detailed in issue #2548 (https://github.com/ReactiveX/RxSwift/issues/2548).  While the issue is already marked as Closed and details of the needed fix mentioned in that issue, the fix itself was not actually implemented.

This resolves the issue for both the RxExample-iOS and RxExample-macOS targets.

## Implementation Detail
Replaced `Observable<Event>` with `RxSwift.Observable<Event>`, alleviating the compiler's confusion with Apple's `Swift.Observable` type.