### PR TITLE
Fix `.throttle` with `.seconds()` rounding issue.

### DIFF
--- a/RxSwift/Date+Dispatch.swift
+++ b/RxSwift/Date+Dispatch.swift
@@ -45,7 +45,7 @@ extension DispatchTimeInterval {
             let interval = laterDate.timeIntervalSince(earlierDate)
             let remainder = Double(value) - interval * factor
             guard remainder > 0 else { return 0 }
-            return Int(remainder.rounded(.toNearestOrAwayFromZero))
+            return Int(remainder.rounded(.up))
         }
     }
 }


### PR DESCRIPTION
When using `.seconds(1)`, 2 elements are emitted per second.
MRE with problem reproduction:

<details>

<summary>MRE</summary>

```swift

import SwiftUI
import RxSwift
import RxCocoa

struct ContentView: View {
    private let valuesObs = PublishRelay<Int>()
    private let bag = DisposeBag()

    init() {
        valuesObs
            .throttle(.milliseconds(1000), latest: true, scheduler: MainScheduler.instance)
            .subscribe(onNext: {
                print(".milliseconds(1000) throttle date: \(formatter.string(from: Date())), value: \($0)")
            })
            .disposed(by: bag)
        valuesObs
            .throttle(.seconds(1), latest: true, scheduler: MainScheduler.instance)
            .subscribe(onNext: {
                print(".seconds(1) throttle date: \(formatter.string(from: Date())), value: \($0)")
            })
            .disposed(by: bag)
    }

    var body: some View {
        Image(systemName: "globe")
            .task {
                for i in 0...999 {
                    valuesObs.accept(i)
                    try? await Task.sleep(for: .milliseconds(100))
                }
            }
    }
}

let formatter: DateFormatter = {
    let formatter = DateFormatter()
    formatter.dateFormat = "mm:ss.SSS"

    return formatter
}()

```

</details>

Result of MRE:

```

.milliseconds(1000) throttle date: 24:50.981, value: 0
.seconds(1) throttle date: 24:50.981, value: 0
.seconds(1) throttle date: 24:51.508, value: 5
.milliseconds(1000) throttle date: 24:51.983, value: 9
.seconds(1) throttle date: 24:52.037, value: 10
.seconds(1) throttle date: 24:52.566, value: 15
.milliseconds(1000) throttle date: 24:52.984, value: 19
.seconds(1) throttle date: 24:53.084, value: 20
.seconds(1) throttle date: 24:53.604, value: 25
...

```

As we can see, due to rounding, 2 elements are emitted per second, but only one should.