### PR TITLE
Appearance fix for iOS example.

### DIFF
--- a/RxExample/RxExample.xcodeproj/project.pbxproj
+++ b/RxExample/RxExample.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		2864D5F31D995FCD004F8484 /* Application+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2864D5F11D995FCD004F8484 /* Application+Extensions.swift */; };
 		8479BC721C3BDAD400FB8B54 /* ImagePickerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8479BC701C3BCB9800FB8B54 /* ImagePickerController.swift */; };
 		927A78B82117A5E700A45638 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8BCD3DE1C1480E9005F1280 /* Operators.swift */; };
+		A34040282C47AC34009E3F74 /* BaseNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A34040202C47AC2F009E3F74 /* BaseNavigationController.swift */; };
 		A5CD038F1F1670E50005A376 /* CustomPickerViewAdapterExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CD038E1F1670E50005A376 /* CustomPickerViewAdapterExampleViewController.swift */; };
 		AE51C1C91DE735D8005BAF5F /* APIWrappers.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE51C1C81DE735D8005BAF5F /* APIWrappers.storyboard */; };
 		AE51C1CB1DE735E3005BAF5F /* Calculator.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AE51C1CA1DE735E3005BAF5F /* Calculator.storyboard */; };
@@ -304,6 +305,7 @@
 		780D63E2226B320A00BEACB0 /* Rx.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; name = Rx.playground; path = ../Rx.playground; sourceTree = "<group>"; };
 		787BBB5A226B2A6100279500 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8479BC701C3BCB9800FB8B54 /* ImagePickerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImagePickerController.swift; sourceTree = "<group>"; };
+		A34040202C47AC2F009E3F74 /* BaseNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNavigationController.swift; sourceTree = "<group>"; };
 		A5CD038E1F1670E50005A376 /* CustomPickerViewAdapterExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomPickerViewAdapterExampleViewController.swift; sourceTree = "<group>"; };
 		AE51C1C81DE735D8005BAF5F /* APIWrappers.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = APIWrappers.storyboard; sourceTree = "<group>"; };
 		AE51C1CA1DE735E3005BAF5F /* Calculator.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Calculator.storyboard; sourceTree = "<group>"; };
@@ -937,6 +939,7 @@
 				C8DF92E11B0B32DA009BCF9A /* Main.storyboard */,
 				C8DF92E21B0B32DA009BCF9A /* RootViewController.swift */,
 				C8DF92C81B0B2F84009BCF9A /* AppDelegate.swift */,
+				A34040202C47AC2F009E3F74 /* BaseNavigationController.swift */,
 				C8CDF0C01D688DF700C18F99 /* UITableView+Extensions.swift */,
 			);
 			path = iOS;
@@ -1321,6 +1324,7 @@
 				C8A2A2C81B4049E300F11F09 /* PseudoRandomGenerator.swift in Sources */,
 				C8D132151C42B54B00B59FFF /* UIImagePickerController+RxCreate.swift in Sources */,
 				252C9F781F14111800F5F951 /* SimplePickerViewExampleViewController.swift in Sources */,
+				A34040282C47AC34009E3F74 /* BaseNavigationController.swift in Sources */,
 				C8984CD51C36BC3E001E4272 /* PartialUpdatesViewController.swift in Sources */,
 				C82FF1371F93E84600BDB34D /* Deprecated.swift in Sources */,
 				C88CB7261D8F253D0021D83F /* RxImagePickerDelegateProxy.swift in Sources */,

--- a/RxExample/RxExample/Info-iOS.plist
+++ b/RxExample/RxExample/Info-iOS.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/RxExample/RxExample/iOS/BaseNavigationController.swift
+++ b/RxExample/RxExample/iOS/BaseNavigationController.swift
@@ -1,0 +1,27 @@
+//
+//  BaseNavigationController.swift
+//  RxExample
+//
+//  Created by Volodymyr Andriienko on 17.07.2024.
+//  Copyright © 2024 Krunoslav Zaher. All rights reserved.
+//
+
+import UIKit
+
+open class BaseNavigationController: UINavigationController {
+
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if #available(iOS 13.0, *) {
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            navigationBar.standardAppearance = appearance
+            navigationBar.scrollEdgeAppearance = appearance
+            navigationBar.compactAppearance = appearance
+            if #available(iOS 15.0, *) {
+                navigationBar.compactScrollEdgeAppearance = appearance
+            }
+        }
+    }
+}

--- a/RxExample/RxExample/iOS/Main.storyboard
+++ b/RxExample/RxExample/iOS/Main.storyboard
@@ -7,10 +7,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Navigation Controller-->
+        <!--Base Navigation Controller-->
         <scene sceneID="eu0-Rq-LY9">
             <objects>
-                <navigationController extendedLayoutIncludesOpaqueBars="YES" id="E5v-jn-n2n" sceneMemberID="viewController">
+                <navigationController extendedLayoutIncludesOpaqueBars="YES" id="E5v-jn-n2n" customClass="BaseNavigationController" customModule="RxExample_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="q9W-TG-AP1">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>


### PR DESCRIPTION
Set to `Light` `Appearance` in `Info.plist`. The `navigationBar` was configured programmatically for iOS > 13.

To fix the following issues if the dark theme is selected:

![appearance_issue_0](https://github.com/user-attachments/assets/8985f27d-7414-4940-89ec-04277a74b84e)