### PR TITLE
Link XCTest weakly in RxTest to enable static linking

### DIFF
--- a/RxTest.podspec
+++ b/RxTest.podspec
@@ -54,7 +54,7 @@ func testMap() {
   s.source_files          = 'RxTest/**/*.swift', 'Platform/**/*.swift'
   s.exclude_files         = 'RxTest/Platform/**/*.swift'
 
-  s.framework    = 'XCTest'
+  s.weak_framework    = 'XCTest'
 
   s.dependency 'RxSwift', '6.6.0'
   s.swift_version = '5.1'
@@ -62,5 +62,7 @@ func testMap() {
   s.pod_target_xcconfig = {
     'ENABLE_BITCODE' => 'NO',
     'APPLICATION_EXTENSION_API_ONLY' => 'YES',
+    'ENABLE_TESTING_SEARCH_PATHS' => 'YES',
+    'OTHER_LDFLAGS' => '$(inherited) -weak-lXCTestSwiftSupport -Xlinker -no_application_extension',
   }
 end


### PR DESCRIPTION
When static linking is enabled (usually [a CocoaPods plugin](https://github.com/microsoft/cocoapods-pod-linkage)) the build might fail due to RxTest. We have encountered this on tvOS target using app extension.

<img width="223" alt="Screenshot 2024-03-27 at 11 28 19" src="https://github.com/ReactiveX/RxSwift/assets/708312/b1dc771c-3f2c-4a4a-a32b-64e770801999">

By enabling weak linking and correct linker flags for tests the pod will compile successfully. Inpired by [solution in Nimble framework](https://github.com/Quick/Nimble/blob/256e242d294b691103305588cbab176ed617a39e/Nimble.podspec#L26).
