### PR TITLE
Fix the crash issue with objc_sync_enter lock when using Firebase.

### DIFF
--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -554,10 +554,6 @@ extension Reactive where Base: AnyObject {
 	}
 
     func synchronized<T>( _ action: () -> T) -> T {
-        objc_sync_enter(self.base)
-        let result = action()
-        objc_sync_exit(self.base)
-        return result
         lock.lock()
 		defer { lock.unlock() }
         return action()


### PR DESCRIPTION
- Related crashes
https://github.com/firebase/firebase-ios-sdk/issues/5998
https://github.com/firebase/firebase-ios-sdk/issues/4790

- Theoretical reference
https://github.com/apple/darwin-libplatform/blob/main/src/os/lock.c#L494
https://developer.apple.com/documentation/foundation/posixerror/2293610-eownerdead
https://straypixels.net/swift-dictionary-locking/