### PR TITLE
Remove unused/unneeded method.

### DIFF
--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -40,10 +40,6 @@ public class ReplaySubject<Element>
         fileprivate let synchronizationTracker = SynchronizationTracker()
     #endif
 
-    func unsubscribe(_ key: DisposeKey) {
-        rxAbstractMethod()
-    }
-
     final var isStopped: Bool {
         self.stopped
     }


### PR DESCRIPTION
The unsubscribe(_:) method is not used internally and isn't exposed publicly.