### PR TITLE
Add Sendable conformance to AtomicInt

### DIFF
--- a/Platform/AtomicInt.swift
+++ b/Platform/AtomicInt.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-final class AtomicInt: NSLock {
+final class AtomicInt: NSLock, @unchecked Sendable {
     fileprivate var value: Int32
     public init(_ value: Int32 = 0) {
         self.value = value


### PR DESCRIPTION
This fixes the following warning that shows up in Xcode 16 beta 6:

> Class 'AtomicInt' must restate inherited '@unchecked Sendable' conformance