### PR TITLE
Support .editorConfig for consistent code formatting

### DIFF
--- a/.editorConfig
+++ b/.editorConfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+


### PR DESCRIPTION
Starting with Xcode 16, `.editorConfig` is supported for consistent code formatting.

> [New Features in Xcode 16 Beta](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes#New-Features-in-Xcode-16-Beta)
Added support for EditorConfig. The editor now respects indentation settings given in .editorconfig files. Xcode supports the following settings: indent_style, tab_width, indent_size, end_of_line, insert_final_newline, max_line_length, and trim_trailing_whitespace. See https://editorconfig.org/ for more information. Settings from .editorconfig files normally take precedence over settings given in the “Text Editing” section of View > Inspectors > File for a file or group. This can be disabled by unchecking the “Prefer Settings from EditorConfig” checkbox on the Indentation tab of Xcode > Settings > Text Editing. (20796230)

This will allow developers who use a 2-space indentation setting in Xcode Editor to easily modify RxSwift code, which uses a 4-space indentation, without needing to change their configurations.
While there may not be many significant code changes to RxSwift going forward, it would still be nice to have this support.