### PR TITLE
Add a didFailProvisionalNavigation observer.

### DIFF
--- a/RxCocoa/iOS/WKWebView+Rx.swift
+++ b/RxCocoa/iOS/WKWebView+Rx.swift
@@ -52,6 +52,17 @@ extension Reactive where Base: WKWebView {
                 )
             }
     }
+
+    public var didFailProvisionalNavigation: Observable<(WKNavigation, Error)> {
+        navigationDelegate
+            .methodInvoked(#selector(WKNavigationDelegate.webView(_:didFailProvisionalNavigation:withError:)))
+            .map { a in
+                (
+                    try castOrThrow(WKNavigation.self,a[1]),
+                    try castOrThrow(Error.self, a[2])
+                )
+            }
+        }
 }
 
 #endif

--- a/Tests/RxCocoaTests/WKWebView+RxTests.swift
+++ b/Tests/RxCocoaTests/WKWebView+RxTests.swift
@@ -90,6 +90,22 @@ final class WKWebViewTests: RxTest {
         XCTAssertEqual(expectedError, error as? MockError)
         subscription.dispose()
     }
+
+    func testdidFailProvisionalNavigation() {
+        let expectedNavigation = SafeWKNavigation()
+        let expexctedError = MockError.error("Something went wrong！")
+        let webView = WKWebView(frame: .zero)
+        var navigation: WKNavigation?
+        var error: Error?
+        let subscription = webView.rx.didFailProvisionalNavigation.subscribe { (nav, err) in
+            navigation = nav
+            error = err
+        }
+        webView.navigationDelegate!.webView?(webView, didFailProvisionalNavigation: expectedNavigation, withError:expexctedError)
+        XCTAssertEqual(expectedNavigation, navigation)
+        XCTAssertEqual(expexctedError, error as? MockError)
+        subscription.dispose()
+    }
 }
 
 // MARK: - Test Helpers


### PR DESCRIPTION
# Overview

I am encountering a significant issue as didFailProvisionalNavigation is missing in `WKWebView+Rx`.

For more details on this function, please refer to the Apple Developer documentation: 

```Swift
webView(_:didFailProvisionalNavigation:withError:)
```

https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455637-webview

I have added this function and would greatly appreciate it if knowledgeable individuals could review it.

Thank you very much in advance for your assistance.