### PR TITLE
add the deployment_target for visionOS in Podspec

### DIFF
--- a/RxBlocking.podspec
+++ b/RxBlocking.podspec
@@ -21,6 +21,7 @@ Waiting for observable sequence to complete before exiting command line applicat
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target = '9.0'
+  s.visionos.deployment_target = "1.0" if s.respond_to?(:visionos)
 
   s.source_files          = 'RxBlocking/**/*.swift', 'Platform/**/*.swift'
   s.exclude_files         = 'RxBlocking/Platform/**/*.swift'

--- a/RxCocoa.podspec
+++ b/RxCocoa.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target = '9.0'
+  s.visionos.deployment_target = "1.0" if s.respond_to?(:visionos)
 
   s.header_dir            = "RxCocoa"
   s.source_files          = 'RxCocoa/**/*.{swift,h,m}', 'Platform/**/*.swift'

--- a/RxRelay.podspec
+++ b/RxRelay.podspec
@@ -21,6 +21,7 @@ Relays for RxSwift - PublishRelay, BehaviorRelay and ReplayRelay
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target = '9.0'
+  s.visionos.deployment_target = "1.0" if s.respond_to?(:visionos)
 
   s.source_files          = 'RxRelay/**/*.{swift,h,m}'
 

--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -31,6 +31,7 @@ gitDiff().grep("bug").less          // sequences of swift objects
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '3.0'
   s.tvos.deployment_target = '9.0'
+  s.visionos.deployment_target = "1.0" if s.respond_to?(:visionos)
 
   s.source_files          = 'RxSwift/**/*.swift', 'Platform/**/*.swift'
   s.exclude_files         = 'RxSwift/Platform/**/*.swift'


### PR DESCRIPTION
fix this issue https://github.com/ReactiveX/RxSwift/issues/2601#issue-2297554328 
-  add the deployment_target for visionOS in Podspec

- add extra if sentence ->  ` if s.respond_to?(:visionos)` 
because of this issue [pod install not working with lower version of Cocoapods due to visionOS](https://github.com/software-mansion/react-native-svg/pull/2240)