### PR TITLE
Don't retain receiver of Completable.andThen beyond its completion

### DIFF
--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -105,6 +105,8 @@ final class CompletableAndThenTest_ : CompletableAndThenTest, RxTestCase {
     ("testCompletableCompleted_CompletableCompleted", CompletableAndThenTest.testCompletableCompleted_CompletableCompleted),
     ("testCompletableError_CompletableCompleted", CompletableAndThenTest.testCompletableError_CompletableCompleted),
     ("testCompletableCompleted_CompletableError", CompletableAndThenTest.testCompletableCompleted_CompletableError),
+    ("testCompletable_FirstCompletableNotRetainedBeyondCompletion", CompletableAndThenTest.testCompletable_FirstCompletableNotRetainedBeyondCompletion),
+    ("testCompletable_FirstCompletableNotRetainedBeyondFailure", CompletableAndThenTest.testCompletable_FirstCompletableNotRetainedBeyondFailure),
     ("testCompletableEmpty_SingleCompleted", CompletableAndThenTest.testCompletableEmpty_SingleCompleted),
     ("testCompletableCompleted_SingleNormal", CompletableAndThenTest.testCompletableCompleted_SingleNormal),
     ("testCompletableError_SingleNormal", CompletableAndThenTest.testCompletableError_SingleNormal),

--- a/Tests/RxSwiftTests/Completable+AndThen.swift
+++ b/Tests/RxSwiftTests/Completable+AndThen.swift
@@ -174,7 +174,7 @@ extension CompletableAndThenTest {
             disposable.dispose()
         }
 
-        // completable has completed by now
+        // completable has terminated with error by now
         scheduler.advanceTo(300)
 
         weak var weakObject = object

--- a/Tests/RxSwiftTests/Completable+AndThen.swift
+++ b/Tests/RxSwiftTests/Completable+AndThen.swift
@@ -125,7 +125,39 @@ extension CompletableAndThenTest {
 
         let x: TestableObservable<Never> = scheduler.createHotObservable([
             .completed(210),
-            ])
+        ])
+
+        var object = Optional.some(TestObject())
+
+        var completable = x.asCompletable()
+            .do(onCompleted: { [object] in
+                _ = object
+            })
+
+        let disposable = completable
+            .andThen(.never())
+            .subscribe()
+
+        defer {
+            disposable.dispose()
+        }
+
+        // completable has completed by now
+        scheduler.advanceTo(300)
+
+        weak var weakObject = object
+        object = nil
+        completable = .never()
+
+        XCTAssertNil(weakObject)
+    }
+
+    func testCompletable_FirstCompletableNotRetainedBeyondFailure() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let x: TestableObservable<Never> = scheduler.createHotObservable([
+            .error(210, TestError.dummyError),
+        ])
 
         var object = Optional.some(TestObject())
 

--- a/Tests/RxSwiftTests/Completable+AndThen.swift
+++ b/Tests/RxSwiftTests/Completable+AndThen.swift
@@ -120,6 +120,38 @@ extension CompletableAndThenTest {
             ])
     }
 
+    func testCompletable_FirstCompletableNotRetainedBeyondCompletion() {
+        let scheduler = TestScheduler(initialClock: 0)
+
+        let x: TestableObservable<Never> = scheduler.createHotObservable([
+            .completed(210),
+            ])
+
+        var object = Optional.some(TestObject())
+
+        var completable = x.asCompletable()
+            .do(onCompleted: { [object] in
+                _ = object
+            })
+
+        let disposable = completable
+            .andThen(.never())
+            .subscribe()
+
+        defer {
+            disposable.dispose()
+        }
+
+        // completable has completed by now
+        scheduler.advanceTo(300)
+
+        weak var weakObject = object
+        object = nil
+        completable = .never()
+
+        XCTAssertNil(weakObject)
+    }
+
     #if TRACE_RESOURCES
         func testAndThenCompletableReleasesResourcesOnComplete() {
             _ = Completable.empty().andThen(Completable.empty()).subscribe()
@@ -574,4 +606,7 @@ extension CompletableAndThenTest {
             _ = Completable.empty().andThen(Observable<Int>.error(testError)).subscribe()
         }
     #endif
+}
+
+private class TestObject {
 }


### PR DESCRIPTION
Otherwise the creation closure and operator closures involved in the Completable (and hence all objects captured by them) are retained until the outer stream completes or terminates with error.