### PR TITLE
Adds `asDriver()` operator to `PublishRelay`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+* Adds `asDriver()` operator to `PublishRelay`.
 * Use `AtomicInt` for `BooleanDisposable`s to prevent potential rase condition. #2419
 * Renames 'OSX' to 'macOS' in Availability Check.
 * Renames 'OSXApplicationExtension' to 'macOSApplicationExtension' in Availability Check.

--- a/Rx.xcodeproj/project.pbxproj
+++ b/Rx.xcodeproj/project.pbxproj
@@ -809,6 +809,7 @@
 		DB0B922C26FB3569005CEED9 /* PrimitiveSequence+ConcurrencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB0B922A26FB34D3005CEED9 /* PrimitiveSequence+ConcurrencyTests.swift */; };
 		DB8157D3264941B300164D4B /* UIApplication+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8157D2264941B200164D4B /* UIApplication+RxTests.swift */; };
 		DB8157E9264941EB00164D4B /* UIApplication+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB8157E8264941EB00164D4B /* UIApplication+Rx.swift */; };
+		E4E0AB112B5E028100507065 /* PublishRelay+Driver.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4E0AB102B5E028100507065 /* PublishRelay+Driver.swift */; };
 		ECBBA59B1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */; };
 		ECBBA59E1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */; };
 		ECBBA5A11DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */; };
@@ -1469,6 +1470,7 @@
 		DB0B922A26FB34D3005CEED9 /* PrimitiveSequence+ConcurrencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PrimitiveSequence+ConcurrencyTests.swift"; sourceTree = "<group>"; };
 		DB8157D2264941B200164D4B /* UIApplication+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+RxTests.swift"; sourceTree = "<group>"; };
 		DB8157E8264941EB00164D4B /* UIApplication+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIApplication+Rx.swift"; sourceTree = "<group>"; };
+		E4E0AB102B5E028100507065 /* PublishRelay+Driver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublishRelay+Driver.swift"; sourceTree = "<group>"; };
 		ECBBA59A1DF8C0BA00DDDC2E /* UITabBarController+Rx.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Rx.swift"; sourceTree = "<group>"; };
 		ECBBA59D1DF8C0D400DDDC2E /* RxTabBarControllerDelegateProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RxTabBarControllerDelegateProxy.swift; sourceTree = "<group>"; };
 		ECBBA5A01DF8C0FF00DDDC2E /* UITabBarController+RxTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITabBarController+RxTests.swift"; sourceTree = "<group>"; };
@@ -2339,6 +2341,7 @@
 				C89AB1AF1DAAC3350065FBE6 /* ControlProperty+Driver.swift */,
 				C89AB1B01DAAC3350065FBE6 /* Driver+Subscription.swift */,
 				C89AB1B11DAAC3350065FBE6 /* Driver.swift */,
+				E4E0AB102B5E028100507065 /* PublishRelay+Driver.swift */,
 				CD8F7AC427BA9187001574EB /* Infallible+Driver.swift */,
 				C89AB1B21DAAC3350065FBE6 /* ObservableConvertibleType+Driver.swift */,
 			);
@@ -3026,6 +3029,7 @@
 				844BC8B41CE4FD7500F5C7CB /* UIPickerView+Rx.swift in Sources */,
 				C83E39802189066F001F4F0E /* NSControl+Rx.swift in Sources */,
 				C8093EE31B8A732E0088E94D /* DelegateProxyType.swift in Sources */,
+				E4E0AB112B5E028100507065 /* PublishRelay+Driver.swift in Sources */,
 				C8093EFD1B8A732E0088E94D /* RxTarget.swift in Sources */,
 				C88254361B8A752B00B02D69 /* UITextView+Rx.swift in Sources */,
 				C88254171B8A752B00B02D69 /* RxTableViewReactiveArrayDataSource.swift in Sources */,

--- a/RxCocoa/Traits/Driver/PublishRelay+Driver.swift
+++ b/RxCocoa/Traits/Driver/PublishRelay+Driver.swift
@@ -1,0 +1,21 @@
+//
+//  PublishRelay+Driver.swift
+//  RxCocoa
+//
+//  Created by Damon on 2024/01/22.
+//  Copyright © 2024 Krunoslav Zaher. All rights reserved.
+//
+
+import RxSwift
+import RxRelay
+
+extension PublishRelay {
+    /// Converts `PublishRelay` to `Driver`.
+    ///
+    /// - returns: Observable sequence.
+    public func asDriver() -> Driver<Element> {
+        let source = self.asObservable()
+            .observe(on:DriverSharingStrategy.scheduler)
+        return SharedSequence(source)
+    }
+}

--- a/RxCocoa/Traits/Driver/PublishRelay+Driver.swift
+++ b/RxCocoa/Traits/Driver/PublishRelay+Driver.swift
@@ -2,7 +2,7 @@
 //  PublishRelay+Driver.swift
 //  RxCocoa
 //
-//  Created by Damon on 2024/01/22.
+//  Created by Gongcu on 2024/01/22.
 //  Copyright © 2024 Krunoslav Zaher. All rights reserved.
 //
 

--- a/Tests/RxCocoaTests/Driver+Test.swift
+++ b/Tests/RxCocoaTests/Driver+Test.swift
@@ -177,6 +177,21 @@ extension DriverTest {
 
         XCTAssertEqual(results, [0, 1, 2])
     }
+  
+  func testPublishRelayAsDriver() {
+      let hotObservable: PublishRelay<Int> = PublishRelay()
+      let xs = Driver.zip(hotObservable.asDriver(), Driver.of(0, 0)) { x, _ in
+          return x
+      }
+
+      let results = subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription(xs, expectationFulfilled: { $0 == 2 }) {
+          hotObservable.accept(1)
+          hotObservable.accept(2)
+      }
+
+      XCTAssertEqual(results, [1, 2])
+  }
+  
     
     func testInfallibleAsDriver() {
         let hotObservable = BackgroundThreadPrimitiveHotObservable<Int>()


### PR DESCRIPTION
Currently, only `BehaviorRelay` has `asDriver()`, so I added the same operator to `PublishRelay`.

[BehaviorRelay+Driver.swift](https://github.com/ReactiveX/RxSwift/blob/main/RxCocoa/Traits/Driver/BehaviorRelay%2BDriver.swift)