### PR TITLE
Deprecated code warnings in playground Filtering_and_Conditional_Operators.xcplaygroundpage

### DIFF
--- a/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage/Contents.swift
+++ b/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage/Contents.swift
@@ -195,7 +195,7 @@ example("skipWhileWithIndex") {
     
     Observable.of("🐱", "🐰", "🐶", "🐸", "🐷", "🐵")
         .enumerated()
-        .skipWhile { $0.index < 3 }
+        .skip(while: { $0.index < 3 })
         .map { $0.element }
         .subscribe(onNext: { print($0) })
         .disposed(by: disposeBag)
@@ -213,7 +213,7 @@ example("skipUntil") {
     let referenceSequence = PublishSubject<String>()
     
     sourceSequence
-        .skipUntil(referenceSequence)
+        .skip(until: referenceSequence)
         .subscribe(onNext: { print($0) })
         .disposed(by: disposeBag)
     


### PR DESCRIPTION
This resolves issue #2569 

Deprecated code warnings in playground Filtering_and_Conditional_Operators.xcplaygroundpage

RxSwift/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage:198:10 'skipWhile' is deprecated: renamed to 'skip(while:)'

RxSwift/Rx.playground/Pages/Filtering_and_Conditional_Operators.xcplaygroundpage:216:10 'skipUntil' is deprecated: renamed to 'skip(until:)'

