### PR TITLE
Bump up swift-tools-version to 5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 
 import PackageDescription
 


### PR DESCRIPTION
Bazel community would appreciate this a lot. We can't consume this package if the swift-tools-version is below 5.2 via [rules_swift_package_manager](https://github.com/cgrindel/rules_swift_package_manager)