### PR TITLE
Mark Operator Closures as @Sendable

### DIFF
--- a/Platform/RecursiveLock.swift
+++ b/Platform/RecursiveLock.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 #if TRACE_RESOURCES
-    class RecursiveLock: NSRecursiveLock {
+    class RecursiveLock: NSRecursiveLock, @unchecked Sendable {
         override init() {
             _ = Resources.incrementTotal()
             super.init()

--- a/Rx.playground/Sources/SupportCode.swift
+++ b/Rx.playground/Sources/SupportCode.swift
@@ -24,7 +24,7 @@ public enum TestError: Swift.Error {
  - parameter delay: time in seconds to wait before executing `closure`
  - parameter closure: `Void` closure
  */
-public func delay(_ delay: Double, closure: @escaping () -> Void) {
+public func delay(_ delay: Double, closure: @escaping @Sendable () -> Void) {
 
     DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
         closure()

--- a/RxBlocking/RunLoopLock.swift
+++ b/RxBlocking/RunLoopLock.swift
@@ -31,7 +31,7 @@ final class RunLoopLock {
         self.currentRunLoop = CFRunLoopGetCurrent()
     }
 
-    func dispatch(_ action: @escaping () -> Void) {
+    func dispatch(_ action: @escaping @Sendable () -> Void) {
         CFRunLoopPerformBlock(self.currentRunLoop, runLoopModeRaw) {
             if CurrentThreadScheduler.isScheduleRequired {
                 _ = CurrentThreadScheduler.instance.schedule(()) { _ in

--- a/RxCocoa/Common/ControlTarget.swift
+++ b/RxCocoa/Common/ControlTarget.swift
@@ -22,7 +22,7 @@ import RxSwift
 
 // This should be only used from `MainScheduler`
 final class ControlTarget: RxTarget {
-    typealias Callback = (Control) -> Void
+    typealias Callback = @Sendable (Control) -> Void
 
     let selector: Selector = #selector(ControlTarget.eventHandler(_:))
 
@@ -72,7 +72,8 @@ final class ControlTarget: RxTarget {
             callback(control)
         }
     }
-
+    
+    @Sendable
     override func dispose() {
         super.dispose()
 #if os(iOS) || os(tvOS) || os(visionOS)

--- a/RxCocoa/Common/ControlTarget.swift
+++ b/RxCocoa/Common/ControlTarget.swift
@@ -77,7 +77,9 @@ final class ControlTarget: RxTarget {
     override func dispose() {
         super.dispose()
 #if os(iOS) || os(tvOS) || os(visionOS)
-        self.control?.removeTarget(self, action: self.selector, for: self.controlEvents)
+        MainScheduler.assumeMainActor(execute: {        
+            self.control?.removeTarget(self, action: self.selector, for: self.controlEvents)
+        })
 #elseif os(macOS)
         self.control?.target = nil
         self.control?.action = nil

--- a/RxCocoa/Common/DelegateProxy.swift
+++ b/RxCocoa/Common/DelegateProxy.swift
@@ -266,7 +266,7 @@
         fileprivate let selector: Selector
 
         init<P, D>(selector: Selector, delegateProxy _delegateProxy: DelegateProxy<P, D>) {
-            weak var weakDelegateProxy = _delegateProxy
+            nonisolated(unsafe) weak var weakDelegateProxy = _delegateProxy
 
             let dispatcher = PublishSubject<[Any]>()
             self.dispatcher = dispatcher

--- a/RxCocoa/Common/DelegateProxyType.swift
+++ b/RxCocoa/Common/DelegateProxyType.swift
@@ -214,7 +214,7 @@ extension DelegateProxyType {
     /// - parameter onProxyForObject: Object that has `delegate` property.
     /// - returns: Disposable object that can be used to clear forward delegate.
     public static func installForwardDelegate(_ forwardDelegate: Delegate, retainDelegate: Bool, onProxyForObject object: ParentObject) -> Disposable {
-        weak var weakForwardDelegate: AnyObject? = forwardDelegate as AnyObject
+        nonisolated(unsafe) weak var weakForwardDelegate: AnyObject? = forwardDelegate as AnyObject
         let proxy = self.proxy(for: object)
 
         assert(proxy._forwardToDelegate() === nil, "This is a feature to warn you that there is already a delegate (or data source) set somewhere previously. The action you are trying to perform will clear that delegate (data source) and that means that some of your features that depend on that delegate (data source) being set will likely stop working.\n" +
@@ -360,7 +360,7 @@ extension DelegateProxyType where ParentObject: HasPrefetchDataSource, Self.Dele
                     
                 return Disposables.create { [weak object] in
                     subscription.dispose()
-
+                    
                     if object?.window != nil {
                         object?.layoutIfNeeded()
                     }

--- a/RxCocoa/Common/Infallible+Bind.swift
+++ b/RxCocoa/Common/Infallible+Bind.swift
@@ -70,7 +70,7 @@ extension InfallibleType {
     - parameter onNext: Action to invoke for each element in the observable sequence.
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
-    public func bind(onNext: @escaping (Element) -> Void) -> Disposable {
+    public func bind(onNext: @escaping @Sendable (Element) -> Void) -> Disposable {
         self.subscribe(onNext: onNext)
     }
 

--- a/RxCocoa/Common/Observable+Bind.swift
+++ b/RxCocoa/Common/Observable+Bind.swift
@@ -75,7 +75,7 @@ extension ObservableType {
     */
     public func bind<Object: AnyObject>(
         with object: Object,
-        onNext: @escaping (Object, Element) -> Void
+        onNext: @escaping @Sendable (Object, Element) -> Void
     ) -> Disposable {
         self.subscribe(onNext: { [weak object] in
             guard let object = object else { return }
@@ -94,7 +94,7 @@ extension ObservableType {
     - parameter onNext: Action to invoke for each element in the observable sequence.
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
-    public func bind(onNext: @escaping (Element) -> Void) -> Disposable {
+    public func bind(onNext: @escaping @Sendable (Element) -> Void) -> Disposable {
         self.subscribe(onNext: onNext,
                        onError: { error in
                         rxFatalErrorInDebug("Binding error: \(error)")

--- a/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+KVORepresentable.swift
@@ -38,7 +38,7 @@ extension Reactive where Base: NSObject {
      */
     public func observe<Element: KVORepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Element?> {
         return self.observe(Element.KVOType.self, keyPath, options: options, retainSelf: retainSelf)
-            .map(Element.init)
+            .map({ Element(KVOValue: $0) })
     }
 }
 
@@ -52,7 +52,7 @@ extension Reactive where Base: NSObject {
         */
         public func observeWeakly<Element: KVORepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Element?> {
             return self.observeWeakly(Element.KVOType.self, keyPath, options: options)
-                .map(Element.init)
+                .map({ Element(KVOValue: $0) })
         }
     }
 #endif

--- a/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
+++ b/RxCocoa/Foundation/NSObject+Rx+RawRepresentable.swift
@@ -24,7 +24,7 @@ extension Reactive where Base: NSObject {
      */
     public func observe<Element: RawRepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial], retainSelf: Bool = true) -> Observable<Element?> where Element.RawValue: KVORepresentable {
         return self.observe(Element.RawValue.KVOType.self, keyPath, options: options, retainSelf: retainSelf)
-            .map(Element.init)
+            .map({ Element(KVOValue: $0) })
     }
 }
 
@@ -44,7 +44,7 @@ extension Reactive where Base: NSObject {
          */
         public func observeWeakly<Element: RawRepresentable>(_ type: Element.Type, _ keyPath: String, options: KeyValueObservingOptions = [.new, .initial]) -> Observable<Element?> where Element.RawValue: KVORepresentable {
             return self.observeWeakly(Element.RawValue.KVOType.self, keyPath, options: options)
-                .map(Element.init)
+                .map({ Element(KVOValue: $0) })
         }
     }
 #endif

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -373,7 +373,8 @@ private final class KVOObserver
         super.init(target: parent.target, retainTarget: parent.retainTarget, keyPath: parent.keyPath, options: parent.options.nsOptions, callback: callback)
         self.retainSelf = self
     }
-
+    
+    @Sendable
     override func dispose() {
         super.dispose()
         self.retainSelf = nil

--- a/RxCocoa/Foundation/NSObject+Rx.swift
+++ b/RxCocoa/Foundation/NSObject+Rx.swift
@@ -484,7 +484,7 @@ private extension KeyValueObservingOptions {
         options: KeyValueObservingOptions
         ) -> Observable<AnyObject?> {
 
-        weak var weakTarget: AnyObject? = target
+        nonisolated(unsafe) weak var weakTarget: AnyObject? = target
 
         let propertyName = keyPathSections[0]
         let remainingPaths = Array(keyPathSections[1..<keyPathSections.count])

--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -149,7 +149,7 @@ extension Reactive where Base: URLSession {
 
             task.resume()
 
-            return Disposables.create(with: task.cancel)
+            return Disposables.create(with: { task.cancel() })
         }
     }
 

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -157,9 +157,9 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     */
     public func drive<Object: AnyObject>(
         with object: Object,
-        onNext: ((Object, Element) -> Void)? = nil,
-        onCompleted: ((Object) -> Void)? = nil,
-        onDisposed: ((Object) -> Void)? = nil
+        onNext: (@Sendable (Object, Element) -> Void)? = nil,
+        onCompleted: (@Sendable (Object) -> Void)? = nil,
+        onDisposed: (@Sendable (Object) -> Void)? = nil
     ) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.asObservable().subscribe(with: object, onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
@@ -179,9 +179,9 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
     public func drive(
-        onNext: ((Element) -> Void)? = nil,
-        onCompleted: (() -> Void)? = nil,
-        onDisposed: (() -> Void)? = nil
+        onNext: (@Sendable (Element) -> Void)? = nil,
+        onCompleted: (@Sendable () -> Void)? = nil,
+        onDisposed: (@Sendable () -> Void)? = nil
     ) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
         return self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)

--- a/RxCocoa/Traits/Driver/Driver+Subscription.swift
+++ b/RxCocoa/Traits/Driver/Driver+Subscription.swift
@@ -157,12 +157,12 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     */
     public func drive<Object: AnyObject>(
         with object: Object,
-        onNext: (@Sendable (Object, Element) -> Void)? = nil,
-        onCompleted: (@Sendable (Object) -> Void)? = nil,
+        onNext: (@Sendable @MainActor (Object, Element) -> Void)? = nil,
+        onCompleted: (@Sendable @MainActor (Object) -> Void)? = nil,
         onDisposed: (@Sendable (Object) -> Void)? = nil
     ) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
-        return self.asObservable().subscribe(with: object, onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
+        return self.asObservable().subscribe(with: object, onNext: onNext.flatMap({ MainScheduler.assumeMainActor($0) }), onCompleted: onCompleted.flatMap({ MainScheduler.assumeMainActor($0) }), onDisposed: onDisposed)
     }
     
     /**
@@ -179,12 +179,12 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     - returns: Subscription object used to unsubscribe from the observable sequence.
     */
     public func drive(
-        onNext: (@Sendable (Element) -> Void)? = nil,
-        onCompleted: (@Sendable () -> Void)? = nil,
+        onNext: (@Sendable @MainActor (Element) -> Void)? = nil,
+        onCompleted: (@Sendable @MainActor () -> Void)? = nil,
         onDisposed: (@Sendable () -> Void)? = nil
     ) -> Disposable {
         MainScheduler.ensureRunningOnMainThread(errorMessage: errorMessage)
-        return self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
+        return self.asObservable().subscribe(onNext: onNext.flatMap({ MainScheduler.assumeMainActor($0) }), onCompleted: onCompleted.flatMap({ MainScheduler.assumeMainActor($0) }), onDisposed: onDisposed)
     }
 
     /**

--- a/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
+++ b/RxCocoa/Traits/Driver/ObservableConvertibleType+Driver.swift
@@ -45,7 +45,7 @@ extension ObservableConvertibleType {
     - parameter onErrorRecover: Calculates driver that continues to drive the sequence in case of error.
     - returns: Driver trait.
     */
-    public func asDriver(onErrorRecover: @escaping (_ error: Swift.Error) -> Driver<Element>) -> Driver<Element> {
+    public func asDriver(onErrorRecover: @escaping @Sendable (_ error: Swift.Error) -> Driver<Element>) -> Driver<Element> {
         let source = self
             .asObservable()
             .observe(on:DriverSharingStrategy.scheduler)

--- a/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift
@@ -45,7 +45,7 @@ extension ObservableConvertibleType {
      - parameter onErrorRecover: Calculates driver that continues to drive the sequence in case of error.
      - returns: Driving observable sequence.
      */
-    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorRecover: @escaping (_ error: Swift.Error) -> SharedSequence<S, Element>) -> SharedSequence<S, Element> {
+    public func asSharedSequence<S>(sharingStrategy: S.Type = S.self, onErrorRecover: @escaping @Sendable (_ error: Swift.Error) -> SharedSequence<S, Element>) -> SharedSequence<S, Element> {
         let source = self
             .asObservable()
             .observe(on:S.scheduler)

--- a/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SchedulerType+SharedSequence.swift
@@ -28,7 +28,7 @@ public enum SharingScheduler {
 
      **This shouldn't be used in normal release builds.**
      */
-    static public func mock(makeScheduler: @escaping () -> SchedulerType, action: () throws -> Void) rethrows {
+    static public func mock(makeScheduler: @escaping @Sendable () -> SchedulerType, action: () throws -> Void) rethrows {
         let originalMake = make
         make = makeScheduler
         defer {

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
@@ -273,7 +273,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
         -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators+arity.swift
@@ -21,7 +21,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.Element, O2.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, resultSelector: @escaping @Sendable (O1.Element, O2.Element) throws -> Element)
         -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy {
         let source = Observable.zip(
@@ -59,7 +59,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.Element, O2.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, resultSelector: @escaping @Sendable (O1.Element, O2.Element) throws -> Element)
         -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy {
         let source = Observable.combineLatest(
@@ -101,7 +101,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.Element, O2.Element, O3.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element) throws -> Element)
         -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy {
@@ -141,7 +141,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.Element, O2.Element, O3.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element) throws -> Element)
         -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy {
@@ -185,7 +185,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
         -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
@@ -227,7 +227,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
         -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
@@ -317,7 +317,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
         -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
@@ -365,7 +365,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
         -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
@@ -411,7 +411,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
         -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
@@ -461,7 +461,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
         -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
@@ -509,7 +509,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
         -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
@@ -561,7 +561,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
         -> SharedSequence<O1.SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,
@@ -611,7 +611,7 @@ extension SharedSequence {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: SharedSequenceConvertibleType, O2: SharedSequenceConvertibleType, O3: SharedSequenceConvertibleType, O4: SharedSequenceConvertibleType, O5: SharedSequenceConvertibleType, O6: SharedSequenceConvertibleType, O7: SharedSequenceConvertibleType, O8: SharedSequenceConvertibleType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
         -> SharedSequence<SharingStrategy, Element> where SharingStrategy == O1.SharingStrategy,
             SharingStrategy == O2.SharingStrategy,
             SharingStrategy == O3.SharingStrategy,

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -17,7 +17,7 @@ extension SharedSequenceConvertibleType {
     - parameter selector: A transform function to apply to each source element.
     - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
     */
-    public func map<Result>(_ selector: @escaping (Element) -> Result) -> SharedSequence<SharingStrategy, Result> {
+    public func map<Result>(_ selector: @escaping @Sendable (Element) -> Result) -> SharedSequence<SharingStrategy, Result> {
         let source = self
             .asObservable()
             .map(selector)
@@ -35,7 +35,7 @@ extension SharedSequenceConvertibleType {
      - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
      
      */
-    public func compactMap<Result>(_ selector: @escaping (Element) -> Result?) -> SharedSequence<SharingStrategy, Result> {
+    public func compactMap<Result>(_ selector: @escaping @Sendable (Element) -> Result?) -> SharedSequence<SharingStrategy, Result> {
         let source = self
             .asObservable()
             .compactMap(selector)
@@ -51,7 +51,7 @@ extension SharedSequenceConvertibleType {
     - parameter predicate: A function to test each source element for a condition.
     - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
     */
-    public func filter(_ predicate: @escaping (Element) -> Bool) -> SharedSequence<SharingStrategy, Element> {
+    public func filter(_ predicate: @escaping @Sendable (Element) -> Bool) -> SharedSequence<SharingStrategy, Element> {
         let source = self
             .asObservable()
             .filter(predicate)
@@ -92,7 +92,7 @@ extension SharedSequenceConvertibleType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source producing an
      Observable of Observable sequences and that at any point in time produces the elements of the most recent inner observable sequence that has been received.
      */
-    public func flatMapLatest<Sharing, Result>(_ selector: @escaping (Element) -> SharedSequence<Sharing, Result>)
+    public func flatMapLatest<Sharing, Result>(_ selector: @escaping @Sendable (Element) -> SharedSequence<Sharing, Result>)
         -> SharedSequence<Sharing, Result> {
         let source: Observable<Result> = self
             .asObservable()
@@ -111,7 +111,7 @@ extension SharedSequenceConvertibleType {
      - parameter selector: A transform function to apply to element that was observed while no observable is executing in parallel.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence that was received while no other sequence was being calculated.
      */
-    public func flatMapFirst<Sharing, Result>(_ selector: @escaping (Element) -> SharedSequence<Sharing, Result>)
+    public func flatMapFirst<Sharing, Result>(_ selector: @escaping @Sendable (Element) -> SharedSequence<Sharing, Result>)
         -> SharedSequence<Sharing, Result> {
         let source: Observable<Result> = self
             .asObservable()
@@ -134,7 +134,7 @@ extension SharedSequenceConvertibleType {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onNext: ((Element) -> Void)? = nil, afterNext: ((Element) -> Void)? = nil, onCompleted: (() -> Void)? = nil, afterCompleted: (() -> Void)? = nil, onSubscribe: (() -> Void)? = nil, onSubscribed: (() -> Void)? = nil, onDispose: (() -> Void)? = nil)
+    public func `do`(onNext: (@Sendable (Element) -> Void)? = nil, afterNext: (@Sendable (Element) -> Void)? = nil, onCompleted: (@Sendable () -> Void)? = nil, afterCompleted: (@Sendable () -> Void)? = nil, onSubscribe: (@Sendable () -> Void)? = nil, onSubscribed: (@Sendable () -> Void)? = nil, onDispose: (@Sendable () -> Void)? = nil)
         -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .do(onNext: onNext, afterNext: afterNext, onCompleted: onCompleted, afterCompleted: afterCompleted, onSubscribe: onSubscribe, onSubscribed: onSubscribed, onDispose: onDispose)
@@ -184,7 +184,7 @@ extension SharedSequenceConvertibleType {
     - parameter keySelector: A function to compute the comparison key for each element.
     - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value, from the source sequence.
     */
-    public func distinctUntilChanged<Key: Equatable>(_ keySelector: @escaping (Element) -> Key) -> SharedSequence<SharingStrategy, Element> {
+    public func distinctUntilChanged<Key: Equatable>(_ keySelector: @escaping @Sendable (Element) -> Key) -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .distinctUntilChanged(keySelector, comparer: { $0 == $1 })
         return SharedSequence(source)
@@ -196,7 +196,7 @@ extension SharedSequenceConvertibleType {
     - parameter comparer: Equality comparer for computed key values.
     - returns: An observable sequence only containing the distinct contiguous elements, based on `comparer`, from the source sequence.
     */
-    public func distinctUntilChanged(_ comparer: @escaping (Element, Element) -> Bool) -> SharedSequence<SharingStrategy, Element> {
+    public func distinctUntilChanged(_ comparer: @escaping @Sendable (Element, Element) -> Bool) -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .distinctUntilChanged({ $0 }, comparer: comparer)
         return SharedSequence<SharingStrategy, Element>(source)
@@ -209,7 +209,7 @@ extension SharedSequenceConvertibleType {
     - parameter comparer: Equality comparer for computed key values.
     - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value and the comparer, from the source sequence.
     */
-    public func distinctUntilChanged<K>(_ keySelector: @escaping (Element) -> K, comparer: @escaping (K, K) -> Bool) -> SharedSequence<SharingStrategy, Element> {
+    public func distinctUntilChanged<K>(_ keySelector: @escaping @Sendable (Element) -> K, comparer: @escaping @Sendable (K, K) -> Bool) -> SharedSequence<SharingStrategy, Element> {
         let source = self.asObservable()
             .distinctUntilChanged(keySelector, comparer: comparer)
         return SharedSequence<SharingStrategy, Element>(source)
@@ -226,7 +226,7 @@ extension SharedSequenceConvertibleType {
     - parameter selector: A transform function to apply to each element.
     - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
     */
-    public func flatMap<Sharing, Result>(_ selector: @escaping (Element) -> SharedSequence<Sharing, Result>) -> SharedSequence<Sharing, Result> {
+    public func flatMap<Sharing, Result>(_ selector: @escaping @Sendable (Element) -> SharedSequence<Sharing, Result>) -> SharedSequence<Sharing, Result> {
         let source = self.asObservable()
             .flatMap(selector)
         
@@ -398,7 +398,7 @@ extension SharedSequence {
      - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func zip<Collection: Swift.Collection, Result>(_ collection: Collection, resultSelector: @escaping ([Element]) throws -> Result) -> SharedSequence<SharingStrategy, Result>
+    public static func zip<Collection: Swift.Collection, Result>(_ collection: Collection, resultSelector: @escaping @Sendable ([Element]) throws -> Result) -> SharedSequence<SharingStrategy, Result>
         where Collection.Element == SharedSequence<SharingStrategy, Element> {
         let source = Observable.zip(collection.map { $0.asSharedSequence().asObservable() }, resultSelector: resultSelector)
         return SharedSequence<SharingStrategy, Result>(source)
@@ -425,7 +425,7 @@ extension SharedSequence {
      - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func combineLatest<Collection: Swift.Collection, Result>(_ collection: Collection, resultSelector: @escaping ([Element]) throws -> Result) -> SharedSequence<SharingStrategy, Result>
+    public static func combineLatest<Collection: Swift.Collection, Result>(_ collection: Collection, resultSelector: @escaping @Sendable ([Element]) throws -> Result) -> SharedSequence<SharingStrategy, Result>
         where Collection.Element == SharedSequence<SharingStrategy, Element> {
         let source = Observable.combineLatest(collection.map { $0.asObservable() }, resultSelector: resultSelector)
         return SharedSequence<SharingStrategy, Result>(source)
@@ -503,7 +503,7 @@ extension SharedSequenceConvertibleType {
     - parameter resultSelector: Function to invoke for each element from the self combined with the latest element from the second source, if any.
     - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
     */
-    public func withLatestFrom<SecondO: SharedSequenceConvertibleType, ResultType>(_ second: SecondO, resultSelector: @escaping (Element, SecondO.Element) -> ResultType) -> SharedSequence<SharingStrategy, ResultType> where SecondO.SharingStrategy == SharingStrategy {
+    public func withLatestFrom<SecondO: SharedSequenceConvertibleType, ResultType>(_ second: SecondO, resultSelector: @escaping @Sendable (Element, SecondO.Element) -> ResultType) -> SharedSequence<SharingStrategy, ResultType> where SecondO.SharingStrategy == SharingStrategy {
         let source = self.asObservable()
             .withLatestFrom(second.asSharedSequence(), resultSelector: resultSelector)
 

--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift
@@ -355,7 +355,7 @@ extension SharedSequenceConvertibleType {
     - parameter accumulator: An accumulator function to be invoked on each element.
     - returns: An observable sequence containing the accumulated values.
     */
-    public func scan<A>(_ seed: A, accumulator: @escaping (A, Element) -> A)
+    public func scan<A>(_ seed: A, accumulator: @escaping @Sendable (A, Element) -> A)
         -> SharedSequence<SharingStrategy, A> {
         let source = self.asObservable()
             .scan(seed, accumulator: accumulator)
@@ -458,7 +458,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      */
     public func withUnretained<Object: AnyObject, Out>(
         _ obj: Object,
-        resultSelector: @escaping (Object, Element) -> Out
+        resultSelector: @escaping @Sendable (Object, Element) -> Out
     ) -> SharedSequence<SharingStrategy, Out> {
         SharedSequence(self.asObservable().withUnretained(obj, resultSelector: resultSelector))
     }
@@ -482,7 +482,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
     @available(*, message: "withUnretained has been deprecated for Driver. Consider using `drive(with:onNext:onCompleted:onDisposed:)`, instead", unavailable)
     public func withUnretained<Object: AnyObject, Out>(
         _ obj: Object,
-        resultSelector: @escaping (Object, Element) -> Out
+        resultSelector: @escaping @Sendable (Object, Element) -> Out
     ) -> SharedSequence<SharingStrategy, Out> {
         SharedSequence(self.asObservable().withUnretained(obj, resultSelector: resultSelector))
     }

--- a/RxCocoa/Traits/SharedSequence/SharedSequence.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence.swift
@@ -136,7 +136,7 @@ extension SharedSequence {
      - parameter observableFactory: Observable factory function to invoke for each observer that subscribes to the resulting sequence.
      - returns: An observable sequence whose observers trigger an invocation of the given observable factory function.
      */
-    public static func deferred(_ observableFactory: @escaping () -> SharedSequence<SharingStrategy, Element>)
+    public static func deferred(_ observableFactory: @escaping @Sendable () -> SharedSequence<SharingStrategy, Element>)
         -> SharedSequence<SharingStrategy, Element> {
         SharedSequence(Observable.deferred { observableFactory().asObservable() })
     }

--- a/RxCocoa/Traits/Signal/ObservableConvertibleType+Signal.swift
+++ b/RxCocoa/Traits/Signal/ObservableConvertibleType+Signal.swift
@@ -45,7 +45,7 @@ extension ObservableConvertibleType {
      - parameter onErrorRecover: Calculates signal that continues to emit the sequence in case of error.
      - returns: Signal trait.
      */
-    public func asSignal(onErrorRecover: @escaping (_ error: Swift.Error) -> Signal<Element>) -> Signal<Element> {
+    public func asSignal(onErrorRecover: @escaping @Sendable (_ error: Swift.Error) -> Signal<Element>) -> Signal<Element> {
         let source = self
             .asObservable()
             .observe(on: SignalSharingStrategy.scheduler)

--- a/RxCocoa/Traits/Signal/Signal+Subscription.swift
+++ b/RxCocoa/Traits/Signal/Signal+Subscription.swift
@@ -132,9 +132,9 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      */
     public func emit<Object: AnyObject>(
         with object: Object,
-        onNext: ((Object, Element) -> Void)? = nil,
-        onCompleted: ((Object) -> Void)? = nil,
-        onDisposed: ((Object) -> Void)? = nil
+        onNext: (@Sendable (Object, Element) -> Void)? = nil,
+        onCompleted: (@Sendable (Object) -> Void)? = nil,
+        onDisposed: (@Sendable (Object) -> Void)? = nil
     ) -> Disposable {
         self.asObservable().subscribe(
             with: object,
@@ -157,9 +157,9 @@ extension SharedSequenceConvertibleType where SharingStrategy == SignalSharingSt
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
     public func emit(
-        onNext: ((Element) -> Void)? = nil,
-        onCompleted: (() -> Void)? = nil,
-        onDisposed: (() -> Void)? = nil
+        onNext: (@Sendable (Element) -> Void)? = nil,
+        onCompleted: (@Sendable () -> Void)? = nil,
+        onDisposed: (@Sendable () -> Void)? = nil
     ) -> Disposable {
         self.asObservable().subscribe(onNext: onNext, onCompleted: onCompleted, onDisposed: onDisposed)
     }

--- a/RxCocoa/iOS/DataSources/RxCollectionViewReactiveArrayDataSource.swift
+++ b/RxCocoa/iOS/DataSources/RxCollectionViewReactiveArrayDataSource.swift
@@ -50,7 +50,9 @@ class RxCollectionViewReactiveArrayDataSourceSequenceWrapper<Sequence: Swift.Seq
     func collectionView(_ collectionView: UICollectionView, observedEvent: Event<Sequence>) {
         Binder(self) { collectionViewDataSource, sectionModels in
             let sections = Array(sectionModels)
-            collectionViewDataSource.collectionView(collectionView, observedElements: sections)
+            MainScheduler.assumeMainActor(execute: {
+                collectionViewDataSource.collectionView(collectionView, observedElements: sections)
+            })
         }.on(observedEvent)
     }
 }
@@ -61,7 +63,7 @@ class RxCollectionViewReactiveArrayDataSource<Element>
     : _RxCollectionViewReactiveArrayDataSource
     , SectionedViewDataSourceType {
     
-    typealias CellFactory = (UICollectionView, Int, Element) -> UICollectionViewCell
+    typealias CellFactory = @MainActor (UICollectionView, Int, Element) -> UICollectionViewCell
     
     var itemModels: [Element]?
     

--- a/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
+++ b/RxCocoa/iOS/DataSources/RxPickerViewAdapter.swift
@@ -12,7 +12,7 @@ import UIKit
 import RxSwift
 
 class RxPickerViewArrayDataSource<T>: NSObject, UIPickerViewDataSource, SectionedViewDataSourceType {
-    fileprivate var items: [T] = []
+    nonisolated(unsafe) fileprivate var items: [T] = []
     
     func model(at indexPath: IndexPath) throws -> Any {
         guard items.indices ~= indexPath.row else {
@@ -38,7 +38,9 @@ class RxPickerViewSequenceDataSource<Sequence: Swift.Sequence>
     func pickerView(_ pickerView: UIPickerView, observedEvent: Event<Sequence>) {
         Binder(self) { dataSource, items in
             dataSource.items = items
-            pickerView.reloadAllComponents()
+            MainScheduler.assumeMainActor(execute: {
+                pickerView.reloadAllComponents()
+            })
         }
         .on(observedEvent.map(Array.init))
     }
@@ -48,7 +50,7 @@ final class RxStringPickerViewAdapter<Sequence: Swift.Sequence>
     : RxPickerViewSequenceDataSource<Sequence>
     , UIPickerViewDelegate {
     
-    typealias TitleForRow = (Int, Sequence.Element) -> String?
+    typealias TitleForRow = @MainActor (Int, Sequence.Element) -> String?
     private let titleForRow: TitleForRow
     
     init(titleForRow: @escaping TitleForRow) {
@@ -62,7 +64,7 @@ final class RxStringPickerViewAdapter<Sequence: Swift.Sequence>
 }
 
 final class RxAttributedStringPickerViewAdapter<Sequence: Swift.Sequence>: RxPickerViewSequenceDataSource<Sequence>, UIPickerViewDelegate {
-    typealias AttributedTitleForRow = (Int, Sequence.Element) -> NSAttributedString?
+    typealias AttributedTitleForRow = @MainActor (Int, Sequence.Element) -> NSAttributedString?
     private let attributedTitleForRow: AttributedTitleForRow
     
     init(attributedTitleForRow: @escaping AttributedTitleForRow) {
@@ -76,7 +78,7 @@ final class RxAttributedStringPickerViewAdapter<Sequence: Swift.Sequence>: RxPic
 }
 
 final class RxPickerViewAdapter<Sequence: Swift.Sequence>: RxPickerViewSequenceDataSource<Sequence>, UIPickerViewDelegate {
-    typealias ViewForRow = (Int, Sequence.Element, UIView?) -> UIView
+    typealias ViewForRow = @MainActor (Int, Sequence.Element, UIView?) -> UIView
     private let viewForRow: ViewForRow
     
     init(viewForRow: @escaping ViewForRow) {

--- a/RxCocoa/iOS/DataSources/RxTableViewReactiveArrayDataSource.swift
+++ b/RxCocoa/iOS/DataSources/RxTableViewReactiveArrayDataSource.swift
@@ -50,7 +50,9 @@ class RxTableViewReactiveArrayDataSourceSequenceWrapper<Sequence: Swift.Sequence
     func tableView(_ tableView: UITableView, observedEvent: Event<Sequence>) {
         Binder(self) { tableViewDataSource, sectionModels in
             let sections = Array(sectionModels)
-            tableViewDataSource.tableView(tableView, observedElements: sections)
+            MainScheduler.assumeMainActor(execute: {
+                tableViewDataSource.tableView(tableView, observedElements: sections)
+            })
         }.on(observedEvent)
     }
 }
@@ -59,7 +61,7 @@ class RxTableViewReactiveArrayDataSourceSequenceWrapper<Sequence: Swift.Sequence
 class RxTableViewReactiveArrayDataSource<Element>
     : _RxTableViewReactiveArrayDataSource
     , SectionedViewDataSourceType {
-    typealias CellFactory = (UITableView, Int, Element) -> UITableViewCell
+    typealias CellFactory = @MainActor (UITableView, Int, Element) -> UITableViewCell
     
     var itemModels: [Element]?
     

--- a/RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxCollectionViewDelegateProxy.swift
@@ -21,6 +21,7 @@ open class RxCollectionViewDelegateProxy
     /// Initializes `RxCollectionViewDelegateProxy`
     ///
     /// - parameter collectionView: Parent object for delegate proxy.
+    nonisolated
     public init(collectionView: UICollectionView) {
         self.collectionView = collectionView
         super.init(scrollView: collectionView)

--- a/RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTableViewDelegateProxy.swift
@@ -19,6 +19,7 @@ open class RxTableViewDelegateProxy
     public weak private(set) var tableView: UITableView?
 
     /// - parameter tableView: Parent object for delegate proxy.
+    nonisolated
     public init(tableView: UITableView) {
         self.tableView = tableView
         super.init(scrollView: tableView)

--- a/RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift
+++ b/RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift
@@ -19,6 +19,7 @@ open class RxTextViewDelegateProxy
     public weak private(set) var textView: UITextView?
 
     /// - parameter textview: Parent object for delegate proxy.
+    nonisolated
     public init(textView: UITextView) {
         self.textView = textView
         super.init(scrollView: textView)

--- a/RxCocoa/iOS/UIActivityIndicatorView+Rx.swift
+++ b/RxCocoa/iOS/UIActivityIndicatorView+Rx.swift
@@ -14,13 +14,17 @@ import RxSwift
 extension Reactive where Base: UIActivityIndicatorView {
     /// Bindable sink for `startAnimating()`, `stopAnimating()` methods.
     public var isAnimating: Binder<Bool> {
-        Binder(self.base) { activityIndicator, active in
-            if active {
-                activityIndicator.startAnimating()
-            } else {
-                activityIndicator.stopAnimating()
+        MainScheduler.assumeMainActor(execute: {
+            Binder(self.base) { activityIndicator, active in
+                MainScheduler.assumeMainActor(execute: {
+                    if active {
+                        activityIndicator.startAnimating()
+                    } else {
+                        activityIndicator.stopAnimating()
+                    }
+                })
             }
-        }
+        })
     }
 }
 

--- a/RxCocoa/iOS/UIApplication+Rx.swift
+++ b/RxCocoa/iOS/UIApplication+Rx.swift
@@ -17,7 +17,7 @@ extension Reactive where Base: UIApplication {
   /// Bindable sink for `isNetworkActivityIndicatorVisible`.
   public var isNetworkActivityIndicatorVisible: Binder<Bool> {
     return Binder(self.base) { application, active in
-      application.isNetworkActivityIndicatorVisible = active
+      MainScheduler.assumeMainActor(execute: { application.isNetworkActivityIndicatorVisible = active })
     }
   }
 }

--- a/RxCocoa/iOS/UIBarButtonItem+Rx.swift
+++ b/RxCocoa/iOS/UIBarButtonItem+Rx.swift
@@ -43,7 +43,7 @@ final class BarButtonItemTarget: RxTarget {
     weak var barButtonItem: UIBarButtonItem?
     var callback: Callback!
     
-    init(barButtonItem: UIBarButtonItem, callback: @escaping () -> Void) {
+    init(barButtonItem: UIBarButtonItem, callback: @escaping @Sendable () -> Void) {
         self.barButtonItem = barButtonItem
         self.callback = callback
         super.init()

--- a/RxCocoa/iOS/UIButton+Rx.swift
+++ b/RxCocoa/iOS/UIButton+Rx.swift
@@ -46,21 +46,27 @@ extension Reactive where Base: UIButton {
     /// Reactive wrapper for `setTitle(_:for:)`
     public func title(for controlState: UIControl.State = []) -> Binder<String?> {
         Binder(self.base) { button, title in
-            button.setTitle(title, for: controlState)
+            MainScheduler.assumeMainActor(execute: {
+                button.setTitle(title, for: controlState)
+            })
         }
     }
 
     /// Reactive wrapper for `setImage(_:for:)`
     public func image(for controlState: UIControl.State = []) -> Binder<UIImage?> {
         Binder(self.base) { button, image in
-            button.setImage(image, for: controlState)
+            MainScheduler.assumeMainActor(execute: {
+                button.setImage(image, for: controlState)
+            })
         }
     }
 
     /// Reactive wrapper for `setBackgroundImage(_:for:)`
     public func backgroundImage(for controlState: UIControl.State = []) -> Binder<UIImage?> {
         Binder(self.base) { button, image in
-            button.setBackgroundImage(image, for: controlState)
+            MainScheduler.assumeMainActor(execute: {
+                button.setBackgroundImage(image, for: controlState)
+            })
         }
     }
     
@@ -75,7 +81,9 @@ extension Reactive where Base: UIButton {
         /// Reactive wrapper for `setAttributedTitle(_:controlState:)`
         public func attributedTitle(for controlState: UIControl.State = []) -> Binder<NSAttributedString?> {
             return Binder(self.base) { button, attributedTitle -> Void in
-                button.setAttributedTitle(attributedTitle, for: controlState)
+                MainScheduler.assumeMainActor(execute: {
+                    button.setAttributedTitle(attributedTitle, for: controlState)
+                })
             }
         }
     }

--- a/RxCocoa/iOS/UICollectionView+Rx.swift
+++ b/RxCocoa/iOS/UICollectionView+Rx.swift
@@ -41,7 +41,7 @@ extension Reactive where Base: UICollectionView {
     */
     public func items<Sequence: Swift.Sequence, Source: ObservableType>
         (_ source: Source)
-        -> (_ cellFactory: @escaping (UICollectionView, Int, Sequence.Element) -> UICollectionViewCell)
+        -> (_ cellFactory: @escaping @Sendable (UICollectionView, Int, Sequence.Element) -> UICollectionViewCell)
         -> Disposable where Source.Element == Sequence {
         return { cellFactory in
             let dataSource = RxCollectionViewReactiveArrayDataSourceSequenceWrapper<Sequence>(cellFactory: cellFactory)
@@ -76,7 +76,7 @@ extension Reactive where Base: UICollectionView {
     public func items<Sequence: Swift.Sequence, Cell: UICollectionViewCell, Source: ObservableType>
         (cellIdentifier: String, cellType: Cell.Type = Cell.self)
         -> (_ source: Source)
-        -> (_ configureCell: @escaping (Int, Sequence.Element, Cell) -> Void)
+        -> (_ configureCell: @escaping @Sendable (Int, Sequence.Element, Cell) -> Void)
         -> Disposable where Source.Element == Sequence {
         return { source in
             return { configureCell in

--- a/RxCocoa/iOS/UIPickerView+Rx.swift
+++ b/RxCocoa/iOS/UIPickerView+Rx.swift
@@ -69,13 +69,14 @@
                 guard let view = view else {
                     return Observable.empty()
                 }
-
-                let model: [T] = try (0 ..< view.numberOfComponents).map { component in
-                    let row = view.selectedRow(inComponent: component)
-                    return try view.rx.model(at: IndexPath(row: row, section: component))
-                }
-
-                return Observable.just(model)
+                return try MainScheduler.assumeMainActor(execute: {
+                    let model: [T] = try (0 ..< view.numberOfComponents).map { component in
+                        let row = view.selectedRow(inComponent: component)
+                        return try view.rx.model(at: IndexPath(row: row, section: component))
+                    }
+                    
+                    return Observable.just(model)
+                })
             }
             
             return ControlEvent(events: source)
@@ -106,7 +107,7 @@
         
         public func itemTitles<Sequence: Swift.Sequence, Source: ObservableType>
             (_ source: Source)
-            -> (_ titleForRow: @escaping (Int, Sequence.Element) -> String?)
+            -> (_ titleForRow: @escaping @Sendable (Int, Sequence.Element) -> String?)
             -> Disposable where Source.Element == Sequence {
                 return { titleForRow in
                     let adapter = RxStringPickerViewAdapter<Sequence>(titleForRow: titleForRow)
@@ -139,7 +140,7 @@
 
         public func itemAttributedTitles<Sequence: Swift.Sequence, Source: ObservableType>
             (_ source: Source)
-            -> (_ attributedTitleForRow: @escaping (Int, Sequence.Element) -> NSAttributedString?)
+            -> (_ attributedTitleForRow: @escaping @Sendable (Int, Sequence.Element) -> NSAttributedString?)
             -> Disposable where Source.Element == Sequence {
                 return { attributedTitleForRow in
                     let adapter = RxAttributedStringPickerViewAdapter<Sequence>(attributedTitleForRow: attributedTitleForRow)
@@ -178,7 +179,7 @@
 
         public func items<Sequence: Swift.Sequence, Source: ObservableType>
             (_ source: Source)
-            -> (_ viewForRow: @escaping (Int, Sequence.Element, UIView?) -> UIView)
+            -> (_ viewForRow: @escaping @Sendable (Int, Sequence.Element, UIView?) -> UIView)
             -> Disposable where Source.Element == Sequence {
                 return { viewForRow in
                     let adapter = RxPickerViewAdapter<Sequence>(viewForRow: viewForRow)

--- a/RxCocoa/iOS/UIRefreshControl+Rx.swift
+++ b/RxCocoa/iOS/UIRefreshControl+Rx.swift
@@ -15,11 +15,13 @@ extension Reactive where Base: UIRefreshControl {
     /// Bindable sink for `beginRefreshing()`, `endRefreshing()` methods.
     public var isRefreshing: Binder<Bool> {
         return Binder(self.base) { refreshControl, refresh in
-            if refresh {
-                refreshControl.beginRefreshing()
-            } else {
-                refreshControl.endRefreshing()
-            }
+            MainScheduler.assumeMainActor(execute: {
+                if refresh {
+                    refreshControl.beginRefreshing()
+                } else {
+                    refreshControl.endRefreshing()
+                }
+            })
         }
     }
 

--- a/RxCocoa/iOS/UIScrollView+Rx.swift
+++ b/RxCocoa/iOS/UIScrollView+Rx.swift
@@ -27,7 +27,9 @@
             let proxy = RxScrollViewDelegateProxy.proxy(for: base)
 
             let bindingObserver = Binder(self.base) { scrollView, contentOffset in
-                scrollView.contentOffset = contentOffset
+                MainScheduler.assumeMainActor(execute: {                
+                    scrollView.contentOffset = contentOffset
+                })
             }
 
             return ControlProperty(values: proxy.contentOffsetBehaviorSubject, valueSink: bindingObserver)

--- a/RxCocoa/iOS/UISegmentedControl+Rx.swift
+++ b/RxCocoa/iOS/UISegmentedControl+Rx.swift
@@ -31,21 +31,27 @@ extension Reactive where Base: UISegmentedControl {
     /// Reactive wrapper for `setEnabled(_:forSegmentAt:)`
     public func enabledForSegment(at index: Int) -> Binder<Bool> {
         return Binder(self.base) { segmentedControl, segmentEnabled -> Void in
-            segmentedControl.setEnabled(segmentEnabled, forSegmentAt: index)
+            MainScheduler.assumeMainActor(execute: {
+                segmentedControl.setEnabled(segmentEnabled, forSegmentAt: index)
+            })
         }
     }
     
     /// Reactive wrapper for `setTitle(_:forSegmentAt:)`
     public func titleForSegment(at index: Int) -> Binder<String?> {
         return Binder(self.base) { segmentedControl, title -> Void in
-            segmentedControl.setTitle(title, forSegmentAt: index)
+            MainScheduler.assumeMainActor(execute: {
+                segmentedControl.setTitle(title, forSegmentAt: index)
+            })
         }
     }
     
     /// Reactive wrapper for `setImage(_:forSegmentAt:)`
     public func imageForSegment(at index: Int) -> Binder<UIImage?> {
         return Binder(self.base) { segmentedControl, image -> Void in
-            segmentedControl.setImage(image, forSegmentAt: index)
+            MainScheduler.assumeMainActor(execute: {
+                segmentedControl.setImage(image, forSegmentAt: index)
+            })
         }
     }
 

--- a/RxCocoa/iOS/UITableView+Rx.swift
+++ b/RxCocoa/iOS/UITableView+Rx.swift
@@ -41,7 +41,7 @@ extension Reactive where Base: UITableView {
      */
     public func items<Sequence: Swift.Sequence, Source: ObservableType>
         (_ source: Source)
-        -> (_ cellFactory: @escaping (UITableView, Int, Sequence.Element) -> UITableViewCell)
+        -> (_ cellFactory: @escaping @Sendable (UITableView, Int, Sequence.Element) -> UITableViewCell)
         -> Disposable
         where Source.Element == Sequence {
             return { cellFactory in
@@ -76,7 +76,7 @@ extension Reactive where Base: UITableView {
     public func items<Sequence: Swift.Sequence, Cell: UITableViewCell, Source: ObservableType>
         (cellIdentifier: String, cellType: Cell.Type = Cell.self)
         -> (_ source: Source)
-        -> (_ configureCell: @escaping (Int, Sequence.Element, Cell) -> Void)
+        -> (_ configureCell: @escaping @Sendable (Int, Sequence.Element, Cell) -> Void)
         -> Disposable
         where Source.Element == Sequence {
         return { source in

--- a/RxCocoa/macOS/NSControl+Rx.swift
+++ b/RxCocoa/macOS/NSControl+Rx.swift
@@ -47,8 +47,8 @@ extension Reactive where Base: NSControl {
     /// - parameter getter: Property value getter.
     /// - parameter setter: Property value setter.
     public func controlProperty<T>(
-        getter: @escaping (Base) -> T,
-        setter: @escaping (Base, T) -> Void
+        getter: @escaping @Sendable (Base) -> T,
+        setter: @escaping @Sendable (Base, T) -> Void
     ) -> ControlProperty<T> {
         MainScheduler.ensureRunningOnMainThread()
 

--- a/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
+++ b/RxExample/Extensions/RxCLLocationManagerDelegateProxy.swift
@@ -10,7 +10,7 @@ import CoreLocation
 import RxSwift
 import RxCocoa
 
-extension CLLocationManager: HasDelegate {
+extension CLLocationManager: @retroactive HasDelegate {
     public typealias Delegate = CLLocationManagerDelegate
 }
 

--- a/RxExample/Extensions/RxImagePickerDelegateProxy.swift
+++ b/RxExample/Extensions/RxImagePickerDelegateProxy.swift
@@ -15,6 +15,7 @@ import UIKit
 open class RxImagePickerDelegateProxy
     : RxNavigationControllerDelegateProxy, UIImagePickerControllerDelegate {
 
+    nonisolated
     public init(imagePicker: UIImagePickerController) {
         super.init(navigationController: imagePicker)
     }

--- a/RxExample/RxDataSources/RxDataSources/TableViewSectionedDataSource.swift
+++ b/RxExample/RxDataSources/RxDataSources/TableViewSectionedDataSource.swift
@@ -19,21 +19,21 @@ open class TableViewSectionedDataSource<Section: SectionModelType>
     
     public typealias Item = Section.Item
 
-    public typealias ConfigureCell = (TableViewSectionedDataSource<Section>, UITableView, IndexPath, Item) -> UITableViewCell
-    public typealias TitleForHeaderInSection = (TableViewSectionedDataSource<Section>, Int) -> String?
-    public typealias TitleForFooterInSection = (TableViewSectionedDataSource<Section>, Int) -> String?
-    public typealias CanEditRowAtIndexPath = (TableViewSectionedDataSource<Section>, IndexPath) -> Bool
-    public typealias CanMoveRowAtIndexPath = (TableViewSectionedDataSource<Section>, IndexPath) -> Bool
+    public typealias ConfigureCell = @Sendable @MainActor (TableViewSectionedDataSource<Section>, UITableView, IndexPath, Item) -> UITableViewCell
+    public typealias TitleForHeaderInSection = @Sendable @MainActor (TableViewSectionedDataSource<Section>, Int) -> String?
+    public typealias TitleForFooterInSection = @Sendable @MainActor (TableViewSectionedDataSource<Section>, Int) -> String?
+    public typealias CanEditRowAtIndexPath = @Sendable @MainActor (TableViewSectionedDataSource<Section>, IndexPath) -> Bool
+    public typealias CanMoveRowAtIndexPath = @Sendable @MainActor (TableViewSectionedDataSource<Section>, IndexPath) -> Bool
 
     #if os(iOS)
-        public typealias SectionIndexTitles = (TableViewSectionedDataSource<Section>) -> [String]?
-        public typealias SectionForSectionIndexTitle = (TableViewSectionedDataSource<Section>, _ title: String, _ index: Int) -> Int
+        public typealias SectionIndexTitles = @Sendable @MainActor (TableViewSectionedDataSource<Section>) -> [String]?
+        public typealias SectionForSectionIndexTitle = @Sendable @MainActor (TableViewSectionedDataSource<Section>, _ title: String, _ index: Int) -> Int
     #endif
 
     #if os(iOS)
         public init(
                 configureCell: @escaping ConfigureCell,
-                titleForHeaderInSection: @escaping  TitleForHeaderInSection = { _, _ in nil },
+                titleForHeaderInSection: @escaping TitleForHeaderInSection = { _, _ in nil },
                 titleForFooterInSection: @escaping TitleForFooterInSection = { _, _ in nil },
                 canEditRowAtIndexPath: @escaping CanEditRowAtIndexPath = { _, _ in false },
                 canMoveRowAtIndexPath: @escaping CanMoveRowAtIndexPath = { _, _ in false },
@@ -173,47 +173,49 @@ open class TableViewSectionedDataSource<Section: SectionModelType>
     
 
     // UITableViewDataSource
-    
+    @MainActor
     open func numberOfSections(in tableView: UITableView) -> Int {
         _sectionModels.count
     }
-    
+    @MainActor
     open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         guard _sectionModels.count > section else { return 0 }
         return _sectionModels[section].items.count
     }
-    
+    @MainActor
     open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         precondition(indexPath.item < _sectionModels[indexPath.section].items.count)
         
         return configureCell(self, tableView, indexPath, self[indexPath])
     }
-    
+    @MainActor
     open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         titleForHeaderInSection(self, section)
     }
-   
+    @MainActor
     open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         titleForFooterInSection(self, section)
     }
-    
+    @MainActor
     open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         canEditRowAtIndexPath(self, indexPath)
     }
-   
+    @MainActor
     open func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
         canMoveRowAtIndexPath(self, indexPath)
     }
-
+    @MainActor
     open func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
         self._sectionModels.moveFromSourceIndexPath(sourceIndexPath, destinationIndexPath: destinationIndexPath)
     }
 
     #if os(iOS)
+    @MainActor
     open func sectionIndexTitles(for tableView: UITableView) -> [String]? {
         sectionIndexTitles(self)
     }
     
+    @MainActor
     open func tableView(_ tableView: UITableView, sectionForSectionIndexTitle title: String, at index: Int) -> Int {
         sectionForSectionIndexTitle(self, title, index)
     }

--- a/RxExample/RxExample-iOSTests/Mocks/MockGitHubAPI.swift
+++ b/RxExample/RxExample-iOSTests/Mocks/MockGitHubAPI.swift
@@ -9,12 +9,12 @@
 import RxSwift
 
 class MockGitHubAPI : GitHubAPI {
-    let _usernameAvailable: (String) -> Observable<Bool>
-    let _signup: ((String, String)) -> Observable<Bool>
+    let _usernameAvailable: @Sendable (String) -> Observable<Bool>
+    let _signup: @Sendable ((String, String)) -> Observable<Bool>
 
     init(
-        usernameAvailable: @escaping (String) -> Observable<Bool> = notImplemented(),
-        signup: @escaping ((String, String)) -> Observable<Bool> = notImplemented()
+        usernameAvailable: @escaping @Sendable (String) -> Observable<Bool> = notImplemented(),
+        signup: @escaping @Sendable ((String, String)) -> Observable<Bool> = notImplemented()
         ) {
         _usernameAvailable = usernameAvailable
         _signup = signup

--- a/RxExample/RxExample-iOSTests/Mocks/MockWireframe.swift
+++ b/RxExample/RxExample-iOSTests/Mocks/MockWireframe.swift
@@ -10,11 +10,11 @@ import RxSwift
 import Foundation
 
 class MockWireframe: Wireframe {
-    let _openURL: (URL) -> Void
-    let _promptFor: (String, Any, [Any]) -> Observable<Any>
+    let _openURL: @Sendable (URL) -> Void
+    let _promptFor: @Sendable (String, Any, [Any]) -> Observable<Any>
 
-    init(openURL: @escaping (URL) -> Void = notImplementedSync(),
-         promptFor: @escaping (String, Any, [Any]) -> Observable<Any> = notImplemented()) {
+    init(openURL: @escaping @Sendable (URL) -> Void = notImplementedSync(),
+         promptFor: @escaping @Sendable (String, Any, [Any]) -> Observable<Any> = notImplemented()) {
         _openURL = openURL
         _promptFor = promptFor
     }

--- a/RxExample/RxExample-iOSTests/Mocks/NotImplementedStubs.swift
+++ b/RxExample/RxExample-iOSTests/Mocks/NotImplementedStubs.swift
@@ -22,25 +22,25 @@ func genericFatal<T>(_ message: String) -> T {
 
 // MARK: Not implemented stubs
 
-func notImplemented<T1, T2>() -> (T1) -> Observable<T2> {
+func notImplemented<T1, T2>() -> @Sendable (T1) -> Observable<T2> {
     return { _ -> Observable<T2> in
         return genericFatal("Not implemented")
     }
 }
 
-func notImplemented<T1, T2, T3>() -> (T1, T2) -> Observable<T3> {
+func notImplemented<T1, T2, T3>() -> @Sendable (T1, T2) -> Observable<T3> {
     return { _, _ -> Observable<T3> in
         return genericFatal("Not implemented")
     }
 }
 
-func notImplemented<T1, T2, T3, T4>() -> (T1, T2, T3) -> Observable<T4> {
+func notImplemented<T1, T2, T3, T4>() -> @Sendable (T1, T2, T3) -> Observable<T4> {
     return { _, _, _ -> Observable<T4> in
         return genericFatal("Not implemented")
     }
 }
 
-func notImplementedSync<T1>() -> (T1) -> Void {
+func notImplementedSync<T1>() -> @Sendable (T1) -> Void {
     return { _ in
         genericFatal("Not implemented")
     }

--- a/RxExample/RxExample-iOSTests/TestScheduler+MarbleTests.swift
+++ b/RxExample/RxExample-iOSTests/TestScheduler+MarbleTests.swift
@@ -137,10 +137,10 @@ extension TestScheduler {
      - returns: Observable sequence specified by timeline and values.
     */
     func createObservable<T>(_ events: [[Recorded<Event<T>>]]) -> Observable<T> {
-        var attemptCount = 0
+        nonisolated(unsafe) var attemptCount = 0
         print("created for \(events)")
 
-        return Observable.create { observer in
+        return Observable.create { @Sendable observer in
             if attemptCount >= events.count {
                 fatalError("This is attempt # \(attemptCount + 1), but timeline only allows \(events.count).\n\(events)")
             }
@@ -172,7 +172,7 @@ extension TestScheduler {
      - returns: Implementation of method that accepts arguments with parameter `Arg` and returns observable sequence
         with parameter `Ret`.
      */
-    func mock<Arg, Ret>(values: [String: Ret], errors: [String: Swift.Error] = [:], timelineSelector: @escaping (Arg) -> String) -> (Arg) -> Observable<Ret> {
+    func mock<Arg, Ret>(values: [String: Ret], errors: [String: Swift.Error] = [:], timelineSelector: @escaping @Sendable (Arg) -> String) -> (Arg) -> Observable<Ret> {
         return { (parameters: Arg) -> Observable<Ret> in
             let timeline = timelineSelector(parameters)
 

--- a/RxExample/RxExample/Examples/ImagePicker/UIImagePickerController+RxCreate.swift
+++ b/RxExample/RxExample/Examples/ImagePicker/UIImagePickerController+RxCreate.swift
@@ -25,37 +25,39 @@ func dismissViewController(_ viewController: UIViewController, animated: Bool) {
 }
 
 extension Reactive where Base: UIImagePickerController {
-    static func createWithParent(_ parent: UIViewController?, animated: Bool = true, configureImagePicker: @escaping (UIImagePickerController) throws -> Void = { x in }) -> Observable<UIImagePickerController> {
+    static func createWithParent(_ parent: UIViewController?, animated: Bool = true, configureImagePicker: @escaping @Sendable (UIImagePickerController) throws -> Void = { x in }) -> Observable<UIImagePickerController> {
         return Observable.create { [weak parent] observer in
-            let imagePicker = UIImagePickerController()
-            let dismissDisposable = imagePicker.rx
-                .didCancel
-                .subscribe(onNext: { [weak imagePicker] _ in
-                    guard let imagePicker = imagePicker else {
-                        return
-                    }
+            MainScheduler.assumeMainActor(execute: {
+                let imagePicker = UIImagePickerController()
+                let dismissDisposable = imagePicker.rx
+                    .didCancel
+                    .subscribe(onNext: { [weak imagePicker] _ in
+                        guard let imagePicker = imagePicker else {
+                            return
+                        }
+                        dismissViewController(imagePicker, animated: animated)
+                    })
+                
+                do {
+                    try configureImagePicker(imagePicker)
+                }
+                catch let error {
+                    observer.on(.error(error))
+                    return Disposables.create()
+                }
+                
+                guard let parent = parent else {
+                    observer.on(.completed)
+                    return Disposables.create()
+                }
+                
+                parent.present(imagePicker, animated: animated, completion: nil)
+                observer.on(.next(imagePicker))
+                
+                return Disposables.create(dismissDisposable, Disposables.create {
                     dismissViewController(imagePicker, animated: animated)
                 })
-            
-            do {
-                try configureImagePicker(imagePicker)
-            }
-            catch let error {
-                observer.on(.error(error))
-                return Disposables.create()
-            }
-
-            guard let parent = parent else {
-                observer.on(.completed)
-                return Disposables.create()
-            }
-
-            parent.present(imagePicker, animated: animated, completion: nil)
-            observer.on(.next(imagePicker))
-            
-            return Disposables.create(dismissDisposable, Disposables.create {
-                    dismissViewController(imagePicker, animated: animated)
-                })
+            })
         }
     }
 }

--- a/RxExample/RxExample/Feedbacks.swift
+++ b/RxExample/RxExample/Feedbacks.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2017 Krunoslav Zaher. All rights reserved.
 //
 
-import RxSwift
-import RxCocoa
+@preconcurrency import RxSwift
+@preconcurrency import RxCocoa
 
 // Taken from RxFeedback repo
 
@@ -26,9 +26,9 @@ import RxCocoa
  - returns: Feedback loop performing the effects.
  */
 public func react<State, Query, Event>(
-    query: @escaping (State) -> Query?,
-    areEqual: @escaping (Query, Query) -> Bool,
-    effects: @escaping (Query) -> Observable<Event>
+    query: @escaping @Sendable (State) -> Query?,
+    areEqual: @escaping @Sendable (Query, Query) -> Bool,
+    effects: @escaping @Sendable (Query) -> Observable<Event>
     ) -> (ObservableSchedulerContext<State>) -> Observable<Event> {
     return { state in
         return state.map(query)
@@ -65,8 +65,8 @@ public func react<State, Query, Event>(
  - returns: Feedback loop performing the effects.
  */
 public func react<State, Query: Equatable, Event>(
-    query: @escaping (State) -> Query?,
-    effects: @escaping (Query) -> Observable<Event>
+    query: @escaping @Sendable (State) -> Query?,
+    effects: @escaping @Sendable (Query) -> Observable<Event>
     ) -> (ObservableSchedulerContext<State>) -> Observable<Event> {
     return react(query: query, areEqual: { $0 == $1 }, effects: effects)
 }
@@ -86,9 +86,9 @@ public func react<State, Query: Equatable, Event>(
  - returns: Feedback loop performing the effects.
  */
 public func react<State, Query, Event>(
-    query: @escaping (State) -> Query?,
-    areEqual: @escaping (Query, Query) -> Bool,
-    effects: @escaping (Query) -> Signal<Event>
+    query: @escaping @Sendable (State) -> Query?,
+    areEqual: @escaping @Sendable (Query, Query) -> Bool,
+    effects: @escaping @Sendable (Query) -> Signal<Event>
     ) -> (Driver<State>) -> Signal<Event> {
     return { state in
         let observableSchedulerContext = ObservableSchedulerContext<State>(
@@ -114,8 +114,8 @@ public func react<State, Query, Event>(
  - returns: Feedback loop performing the effects.
  */
 public func react<State, Query: Equatable, Event>(
-    query: @escaping (State) -> Query?,
-    effects: @escaping (Query) -> Signal<Event>
+    query: @escaping @Sendable (State) -> Query?,
+    effects: @escaping @Sendable (Query) -> Signal<Event>
     ) -> (Driver<State>) -> Signal<Event> {
     return { state in
         let observableSchedulerContext = ObservableSchedulerContext<State>(
@@ -141,8 +141,8 @@ public func react<State, Query: Equatable, Event>(
  - returns: Feedback loop performing the effects.
  */
 public func react<State, Query, Event>(
-    query: @escaping (State) -> Query?,
-    effects: @escaping (Query) -> Observable<Event>
+    query: @escaping @Sendable (State) -> Query?,
+    effects: @escaping @Sendable (Query) -> Observable<Event>
     ) -> (ObservableSchedulerContext<State>) -> Observable<Event> {
     return { state in
         return state.map(query)
@@ -172,8 +172,8 @@ public func react<State, Query, Event>(
  - returns: Feedback loop performing the effects.
  */
 public func react<State, Query, Event>(
-    query: @escaping (State) -> Query?,
-    effects: @escaping (Query) -> Signal<Event>
+    query: @escaping @Sendable (State) -> Query?,
+    effects: @escaping @Sendable (Query) -> Signal<Event>
     ) -> (Driver<State>) -> Signal<Event> {
     return { state in
         let observableSchedulerContext = ObservableSchedulerContext<State>(
@@ -200,8 +200,8 @@ public func react<State, Query, Event>(
  - returns: Feedback loop performing the effects.
  */
 public func react<State, Query, Event>(
-    query: @escaping (State) -> Set<Query>,
-    effects: @escaping (Query) -> Observable<Event>
+    query: @escaping @Sendable (State) -> Set<Query>,
+    effects: @escaping @Sendable (Query) -> Observable<Event>
     ) -> (ObservableSchedulerContext<State>) -> Observable<Event> {
     return { state in
         let query = state.map(query)
@@ -250,8 +250,8 @@ extension ObservableType {
  - returns: Feedback loop performing the effects.
  */
 public func react<State, Query, Event>(
-    query: @escaping (State) -> Set<Query>,
-    effects: @escaping (Query) -> Signal<Event>
+    query: @escaping @Sendable (State) -> Set<Query>,
+    effects: @escaping @Sendable (Query) -> Signal<Event>
     ) -> (Driver<State>) -> Signal<Event> {
     return { (state: Driver<State>) -> Signal<Event> in
         let observableSchedulerContext = ObservableSchedulerContext<State>(
@@ -314,7 +314,7 @@ public class Bindings<Event>: Disposable {
 /**
  Bi-directional binding of a system State to external state machine and events from it.
  */
-public func bind<State, Event>(_ bindings: @escaping (ObservableSchedulerContext<State>) -> (Bindings<Event>)) -> (ObservableSchedulerContext<State>) -> Observable<Event> {
+public func bind<State, Event>(_ bindings: @escaping @Sendable (ObservableSchedulerContext<State>) -> (Bindings<Event>)) -> @Sendable (ObservableSchedulerContext<State>) -> Observable<Event> {
     return { (state: ObservableSchedulerContext<State>) -> Observable<Event> in
         return Observable<Event>.using({ () -> Bindings<Event> in
             return bindings(state)
@@ -329,7 +329,7 @@ public func bind<State, Event>(_ bindings: @escaping (ObservableSchedulerContext
  Bi-directional binding of a system State to external state machine and events from it.
  Strongify owner.
  */
-public func bind<State, Event, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, ObservableSchedulerContext<State>) -> (Bindings<Event>))
+public func bind<State, Event, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping @Sendable (WeakOwner, ObservableSchedulerContext<State>) -> (Bindings<Event>))
     -> (ObservableSchedulerContext<State>) -> Observable<Event> where WeakOwner: AnyObject {
         return bind(bindingsStrongify(owner, bindings))
 }
@@ -337,7 +337,7 @@ public func bind<State, Event, WeakOwner>(_ owner: WeakOwner, _ bindings: @escap
 /**
  Bi-directional binding of a system State to external state machine and events from it.
  */
-public func bind<State, Event>(_ bindings: @escaping (Driver<State>) -> (Bindings<Event>)) -> (Driver<State>) -> Signal<Event> {
+public func bind<State, Event>(_ bindings: @escaping @Sendable (Driver<State>) -> (Bindings<Event>)) -> @Sendable (Driver<State>) -> Signal<Event> {
     return { (state: Driver<State>) -> Signal<Event> in
         return Observable<Event>.using({ () -> Bindings<Event> in
             return bindings(state)
@@ -354,12 +354,13 @@ public func bind<State, Event>(_ bindings: @escaping (Driver<State>) -> (Binding
  Bi-directional binding of a system State to external state machine and events from it.
  Strongify owner.
  */
-public func bind<State, Event, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, Driver<State>) -> (Bindings<Event>))
-    -> (Driver<State>) -> Signal<Event> where WeakOwner: AnyObject {
+public func bind<State, Event, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping @Sendable (WeakOwner, Driver<State>) -> (Bindings<Event>))
+    -> @Sendable (Driver<State>) -> Signal<Event> where WeakOwner: AnyObject {
         return bind(bindingsStrongify(owner, bindings))
 }
 
-private func bindingsStrongify<Event, O, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping (WeakOwner, O) -> (Bindings<Event>))
+@Sendable
+private func bindingsStrongify<Event, O, WeakOwner>(_ owner: WeakOwner, _ bindings: @escaping @Sendable (WeakOwner, O) -> (Bindings<Event>))
     -> (O) -> (Bindings<Event>) where WeakOwner: AnyObject {
         return { [weak owner] state -> Bindings<Event> in
             guard let strongOwner = owner else {

--- a/RxExample/RxExample/Observable+Extensions.swift
+++ b/RxExample/RxExample/Observable+Extensions.swift
@@ -30,7 +30,7 @@ extension ObservableType where Element == Any {
      */
     public static func system<State, Event>(
         initialState: State,
-        reduce: @escaping (State, Event) -> State,
+        reduce: @escaping @Sendable (State, Event) -> State,
         scheduler: ImmediateSchedulerType,
         scheduledFeedback: [Feedback<State, Event>]
         ) -> Observable<State> {
@@ -61,7 +61,7 @@ extension ObservableType where Element == Any {
 
     public static func system<State, Event>(
         initialState: State,
-        reduce: @escaping (State, Event) -> State,
+        reduce: @escaping @Sendable (State, Event) -> State,
         scheduler: ImmediateSchedulerType,
         scheduledFeedback: Feedback<State, Event>...
         ) -> Observable<State> {
@@ -86,7 +86,7 @@ extension SharedSequenceConvertibleType where Element == Any, SharingStrategy ==
      */
     public static func system<State, Event>(
             initialState: State,
-            reduce: @escaping (State, Event) -> State,
+            reduce: @escaping @Sendable (State, Event) -> State,
             feedback: [Feedback<State, Event>]
         ) -> Driver<State> {
         let observableFeedbacks: [(ObservableSchedulerContext<State>) -> Observable<Event>] = feedback.map { feedback in
@@ -107,7 +107,7 @@ extension SharedSequenceConvertibleType where Element == Any, SharingStrategy ==
 
     public static func system<State, Event>(
                 initialState: State,
-                reduce: @escaping (State, Event) -> State,
+                reduce: @escaping @Sendable (State, Event) -> State,
                 feedback: Feedback<State, Event>...
         ) -> Driver<State> {
         system(initialState: initialState, reduce: reduce, feedback: feedback)

--- a/RxExample/RxExample/Services/ActivityIndicator.swift
+++ b/RxExample/RxExample/Services/ActivityIndicator.swift
@@ -13,7 +13,7 @@ private struct ActivityToken<E> : ObservableConvertibleType, Disposable {
     private let _source: Observable<E>
     private let _dispose: Cancelable
 
-    init(source: Observable<E>, disposeAction: @escaping () -> Void) {
+    init(source: Observable<E>, disposeAction: @escaping @Sendable () -> Void) {
         _source = source
         _dispose = Disposables.create(with: disposeAction)
     }
@@ -55,13 +55,15 @@ public class ActivityIndicator : SharedSequenceConvertibleType {
             return t.asObservable()
         }
     }
-
+    
+    @Sendable
     private func increment() {
         _lock.lock()
         _relay.accept(_relay.value + 1)
         _lock.unlock()
     }
-
+    
+    @Sendable
     private func decrement() {
         _lock.lock()
         _relay.accept(_relay.value - 1)

--- a/RxExample/RxExample/Services/GeolocationService.swift
+++ b/RxExample/RxExample/Services/GeolocationService.swift
@@ -13,8 +13,8 @@ import RxCocoa
 class GeolocationService {
     
     static let instance = GeolocationService()
-    private (set) var authorized: Driver<Bool>
-    private (set) var location: Driver<CLLocationCoordinate2D>
+    private(set) var authorized: Driver<Bool>
+    private(set) var location: Driver<CLLocationCoordinate2D>
     
     private let locationManager = CLLocationManager()
     

--- a/RxExample/RxExample/Services/UIImageView+DownloadableImage.swift
+++ b/RxExample/RxExample/Services/UIImageView+DownloadableImage.swift
@@ -20,19 +20,21 @@ extension Reactive where Base: UIImageView {
 
     func downloadableImageAnimated(_ transitionType: String?) -> Binder<DownloadableImage> {
         return Binder(base) { imageView, image in
-            for subview in imageView.subviews {
-                subview.removeFromSuperview()
-            }
-            switch image {
-            case .content(let image):
-                (imageView as UIImageView).rx.image.on(.next(image))
-            case .offlinePlaceholder:
-                let label = UILabel(frame: imageView.bounds)
-                label.textAlignment = .center
-                label.font = UIFont.systemFont(ofSize: 35)
-                label.text = "⚠️"
-                imageView.addSubview(label)
-            }
+            MainScheduler.assumeMainActor(execute: {
+                for subview in imageView.subviews {
+                    subview.removeFromSuperview()
+                }
+                switch image {
+                case .content(let image):
+                    (imageView as UIImageView).rx.image.on(.next(image))
+                case .offlinePlaceholder:
+                    let label = UILabel(frame: imageView.bounds)
+                    label.textAlignment = .center
+                    label.font = UIFont.systemFont(ofSize: 35)
+                    label.text = "⚠️"
+                    imageView.addSubview(label)
+                }
+            })
         }
     }
 }

--- a/RxSwift/AnyObserver.swift
+++ b/RxSwift/AnyObserver.swift
@@ -11,7 +11,7 @@
 /// Forwards operations to an arbitrary underlying observer with the same `Element` type, hiding the specifics of the underlying observer type.
 public struct AnyObserver<Element> : ObserverType {
     /// Anonymous event handler type.
-    public typealias EventHandler = (Event<Element>) -> Void
+    public typealias EventHandler = @Sendable (Event<Element>) -> Void
 
     private let observer: EventHandler
 

--- a/RxSwift/AnyObserver.swift
+++ b/RxSwift/AnyObserver.swift
@@ -61,7 +61,7 @@ extension ObserverType {
     /// Each event sent to result observer is transformed and sent to `self`.
     ///
     /// - returns: observer that transforms events.
-    public func mapObserver<Result>(_ transform: @escaping (Result) throws -> Element) -> AnyObserver<Result> {
+    public func mapObserver<Result>(_ transform: @escaping @Sendable (Result) throws -> Element) -> AnyObserver<Result> {
         AnyObserver { e in
             self.on(e.map(transform))
         }

--- a/RxSwift/Binder.swift
+++ b/RxSwift/Binder.swift
@@ -25,7 +25,7 @@ public struct Binder<Value>: ObserverType, @unchecked Sendable {
     /// - parameter target: Target object.
     /// - parameter scheduler: Scheduler used to bind the events.
     /// - parameter binding: Binding logic.
-    public init<Target: AnyObject>(_ target: Target, scheduler: ImmediateSchedulerType = MainScheduler(), binding: @escaping (Target, Value) -> Void) {
+    public init<Target: AnyObject>(_ target: Target, scheduler: ImmediateSchedulerType = MainScheduler(), binding: @escaping @Sendable (Target, Value) -> Void) {
         nonisolated(unsafe) weak var weakTarget = target
 
         self.binding = { event in

--- a/RxSwift/Binder.swift
+++ b/RxSwift/Binder.swift
@@ -15,10 +15,10 @@
  
  By default it binds elements on main scheduler.
  */
-public struct Binder<Value>: ObserverType {
+public struct Binder<Value>: ObserverType, @unchecked Sendable {
     public typealias Element = Value
     
-    private let binding: (Event<Value>) -> Void
+    private let binding: @Sendable (Event<Value>) -> Void
 
     /// Initializes `Binder`
     ///
@@ -26,7 +26,7 @@ public struct Binder<Value>: ObserverType {
     /// - parameter scheduler: Scheduler used to bind the events.
     /// - parameter binding: Binding logic.
     public init<Target: AnyObject>(_ target: Target, scheduler: ImmediateSchedulerType = MainScheduler(), binding: @escaping (Target, Value) -> Void) {
-        weak var weakTarget = target
+        nonisolated(unsafe) weak var weakTarget = target
 
         self.binding = { event in
             switch event {
@@ -46,6 +46,7 @@ public struct Binder<Value>: ObserverType {
     }
 
     /// Binds next element to owner view as described in `binding`.
+    @Sendable
     public func on(_ event: Event<Value>) {
         self.binding(event)
     }

--- a/RxSwift/Concurrency/AsyncLock.swift
+++ b/RxSwift/Concurrency/AsyncLock.swift
@@ -20,7 +20,7 @@ final class AsyncLock<I: InvocableType>
     : Disposable
     , Lock
     , SynchronizedDisposeType {
-    typealias Action = () -> Void
+    typealias Action = @Sendable () -> Void
     
     private var _lock = SpinLock()
     

--- a/RxSwift/Disposables/AnonymousDisposable.swift
+++ b/RxSwift/Disposables/AnonymousDisposable.swift
@@ -10,7 +10,7 @@
 ///
 /// When dispose method is called, disposal action will be dereferenced.
 private final class AnonymousDisposable : DisposeBase, Cancelable {
-    public typealias DisposeAction = () -> Void
+    public typealias DisposeAction = @Sendable () -> Void
 
     private let disposed = AtomicInt(0)
     private var disposeAction: DisposeAction?
@@ -52,7 +52,7 @@ extension Disposables {
     /// Constructs a new disposable with the given action used for disposal.
     ///
     /// - parameter dispose: Disposal action which will be run upon calling `dispose`.
-    public static func create(with dispose: @escaping () -> Void) -> Cancelable {
+    public static func create(with dispose: @escaping @Sendable () -> Void) -> Cancelable {
         AnonymousDisposable(disposeAction: dispose)
     }
 

--- a/RxSwift/Disposables/ScheduledDisposable.swift
+++ b/RxSwift/Disposables/ScheduledDisposable.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Krunoslav Zaher. All rights reserved.
 //
 
-private let disposeScheduledDisposable: (ScheduledDisposable) -> Disposable = { sd in
+private let disposeScheduledDisposable: @Sendable (ScheduledDisposable) -> Disposable = { sd in
     sd.disposeInner()
     return Disposables.create()
 }

--- a/RxSwift/ImmediateSchedulerType.swift
+++ b/RxSwift/ImmediateSchedulerType.swift
@@ -15,7 +15,7 @@ public protocol ImmediateSchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable
+    func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable
 }
 
 extension ImmediateSchedulerType {
@@ -26,7 +26,7 @@ extension ImmediateSchedulerType {
     - parameter action: Action to execute recursively. The last parameter passed to the action is used to trigger recursive scheduling of the action, passing in recursive invocation state.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func scheduleRecursive<State>(_ state: State, action: @escaping (_ state: State, _ recurse: (State) -> Void) -> Void) -> Disposable {
+    public func scheduleRecursive<State>(_ state: State, action: @escaping @Sendable (_ state: State, _ recurse: (State) -> Void) -> Void) -> Disposable {
         let recursiveScheduler = RecursiveImmediateScheduler(action: action, scheduler: self)
         
         recursiveScheduler.schedule(state)

--- a/RxSwift/Observable+Concurrency.swift
+++ b/RxSwift/Observable+Concurrency.swift
@@ -27,7 +27,7 @@ public extension ObservableConvertibleType {
     /// ```
     var values: AsyncThrowingStream<Element, Error> {
         AsyncThrowingStream<Element, Error> { continuation in
-            var isFinished = false
+            nonisolated(unsafe) var isFinished = false
             let disposable = asObservable().subscribe(
                 onNext: { value in continuation.yield(value) },
                 onError: { error in

--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - parameter on: Action to invoke for each event in the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(_ on: @escaping (Event<Element>) -> Void) -> Disposable {
+    public func subscribe(_ on: @escaping @Sendable (Event<Element>) -> Void) -> Disposable {
         let observer = AnonymousObserver { e in
             on(e)
         }
@@ -41,10 +41,10 @@ extension ObservableType {
      */
     public func subscribe<Object: AnyObject>(
         with object: Object,
-        onNext: ((Object, Element) -> Void)? = nil,
-        onError: ((Object, Swift.Error) -> Void)? = nil,
-        onCompleted: ((Object) -> Void)? = nil,
-        onDisposed: ((Object) -> Void)? = nil
+        onNext: (@Sendable (Object, Element) -> Void)? = nil,
+        onError: (@Sendable (Object, Swift.Error) -> Void)? = nil,
+        onCompleted: (@Sendable (Object) -> Void)? = nil,
+        onDisposed: (@Sendable (Object) -> Void)? = nil
     ) -> Disposable {
         subscribe(
             onNext: { [weak object] in
@@ -77,10 +77,10 @@ extension ObservableType {
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
     public func subscribe(
-        onNext: ((Element) -> Void)? = nil,
-        onError: ((Swift.Error) -> Void)? = nil,
-        onCompleted: (() -> Void)? = nil,
-        onDisposed: (() -> Void)? = nil
+        onNext: (@Sendable (Element) -> Void)? = nil,
+        onError: (@Sendable (Swift.Error) -> Void)? = nil,
+        onCompleted: (@Sendable () -> Void)? = nil,
+        onDisposed: (@Sendable () -> Void)? = nil
     ) -> Disposable {
             let disposable: Disposable
             
@@ -130,8 +130,8 @@ extension ObservableType {
 import Foundation
 
 extension Hooks {
-    public typealias DefaultErrorHandler = (_ subscriptionCallStack: [String], _ error: Error) -> Void
-    public typealias CustomCaptureSubscriptionCallstack = () -> [String]
+    public typealias DefaultErrorHandler = @Sendable (_ subscriptionCallStack: [String], _ error: Error) -> Void
+    public typealias CustomCaptureSubscriptionCallstack = @Sendable () -> [String]
 
     private static let lock = RecursiveLock()
     private static var _defaultErrorHandler: DefaultErrorHandler = { subscriptionCallStack, error in

--- a/RxSwift/Observables/Amb.swift
+++ b/RxSwift/Observables/Amb.swift
@@ -49,7 +49,7 @@ final private class AmbObserver<Observer: ObserverType>: ObserverType {
     typealias Element = Observer.Element 
     typealias Parent = AmbSink<Observer>
     typealias This = AmbObserver<Observer>
-    typealias Sink = (This, Event<Element>) -> Void
+    typealias Sink = @Sendable (This, Event<Element>) -> Void
     
     private let parent: Parent
     fileprivate var sink: Sink
@@ -100,7 +100,7 @@ final private class AmbSink<Observer: ObserverType>: Sink<Observer> {
         let subscription2 = SingleAssignmentDisposable()
         let disposeAll = Disposables.create(subscription1, subscription2)
         
-        let forwardEvent = { (o: AmbObserverType, event: Event<Element>) -> Void in
+        let forwardEvent = { @Sendable (o: AmbObserverType, event: Event<Element>) -> Void in
             self.forwardOn(event)
             if event.isStopEvent {
                 self.dispose()

--- a/RxSwift/Observables/Catch.swift
+++ b/RxSwift/Observables/Catch.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter handler: Error handler function, producing another observable sequence.
      - returns: An observable sequence containing the source sequence's elements, followed by the elements produced by the handler's resulting observable sequence in case an error occurred.
      */
-    public func `catch`(_ handler: @escaping (Swift.Error) throws -> Observable<Element>)
+    public func `catch`(_ handler: @escaping @Sendable (Swift.Error) throws -> Observable<Element>)
         -> Observable<Element> {
         Catch(source: self.asObservable(), handler: handler)
     }
@@ -30,7 +30,7 @@ extension ObservableType {
      - returns: An observable sequence containing the source sequence's elements, followed by the elements produced by the handler's resulting observable sequence in case an error occurred.
      */
     @available(*, deprecated, renamed: "catch(_:)")
-    public func catchError(_ handler: @escaping (Swift.Error) throws -> Observable<Element>)
+    public func catchError(_ handler: @escaping @Sendable (Swift.Error) throws -> Observable<Element>)
         -> Observable<Element> {
         `catch`(handler)
     }
@@ -189,7 +189,7 @@ final private class CatchSink<Observer: ObserverType>: Sink<Observer>, ObserverT
 }
 
 final private class Catch<Element>: Producer<Element> {
-    typealias Handler = (Swift.Error) throws -> Observable<Element>
+    typealias Handler = @Sendable (Swift.Error) throws -> Observable<Element>
     
     fileprivate let source: Observable<Element>
     fileprivate let handler: Handler

--- a/RxSwift/Observables/CombineLatest+Collection.swift
+++ b/RxSwift/Observables/CombineLatest+Collection.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func combineLatest<Collection: Swift.Collection>(_ collection: Collection, resultSelector: @escaping ([Collection.Element.Element]) throws -> Element) -> Observable<Element>
+    public static func combineLatest<Collection: Swift.Collection>(_ collection: Collection, resultSelector: @escaping @Sendable ([Collection.Element.Element]) throws -> Element) -> Observable<Element>
         where Collection.Element: ObservableType {
         CombineLatestCollectionType(sources: collection, resultSelector: resultSelector)
     }
@@ -145,7 +145,7 @@ final class CombineLatestCollectionTypeSink<Collection: Swift.Collection, Observ
 }
 
 final class CombineLatestCollectionType<Collection: Swift.Collection, Result>: Producer<Result> where Collection.Element: ObservableConvertibleType {
-    typealias ResultSelector = ([Collection.Element.Element]) throws -> Result
+    typealias ResultSelector = @Sendable ([Collection.Element.Element]) throws -> Result
     
     let sources: Collection
     let resultSelector: ResultSelector

--- a/RxSwift/Observables/CombineLatest+arity.swift
+++ b/RxSwift/Observables/CombineLatest+arity.swift
@@ -21,7 +21,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType>
-        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.Element, O2.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, resultSelector: @escaping @Sendable (O1.Element, O2.Element) throws -> Element)
             -> Observable<Element> {
         return CombineLatest2(
             source1: source1.asObservable(), source2: source2.asObservable(),
@@ -84,7 +84,7 @@ final class CombineLatestSink2_<E1, E2, Observer: ObserverType> : CombineLatestS
 }
 
 final class CombineLatest2<E1, E2, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -119,7 +119,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.Element, O2.Element, O3.Element) throws -> Element)
+        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element) throws -> Element)
             -> Observable<Element> {
         return CombineLatest3(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(),
@@ -187,7 +187,7 @@ final class CombineLatestSink3_<E1, E2, E3, Observer: ObserverType> : CombineLat
 }
 
 final class CombineLatest3<E1, E2, E3, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -224,7 +224,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
             -> Observable<Element> {
         return CombineLatest4(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(),
@@ -297,7 +297,7 @@ final class CombineLatestSink4_<E1, E2, E3, E4, Observer: ObserverType> : Combin
 }
 
 final class CombineLatest4<E1, E2, E3, E4, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -336,7 +336,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
             -> Observable<Element> {
         return CombineLatest5(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(),
@@ -414,7 +414,7 @@ final class CombineLatestSink5_<E1, E2, E3, E4, E5, Observer: ObserverType> : Co
 }
 
 final class CombineLatest5<E1, E2, E3, E4, E5, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4, E5) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4, E5) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -455,7 +455,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
             -> Observable<Element> {
         return CombineLatest6(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(),
@@ -538,7 +538,7 @@ final class CombineLatestSink6_<E1, E2, E3, E4, E5, E6, Observer: ObserverType> 
 }
 
 final class CombineLatest6<E1, E2, E3, E4, E5, E6, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4, E5, E6) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4, E5, E6) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -581,7 +581,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
             -> Observable<Element> {
         return CombineLatest7(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(),
@@ -669,7 +669,7 @@ final class CombineLatestSink7_<E1, E2, E3, E4, E5, E6, E7, Observer: ObserverTy
 }
 
 final class CombineLatest7<E1, E2, E3, E4, E5, E6, E7, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4, E5, E6, E7) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -714,7 +714,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
             -> Observable<Element> {
         return CombineLatest8(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(),
@@ -807,7 +807,7 @@ final class CombineLatestSink8_<E1, E2, E3, E4, E5, E6, E7, E8, Observer: Observ
 }
 
 final class CombineLatest8<E1, E2, E3, E4, E5, E6, E7, E8, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>

--- a/RxSwift/Observables/CombineLatest.swift
+++ b/RxSwift/Observables/CombineLatest.swift
@@ -94,7 +94,7 @@ final class CombineLatestObserver<Element>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias ValueSetter = (Element) -> Void
+    typealias ValueSetter = @Sendable (Element) -> Void
     
     private let parent: CombineLatestProtocol
     

--- a/RxSwift/Observables/CompactMap.swift
+++ b/RxSwift/Observables/CompactMap.swift
@@ -15,14 +15,14 @@ extension ObservableType {
      - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
 
      */
-    public func compactMap<Result>(_ transform: @escaping (Element) throws -> Result?)
+    public func compactMap<Result>(_ transform: @escaping @Sendable (Element) throws -> Result?)
         -> Observable<Result> {
         CompactMap(source: self.asObservable(), transform: transform)
     }
 }
 
 final private class CompactMapSink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType {
-    typealias Transform = (SourceType) throws -> ResultType?
+    typealias Transform = @Sendable (SourceType) throws -> ResultType?
 
     typealias ResultType = Observer.Element 
     typealias Element = SourceType
@@ -57,7 +57,7 @@ final private class CompactMapSink<SourceType, Observer: ObserverType>: Sink<Obs
 }
 
 final private class CompactMap<SourceType, ResultType>: Producer<ResultType> {
-    typealias Transform = (SourceType) throws -> ResultType?
+    typealias Transform = @Sendable (SourceType) throws -> ResultType?
 
     private let source: Observable<SourceType>
 

--- a/RxSwift/Observables/Create.swift
+++ b/RxSwift/Observables/Create.swift
@@ -17,7 +17,7 @@ extension ObservableType {
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(_ subscribe: @escaping (AnyObserver<Element>) -> Disposable) -> Observable<Element> {
+    public static func create(_ subscribe: @escaping @Sendable (AnyObserver<Element>) -> Disposable) -> Observable<Element> {
         AnonymousObservable(subscribe)
     }
 }
@@ -62,7 +62,7 @@ final private class AnonymousObservableSink<Observer: ObserverType>: Sink<Observ
 }
 
 final private class AnonymousObservable<Element>: Producer<Element> {
-    typealias SubscribeHandler = (AnyObserver<Element>) -> Disposable
+    typealias SubscribeHandler = @Sendable (AnyObserver<Element>) -> Disposable
 
     let subscribeHandler: SubscribeHandler
 

--- a/RxSwift/Observables/Debounce.swift
+++ b/RxSwift/Observables/Debounce.swift
@@ -87,6 +87,7 @@ final private class DebounceSink<Observer: ObserverType>
         }
     }
 
+    @Sendable
     func propagate(_ currentId: UInt64) -> Disposable {
         self.lock.performLocked {
             let originalValue = self.value

--- a/RxSwift/Observables/Deferred.swift
+++ b/RxSwift/Observables/Deferred.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter observableFactory: Observable factory function to invoke for each observer that subscribes to the resulting sequence.
      - returns: An observable sequence whose observers trigger an invocation of the given observable factory function.
      */
-    public static func deferred(_ observableFactory: @escaping () throws -> Observable<Element>)
+    public static func deferred(_ observableFactory: @escaping @Sendable () throws -> Observable<Element>)
         -> Observable<Element> {
         Deferred(observableFactory: observableFactory)
     }
@@ -56,7 +56,7 @@ final private class DeferredSink<Source: ObservableType, Observer: ObserverType>
 }
 
 final private class Deferred<Source: ObservableType>: Producer<Source.Element> {
-    typealias Factory = () throws -> Source
+    typealias Factory = @Sendable () throws -> Source
     
     let observableFactory : Factory
     

--- a/RxSwift/Observables/Delay.swift
+++ b/RxSwift/Observables/Delay.swift
@@ -60,6 +60,7 @@ final private class DelaySink<Observer: ObserverType>
     // scheduler so this process needs to be synchronized somehow.
     //
     // Another complication is that scheduler is potentially concurrent so internal queue is used.
+    @Sendable
     func drainQueue(state: (), scheduler: AnyRecursiveScheduler<()>) {
         self.lock.lock()    
         let hasFailed = self.errorEvent != nil

--- a/RxSwift/Observables/DistinctUntilChanged.swift
+++ b/RxSwift/Observables/DistinctUntilChanged.swift
@@ -30,7 +30,7 @@ extension ObservableType {
      - parameter keySelector: A function to compute the comparison key for each element.
      - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value, from the source sequence.
      */
-    public func distinctUntilChanged<Key: Equatable>(_ keySelector: @escaping (Element) throws -> Key)
+    public func distinctUntilChanged<Key: Equatable>(_ keySelector: @escaping @Sendable (Element) throws -> Key)
         -> Observable<Element> {
         self.distinctUntilChanged(keySelector, comparer: { $0 == $1 })
     }
@@ -43,7 +43,7 @@ extension ObservableType {
      - parameter comparer: Equality comparer for computed key values.
      - returns: An observable sequence only containing the distinct contiguous elements, based on `comparer`, from the source sequence.
      */
-    public func distinctUntilChanged(_ comparer: @escaping (Element, Element) throws -> Bool)
+    public func distinctUntilChanged(_ comparer: @escaping @Sendable (Element, Element) throws -> Bool)
         -> Observable<Element> {
         self.distinctUntilChanged({ $0 }, comparer: comparer)
     }
@@ -57,7 +57,7 @@ extension ObservableType {
      - parameter comparer: Equality comparer for computed key values.
      - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value and the comparer, from the source sequence.
      */
-    public func distinctUntilChanged<K>(_ keySelector: @escaping (Element) throws -> K, comparer: @escaping (K, K) throws -> Bool)
+    public func distinctUntilChanged<K>(_ keySelector: @escaping @Sendable (Element) throws -> K, comparer: @escaping @Sendable (K, K) throws -> Bool)
         -> Observable<Element> {
             return DistinctUntilChanged(source: self.asObservable(), selector: keySelector, comparer: comparer)
     }
@@ -116,8 +116,8 @@ final private class DistinctUntilChangedSink<Observer: ObserverType, Key>: Sink<
 }
 
 final private class DistinctUntilChanged<Element, Key>: Producer<Element> {
-    typealias KeySelector = (Element) throws -> Key
-    typealias EqualityComparer = (Key, Key) throws -> Bool
+    typealias KeySelector = @Sendable (Element) throws -> Key
+    typealias EqualityComparer = @Sendable (Key, Key) throws -> Bool
     
     private let source: Observable<Element>
     fileprivate let selector: KeySelector

--- a/RxSwift/Observables/Do.swift
+++ b/RxSwift/Observables/Do.swift
@@ -23,7 +23,7 @@ extension ObservableType {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onNext: ((Element) throws -> Void)? = nil, afterNext: ((Element) throws -> Void)? = nil, onError: ((Swift.Error) throws -> Void)? = nil, afterError: ((Swift.Error) throws -> Void)? = nil, onCompleted: (() throws -> Void)? = nil, afterCompleted: (() throws -> Void)? = nil, onSubscribe: (() -> Void)? = nil, onSubscribed: (() -> Void)? = nil, onDispose: (() -> Void)? = nil)
+    public func `do`(onNext: (@Sendable (Element) throws -> Void)? = nil, afterNext: (@Sendable (Element) throws -> Void)? = nil, onError: (@Sendable (Swift.Error) throws -> Void)? = nil, afterError: (@Sendable (Swift.Error) throws -> Void)? = nil, onCompleted: (@Sendable () throws -> Void)? = nil, afterCompleted: (@Sendable () throws -> Void)? = nil, onSubscribe: (@Sendable () -> Void)? = nil, onSubscribed: (@Sendable () -> Void)? = nil, onDispose: (@Sendable () -> Void)? = nil)
         -> Observable<Element> {
             return Do(source: self.asObservable(), eventHandler: { e in
                 switch e {
@@ -49,8 +49,8 @@ extension ObservableType {
 
 final private class DoSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
     typealias Element = Observer.Element 
-    typealias EventHandler = (Event<Element>) throws -> Void
-    typealias AfterEventHandler = (Event<Element>) throws -> Void
+    typealias EventHandler = @Sendable (Event<Element>) throws -> Void
+    typealias AfterEventHandler = @Sendable (Event<Element>) throws -> Void
     
     private let eventHandler: EventHandler
     private let afterEventHandler: AfterEventHandler
@@ -78,17 +78,17 @@ final private class DoSink<Observer: ObserverType>: Sink<Observer>, ObserverType
 }
 
 final private class Do<Element>: Producer<Element> {
-    typealias EventHandler = (Event<Element>) throws -> Void
-    typealias AfterEventHandler = (Event<Element>) throws -> Void
+    typealias EventHandler = @Sendable (Event<Element>) throws -> Void
+    typealias AfterEventHandler = @Sendable (Event<Element>) throws -> Void
     
     private let source: Observable<Element>
     private let eventHandler: EventHandler
     private let afterEventHandler: AfterEventHandler
-    private let onSubscribe: (() -> Void)?
-    private let onSubscribed: (() -> Void)?
-    private let onDispose: (() -> Void)?
+    private let onSubscribe: (@Sendable () -> Void)?
+    private let onSubscribed: (@Sendable () -> Void)?
+    private let onDispose: (@Sendable () -> Void)?
     
-    init(source: Observable<Element>, eventHandler: @escaping EventHandler, afterEventHandler: @escaping AfterEventHandler, onSubscribe: (() -> Void)?, onSubscribed: (() -> Void)?, onDispose: (() -> Void)?) {
+    init(source: Observable<Element>, eventHandler: @escaping EventHandler, afterEventHandler: @escaping AfterEventHandler, onSubscribe: (@Sendable () -> Void)?, onSubscribed: (@Sendable () -> Void)?, onDispose: (@Sendable () -> Void)?) {
         self.source = source
         self.eventHandler = eventHandler
         self.afterEventHandler = afterEventHandler

--- a/RxSwift/Observables/Filter.swift
+++ b/RxSwift/Observables/Filter.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
      */
-    public func filter(_ predicate: @escaping (Element) throws -> Bool)
+    public func filter(_ predicate: @escaping @Sendable (Element) throws -> Bool)
         -> Observable<Element> {
         Filter(source: self.asObservable(), predicate: predicate)
     }
@@ -37,7 +37,7 @@ extension ObservableType {
 }
 
 final private class FilterSink<Observer: ObserverType>: Sink<Observer>, ObserverType {
-    typealias Predicate = (Element) throws -> Bool
+    typealias Predicate = @Sendable (Element) throws -> Bool
     typealias Element = Observer.Element
     
     private let predicate: Predicate
@@ -68,7 +68,7 @@ final private class FilterSink<Observer: ObserverType>: Sink<Observer>, Observer
 }
 
 final private class Filter<Element>: Producer<Element> {
-    typealias Predicate = (Element) throws -> Bool
+    typealias Predicate = @Sendable (Element) throws -> Bool
     
     private let source: Observable<Element>
     private let predicate: Predicate

--- a/RxSwift/Observables/Generate.swift
+++ b/RxSwift/Observables/Generate.swift
@@ -19,7 +19,7 @@ extension ObservableType {
      - parameter scheduler: Scheduler on which to run the generator loop.
      - returns: The generated sequence.
      */
-    public static func generate(initialState: Element, condition: @escaping (Element) throws -> Bool, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance, iterate: @escaping (Element) throws -> Element) -> Observable<Element> {
+    public static func generate(initialState: Element, condition: @escaping @Sendable (Element) throws -> Bool, scheduler: ImmediateSchedulerType = CurrentThreadScheduler.instance, iterate: @escaping @Sendable (Element) throws -> Element) -> Observable<Element> {
         Generate(initialState: initialState, condition: condition, iterate: iterate, resultSelector: { $0 }, scheduler: scheduler)
     }
 }
@@ -65,12 +65,12 @@ final private class GenerateSink<Sequence, Observer: ObserverType>: Sink<Observe
 
 final private class Generate<Sequence, Element>: Producer<Element> {
     fileprivate let initialState: Sequence
-    fileprivate let condition: (Sequence) throws -> Bool
-    fileprivate let iterate: (Sequence) throws -> Sequence
-    fileprivate let resultSelector: (Sequence) throws -> Element
+    fileprivate let condition: @Sendable (Sequence) throws -> Bool
+    fileprivate let iterate: @Sendable (Sequence) throws -> Sequence
+    fileprivate let resultSelector: @Sendable (Sequence) throws -> Element
     fileprivate let scheduler: ImmediateSchedulerType
     
-    init(initialState: Sequence, condition: @escaping (Sequence) throws -> Bool, iterate: @escaping (Sequence) throws -> Sequence, resultSelector: @escaping (Sequence) throws -> Element, scheduler: ImmediateSchedulerType) {
+    init(initialState: Sequence, condition: @escaping @Sendable (Sequence) throws -> Bool, iterate: @escaping @Sendable (Sequence) throws -> Sequence, resultSelector: @escaping @Sendable (Sequence) throws -> Element, scheduler: ImmediateSchedulerType) {
         self.initialState = initialState
         self.condition = condition
         self.iterate = iterate

--- a/RxSwift/Observables/GroupBy.swift
+++ b/RxSwift/Observables/GroupBy.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter keySelector: A function to extract the key for each element.
      - returns: A sequence of observable groups, each of which corresponds to a unique key value, containing all elements that share that same key value.
      */
-    public func groupBy<Key: Hashable>(keySelector: @escaping (Element) throws -> Key)
+    public func groupBy<Key: Hashable>(keySelector: @escaping @Sendable (Element) throws -> Key)
         -> Observable<GroupedObservable<Key, Element>> {
         GroupBy(source: self.asObservable(), selector: keySelector)
     }
@@ -116,7 +116,7 @@ final private class GroupBySink<Key: Hashable, Element, Observer: ObserverType>
 }
 
 final private class GroupBy<Key: Hashable, Element>: Producer<GroupedObservable<Key,Element>> {
-    typealias KeySelector = (Element) throws -> Key
+    typealias KeySelector = @Sendable (Element) throws -> Key
 
     fileprivate let source: Observable<Element>
     fileprivate let selector: KeySelector

--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -17,14 +17,14 @@ extension ObservableType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
 
      */
-    public func map<Result>(_ transform: @escaping (Element) throws -> Result)
+    public func map<Result>(_ transform: @escaping @Sendable (Element) throws -> Result)
         -> Observable<Result> {
         Map(source: self.asObservable(), transform: transform)
     }
 }
 
 final private class MapSink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType {
-    typealias Transform = (SourceType) throws -> ResultType
+    typealias Transform = @Sendable (SourceType) throws -> ResultType
 
     typealias ResultType = Observer.Element 
 
@@ -57,7 +57,7 @@ final private class MapSink<SourceType, Observer: ObserverType>: Sink<Observer>,
 }
 
 final private class Map<SourceType, ResultType>: Producer<ResultType> {
-    typealias Transform = (SourceType) throws -> ResultType
+    typealias Transform = @Sendable (SourceType) throws -> ResultType
 
     private let source: Observable<SourceType>
 

--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMap<Source: ObservableConvertibleType>(_ selector: @escaping (Element) throws -> Source)
+    public func flatMap<Source: ObservableConvertibleType>(_ selector: @escaping @Sendable (Element) throws -> Source)
         -> Observable<Source.Element> {
             return FlatMap(source: self.asObservable(), selector: selector)
     }
@@ -34,7 +34,7 @@ extension ObservableType {
      - parameter selector: A transform function to apply to element that was observed while no observable is executing in parallel.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence that was received while no other sequence was being calculated.
      */
-    public func flatMapFirst<Source: ObservableConvertibleType>(_ selector: @escaping (Element) throws -> Source)
+    public func flatMapFirst<Source: ObservableConvertibleType>(_ selector: @escaping @Sendable (Element) throws -> Source)
         -> Observable<Source.Element> {
             return FlatMapFirst(source: self.asObservable(), selector: selector)
     }
@@ -130,7 +130,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements of each observed inner sequence, in sequential order.
      */
     
-    public func concatMap<Source: ObservableConvertibleType>(_ selector: @escaping (Element) throws -> Source)
+    public func concatMap<Source: ObservableConvertibleType>(_ selector: @escaping @Sendable (Element) throws -> Source)
         -> Observable<Source.Element> {
         return ConcatMap(source: self.asObservable(), selector: selector)
     }
@@ -185,7 +185,7 @@ private final class MergeLimitedSinkIter<SourceElement, SourceSequence: Observab
 }
 
 private final class ConcatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>: MergeLimitedSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
-    typealias Selector = (SourceElement) throws -> SourceSequence
+    typealias Selector = @Sendable (SourceElement) throws -> SourceSequence
     
     private let selector: Selector
     
@@ -339,7 +339,7 @@ private final class MergeBasicSink<Source: ObservableConvertibleType, Observer: 
 // MARK: flatMap
 
 private final class FlatMapSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
-    typealias Selector = (SourceElement) throws -> SourceSequence
+    typealias Selector = @Sendable (SourceElement) throws -> SourceSequence
 
     private let selector: Selector
 
@@ -356,7 +356,7 @@ private final class FlatMapSink<SourceElement, SourceSequence: ObservableConvert
 // MARK: FlatMapFirst
 
 private final class FlatMapFirstSink<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType> : MergeSink<SourceElement, SourceSequence, Observer> where Observer.Element == SourceSequence.Element {
-    typealias Selector = (SourceElement) throws -> SourceSequence
+    typealias Selector = @Sendable (SourceElement) throws -> SourceSequence
 
     private let selector: Selector
 
@@ -516,7 +516,7 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
 // MARK: Producers
 
 final private class FlatMap<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.Element> {
-    typealias Selector = (SourceElement) throws -> SourceSequence
+    typealias Selector = @Sendable (SourceElement) throws -> SourceSequence
 
     private let source: Observable<SourceElement>
     
@@ -535,7 +535,7 @@ final private class FlatMap<SourceElement, SourceSequence: ObservableConvertible
 }
 
 final private class FlatMapFirst<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.Element> {
-    typealias Selector = (SourceElement) throws -> SourceSequence
+    typealias Selector = @Sendable (SourceElement) throws -> SourceSequence
 
     private let source: Observable<SourceElement>
 
@@ -554,7 +554,7 @@ final private class FlatMapFirst<SourceElement, SourceSequence: ObservableConver
 }
 
 final class ConcatMap<SourceElement, SourceSequence: ObservableConvertibleType>: Producer<SourceSequence.Element> {
-    typealias Selector = (SourceElement) throws -> SourceSequence
+    typealias Selector = @Sendable (SourceElement) throws -> SourceSequence
     
     private let source: Observable<SourceElement>
     private let selector: Selector

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -141,7 +141,7 @@ extension ObservableType {
      - parameter makeSubject: Factory function used to instantiate a subject for each connection.
      - returns: A connectable observable sequence that upon connection causes the source sequence to push results into the specified subject.
      */
-    public func multicast<Subject: SubjectType>(makeSubject: @escaping () -> Subject)
+    public func multicast<Subject: SubjectType>(makeSubject: @escaping @Sendable () -> Subject)
         -> ConnectableObservable<Subject.Element> where Subject.Observer.Element == Element {
         ConnectableObservableAdapter(source: self.asObservable(), makeSubject: makeSubject)
     }
@@ -198,7 +198,7 @@ final private class ConnectableObservableAdapter<Subject: SubjectType>
     typealias ConnectionType = Connection<Subject>
 
     private let source: Observable<Subject.Observer.Element>
-    private let makeSubject: () -> Subject
+    private let makeSubject: @Sendable () -> Subject
 
     fileprivate let lock = RecursiveLock()
     fileprivate var subject: Subject?
@@ -206,7 +206,7 @@ final private class ConnectableObservableAdapter<Subject: SubjectType>
     // state
     fileprivate var connection: ConnectionType?
 
-    init(source: Observable<Subject.Observer.Element>, makeSubject: @escaping () -> Subject) {
+    init(source: Observable<Subject.Observer.Element>, makeSubject: @escaping @Sendable () -> Subject) {
         self.source = source
         self.makeSubject = makeSubject
         self.subject = nil

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -38,7 +38,7 @@ extension ObservableType {
     - parameter selector: Selector function which can use the multicasted source sequence subject to the policies enforced by the created subject.
     - returns: An observable sequence that contains the elements of a sequence produced by multicasting the source sequence within a selector function.
     */
-    public func multicast<Subject: SubjectType, Result>(_ subjectSelector: @escaping () throws -> Subject, selector: @escaping (Observable<Subject.Element>) throws -> Observable<Result>)
+    public func multicast<Subject: SubjectType, Result>(_ subjectSelector: @escaping @Sendable () throws -> Subject, selector: @escaping @Sendable (Observable<Subject.Element>) throws -> Observable<Result>)
         -> Observable<Result> where Subject.Observer.Element == Element {
         return Multicast(
             source: self.asObservable(),
@@ -384,8 +384,8 @@ final private class MulticastSink<Subject: SubjectType, Observer: ObserverType>:
 }
 
 final private class Multicast<Subject: SubjectType, Result>: Producer<Result> {
-    typealias SubjectSelectorType = () throws -> Subject
-    typealias SelectorType = (Observable<Subject.Element>) throws -> Observable<Result>
+    typealias SubjectSelectorType = @Sendable () throws -> Subject
+    typealias SelectorType = @Sendable (Observable<Subject.Element>) throws -> Observable<Result>
 
     fileprivate let source: Observable<Subject.Observer.Element>
     fileprivate let subjectSelector: SubjectSelectorType

--- a/RxSwift/Observables/ObserveOn.swift
+++ b/RxSwift/Observables/ObserveOn.swift
@@ -183,7 +183,7 @@ final private class ObserveOnSerialDispatchQueueSink<Observer: ObserverType>: Ob
 
     let cancel: Cancelable
 
-    var cachedScheduleLambda: (((sink: ObserveOnSerialDispatchQueueSink<Observer>, event: Event<Element>)) -> Disposable)!
+    var cachedScheduleLambda: (@Sendable ((sink: ObserveOnSerialDispatchQueueSink<Observer>, event: Event<Element>)) -> Disposable)!
 
     init(scheduler: SerialDispatchQueueScheduler, observer: Observer, cancel: Cancelable) {
         self.scheduler = scheduler
@@ -191,7 +191,7 @@ final private class ObserveOnSerialDispatchQueueSink<Observer: ObserverType>: Ob
         self.cancel = cancel
         super.init()
 
-        self.cachedScheduleLambda = { pair in
+        self.cachedScheduleLambda = { @Sendable pair in
             guard !cancel.isDisposed else { return Disposables.create() }
 
             pair.sink.observer.on(pair.event)

--- a/RxSwift/Observables/ObserveOn.swift
+++ b/RxSwift/Observables/ObserveOn.swift
@@ -118,6 +118,7 @@ final private class ObserveOnSink<Observer: ObserverType>: ObserverBase<Observer
         }
     }
 
+    @Sendable
     func run(_ state: (), _ recurse: (()) -> Void) {
         let (nextEvent, observer) = self.lock.performLocked { () -> (Event<Element>?, Observer) in
             if !self.queue.isEmpty {

--- a/RxSwift/Observables/Reduce.swift
+++ b/RxSwift/Observables/Reduce.swift
@@ -20,7 +20,7 @@ extension ObservableType {
     - parameter mapResult: A function to transform the final accumulator value into the result value.
     - returns: An observable sequence containing a single element with the final accumulator value.
     */
-    public func reduce<A, Result>(_ seed: A, accumulator: @escaping (A, Element) throws -> A, mapResult: @escaping (A) throws -> Result)
+    public func reduce<A, Result>(_ seed: A, accumulator: @escaping @Sendable (A, Element) throws -> A, mapResult: @escaping @Sendable (A) throws -> Result)
         -> Observable<Result> {
         Reduce(source: self.asObservable(), seed: seed, accumulator: accumulator, mapResult: mapResult)
     }
@@ -36,7 +36,7 @@ extension ObservableType {
     - parameter accumulator: A accumulator function to be invoked on each element.
     - returns: An observable sequence containing a single element with the final accumulator value.
     */
-    public func reduce<A>(_ seed: A, accumulator: @escaping (A, Element) throws -> A)
+    public func reduce<A>(_ seed: A, accumulator: @escaping @Sendable (A, Element) throws -> A)
         -> Observable<A> {
         Reduce(source: self.asObservable(), seed: seed, accumulator: accumulator, mapResult: { $0 })
     }
@@ -85,8 +85,8 @@ final private class ReduceSink<SourceType, AccumulateType, Observer: ObserverTyp
 }
 
 final private class Reduce<SourceType, AccumulateType, ResultType>: Producer<ResultType> {
-    typealias AccumulatorType = (AccumulateType, SourceType) throws -> AccumulateType
-    typealias ResultSelectorType = (AccumulateType) throws -> ResultType
+    typealias AccumulatorType = @Sendable (AccumulateType, SourceType) throws -> AccumulateType
+    typealias ResultSelectorType = @Sendable (AccumulateType) throws -> ResultType
     
     private let source: Observable<SourceType>
     fileprivate let seed: AccumulateType

--- a/RxSwift/Observables/RetryWhen.swift
+++ b/RxSwift/Observables/RetryWhen.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter notificationHandler: A handler that is passed an observable sequence of errors raised by the source observable and returns and observable that either continues, completes or errors. This behavior is then applied to the source observable.
      - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
      */
-    public func retry<TriggerObservable: ObservableType, Error: Swift.Error>(when notificationHandler: @escaping (Observable<Error>) -> TriggerObservable)
+    public func retry<TriggerObservable: ObservableType, Error: Swift.Error>(when notificationHandler: @escaping @Sendable (Observable<Error>) -> TriggerObservable)
         -> Observable<Element> {
         RetryWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
     }
@@ -31,7 +31,7 @@ extension ObservableType {
      - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
      */
     @available(*, deprecated, renamed: "retry(when:)")
-    public func retryWhen<TriggerObservable: ObservableType, Error: Swift.Error>(_ notificationHandler: @escaping (Observable<Error>) -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType, Error: Swift.Error>(_ notificationHandler: @escaping @Sendable (Observable<Error>) -> TriggerObservable)
         -> Observable<Element> {
         retry(when: notificationHandler)
     }
@@ -45,7 +45,7 @@ extension ObservableType {
      - parameter notificationHandler: A handler that is passed an observable sequence of errors raised by the source observable and returns and observable that either continues, completes or errors. This behavior is then applied to the source observable.
      - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
      */
-    public func retry<TriggerObservable: ObservableType>(when notificationHandler: @escaping (Observable<Swift.Error>) -> TriggerObservable)
+    public func retry<TriggerObservable: ObservableType>(when notificationHandler: @escaping @Sendable (Observable<Swift.Error>) -> TriggerObservable)
         -> Observable<Element> {
         RetryWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
     }
@@ -60,7 +60,7 @@ extension ObservableType {
      - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
      */
     @available(*, deprecated, renamed: "retry(when:)")
-    public func retryWhen<TriggerObservable: ObservableType>(_ notificationHandler: @escaping (Observable<Swift.Error>) -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType>(_ notificationHandler: @escaping @Sendable (Observable<Swift.Error>) -> TriggerObservable)
         -> Observable<Element> {
         RetryWhenSequence(sources: InfiniteSequence(repeatedValue: self.asObservable()), notificationHandler: notificationHandler)
     }
@@ -196,9 +196,9 @@ final private class RetryWhenSequence<Sequence: Swift.Sequence, TriggerObservabl
     typealias Element = Sequence.Element.Element
     
     private let sources: Sequence
-    fileprivate let notificationHandler: (Observable<Error>) -> TriggerObservable
+    fileprivate let notificationHandler: @Sendable (Observable<Error>) -> TriggerObservable
     
-    init(sources: Sequence, notificationHandler: @escaping (Observable<Error>) -> TriggerObservable) {
+    init(sources: Sequence, notificationHandler: @escaping @Sendable (Observable<Error>) -> TriggerObservable) {
         self.sources = sources
         self.notificationHandler = notificationHandler
     }

--- a/RxSwift/Observables/Scan.swift
+++ b/RxSwift/Observables/Scan.swift
@@ -19,7 +19,7 @@ extension ObservableType {
      - parameter accumulator: An accumulator function to be invoked on each element.
      - returns: An observable sequence containing the accumulated values.
      */
-    public func scan<A>(into seed: A, accumulator: @escaping (inout A, Element) throws -> Void)
+    public func scan<A>(into seed: A, accumulator: @escaping @Sendable (inout A, Element) throws -> Void)
         -> Observable<A> {
         Scan(source: self.asObservable(), seed: seed, accumulator: accumulator)
     }
@@ -80,7 +80,7 @@ final private class ScanSink<Element, Observer: ObserverType>: Sink<Observer>, O
 }
 
 final private class Scan<Element, Accumulate>: Producer<Accumulate> {
-    typealias Accumulator = (inout Accumulate, Element) throws -> Void
+    typealias Accumulator = @Sendable (inout Accumulate, Element) throws -> Void
     
     private let source: Observable<Element>
     fileprivate let seed: Accumulate

--- a/RxSwift/Observables/Scan.swift
+++ b/RxSwift/Observables/Scan.swift
@@ -35,7 +35,7 @@ extension ObservableType {
      - parameter accumulator: An accumulator function to be invoked on each element.
      - returns: An observable sequence containing the accumulated values.
      */
-    public func scan<A>(_ seed: A, accumulator: @escaping (A, Element) throws -> A)
+    public func scan<A>(_ seed: A, accumulator: @escaping @Sendable (A, Element) throws -> A)
         -> Observable<A> {
         return Scan(source: self.asObservable(), seed: seed) { acc, element in
             let currentAcc = acc

--- a/RxSwift/Observables/SingleAsync.swift
+++ b/RxSwift/Observables/SingleAsync.swift
@@ -30,7 +30,7 @@ extension ObservableType {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that emits a single element or throws an exception if more (or none) of them are emitted.
      */
-    public func single(_ predicate: @escaping (Element) throws -> Bool)
+    public func single(_ predicate: @escaping @Sendable (Element) throws -> Bool)
         -> Observable<Element> {
         SingleAsync(source: self.asObservable(), predicate: predicate)
     }
@@ -86,7 +86,7 @@ private final class SingleAsyncSink<Observer: ObserverType> : Sink<Observer>, Ob
 }
 
 final class SingleAsync<Element>: Producer<Element> {
-    typealias Predicate = (Element) throws -> Bool
+    typealias Predicate = @Sendable (Element) throws -> Bool
     
     private let source: Observable<Element>
     fileprivate let predicate: Predicate?

--- a/RxSwift/Observables/SkipWhile.swift
+++ b/RxSwift/Observables/SkipWhile.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter predicate: A function to test each element for a condition.
      - returns: An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
      */
-    public func skip(while predicate: @escaping (Element) throws -> Bool) -> Observable<Element> {
+    public func skip(while predicate: @escaping @Sendable (Element) throws -> Bool) -> Observable<Element> {
         SkipWhile(source: self.asObservable(), predicate: predicate)
     }
 
@@ -28,7 +28,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
      */
     @available(*, deprecated, renamed: "skip(while:)")
-    public func skipWhile(_ predicate: @escaping (Element) throws -> Bool) -> Observable<Element> {
+    public func skipWhile(_ predicate: @escaping @Sendable (Element) throws -> Bool) -> Observable<Element> {
         SkipWhile(source: self.asObservable(), predicate: predicate)
     }
 }
@@ -69,7 +69,7 @@ final private class SkipWhileSink<Observer: ObserverType>: Sink<Observer>, Obser
 }
 
 final private class SkipWhile<Element>: Producer<Element> {
-    typealias Predicate = (Element) throws -> Bool
+    typealias Predicate = @Sendable (Element) throws -> Bool
 
     private let source: Observable<Element>
     fileprivate let predicate: Predicate

--- a/RxSwift/Observables/Switch.swift
+++ b/RxSwift/Observables/Switch.swift
@@ -19,7 +19,7 @@ extension ObservableType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source producing an
      Observable of Observable sequences and that at any point in time produces the elements of the most recent inner observable sequence that has been received.
      */
-    public func flatMapLatest<Source: ObservableConvertibleType>(_ selector: @escaping (Element) throws -> Source)
+    public func flatMapLatest<Source: ObservableConvertibleType>(_ selector: @escaping @Sendable (Element) throws -> Source)
         -> Observable<Source.Element> {
         return FlatMapLatest(source: self.asObservable(), selector: selector)
     }
@@ -36,7 +36,7 @@ extension ObservableType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source producing an
      Observable of Observable sequences and that at any point in time produces the elements of the most recent inner observable sequence that has been received.
      */
-    public func flatMapLatest<Source: InfallibleType>(_ selector: @escaping (Element) throws -> Source)
+    public func flatMapLatest<Source: InfallibleType>(_ selector: @escaping @Sendable (Element) throws -> Source)
         -> Infallible<Source.Element> {
         return Infallible(flatMapLatest(selector))
     }
@@ -202,7 +202,7 @@ final private class SwitchIdentitySink<Source: ObservableConvertibleType, Observ
 }
 
 final private class MapSwitchSink<SourceType, Source: ObservableConvertibleType, Observer: ObserverType>: SwitchSink<SourceType, Source, Observer> where Observer.Element == Source.Element {
-    typealias Selector = (SourceType) throws -> Source
+    typealias Selector = @Sendable (SourceType) throws -> Source
 
     private let selector: Selector
 
@@ -233,7 +233,7 @@ final private class Switch<Source: ObservableConvertibleType>: Producer<Source.E
 }
 
 final private class FlatMapLatest<SourceType, Source: ObservableConvertibleType>: Producer<Source.Element> {
-    typealias Selector = (SourceType) throws -> Source
+    typealias Selector = @Sendable (SourceType) throws -> Source
 
     private let source: Observable<SourceType>
     private let selector: Selector

--- a/RxSwift/Observables/TakeWithPredicate.swift
+++ b/RxSwift/Observables/TakeWithPredicate.swift
@@ -30,7 +30,7 @@ extension ObservableType {
 
      - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test passes.
      */
-    public func take(until predicate: @escaping (Element) throws -> Bool,
+    public func take(until predicate: @escaping @Sendable (Element) throws -> Bool,
                      behavior: TakeBehavior = .exclusive)
         -> Observable<Element> {
         TakeUntilPredicate(source: self.asObservable(),
@@ -77,7 +77,7 @@ extension ObservableType {
      */
     @available(*, deprecated, renamed: "take(until:behavior:)")
     public func takeUntil(_ behavior: TakeBehavior,
-                          predicate: @escaping (Element) throws -> Bool)
+                          predicate: @escaping @Sendable (Element) throws -> Bool)
         -> Observable<Element> {
         take(until: predicate, behavior: behavior)
     }
@@ -263,7 +263,7 @@ final private class TakeUntilPredicateSink<Observer: ObserverType>
 }
 
 final private class TakeUntilPredicate<Element>: Producer<Element> {
-    typealias Predicate = (Element) throws -> Bool
+    typealias Predicate = @Sendable (Element) throws -> Bool
 
     private let source: Observable<Element>
     fileprivate let predicate: Predicate

--- a/RxSwift/Observables/TakeWithPredicate.swift
+++ b/RxSwift/Observables/TakeWithPredicate.swift
@@ -46,7 +46,7 @@ extension ObservableType {
      - parameter predicate: A function to test each element for a condition.
      - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test no longer passes.
      */
-    public func take(while predicate: @escaping (Element) throws -> Bool,
+    public func take(while predicate: @escaping @Sendable (Element) throws -> Bool,
                      behavior: TakeBehavior = .exclusive)
         -> Observable<Element> {
         take(until: { try !predicate($0) }, behavior: behavior)
@@ -91,7 +91,7 @@ extension ObservableType {
      - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test no longer passes.
      */
     @available(*, deprecated, renamed: "take(while:)")
-    public func takeWhile(_ predicate: @escaping (Element) throws -> Bool)
+    public func takeWhile(_ predicate: @escaping @Sendable (Element) throws -> Bool)
         -> Observable<Element> {
         take(until: { try !predicate($0) }, behavior: .exclusive)
     }

--- a/RxSwift/Observables/Throttle.swift
+++ b/RxSwift/Observables/Throttle.swift
@@ -122,6 +122,7 @@ final private class ThrottleSink<Observer: ObserverType>
         self.lastSentTime = self.parent.scheduler.now
     }
     
+    @Sendable
     func propagate(_: Int) -> Disposable {
         self.lock.performLocked {
             if let lastUnsentElement = self.lastUnsentElement {

--- a/RxSwift/Observables/Using.swift
+++ b/RxSwift/Observables/Using.swift
@@ -16,7 +16,7 @@ extension ObservableType {
      - parameter observableFactory: Factory function to obtain an observable sequence that depends on the obtained resource.
      - returns: An observable sequence whose lifetime controls the lifetime of the dependent resource object.
      */
-    public static func using<Resource: Disposable>(_ resourceFactory: @escaping () throws -> Resource, observableFactory: @escaping (Resource) throws -> Observable<Element>) -> Observable<Element> {
+    public static func using<Resource: Disposable>(_ resourceFactory: @escaping @Sendable () throws -> Resource, observableFactory: @escaping @Sendable (Resource) throws -> Observable<Element>) -> Observable<Element> {
         Using(resourceFactory: resourceFactory, observableFactory: observableFactory)
     }
 }
@@ -70,8 +70,8 @@ final private class Using<SourceType, ResourceType: Disposable>: Producer<Source
     
     typealias Element = SourceType
     
-    typealias ResourceFactory = () throws -> ResourceType
-    typealias ObservableFactory = (ResourceType) throws -> Observable<SourceType>
+    typealias ResourceFactory = @Sendable () throws -> ResourceType
+    typealias ObservableFactory = @Sendable (ResourceType) throws -> Observable<SourceType>
     
     fileprivate let resourceFactory: ResourceFactory
     fileprivate let observableFactory: ObservableFactory

--- a/RxSwift/Observables/WithLatestFrom.swift
+++ b/RxSwift/Observables/WithLatestFrom.swift
@@ -18,7 +18,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke for each element from the self combined with the latest element from the second source, if any.
      - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
      */
-    public func withLatestFrom<Source: ObservableConvertibleType, ResultType>(_ second: Source, resultSelector: @escaping (Element, Source.Element) throws -> ResultType) -> Observable<ResultType> {
+    public func withLatestFrom<Source: ObservableConvertibleType, ResultType>(_ second: Source, resultSelector: @escaping @Sendable (Element, Source.Element) throws -> ResultType) -> Observable<ResultType> {
         WithLatestFrom(first: self.asObservable(), second: second.asObservable(), resultSelector: resultSelector)
     }
 
@@ -131,7 +131,7 @@ final private class WithLatestFromSecond<FirstType, SecondType, Observer: Observ
 }
 
 final private class WithLatestFrom<FirstType, SecondType, ResultType>: Producer<ResultType> {
-    typealias ResultSelector = (FirstType, SecondType) throws -> ResultType
+    typealias ResultSelector = @Sendable (FirstType, SecondType) throws -> ResultType
     
     fileprivate let first: Observable<FirstType>
     fileprivate let second: Observable<SecondType>

--- a/RxSwift/Observables/WithUnretained.swift
+++ b/RxSwift/Observables/WithUnretained.swift
@@ -20,7 +20,7 @@ extension ObservableType {
      */
     public func withUnretained<Object: AnyObject, Out>(
         _ obj: Object,
-        resultSelector: @escaping (Object, Element) -> Out
+        resultSelector: @escaping @Sendable (Object, Element) -> Out
     ) -> Observable<Out> {
         map { [weak obj] element -> Out in
             guard let obj = obj else { throw UnretainedError.failedRetaining }

--- a/RxSwift/Observables/Zip+Collection.swift
+++ b/RxSwift/Observables/Zip+Collection.swift
@@ -15,7 +15,7 @@ extension ObservableType {
      - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func zip<Collection: Swift.Collection>(_ collection: Collection, resultSelector: @escaping ([Collection.Element.Element]) throws -> Element) -> Observable<Element>
+    public static func zip<Collection: Swift.Collection>(_ collection: Collection, resultSelector: @escaping @Sendable ([Collection.Element.Element]) throws -> Element) -> Observable<Element>
         where Collection.Element: ObservableType {
         ZipCollectionType(sources: collection, resultSelector: resultSelector)
     }
@@ -148,7 +148,7 @@ final private class ZipCollectionTypeSink<Collection: Swift.Collection, Observer
 }
 
 final private class ZipCollectionType<Collection: Swift.Collection, Result>: Producer<Result> where Collection.Element: ObservableConvertibleType {
-    typealias ResultSelector = ([Collection.Element.Element]) throws -> Result
+    typealias ResultSelector = @Sendable ([Collection.Element.Element]) throws -> Result
     
     let sources: Collection
     let resultSelector: ResultSelector

--- a/RxSwift/Observables/Zip+arity.swift
+++ b/RxSwift/Observables/Zip+arity.swift
@@ -21,7 +21,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType>
-        (_ source1: O1, _ source2: O2, resultSelector: @escaping (O1.Element, O2.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, resultSelector: @escaping @Sendable (O1.Element, O2.Element) throws -> Element)
         -> Observable<Element> {
         return Zip2(
             source1: source1.asObservable(), source2: source2.asObservable(),
@@ -94,7 +94,7 @@ final class ZipSink2_<E1, E2, Observer: ObserverType> : ZipSink<Observer> {
 }
 
 final class Zip2<E1, E2, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -129,7 +129,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping (O1.Element, O2.Element, O3.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element) throws -> Element)
         -> Observable<Element> {
         return Zip3(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(),
@@ -208,7 +208,7 @@ final class ZipSink3_<E1, E2, E3, Observer: ObserverType> : ZipSink<Observer> {
 }
 
 final class Zip3<E1, E2, E3, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -245,7 +245,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element) throws -> Element)
         -> Observable<Element> {
         return Zip4(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(),
@@ -330,7 +330,7 @@ final class ZipSink4_<E1, E2, E3, E4, Observer: ObserverType> : ZipSink<Observer
 }
 
 final class Zip4<E1, E2, E3, E4, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -369,7 +369,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element) throws -> Element)
         -> Observable<Element> {
         return Zip5(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(),
@@ -460,7 +460,7 @@ final class ZipSink5_<E1, E2, E3, E4, E5, Observer: ObserverType> : ZipSink<Obse
 }
 
 final class Zip5<E1, E2, E3, E4, E5, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4, E5) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4, E5) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -501,7 +501,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element) throws -> Element)
         -> Observable<Element> {
         return Zip6(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(),
@@ -598,7 +598,7 @@ final class ZipSink6_<E1, E2, E3, E4, E5, E6, Observer: ObserverType> : ZipSink<
 }
 
 final class Zip6<E1, E2, E3, E4, E5, E6, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4, E5, E6) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4, E5, E6) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -641,7 +641,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element) throws -> Element)
         -> Observable<Element> {
         return Zip7(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(),
@@ -744,7 +744,7 @@ final class ZipSink7_<E1, E2, E3, E4, E5, E6, E7, Observer: ObserverType> : ZipS
 }
 
 final class Zip7<E1, E2, E3, E4, E5, E6, E7, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4, E5, E6, E7) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>
@@ -789,7 +789,7 @@ extension ObservableType {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func zip<O1: ObservableType, O2: ObservableType, O3: ObservableType, O4: ObservableType, O5: ObservableType, O6: ObservableType, O7: ObservableType, O8: ObservableType>
-        (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
+    (_ source1: O1, _ source2: O2, _ source3: O3, _ source4: O4, _ source5: O5, _ source6: O6, _ source7: O7, _ source8: O8, resultSelector: @escaping @Sendable (O1.Element, O2.Element, O3.Element, O4.Element, O5.Element, O6.Element, O7.Element, O8.Element) throws -> Element)
         -> Observable<Element> {
         return Zip8(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(),
@@ -898,7 +898,7 @@ final class ZipSink8_<E1, E2, E3, E4, E5, E6, E7, E8, Observer: ObserverType> : 
 }
 
 final class Zip8<E1, E2, E3, E4, E5, E6, E7, E8, Result> : Producer<Result> {
-    typealias ResultSelector = (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Result
+    typealias ResultSelector = @Sendable (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Result
 
     let source1: Observable<E1>
     let source2: Observable<E2>

--- a/RxSwift/Observables/Zip.swift
+++ b/RxSwift/Observables/Zip.swift
@@ -85,7 +85,7 @@ final class ZipObserver<Element>
     : ObserverType
     , LockOwnerType
     , SynchronizedOnType {
-    typealias ValueSetter = (Element) -> Void
+    typealias ValueSetter = @Sendable (Element) -> Void
 
     private var parent: ZipSinkProtocol?
     

--- a/RxSwift/ObserverType.swift
+++ b/RxSwift/ObserverType.swift
@@ -14,6 +14,7 @@ public protocol ObserverType {
     /// Notify observer about sequence event.
     ///
     /// - parameter event: Event that occurred.
+    @Sendable
     func on(_ event: Event<Element>)
 }
 

--- a/RxSwift/Observers/AnonymousObserver.swift
+++ b/RxSwift/Observers/AnonymousObserver.swift
@@ -7,7 +7,7 @@
 //
 
 final class AnonymousObserver<Element>: ObserverBase<Element> {
-    typealias EventHandler = (Event<Element>) -> Void
+    typealias EventHandler = @Sendable (Event<Element>) -> Void
     
     private let eventHandler : EventHandler
     

--- a/RxSwift/SchedulerType.swift
+++ b/RxSwift/SchedulerType.swift
@@ -31,7 +31,7 @@ public protocol SchedulerType: ImmediateSchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable) -> Disposable
+    func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable
  
     /**
     Schedules a periodic piece of work.
@@ -42,7 +42,7 @@ public protocol SchedulerType: ImmediateSchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping (StateType) -> StateType) -> Disposable
+    func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping @Sendable (StateType) -> StateType) -> Disposable
 }
 
 extension SchedulerType {
@@ -55,13 +55,13 @@ extension SchedulerType {
     - parameter period: Period for running the work periodically.
     - returns: The disposable object used to cancel the scheduled recurring action (best effort).
     */
-    public func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping (StateType) -> StateType) -> Disposable {
+    public func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping @Sendable (StateType) -> StateType) -> Disposable {
         let schedule = SchedulePeriodicRecursive(scheduler: self, startAfter: startAfter, period: period, action: action, state: state)
             
         return schedule.start()
     }
 
-    func scheduleRecursive<State>(_ state: State, dueTime: RxTimeInterval, action: @escaping (State, AnyRecursiveScheduler<State>) -> Void) -> Disposable {
+    func scheduleRecursive<State>(_ state: State, dueTime: RxTimeInterval, action: @escaping @Sendable (State, AnyRecursiveScheduler<State>) -> Void) -> Disposable {
         let scheduler = AnyRecursiveScheduler(scheduler: self, action: action)
          
         scheduler.schedule(state, dueTime: dueTime)

--- a/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift
@@ -51,7 +51,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public final func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public final func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         self.configuration.schedule(state, action: action)
     }
     
@@ -63,7 +63,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public final func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public final func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         self.configuration.scheduleRelative(state, dueTime: dueTime, action: action)
     }
     
@@ -76,7 +76,7 @@ public class ConcurrentDispatchQueueScheduler: SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping (StateType) -> StateType) -> Disposable {
+    public func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping @Sendable (StateType) -> StateType) -> Disposable {
         self.configuration.schedulePeriodic(state, startAfter: startAfter, period: period, action: action)
     }
 }

--- a/RxSwift/Schedulers/ConcurrentMainScheduler.swift
+++ b/RxSwift/Schedulers/ConcurrentMainScheduler.swift
@@ -42,14 +42,14 @@ public final class ConcurrentMainScheduler : SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         if DispatchQueue.isMain {
             return action(state)
         }
 
         let cancel = SingleAssignmentDisposable()
 
-        self.mainQueue.async {
+        self.mainQueue.async { @Sendable () in
             if cancel.isDisposed {
                 return
             }
@@ -68,7 +68,7 @@ public final class ConcurrentMainScheduler : SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public final func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public final func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         self.mainScheduler.scheduleRelative(state, dueTime: dueTime, action: action)
     }
 
@@ -81,7 +81,7 @@ public final class ConcurrentMainScheduler : SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping (StateType) -> StateType) -> Disposable {
+    public func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping @Sendable (StateType) -> StateType) -> Disposable {
         self.mainScheduler.schedulePeriodic(state, startAfter: startAfter, period: period, action: action)
     }
 }

--- a/RxSwift/Schedulers/CurrentThreadScheduler.swift
+++ b/RxSwift/Schedulers/CurrentThreadScheduler.swift
@@ -87,7 +87,7 @@ public class CurrentThreadScheduler : ImmediateSchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         if CurrentThreadScheduler.isScheduleRequired {
             CurrentThreadScheduler.isScheduleRequired = false
 

--- a/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
+++ b/RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift
@@ -44,7 +44,7 @@ extension DispatchQueueConfiguration {
         // Need more info on this.
         // It looks like just setting timer to fire and not holding a reference to it
         // until deadline causes timer cancellation.
-        var timerReference: DispatchSourceTimer? = timer
+        nonisolated(unsafe) var timerReference: DispatchSourceTimer? = timer
         let cancelTimer = Disposables.create {
             timerReference?.cancel()
             timerReference = nil
@@ -78,7 +78,7 @@ extension DispatchQueueConfiguration {
         // Need more info on this.
         // It looks like just setting timer to fire and not holding a reference to it
         // until deadline causes timer cancellation.
-        var timerReference: DispatchSourceTimer? = timer
+        nonisolated(unsafe) var timerReference: DispatchSourceTimer? = timer
         let cancelTimer = Disposables.create {
             timerReference?.cancel()
             timerReference = nil

--- a/RxSwift/Schedulers/Internal/ScheduledItem.swift
+++ b/RxSwift/Schedulers/Internal/ScheduledItem.swift
@@ -9,7 +9,7 @@
 struct ScheduledItem<T>
     : ScheduledItemType
     , InvocableType {
-    typealias Action = (T) -> Disposable
+    typealias Action = @Sendable (T) -> Disposable
     
     private let action: Action
     private let state: T

--- a/RxSwift/Schedulers/MainScheduler.swift
+++ b/RxSwift/Schedulers/MainScheduler.swift
@@ -56,7 +56,7 @@ public final class MainScheduler : SerialDispatchQueueScheduler {
         #endif
     }
 
-    override func scheduleInternal<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    override func scheduleInternal<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         let previousNumberEnqueued = increment(self.numberEnqueued)
 
         if DispatchQueue.isMain && previousNumberEnqueued == 0 {

--- a/RxSwift/Schedulers/OperationQueueScheduler.swift
+++ b/RxSwift/Schedulers/OperationQueueScheduler.swift
@@ -32,7 +32,7 @@ public class OperationQueueScheduler: ImmediateSchedulerType {
     - parameter action: Action to execute recursively. The last parameter passed to the action is used to trigger recursive scheduling of the action, passing in recursive invocation state.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         let cancel = SingleAssignmentDisposable()
 
         let operation = BlockOperation {

--- a/RxSwift/Schedulers/RecursiveScheduler.swift
+++ b/RxSwift/Schedulers/RecursiveScheduler.swift
@@ -37,7 +37,7 @@ final class AnyRecursiveScheduler<State> {
     - parameter dueTime: Relative time after which to execute the recursive action.
     */
     func schedule(_ state: State, dueTime: RxTimeInterval) {
-        var scheduleState: ScheduleState = .initial
+        nonisolated(unsafe) var scheduleState: ScheduleState = .initial
 
         let d = self.scheduler.scheduleRelative(state, dueTime: dueTime) { state -> Disposable in
             // best effort
@@ -88,7 +88,7 @@ final class AnyRecursiveScheduler<State> {
     ///
     /// - parameter state: State passed to the action to be executed.
     func schedule(_ state: State) {
-        var scheduleState: ScheduleState = .initial
+        nonisolated(unsafe) var scheduleState: ScheduleState = .initial
 
         let d = self.scheduler.schedule(state) { state -> Disposable in
             // best effort
@@ -135,6 +135,7 @@ final class AnyRecursiveScheduler<State> {
         }
     }
     
+    @Sendable
     func dispose() {
         self.lock.performLocked {
             self.action = nil
@@ -144,7 +145,7 @@ final class AnyRecursiveScheduler<State> {
 }
 
 /// Type erased recursive scheduler.
-final class RecursiveImmediateScheduler<State> {
+final class RecursiveImmediateScheduler<State>: @unchecked Sendable {
     typealias Action =  (_ state: State, _ recurse: (State) -> Void) -> Void
     
     private var lock = SpinLock()
@@ -164,7 +165,7 @@ final class RecursiveImmediateScheduler<State> {
     ///
     /// - parameter state: State passed to the action to be executed.
     func schedule(_ state: State) {
-        var scheduleState: ScheduleState = .initial
+        nonisolated(unsafe) var scheduleState: ScheduleState = .initial
 
         let d = self.scheduler.schedule(state) { state -> Disposable in
             // best effort
@@ -211,6 +212,7 @@ final class RecursiveImmediateScheduler<State> {
         }
     }
     
+    @Sendable
     func dispose() {
         self.lock.performLocked {
             self.action = nil

--- a/RxSwift/Schedulers/SchedulerServices+Emulation.swift
+++ b/RxSwift/Schedulers/SchedulerServices+Emulation.swift
@@ -12,7 +12,7 @@ enum SchedulePeriodicRecursiveCommand {
 }
 
 final class SchedulePeriodicRecursive<State> {
-    typealias RecursiveAction = (State) -> State
+    typealias RecursiveAction = @Sendable (State) -> State
     typealias RecursiveScheduler = AnyRecursiveScheduler<SchedulePeriodicRecursiveCommand>
 
     private let scheduler: SchedulerType
@@ -34,7 +34,8 @@ final class SchedulePeriodicRecursive<State> {
     func start() -> Disposable {
         self.scheduler.scheduleRecursive(SchedulePeriodicRecursiveCommand.tick, dueTime: self.startAfter, action: self.tick)
     }
-
+    
+    @Sendable
     func tick(_ command: SchedulePeriodicRecursiveCommand, scheduler: RecursiveScheduler) {
         // Tries to emulate periodic scheduling as best as possible.
         // The problem that could arise is if handling periodic ticks take too long, or

--- a/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
+++ b/RxSwift/Schedulers/SerialDispatchQueueScheduler.swift
@@ -96,11 +96,11 @@ public class SerialDispatchQueueScheduler : SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public final func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public final func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         self.scheduleInternal(state, action: action)
     }
 
-    func scheduleInternal<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    func scheduleInternal<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         self.configuration.schedule(state, action: action)
     }
 
@@ -112,7 +112,7 @@ public class SerialDispatchQueueScheduler : SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public final func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public final func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         self.configuration.scheduleRelative(state, dueTime: dueTime, action: action)
     }
     
@@ -125,7 +125,7 @@ public class SerialDispatchQueueScheduler : SchedulerType {
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping (StateType) -> StateType) -> Disposable {
+    public func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping @Sendable (StateType) -> StateType) -> Disposable {
         self.configuration.schedulePeriodic(state, startAfter: startAfter, period: period, action: action)
     }
 }

--- a/RxSwift/Schedulers/VirtualTimeScheduler.swift
+++ b/RxSwift/Schedulers/VirtualTimeScheduler.swift
@@ -63,7 +63,7 @@ open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
     - parameter action: Action to be executed.
     - returns: The disposable object used to cancel the scheduled action (best effort).
     */
-    public func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         return self.scheduleRelative(state, dueTime: .microseconds(0)) { a in
             return action(a)
         }
@@ -77,7 +77,7 @@ open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         let time = self.now.addingDispatchInterval(dueTime)
         let absoluteTime = self.converter.convertToVirtualTime(time)
         let adjustedTime = self.adjustScheduledTime(absoluteTime)
@@ -92,7 +92,7 @@ open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleRelativeVirtual<StateType>(_ state: StateType, dueTime: VirtualTimeInterval, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public func scheduleRelativeVirtual<StateType>(_ state: StateType, dueTime: VirtualTimeInterval, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         let time = self.converter.offsetVirtualTime(self.clock, offset: dueTime)
         return self.scheduleAbsoluteVirtual(state, time: time, action: action)
     }
@@ -105,7 +105,7 @@ open class VirtualTimeScheduler<Converter: VirtualTimeConverterType>
      - parameter action: Action to be executed.
      - returns: The disposable object used to cancel the scheduled action (best effort).
      */
-    public func scheduleAbsoluteVirtual<StateType>(_ state: StateType, time: VirtualTime, action: @escaping (StateType) -> Disposable) -> Disposable {
+    public func scheduleAbsoluteVirtual<StateType>(_ state: StateType, time: VirtualTime, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         MainScheduler.ensureExecutingOnScheduler()
 
         let compositeDisposable = CompositeDisposable()
@@ -234,7 +234,7 @@ extension VirtualTimeScheduler: CustomDebugStringConvertible {
 
 final class VirtualSchedulerItem<Time>
     : Disposable {
-    typealias Action = () -> Disposable
+    typealias Action = @Sendable () -> Disposable
     
     let action: Action
     let time: Time

--- a/RxSwift/Traits/Infallible/Infallible+CombineLatest+Collection.swift
+++ b/RxSwift/Traits/Infallible/Infallible+CombineLatest+Collection.swift
@@ -17,7 +17,7 @@ extension InfallibleType {
      - parameter resultSelector: Function to invoke whenever any of the sources produces an element.
      - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
      */
-    public static func combineLatest<Collection: Swift.Collection>(_ collection: Collection, resultSelector: @escaping ([Collection.Element.Element]) throws -> Element) -> Infallible<Element>
+    public static func combineLatest<Collection: Swift.Collection>(_ collection: Collection, resultSelector: @escaping @Sendable ([Collection.Element.Element]) throws -> Element) -> Infallible<Element>
         where Collection.Element: InfallibleType {
         Infallible(CombineLatestCollectionType(sources: collection, resultSelector: resultSelector))
     }

--- a/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.swift
+++ b/RxSwift/Traits/Infallible/Infallible+CombineLatest+arity.swift
@@ -20,7 +20,7 @@ extension Infallible {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<I1: InfallibleType, I2: InfallibleType>
-        (_ source1: I1, _ source2: I2, resultSelector: @escaping (I1.Element, I2.Element) throws -> Element)
+    (_ source1: I1, _ source2: I2, resultSelector: @escaping @Sendable (I1.Element, I2.Element) throws -> Element)
             -> Infallible<Element> {
         Infallible(CombineLatest2(
             source1: source1.asObservable(), source2: source2.asObservable(),
@@ -58,7 +58,7 @@ extension Infallible {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<I1: InfallibleType, I2: InfallibleType, I3: InfallibleType>
-        (_ source1: I1, _ source2: I2, _ source3: I3, resultSelector: @escaping (I1.Element, I2.Element, I3.Element) throws -> Element)
+    (_ source1: I1, _ source2: I2, _ source3: I3, resultSelector: @escaping @Sendable (I1.Element, I2.Element, I3.Element) throws -> Element)
             -> Infallible<Element> {
         Infallible(CombineLatest3(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(),
@@ -96,7 +96,7 @@ extension Infallible {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<I1: InfallibleType, I2: InfallibleType, I3: InfallibleType, I4: InfallibleType>
-        (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, resultSelector: @escaping (I1.Element, I2.Element, I3.Element, I4.Element) throws -> Element)
+    (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, resultSelector: @escaping @Sendable (I1.Element, I2.Element, I3.Element, I4.Element) throws -> Element)
             -> Infallible<Element> {
         Infallible(CombineLatest4(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(),
@@ -134,7 +134,7 @@ extension Infallible {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<I1: InfallibleType, I2: InfallibleType, I3: InfallibleType, I4: InfallibleType, I5: InfallibleType>
-        (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, resultSelector: @escaping (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element) throws -> Element)
+    (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, resultSelector: @escaping @Sendable (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element) throws -> Element)
             -> Infallible<Element> {
         Infallible(CombineLatest5(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(),
@@ -172,7 +172,7 @@ extension Infallible {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<I1: InfallibleType, I2: InfallibleType, I3: InfallibleType, I4: InfallibleType, I5: InfallibleType, I6: InfallibleType>
-        (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, _ source6: I6, resultSelector: @escaping (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element, I6.Element) throws -> Element)
+    (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, _ source6: I6, resultSelector: @escaping @Sendable (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element, I6.Element) throws -> Element)
             -> Infallible<Element> {
         Infallible(CombineLatest6(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(),
@@ -210,7 +210,7 @@ extension Infallible {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<I1: InfallibleType, I2: InfallibleType, I3: InfallibleType, I4: InfallibleType, I5: InfallibleType, I6: InfallibleType, I7: InfallibleType>
-        (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, _ source6: I6, _ source7: I7, resultSelector: @escaping (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element, I6.Element, I7.Element) throws -> Element)
+    (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, _ source6: I6, _ source7: I7, resultSelector: @escaping @Sendable (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element, I6.Element, I7.Element) throws -> Element)
             -> Infallible<Element> {
         Infallible(CombineLatest7(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(),
@@ -248,7 +248,7 @@ extension Infallible {
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
     public static func combineLatest<I1: InfallibleType, I2: InfallibleType, I3: InfallibleType, I4: InfallibleType, I5: InfallibleType, I6: InfallibleType, I7: InfallibleType, I8: InfallibleType>
-        (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, _ source6: I6, _ source7: I7, _ source8: I8, resultSelector: @escaping (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element, I6.Element, I7.Element, I8.Element) throws -> Element)
+    (_ source1: I1, _ source2: I2, _ source3: I3, _ source4: I4, _ source5: I5, _ source6: I6, _ source7: I7, _ source8: I8, resultSelector: @escaping @Sendable (I1.Element, I2.Element, I3.Element, I4.Element, I5.Element, I6.Element, I7.Element, I8.Element) throws -> Element)
             -> Infallible<Element> {
         Infallible(CombineLatest8(
             source1: source1.asObservable(), source2: source2.asObservable(), source3: source3.asObservable(), source4: source4.asObservable(), source5: source5.asObservable(), source6: source6.asObservable(), source7: source7.asObservable(), source8: source8.asObservable(),

--- a/RxSwift/Traits/Infallible/Infallible+Create.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Create.swift
@@ -27,9 +27,9 @@ extension Infallible {
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(subscribe: @escaping (@escaping InfallibleObserver) -> Disposable) -> Infallible<Element> {
-        let source = Observable<Element>.create { observer in
-            subscribe { event in
+    public static func create(subscribe: @escaping @Sendable (@escaping InfallibleObserver) -> Disposable) -> Infallible<Element> {
+        let source = Observable<Element>.create { @Sendable observer in
+            subscribe { @Sendable event in
                 switch event {
                 case .next(let element):
                     observer.onNext(element)

--- a/RxSwift/Traits/Infallible/Infallible+Create.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Create.swift
@@ -17,7 +17,7 @@ public enum InfallibleEvent<Element> {
 }
 
 extension Infallible {
-    public typealias InfallibleObserver = (InfallibleEvent<Element>) -> Void
+    public typealias InfallibleObserver = @Sendable (InfallibleEvent<Element>) -> Void
 
     /**
      Creates an observable sequence from a specified subscribe method implementation.

--- a/RxSwift/Traits/Infallible/Infallible+Operators.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Operators.swift
@@ -123,7 +123,7 @@ extension InfallibleType {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
      */
-    public func filter(_ predicate: @escaping (Element) -> Bool)
+    public func filter(_ predicate: @escaping @Sendable (Element) -> Bool)
         -> Infallible<Element> {
         Infallible(asObservable().filter(predicate))
     }
@@ -140,7 +140,7 @@ extension InfallibleType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
 
      */
-    public func map<Result>(_ transform: @escaping (Element) -> Result)
+    public func map<Result>(_ transform: @escaping @Sendable (Element) -> Result)
         -> Infallible<Result> {
         Infallible(asObservable().map(transform))
     }
@@ -152,7 +152,7 @@ extension InfallibleType {
      - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
 
      */
-    public func compactMap<Result>(_ transform: @escaping (Element) -> Result?)
+    public func compactMap<Result>(_ transform: @escaping @Sendable (Element) -> Result?)
         -> Infallible<Result> {
         Infallible(asObservable().compactMap(transform))
     }
@@ -183,7 +183,7 @@ extension InfallibleType {
      - parameter keySelector: A function to compute the comparison key for each element.
      - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value, from the source sequence.
      */
-    public func distinctUntilChanged<Key: Equatable>(_ keySelector: @escaping (Element) throws -> Key)
+    public func distinctUntilChanged<Key: Equatable>(_ keySelector: @escaping @Sendable (Element) throws -> Key)
         -> Infallible<Element> {
         Infallible(self.asObservable().distinctUntilChanged(keySelector, comparer: { $0 == $1 }))
     }
@@ -196,7 +196,7 @@ extension InfallibleType {
      - parameter comparer: Equality comparer for computed key values.
      - returns: An observable sequence only containing the distinct contiguous elements, based on `comparer`, from the source sequence.
      */
-    public func distinctUntilChanged(_ comparer: @escaping (Element, Element) throws -> Bool)
+    public func distinctUntilChanged(_ comparer: @escaping @Sendable (Element, Element) throws -> Bool)
         -> Infallible<Element> {
         Infallible(self.asObservable().distinctUntilChanged({ $0 }, comparer: comparer))
     }
@@ -210,7 +210,7 @@ extension InfallibleType {
      - parameter comparer: Equality comparer for computed key values.
      - returns: An observable sequence only containing the distinct contiguous elements, based on a computed key value and the comparer, from the source sequence.
      */
-    public func distinctUntilChanged<K>(_ keySelector: @escaping (Element) throws -> K, comparer: @escaping (K, K) throws -> Bool)
+    public func distinctUntilChanged<K>(_ keySelector: @escaping @Sendable (Element) throws -> K, comparer: @escaping @Sendable (K, K) throws -> Bool)
         -> Infallible<Element> {
         Infallible(asObservable().distinctUntilChanged(keySelector, comparer: comparer))
     }
@@ -272,7 +272,7 @@ extension InfallibleType {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMap<Source: ObservableConvertibleType>(_ selector: @escaping (Element) -> Source)
+    public func flatMap<Source: ObservableConvertibleType>(_ selector: @escaping @Sendable (Element) -> Source)
         -> Infallible<Source.Element> {
         Infallible(asObservable().flatMap(selector))
     }
@@ -289,7 +289,7 @@ extension InfallibleType {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source producing an
      Observable of Observable sequences and that at any point in time produces the elements of the most recent inner observable sequence that has been received.
      */
-    public func flatMapLatest<Source: ObservableConvertibleType>(_ selector: @escaping (Element) -> Source)
+    public func flatMapLatest<Source: ObservableConvertibleType>(_ selector: @escaping @Sendable (Element) -> Source)
         -> Infallible<Source.Element> {
         Infallible(asObservable().flatMapLatest(selector))
     }
@@ -303,7 +303,7 @@ extension InfallibleType {
      - parameter selector: A transform function to apply to element that was observed while no observable is executing in parallel.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence that was received while no other sequence was being calculated.
      */
-    public func flatMapFirst<Source: ObservableConvertibleType>(_ selector: @escaping (Element) -> Source)
+    public func flatMapFirst<Source: ObservableConvertibleType>(_ selector: @escaping @Sendable (Element) -> Source)
         -> Infallible<Source.Element> {
         Infallible(asObservable().flatMapFirst(selector))
     }
@@ -383,7 +383,7 @@ extension InfallibleType {
 
      - returns: An observable sequence that contains the elements of each observed inner sequence, in sequential order.
      */
-    public func concatMap<Source: ObservableConvertibleType>(_ selector: @escaping (Element) -> Source)
+    public func concatMap<Source: ObservableConvertibleType>(_ selector: @escaping @Sendable (Element) -> Source)
         -> Infallible<Source.Element> {
         Infallible(asObservable().concatMap(selector))
     }
@@ -445,7 +445,7 @@ extension Infallible {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onNext: ((Element) throws -> Void)? = nil, afterNext: ((Element) throws -> Void)? = nil, onCompleted: (() throws -> Void)? = nil, afterCompleted: (() throws -> Void)? = nil, onSubscribe: (() -> Void)? = nil, onSubscribed: (() -> Void)? = nil, onDispose: (() -> Void)? = nil) -> Infallible<Element> {
+    public func `do`(onNext: (@Sendable (Element) throws -> Void)? = nil, afterNext: (@Sendable (Element) throws -> Void)? = nil, onCompleted: (@Sendable () throws -> Void)? = nil, afterCompleted: (@Sendable () throws -> Void)? = nil, onSubscribe: (@Sendable () -> Void)? = nil, onSubscribed: (@Sendable () -> Void)? = nil, onDispose: (@Sendable () -> Void)? = nil) -> Infallible<Element> {
         Infallible(asObservable().do(onNext: onNext, afterNext: afterNext, onCompleted: onCompleted, afterCompleted: afterCompleted, onSubscribe: onSubscribe, onSubscribed: onSubscribed, onDispose: onDispose))
     }
 }
@@ -463,7 +463,7 @@ extension InfallibleType {
      - parameter accumulator: An accumulator function to be invoked on each element.
      - returns: An observable sequence containing the accumulated values.
      */
-    public func scan<Seed>(into seed: Seed, accumulator: @escaping (inout Seed, Element) -> Void)
+    public func scan<Seed>(into seed: Seed, accumulator: @escaping @Sendable (inout Seed, Element) -> Void)
         -> Infallible<Seed> {
         Infallible(asObservable().scan(into: seed, accumulator: accumulator))
     }
@@ -541,7 +541,7 @@ extension InfallibleType {
 
      - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test passes.
      */
-    public func take(until predicate: @escaping (Element) throws -> Bool,
+    public func take(until predicate: @escaping @Sendable (Element) throws -> Bool,
                      behavior: TakeBehavior = .exclusive)
         -> Infallible<Element> {
         Infallible(asObservable().take(until: predicate, behavior: behavior))
@@ -595,7 +595,7 @@ extension InfallibleType {
      - parameter predicate: A function to test each element for a condition.
      - returns: An infallible sequence that contains the elements from the input sequence starting at the first element in the linear series that does not pass the test specified by predicate.
      */
-    public func skip(while predicate: @escaping (Element) throws -> Bool) -> Infallible<Element> {
+    public func skip(while predicate: @escaping @Sendable (Element) throws -> Bool) -> Infallible<Element> {
         Infallible(asObservable().skip(while: predicate))
     }
 
@@ -694,7 +694,7 @@ extension InfallibleType {
      - parameter resultSelector: Function to invoke for each element from the self combined with the latest element from the second source, if any.
      - returns: An observable sequence containing the result of combining each element of the self  with the latest element from the second source, if any, using the specified result selector function.
      */
-    public func withLatestFrom<Source: InfallibleType, ResultType>(_ second: Source, resultSelector: @escaping (Element, Source.Element) throws -> ResultType) -> Infallible<ResultType> {
+    public func withLatestFrom<Source: InfallibleType, ResultType>(_ second: Source, resultSelector: @escaping @Sendable (Element, Source.Element) throws -> ResultType) -> Infallible<ResultType> {
         Infallible(self.asObservable().withLatestFrom(second.asObservable(), resultSelector: resultSelector))
     }
 

--- a/RxSwift/Traits/Infallible/Infallible+Operators.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Operators.swift
@@ -66,7 +66,7 @@ extension InfallibleType {
      - parameter observableFactory: Observable factory function to invoke for each observer that subscribes to the resulting sequence.
      - returns: An observable sequence whose observers trigger an invocation of the given observable factory function.
      */
-    public static func deferred(_ observableFactory: @escaping () throws -> Infallible<Element>)
+    public static func deferred(_ observableFactory: @escaping @Sendable () throws -> Infallible<Element>)
         -> Infallible<Element> {
         Infallible(.deferred { try observableFactory().asObservable() })
     }
@@ -479,7 +479,7 @@ extension InfallibleType {
      - parameter accumulator: An accumulator function to be invoked on each element.
      - returns: An observable sequence containing the accumulated values.
      */
-    public func scan<Seed>(_ seed: Seed, accumulator: @escaping (Seed, Element) -> Seed)
+    public func scan<Seed>(_ seed: Seed, accumulator: @escaping @Sendable (Seed, Element) -> Seed)
         -> Infallible<Seed> {
         Infallible(asObservable().scan(seed, accumulator: accumulator))
     }
@@ -555,7 +555,7 @@ extension InfallibleType {
      - parameter predicate: A function to test each element for a condition.
      - returns: An observable sequence that contains the elements from the input sequence that occur before the element at which the test no longer passes.
      */
-    public func take(while predicate: @escaping (Element) throws -> Bool,
+    public func take(while predicate: @escaping @Sendable (Element) throws -> Bool,
                      behavior: TakeBehavior = .exclusive)
         -> Infallible<Element> {
         Infallible(asObservable().take(while: predicate, behavior: behavior))
@@ -662,7 +662,7 @@ extension InfallibleType {
      */
     public func withUnretained<Object: AnyObject, Out>(
         _ obj: Object,
-        resultSelector: @escaping (Object, Element) -> Out
+        resultSelector: @escaping @Sendable (Object, Element) -> Out
     ) -> Infallible<Out> {
         Infallible(self.asObservable().withUnretained(obj, resultSelector: resultSelector))
     }

--- a/RxSwift/Traits/Infallible/Infallible+Zip+arity.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Zip+arity.swift
@@ -20,7 +20,7 @@ extension InfallibleType {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, resultSelector: @escaping (E1, E2) throws -> Element)
+    public static func zip<E1, E2>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, resultSelector: @escaping @Sendable (E1, E2) throws -> Element)
         -> Infallible<Element> {
         Infallible(
             Observable.zip(source1.asObservable(), source2.asObservable(), resultSelector: resultSelector)
@@ -38,7 +38,7 @@ extension InfallibleType {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, resultSelector: @escaping (E1, E2, E3) throws -> Element)
+    public static func zip<E1, E2, E3>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, resultSelector: @escaping @Sendable (E1, E2, E3) throws -> Element)
         -> Infallible<Element> {
         Infallible(
             Observable.zip(source1.asObservable(), source2.asObservable(), source3.asObservable(), resultSelector: resultSelector)
@@ -56,7 +56,7 @@ extension InfallibleType {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, resultSelector: @escaping (E1, E2, E3, E4) throws -> Element)
+    public static func zip<E1, E2, E3, E4>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, resultSelector: @escaping @Sendable (E1, E2, E3, E4) throws -> Element)
         -> Infallible<Element> {
         Infallible(
             Observable.zip(source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), resultSelector: resultSelector)
@@ -74,7 +74,7 @@ extension InfallibleType {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, resultSelector: @escaping (E1, E2, E3, E4, E5) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5) throws -> Element)
         -> Infallible<Element> {
         Infallible(
             Observable.zip(source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), resultSelector: resultSelector)
@@ -92,7 +92,7 @@ extension InfallibleType {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, _ source6: Infallible<E6>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, _ source6: Infallible<E6>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6) throws -> Element)
         -> Infallible<Element> {
         Infallible(
             Observable.zip(source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), resultSelector: resultSelector)
@@ -110,7 +110,7 @@ extension InfallibleType {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, _ source6: Infallible<E6>, _ source7: Infallible<E7>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, _ source6: Infallible<E6>, _ source7: Infallible<E7>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6, E7) throws -> Element)
         -> Infallible<Element> {
         Infallible(
             Observable.zip(source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), resultSelector: resultSelector)
@@ -128,7 +128,7 @@ extension InfallibleType {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, _ source6: Infallible<E6>, _ source7: Infallible<E7>, _ source8: Infallible<E8>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: Infallible<E1>, _ source2: Infallible<E2>, _ source3: Infallible<E3>, _ source4: Infallible<E4>, _ source5: Infallible<E5>, _ source6: Infallible<E6>, _ source7: Infallible<E7>, _ source8: Infallible<E8>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Element)
         -> Infallible<Element> {
         Infallible(
             Observable.zip(source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(), resultSelector: resultSelector)

--- a/RxSwift/Traits/Infallible/Infallible.swift
+++ b/RxSwift/Traits/Infallible/Infallible.swift
@@ -48,9 +48,9 @@ extension InfallibleType {
      */
     public func subscribe<Object: AnyObject>(
         with object: Object,
-        onNext: ((Object, Element) -> Void)? = nil,
-        onCompleted: ((Object) -> Void)? = nil,
-        onDisposed: ((Object) -> Void)? = nil
+        onNext: (@Sendable (Object, Element) -> Void)? = nil,
+        onCompleted: (@Sendable (Object) -> Void)? = nil,
+        onDisposed: (@Sendable (Object) -> Void)? = nil
     ) -> Disposable {
         self.asObservable().subscribe(
             with: object,
@@ -72,9 +72,9 @@ extension InfallibleType {
      gracefully completed, errored, or if the generation is canceled by disposing subscription)
      - returns: Subscription object used to unsubscribe from the observable sequence.
     */
-    public func subscribe(onNext: ((Element) -> Void)? = nil,
-                          onCompleted: (() -> Void)? = nil,
-                          onDisposed: (() -> Void)? = nil) -> Disposable {
+    public func subscribe(onNext: (@Sendable (Element) -> Void)? = nil,
+                          onCompleted: (@Sendable () -> Void)? = nil,
+                          onDisposed: (@Sendable () -> Void)? = nil) -> Disposable {
         self.asObservable().subscribe(onNext: onNext,
                                       onCompleted: onCompleted,
                                       onDisposed: onDisposed)
@@ -86,8 +86,8 @@ extension InfallibleType {
      - parameter on: Action to invoke for each event in the observable sequence.
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(_ on: @escaping (InfallibleEvent<Element>) -> Void) -> Disposable {
-        let eventHandler: ((Event<Element>) -> Void) = { event in
+    public func subscribe(_ on: @escaping @Sendable (InfallibleEvent<Element>) -> Void) -> Disposable {
+        let eventHandler: (@Sendable (Event<Element>) -> Void) = { event in
             switch event {
             case .next(let element):
                 on(.next(element))

--- a/RxSwift/Traits/Infallible/ObservableConvertibleType+Infallible.swift
+++ b/RxSwift/Traits/Infallible/ObservableConvertibleType+Infallible.swift
@@ -29,7 +29,7 @@ public extension ObservableConvertibleType {
     /// - parameter onErrorRecover: Recover with the this infallible closure
     ///
     /// - returns: `Infallible<Element>`
-    func asInfallible(onErrorRecover: @escaping (Swift.Error) -> Infallible<Element>) -> Infallible<Element> {
+    func asInfallible(onErrorRecover: @escaping @Sendable (Swift.Error) -> Infallible<Element>) -> Infallible<Element> {
         Infallible(asObservable().catch { onErrorRecover($0).asObservable() })
     }
 }

--- a/RxSwift/Traits/PrimitiveSequence/Maybe.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Maybe.swift
@@ -37,7 +37,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      - parameter subscribe: Implementation of the resulting observable sequence's `subscribe` method.
      - returns: The observable sequence with the specified implementation for the `subscribe` method.
      */
-    public static func create(subscribe: @escaping (@escaping MaybeObserver) -> Disposable) -> PrimitiveSequence<Trait, Element> {
+    public static func create(subscribe: @escaping @Sendable (@escaping MaybeObserver) -> Disposable) -> PrimitiveSequence<Trait, Element> {
         let source = Observable<Element>.create { observer in
             return subscribe { event in
                 switch event {
@@ -60,7 +60,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      
      - returns: Subscription for `observer` that can be used to cancel production of sequence elements and free resources.
      */
-    public func subscribe(_ observer: @escaping (MaybeEvent<Element>) -> Void) -> Disposable {
+    public func subscribe(_ observer: @escaping @Sendable (MaybeEvent<Element>) -> Void) -> Disposable {
         nonisolated(unsafe) var stopped = false
         return self.primitiveSequence.asObservable().subscribe { event in
             if stopped { return }

--- a/RxSwift/Traits/PrimitiveSequence/Maybe.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Maybe.swift
@@ -27,7 +27,7 @@ public typealias Maybe<Element> = PrimitiveSequence<MaybeTrait, Element>
 }
 
 extension PrimitiveSequenceType where Trait == MaybeTrait {
-    public typealias MaybeObserver = (MaybeEvent<Element>) -> Void
+    public typealias MaybeObserver = @Sendable (MaybeEvent<Element>) -> Void
     
     /**
      Creates an observable sequence from a specified subscribe method implementation.
@@ -61,7 +61,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      - returns: Subscription for `observer` that can be used to cancel production of sequence elements and free resources.
      */
     public func subscribe(_ observer: @escaping (MaybeEvent<Element>) -> Void) -> Disposable {
-        var stopped = false
+        nonisolated(unsafe) var stopped = false
         return self.primitiveSequence.asObservable().subscribe { event in
             if stopped { return }
             stopped = true
@@ -94,10 +94,10 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      */
     public func subscribe<Object: AnyObject>(
         with object: Object,
-        onSuccess: ((Object, Element) -> Void)? = nil,
-        onError: ((Object, Swift.Error) -> Void)? = nil,
-        onCompleted: ((Object) -> Void)? = nil,
-        onDisposed: ((Object) -> Void)? = nil
+        onSuccess: (@Sendable (Object, Element) -> Void)? = nil,
+        onError: (@Sendable (Object, Swift.Error) -> Void)? = nil,
+        onCompleted: (@Sendable (Object) -> Void)? = nil,
+        onDisposed: (@Sendable (Object) -> Void)? = nil
     ) -> Disposable {
         subscribe(
             onSuccess: { [weak object] in
@@ -129,10 +129,10 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      gracefully completed, errored, or if the generation is canceled by disposing subscription).
      - returns: Subscription object used to unsubscribe from the observable sequence.
      */
-    public func subscribe(onSuccess: ((Element) -> Void)? = nil,
-                          onError: ((Swift.Error) -> Void)? = nil,
-                          onCompleted: (() -> Void)? = nil,
-                          onDisposed: (() -> Void)? = nil) -> Disposable {
+    public func subscribe(onSuccess: (@Sendable (Element) -> Void)? = nil,
+                          onError: (@Sendable (Swift.Error) -> Void)? = nil,
+                          onCompleted: (@Sendable () -> Void)? = nil,
+                          onDisposed: (@Sendable () -> Void)? = nil) -> Disposable {
         #if DEBUG
             let callStack = Hooks.recordCallStackOnError ? Thread.callStackSymbols : []
         #else
@@ -242,15 +242,15 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      - parameter onDispose: Action to invoke after subscription to source observable has been disposed for any reason. It can be either because sequence terminates for some reason or observer subscription being disposed.
      - returns: The source sequence with the side-effecting behavior applied.
      */
-    public func `do`(onNext: ((Element) throws -> Void)? = nil,
-                     afterNext: ((Element) throws -> Void)? = nil,
-                     onError: ((Swift.Error) throws -> Void)? = nil,
-                     afterError: ((Swift.Error) throws -> Void)? = nil,
-                     onCompleted: (() throws -> Void)? = nil,
-                     afterCompleted: (() throws -> Void)? = nil,
-                     onSubscribe: (() -> Void)? = nil,
-                     onSubscribed: (() -> Void)? = nil,
-                     onDispose: (() -> Void)? = nil)
+    public func `do`(onNext: (@Sendable (Element) throws -> Void)? = nil,
+                     afterNext: (@Sendable (Element) throws -> Void)? = nil,
+                     onError: (@Sendable (Swift.Error) throws -> Void)? = nil,
+                     afterError: (@Sendable (Swift.Error) throws -> Void)? = nil,
+                     onCompleted: (@Sendable () throws -> Void)? = nil,
+                     afterCompleted: (@Sendable () throws -> Void)? = nil,
+                     onSubscribe: (@Sendable () -> Void)? = nil,
+                     onSubscribed: (@Sendable () -> Void)? = nil,
+                     onDispose: (@Sendable () -> Void)? = nil)
         -> Maybe<Element> {
             return Maybe(raw: self.primitiveSequence.source.do(
                 onNext: onNext,
@@ -273,7 +273,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      - parameter predicate: A function to test each source element for a condition.
      - returns: An observable sequence that contains elements from the input sequence that satisfy the condition.
      */
-    public func filter(_ predicate: @escaping (Element) throws -> Bool)
+    public func filter(_ predicate: @escaping @Sendable (Element) throws -> Bool)
         -> Maybe<Element> {
             return Maybe(raw: self.primitiveSequence.source.filter(predicate))
     }
@@ -287,7 +287,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      - returns: An observable sequence whose elements are the result of invoking the transform function on each element of source.
      
      */
-    public func map<Result>(_ transform: @escaping (Element) throws -> Result)
+    public func map<Result>(_ transform: @escaping @Sendable (Element) throws -> Result)
         -> Maybe<Result> {
             return Maybe(raw: self.primitiveSequence.source.map(transform))
     }
@@ -299,7 +299,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      - returns: An observable sequence whose elements are the result of filtering the transform function for each element of the source.
      
      */
-    public func compactMap<Result>(_ transform: @escaping (Element) throws -> Result?)
+    public func compactMap<Result>(_ transform: @escaping @Sendable (Element) throws -> Result?)
         -> Maybe<Result> {
         Maybe(raw: self.primitiveSequence.source.compactMap(transform))
     }
@@ -312,7 +312,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
      - parameter selector: A transform function to apply to each element.
      - returns: An observable sequence whose elements are the result of invoking the one-to-many transform function on each element of the input sequence.
      */
-    public func flatMap<Result>(_ selector: @escaping (Element) throws -> Maybe<Result>)
+    public func flatMap<Result>(_ selector: @escaping @Sendable (Element) throws -> Maybe<Result>)
         -> Maybe<Result> {
             return Maybe<Result>(raw: self.primitiveSequence.source.flatMap(selector))
     }

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
@@ -24,7 +24,7 @@ public extension PrimitiveSequenceType where Trait == SingleTrait {
     static func create(
         detached: Bool = false,
         priority: TaskPriority? = nil,
-        work: @Sendable @escaping () async throws -> Element
+        work: @escaping @Sendable () async throws -> Element
     ) -> PrimitiveSequence<Trait, Element> {
         .create { single in
             let operation: () async throws -> Void = {
@@ -61,7 +61,7 @@ public extension PrimitiveSequenceType where Trait == SingleTrait {
             return try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
-                        var didResume = false
+                        nonisolated(unsafe) var didResume = false
                         disposable.setDisposable(
                             self.subscribe(
                                 onSuccess: {
@@ -111,8 +111,8 @@ public extension PrimitiveSequenceType where Trait == MaybeTrait {
             return try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
-                        var didEmit = false
-                        var didResume = false
+                        nonisolated(unsafe) var didEmit = false
+                        nonisolated(unsafe) var didResume = false
                         disposable.setDisposable(
                             self.subscribe(
                                 onSuccess: { value in
@@ -167,7 +167,7 @@ public extension PrimitiveSequenceType where Trait == CompletableTrait, Element 
             return try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
-                        var didResume = false
+                        nonisolated(unsafe) var didResume = false
                         disposable.setDisposable(
                             self.subscribe(
                                 onCompleted: {

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Zip+arity.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Zip+arity.swift
@@ -20,7 +20,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, resultSelector: @escaping (E1, E2) throws -> Element)
+    public static func zip<E1, E2>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, resultSelector: @escaping @Sendable (E1, E2) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(),
@@ -54,7 +54,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, resultSelector: @escaping (E1, E2) throws -> Element)
+    public static func zip<E1, E2>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, resultSelector: @escaping @Sendable (E1, E2) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(),
@@ -93,7 +93,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, resultSelector: @escaping (E1, E2, E3) throws -> Element)
+    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, resultSelector: @escaping @Sendable (E1, E2, E3) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(),
@@ -127,7 +127,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, resultSelector: @escaping (E1, E2, E3) throws -> Element)
+    public static func zip<E1, E2, E3>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, resultSelector: @escaping @Sendable (E1, E2, E3) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(),
@@ -166,7 +166,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, resultSelector: @escaping (E1, E2, E3, E4) throws -> Element)
+    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, resultSelector: @escaping @Sendable (E1, E2, E3, E4) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(),
@@ -200,7 +200,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, resultSelector: @escaping (E1, E2, E3, E4) throws -> Element)
+    public static func zip<E1, E2, E3, E4>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, resultSelector: @escaping @Sendable (E1, E2, E3, E4) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(),
@@ -239,7 +239,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, resultSelector: @escaping (E1, E2, E3, E4, E5) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(),
@@ -273,7 +273,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, resultSelector: @escaping (E1, E2, E3, E4, E5) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(),
@@ -312,7 +312,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(),
@@ -346,7 +346,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(),
@@ -385,7 +385,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6, E7) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(),
@@ -419,7 +419,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6, E7>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6, E7) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(),
@@ -458,7 +458,7 @@ extension PrimitiveSequenceType where Trait == SingleTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(),
@@ -492,7 +492,7 @@ extension PrimitiveSequenceType where Trait == MaybeTrait {
     - parameter resultSelector: Function to invoke for each series of elements at corresponding indexes in the sources.
     - returns: An observable sequence containing the result of combining elements of the sources using the specified result selector function.
     */
-    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, resultSelector: @escaping (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Element)
+    public static func zip<E1, E2, E3, E4, E5, E6, E7, E8>(_ source1: PrimitiveSequence<Trait, E1>, _ source2: PrimitiveSequence<Trait, E2>, _ source3: PrimitiveSequence<Trait, E3>, _ source4: PrimitiveSequence<Trait, E4>, _ source5: PrimitiveSequence<Trait, E5>, _ source6: PrimitiveSequence<Trait, E6>, _ source7: PrimitiveSequence<Trait, E7>, _ source8: PrimitiveSequence<Trait, E8>, resultSelector: @escaping @Sendable (E1, E2, E3, E4, E5, E6, E7, E8) throws -> Element)
         -> PrimitiveSequence<Trait, Element> {
             return PrimitiveSequence(raw: Observable.zip(
             source1.asObservable(), source2.asObservable(), source3.asObservable(), source4.asObservable(), source5.asObservable(), source6.asObservable(), source7.asObservable(), source8.asObservable(),

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence.swift
@@ -288,7 +288,7 @@ extension PrimitiveSequence {
      - parameter primitiveSequenceFactory: Factory function to obtain an observable sequence that depends on the obtained resource.
      - returns: An observable sequence whose lifetime controls the lifetime of the dependent resource object.
      */
-    public static func using<Resource: Disposable>(_ resourceFactory: @escaping () throws -> Resource, primitiveSequenceFactory: @escaping (Resource) throws -> PrimitiveSequence<Trait, Element>)
+    public static func using<Resource: Disposable>(_ resourceFactory: @escaping @Sendable () throws -> Resource, primitiveSequenceFactory: @escaping (Resource) throws -> PrimitiveSequence<Trait, Element>)
         -> PrimitiveSequence<Trait, Element> {
         PrimitiveSequence(raw: Observable.using(resourceFactory, observableFactory: { (resource: Resource) throws -> Observable<Element> in
             return try primitiveSequenceFactory(resource).asObservable()

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence.swift
@@ -58,7 +58,7 @@ extension PrimitiveSequence {
      - parameter observableFactory: Observable factory function to invoke for each observer that subscribes to the resulting sequence.
      - returns: An observable sequence whose observers trigger an invocation of the given observable factory function.
      */
-    public static func deferred(_ observableFactory: @escaping () throws -> PrimitiveSequence<Trait, Element>)
+    public static func deferred(_ observableFactory: @escaping @Sendable () throws -> PrimitiveSequence<Trait, Element>)
         -> PrimitiveSequence<Trait, Element> {
         return PrimitiveSequence(raw: Observable.deferred {
             try observableFactory().asObservable()
@@ -176,7 +176,7 @@ extension PrimitiveSequence {
      - returns: An observable sequence containing the source sequence's elements, followed by the elements produced by the handler's resulting observable sequence in case an error occurred.
      */
     @available(*, deprecated, renamed: "catch(_:)")
-    public func catchError(_ handler: @escaping (Swift.Error) throws -> PrimitiveSequence<Trait, Element>)
+    public func catchError(_ handler: @escaping @Sendable (Swift.Error) throws -> PrimitiveSequence<Trait, Element>)
         -> PrimitiveSequence<Trait, Element> {
         `catch`(handler)
     }
@@ -189,7 +189,7 @@ extension PrimitiveSequence {
      - parameter handler: Error handler function, producing another observable sequence.
      - returns: An observable sequence containing the source sequence's elements, followed by the elements produced by the handler's resulting observable sequence in case an error occurred.
      */
-    public func `catch`(_ handler: @escaping (Swift.Error) throws -> PrimitiveSequence<Trait, Element>)
+    public func `catch`(_ handler: @escaping @Sendable (Swift.Error) throws -> PrimitiveSequence<Trait, Element>)
         -> PrimitiveSequence<Trait, Element> {
         PrimitiveSequence(raw: self.source.catch { try handler($0).asObservable() })
     }
@@ -216,7 +216,7 @@ extension PrimitiveSequence {
      - parameter notificationHandler: A handler that is passed an observable sequence of errors raised by the source observable and returns and observable that either continues, completes or errors. This behavior is then applied to the source observable.
      - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
      */
-    public func retry<TriggerObservable: ObservableType, Error: Swift.Error>(when notificationHandler: @escaping (Observable<Error>) -> TriggerObservable)
+    public func retry<TriggerObservable: ObservableType, Error: Swift.Error>(when notificationHandler: @escaping @Sendable (Observable<Error>) -> TriggerObservable)
         -> PrimitiveSequence<Trait, Element> {
         PrimitiveSequence(raw: self.source.retry(when: notificationHandler))
     }
@@ -231,7 +231,7 @@ extension PrimitiveSequence {
      - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
      */
     @available(*, deprecated, renamed: "retry(when:)")
-    public func retryWhen<TriggerObservable: ObservableType, Error: Swift.Error>(_ notificationHandler: @escaping (Observable<Error>) -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType, Error: Swift.Error>(_ notificationHandler: @escaping @Sendable (Observable<Error>) -> TriggerObservable)
         -> PrimitiveSequence<Trait, Element> {
         retry(when: notificationHandler)
     }
@@ -245,7 +245,7 @@ extension PrimitiveSequence {
      - parameter notificationHandler: A handler that is passed an observable sequence of errors raised by the source observable and returns and observable that either continues, completes or errors. This behavior is then applied to the source observable.
      - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
      */
-    public func retry<TriggerObservable: ObservableType>(when notificationHandler: @escaping (Observable<Swift.Error>) -> TriggerObservable)
+    public func retry<TriggerObservable: ObservableType>(when notificationHandler: @escaping @Sendable (Observable<Swift.Error>) -> TriggerObservable)
         -> PrimitiveSequence<Trait, Element> {
         PrimitiveSequence(raw: self.source.retry(when: notificationHandler))
     }
@@ -260,7 +260,7 @@ extension PrimitiveSequence {
      - returns: An observable sequence producing the elements of the given sequence repeatedly until it terminates successfully or is notified to error or complete.
      */
     @available(*, deprecated, renamed: "retry(when:)")
-    public func retryWhen<TriggerObservable: ObservableType>(_ notificationHandler: @escaping (Observable<Swift.Error>) -> TriggerObservable)
+    public func retryWhen<TriggerObservable: ObservableType>(_ notificationHandler: @escaping @Sendable (Observable<Swift.Error>) -> TriggerObservable)
         -> PrimitiveSequence<Trait, Element> {
         retry(when: notificationHandler)
     }
@@ -288,7 +288,7 @@ extension PrimitiveSequence {
      - parameter primitiveSequenceFactory: Factory function to obtain an observable sequence that depends on the obtained resource.
      - returns: An observable sequence whose lifetime controls the lifetime of the dependent resource object.
      */
-    public static func using<Resource: Disposable>(_ resourceFactory: @escaping @Sendable () throws -> Resource, primitiveSequenceFactory: @escaping (Resource) throws -> PrimitiveSequence<Trait, Element>)
+    public static func using<Resource: Disposable>(_ resourceFactory: @escaping @Sendable () throws -> Resource, primitiveSequenceFactory: @escaping @Sendable (Resource) throws -> PrimitiveSequence<Trait, Element>)
         -> PrimitiveSequence<Trait, Element> {
         PrimitiveSequence(raw: Observable.using(resourceFactory, observableFactory: { (resource: Resource) throws -> Observable<Element> in
             return try primitiveSequenceFactory(resource).asObservable()

--- a/RxTest/Schedulers/TestScheduler.swift
+++ b/RxTest/Schedulers/TestScheduler.swift
@@ -70,7 +70,7 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
 
      - parameter time: Absolute virtual time at which to execute the action.
      */
-    public func scheduleAt(_ time: TestTime, action: @escaping () -> Void) {
+    public func scheduleAt(_ time: TestTime, action: @escaping @Sendable () -> Void) {
         _ = self.scheduleAbsoluteVirtual((), time: time, action: { _ -> Disposable in
             action()
             return Disposables.create()
@@ -93,10 +93,10 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
     - parameter create: Factory method to create an observable convertible sequence.
     - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
     */
-    public func start<Element, OutputSequence: ObservableConvertibleType>(created: TestTime, subscribed: TestTime, disposed: TestTime, create: @escaping () -> OutputSequence)
+    public func start<Element, OutputSequence: ObservableConvertibleType>(created: TestTime, subscribed: TestTime, disposed: TestTime, create: @escaping @Sendable () -> OutputSequence)
         -> TestableObserver<Element> where OutputSequence.Element == Element {
-        var source: Observable<Element>?
-        var subscription: Disposable?
+        nonisolated(unsafe) var source: Observable<Element>?
+        nonisolated(unsafe) var subscription: Disposable?
         let observer = self.createObserver(Element.self)
         
         _ = self.scheduleAbsoluteVirtual((), time: created) { _ in
@@ -130,7 +130,7 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
      - parameter create: Factory method to create an observable convertible sequence.
      - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
      */
-    public func start<Element, OutputSequence: ObservableConvertibleType>(disposed: TestTime, create: @escaping () -> OutputSequence)
+    public func start<Element, OutputSequence: ObservableConvertibleType>(disposed: TestTime, create: @escaping @Sendable () -> OutputSequence)
         -> TestableObserver<Element> where OutputSequence.Element == Element {
         self.start(created: Defaults.created, subscribed: Defaults.subscribed, disposed: disposed, create: create)
     }
@@ -146,7 +146,7 @@ public class TestScheduler : VirtualTimeScheduler<TestSchedulerVirtualTimeConver
      - parameter create: Factory method to create an observable convertible sequence.
      - returns: Observer with timestamped recordings of events that were received during the virtual time window when the subscription to the source sequence was active.
      */
-    public func start<Element, OutputSequence: ObservableConvertibleType>(_ create: @escaping () -> OutputSequence)
+    public func start<Element, OutputSequence: ObservableConvertibleType>(_ create: @escaping @Sendable () -> OutputSequence)
         -> TestableObserver<Element> where OutputSequence.Element == Element {
          self.start(created: Defaults.created, subscribed: Defaults.subscribed, disposed: Defaults.disposed, create: create)
     }

--- a/Tests/RxCocoaTests/DelegateProxyTest.swift
+++ b/Tests/RxCocoaTests/DelegateProxyTest.swift
@@ -97,12 +97,12 @@ final class DelegateProxyTest : RxTest {
         
         view.delegate = mock
         
-        var observedFeedRequestSentMessage = false
-        var observedMessageInvoked = false
-        var events: [MessageProcessingStage] = []
+        nonisolated(unsafe) var observedFeedRequestSentMessage = false
+        nonisolated(unsafe) var observedMessageInvoked = false
+        nonisolated(unsafe) var events: [MessageProcessingStage] = []
 
-        var delegates: [NSObject?] = []
-        var responds: [Bool] = []
+        nonisolated(unsafe) var delegates: [NSObject?] = []
+        nonisolated(unsafe) var responds: [Bool] = []
 
         _ = view.rx.observeWeakly(NSObject.self, "delegate").skip(1).subscribe(onNext: { delegate in
             delegates.append(delegate)
@@ -155,8 +155,8 @@ final class DelegateProxyTest : RxTest {
         
         view.delegate = mock
         
-        var nMessages = 0
-        var invoked = false
+        nonisolated(unsafe) var nMessages = 0
+        nonisolated(unsafe) var invoked = false
         
         let d = view.rx.proxy.sentMessage(#selector(ThreeDSectionedViewProtocol.threeDView(_:didLearnSomething:)))
             .subscribe(onNext: { n in
@@ -209,13 +209,13 @@ final class DelegateProxyTest : RxTest {
         
         let sentArgument = IndexPath(index: 0)
         
-        var receivedArgumentSentMessage: IndexPath? = nil
-        var receivedArgumentMethodInvoked: IndexPath? = nil
+        nonisolated(unsafe) var receivedArgumentSentMessage: IndexPath? = nil
+        nonisolated(unsafe) var receivedArgumentMethodInvoked: IndexPath? = nil
 
-        var events: [MessageProcessingStage] = []
+        nonisolated(unsafe) var events: [MessageProcessingStage] = []
 
-        var delegates: [NSObject?] = []
-        var responds: [Bool] = []
+        nonisolated(unsafe) var delegates: [NSObject?] = []
+        nonisolated(unsafe) var responds: [Bool] = []
 
         _ = view.rx.observeWeakly(NSObject.self, "delegate").skip(1).subscribe(onNext: { delegate in
             delegates.append(delegate)
@@ -278,8 +278,8 @@ final class DelegateProxyTest : RxTest {
         
         view.delegate = mock
         
-        var completedSentMessage = false
-        var completedMethodInvoked = false
+        nonisolated(unsafe) var completedSentMessage = false
+        nonisolated(unsafe) var completedMethodInvoked = false
 
         autoreleasepool {
             XCTAssertTrue(!mock.responds(to: NSSelectorFromString("threeDView:threeDView:didGetXXX:")))
@@ -359,7 +359,7 @@ extension DelegateProxyTest {
         XCTAssertTrue(view.delegate === proxy)
         XCTAssertTrue(view.rx.proxy.forwardToDelegate() === mock)
 
-        var latestValue: Int? = nil
+        nonisolated(unsafe) var latestValue: Int? = nil
         _ = view.rx.testIt.subscribe(onNext: {
             latestValue = $0
         })
@@ -383,7 +383,7 @@ extension DelegateProxyTest {
 // MARK: Testing extensions
 
 extension DelegateProxyTest {
-    func performDelegateTest<Control: TestDelegateControl, ExtendedProxy: DelegateProxyType>( _ createControl: @autoclosure() -> Control, make: @escaping (Control) -> ExtendedProxy) {
+    func performDelegateTest<Control: TestDelegateControl, ExtendedProxy: DelegateProxyType>( _ createControl: @autoclosure() -> Control, make: @escaping @Sendable (Control) -> ExtendedProxy) {
         ExtendedProxy.register(make: make)
         var control: Control!
 
@@ -391,12 +391,12 @@ extension DelegateProxyTest {
             control = createControl()
         }
 
-        var receivedValueSentMessage: Int!
-        var receivedValueMethodInvoked: Int!
-        var completedSentMessage = false
-        var completedMethodInvoked = false
-        var deallocated = false
-        var stages: [MessageProcessingStage] = []
+        nonisolated(unsafe) var receivedValueSentMessage: Int!
+        nonisolated(unsafe) var receivedValueMethodInvoked: Int!
+        nonisolated(unsafe) var completedSentMessage = false
+        nonisolated(unsafe) var completedMethodInvoked = false
+        nonisolated(unsafe) var deallocated = false
+        nonisolated(unsafe) var stages: [MessageProcessingStage] = []
         let expectation = self.expectation(description: "dealloc")
         autoreleasepool {
             _ = control.testSentMessage.subscribe(onNext: { value in

--- a/Tests/RxCocoaTests/KVOObservableTests.swift
+++ b/Tests/RxCocoaTests/KVOObservableTests.swift
@@ -34,7 +34,7 @@ final class Parent : NSObject {
 
     @objc dynamic var val: String = ""
 
-    init(callback: @escaping (String?) -> Void) {
+    init(callback: @escaping @Sendable (String?) -> Void) {
         super.init()
         
         self.rx.observe(String.self, "val", options: [.initial, .new], retainSelf: false)
@@ -50,7 +50,7 @@ final class Parent : NSObject {
 final class Child : NSObject {
     let disposeBag = DisposeBag()
     
-    init(parent: ParentWithChild, callback: @escaping (String?) -> Void) {
+    init(parent: ParentWithChild, callback: @escaping @Sendable (String?) -> Void) {
         super.init()
         parent.rx.observe(String.self, "val", options: [.initial, .new], retainSelf: false)
             .subscribe(onNext: callback)
@@ -67,7 +67,7 @@ final class ParentWithChild : NSObject {
     
     var child: Child? = nil
     
-    init(callback: @escaping (String?) -> Void) {
+    init(callback: @escaping @Sendable (String?) -> Void) {
         super.init()
         child = Child(parent: self, callback: callback)
     }
@@ -143,8 +143,8 @@ extension KVOObservableTests {
     func testKeyPathObservation_DefaultOptions() {
         testClass = TestClass()
         let os = testClass.rx.observe(\.pr)
-        var latest: String?
-        var completed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var completed = false
 
         _ = os.subscribe(onNext: { latest = $0 },
                          onCompleted: { completed = true })
@@ -171,7 +171,7 @@ extension KVOObservableTests {
     func testKeyPathObservation_NewAndInitialOptions() {
         let testClass = TestClass()
         let os = testClass.rx.observe(\.pr, options: [.new, .initial])
-        var latest: String?
+        nonisolated(unsafe) var latest: String?
 
         let d = os.subscribe(onNext: { latest = $0 })
         testClass.pr = "1"
@@ -195,8 +195,8 @@ extension KVOObservableTests {
     func testKeyPathObservation_NewOptions() {
         testClass = TestClass()
         let os = testClass.rx.observe(\.pr, options: [.new])
-        var latest: String?
-        var completed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var completed = false
 
         _ = os.subscribe(onNext: { latest = $0 },
                          onCompleted: { completed = true })
@@ -230,7 +230,7 @@ extension KVOObservableTests {
         
         let os = testClass.rx.observe(String.self, "pr", options: .new)
         
-        var latest: String?
+        nonisolated(unsafe) var latest: String?
         
         let d = os.subscribe(onNext: { latest = $0 })
         
@@ -264,7 +264,7 @@ extension KVOObservableTests {
         
         let os = testClass.rx.observe(String.self, "pr", options: [.initial, .new])
         
-        var latest: String?
+        nonisolated(unsafe) var latest: String?
         
         let d = os.subscribe(onNext: { latest = $0 })
         
@@ -298,7 +298,7 @@ extension KVOObservableTests {
         
         let os = testClass.rx.observe(String.self, "pr")
         
-        var latest: String?
+        nonisolated(unsafe) var latest: String?
         
         let d = os.subscribe(onNext: { latest = $0 })
         
@@ -328,8 +328,8 @@ extension KVOObservableTests {
     }
     
     func test_ObserveAndDontRetainWorks() {
-        var latest: String?
-        var isDisposed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var isDisposed = false
 
         parent = Parent { n in
             latest = n
@@ -355,8 +355,8 @@ extension KVOObservableTests {
     }
     
     func test_ObserveAndDontRetainWorks2() {
-        var latest: String?
-        var isDisposed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var isDisposed = false
         
         parentWithChild = ParentWithChild { n in
             latest = n
@@ -388,8 +388,8 @@ extension KVOObservableTests {
 extension KVOObservableTests {
     
     func testObserveWeak_SimpleStrongProperty() {
-        var latest: String?
-        var isDisposed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var isDisposed = false
         
         hasStrongProperty = HasStrongProperty()
         
@@ -418,8 +418,8 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_SimpleWeakProperty() {
-        var latest: String?
-        var isDisposed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var isDisposed = false
         
         hasWeakProperty = HasWeakProperty()
         
@@ -450,8 +450,8 @@ extension KVOObservableTests {
     }
 
     func testObserveWeak_ObserveFirst_Weak_Strong_Basic() {
-        var latest: String?
-        var isDisposed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var isDisposed = false
         
         hasStrongProperty = HasStrongProperty()
         hasWeakProperty = HasWeakProperty()
@@ -489,8 +489,8 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_Weak_Strong_Observe_Basic() {
-        var latest: String?
-        var isDisposed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var isDisposed = false
         
         hasStrongProperty = HasStrongProperty()
         hasWeakProperty = HasWeakProperty()
@@ -525,8 +525,8 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_ObserveFirst_Strong_Weak_Basic() {
-        var latest: String?
-        var isDisposed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var isDisposed = false
         
         hasWeakProperty = HasWeakProperty()
         hasStrongProperty = HasStrongProperty()
@@ -564,8 +564,8 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_Strong_Weak_Observe_Basic() {
-        var latest: String?
-        var isDisposed = false
+        nonisolated(unsafe) var latest: String?
+        nonisolated(unsafe) var isDisposed = false
         
         hasWeakProperty = HasWeakProperty()
         hasStrongProperty = HasStrongProperty()
@@ -601,16 +601,16 @@ extension KVOObservableTests {
     
     // compiler won't release weak references otherwise :(
     func _testObserveWeak_Strong_Weak_Observe_NilLastPropertyBecauseOfWeak() -> (HasWeakProperty, NSObject?, Observable<Void>) {
-        var dealloc: Observable<Void>! = nil
+        nonisolated(unsafe) var dealloc: Observable<Void>! = nil
         let child: HasWeakProperty! = HasWeakProperty()
-        var latest: NSObject? = nil
+        nonisolated(unsafe) var latest: NSObject? = nil
         
         autoreleasepool {
             let root: HasStrongProperty! = HasStrongProperty()
             
             root.property = child
             
-            var one: NSObject! = nil
+            nonisolated(unsafe) var one: NSObject! = nil
             
             one = NSObject()
             
@@ -634,7 +634,7 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_Strong_Weak_Observe_NilLastPropertyBecauseOfWeak() {
-        var gone = false
+        nonisolated(unsafe) var gone = false
         let (child, latest, dealloc) = _testObserveWeak_Strong_Weak_Observe_NilLastPropertyBecauseOfWeak()
         _ = dealloc
             .subscribe(onNext: { n in
@@ -647,9 +647,9 @@ extension KVOObservableTests {
     }
     
     func _testObserveWeak_Weak_Weak_Weak_middle_NilifyCorrectly() -> (HasWeakProperty, NSObject?, Observable<Void>) {
-        var dealloc: Observable<Void>! = nil
-        var middle: HasWeakProperty! = HasWeakProperty()
-        var latest: NSObject? = nil
+        nonisolated(unsafe) var dealloc: Observable<Void>! = nil
+        nonisolated(unsafe) var middle: HasWeakProperty! = HasWeakProperty()
+        nonisolated(unsafe) var latest: NSObject? = nil
         let root: HasWeakProperty! = HasWeakProperty()
         
         autoreleasepool {
@@ -683,7 +683,7 @@ extension KVOObservableTests {
     func testObserveWeak_Weak_Weak_Weak_middle_NilifyCorrectly() {
         let (root, latest, deallocatedMiddle) = _testObserveWeak_Weak_Weak_Weak_middle_NilifyCorrectly()
         
-        var gone = false
+        nonisolated(unsafe) var gone = false
         
         _ = deallocatedMiddle
             .subscribe(onCompleted: {
@@ -696,9 +696,9 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_TargetDeallocated() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: String? = nil
+        nonisolated(unsafe) var latest: String? = nil
         
         root.property = "a".duplicate()
         
@@ -712,7 +712,7 @@ extension KVOObservableTests {
        
         XCTAssertTrue(latest == "a")
      
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -727,9 +727,9 @@ extension KVOObservableTests {
     }
     
     func testObserveWeakWithOptions_ObserveNotInitialValue() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: String? = nil
+        nonisolated(unsafe) var latest: String? = nil
         
         root.property = "a".duplicate()
         
@@ -747,7 +747,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == "b")
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -764,9 +764,9 @@ extension KVOObservableTests {
     #if os(macOS)
     // just making sure it's all the same for NS extensions
     func testObserve_ObserveNSRect() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: NSRect? = nil
+        nonisolated(unsafe) var latest: NSRect? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -780,7 +780,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == NSRect(x: -2, y: 0, width: 0, height: 1))
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -800,9 +800,9 @@ extension KVOObservableTests {
     
     // let's just check for one, other ones should have the same check
     func testObserve_ObserveCGRectForBiggerStructureDoesntCrashPropertyTypeReturnsNil() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: CGSize? = nil
+        nonisolated(unsafe) var latest: CGSize? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -821,7 +821,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == nil)
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -836,9 +836,9 @@ extension KVOObservableTests {
     }
     
     func testObserve_ObserveCGRect() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: CGRect? = nil
+        nonisolated(unsafe) var latest: CGRect? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -857,7 +857,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == CGRect(x: -2, y: 0, width: 0, height: 1))
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -872,9 +872,9 @@ extension KVOObservableTests {
     }
     
     func testObserve_ObserveCGSize() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: CGSize? = nil
+        nonisolated(unsafe) var latest: CGSize? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -893,7 +893,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == CGSize(width: 56, height: 1))
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -908,9 +908,9 @@ extension KVOObservableTests {
     }
     
     func testObserve_ObserveCGPoint() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: CGPoint? = nil
+        nonisolated(unsafe) var latest: CGPoint? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -928,7 +928,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == CGPoint(x: -100, y: 1))
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -944,9 +944,9 @@ extension KVOObservableTests {
     
     
     func testObserveWeak_ObserveCGRect() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: CGRect? = nil
+        nonisolated(unsafe) var latest: CGRect? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -961,7 +961,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == CGRect(x: -2, y: 0, width: 0, height: 1))
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -976,9 +976,9 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_ObserveCGSize() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: CGSize? = nil
+        nonisolated(unsafe) var latest: CGSize? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -993,7 +993,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == CGSize(width: 56, height: 1))
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -1008,9 +1008,9 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_ObserveCGPoint() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: CGPoint? = nil
+        nonisolated(unsafe) var latest: CGPoint? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -1026,7 +1026,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == CGPoint(x: -100, y: 1))
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -1041,9 +1041,9 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_ObserveInt() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var latest: Int? = nil
+        nonisolated(unsafe) var latest: Int? = nil
         
         XCTAssertTrue(latest == nil)
         
@@ -1058,7 +1058,7 @@ extension KVOObservableTests {
         
         XCTAssertTrue(latest == 10)
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -1073,9 +1073,9 @@ extension KVOObservableTests {
     }
 
     func testObserveWeak_PropertyDoesntExist() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var lastError: Swift.Error? = nil
+        nonisolated(unsafe) var lastError: Swift.Error? = nil
         
         _ = root.rx.observeWeakly(NSNumber.self, "notExist")
             .subscribe(onError: { error in
@@ -1085,7 +1085,7 @@ extension KVOObservableTests {
         XCTAssertTrue(lastError != nil)
         lastError = nil
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -1099,9 +1099,9 @@ extension KVOObservableTests {
     }
     
     func testObserveWeak_HierarchyPropertyDoesntExist() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
         
-        var lastError: Swift.Error? = nil
+        nonisolated(unsafe) var lastError: Swift.Error? = nil
         
         _ = root.rx.observeWeakly(NSNumber.self, "property.notExist")
             .subscribe(onError: { error in
@@ -1114,7 +1114,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(lastError != nil)
         
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
         
         _ = root
             .rx.deallocated
@@ -1133,9 +1133,9 @@ extension KVOObservableTests {
 
 extension KVOObservableTests {
     func testObserve_ObserveIntegerRepresentable() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: Int?
+        nonisolated(unsafe) var latest: Int?
 
         XCTAssertTrue(latest == nil)
 
@@ -1149,7 +1149,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == 2)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1166,9 +1166,9 @@ extension KVOObservableTests {
     }
 
     func testObserve_ObserveUIntegerRepresentable() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: UInt?
+        nonisolated(unsafe) var latest: UInt?
 
         XCTAssertTrue(latest == nil)
 
@@ -1182,7 +1182,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == 2)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1202,9 +1202,9 @@ extension KVOObservableTests {
 #if !DISABLE_SWIZZLING
     extension KVOObservableTests {
         func testObserveWeak_ObserveIntegerRepresentable() {
-            var root: HasStrongProperty! = HasStrongProperty()
+            nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-            var latest: Int?
+            nonisolated(unsafe) var latest: Int?
 
             XCTAssertTrue(latest == nil)
 
@@ -1220,7 +1220,7 @@ extension KVOObservableTests {
 
             XCTAssertTrue(latest == 2)
 
-            var rootDeallocated = false
+            nonisolated(unsafe) var rootDeallocated = false
 
             _ = root
                 .rx.deallocated
@@ -1235,9 +1235,9 @@ extension KVOObservableTests {
         }
 
         func testObserveWeak_ObserveUIntegerRepresentable() {
-            var root: HasStrongProperty! = HasStrongProperty()
+            nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-            var latest: UInt?
+            nonisolated(unsafe) var latest: UInt?
 
             XCTAssertTrue(latest == nil)
 
@@ -1253,7 +1253,7 @@ extension KVOObservableTests {
 
             XCTAssertTrue(latest == 2)
 
-            var rootDeallocated = false
+            nonisolated(unsafe) var rootDeallocated = false
 
             _ = root
                 .rx.deallocated
@@ -1272,9 +1272,9 @@ extension KVOObservableTests {
 // MARK: RawRepresentable
 extension KVOObservableTests {
     func testObserve_ObserveIntEnum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: IntEnum?
+        nonisolated(unsafe) var latest: IntEnum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1288,7 +1288,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1305,9 +1305,9 @@ extension KVOObservableTests {
     }
 
     func testObserve_ObserveInt32Enum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: Int32Enum?
+        nonisolated(unsafe) var latest: Int32Enum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1321,7 +1321,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1338,9 +1338,9 @@ extension KVOObservableTests {
     }
 
     func testObserve_ObserveInt64Enum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: Int64Enum?
+        nonisolated(unsafe) var latest: Int64Enum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1354,7 +1354,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1372,9 +1372,9 @@ extension KVOObservableTests {
 
 
     func testObserve_ObserveUIntEnum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: UIntEnum?
+        nonisolated(unsafe) var latest: UIntEnum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1388,7 +1388,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1405,9 +1405,9 @@ extension KVOObservableTests {
     }
 
     func testObserve_ObserveUInt32Enum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: UInt32Enum?
+        nonisolated(unsafe) var latest: UInt32Enum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1421,7 +1421,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1438,9 +1438,9 @@ extension KVOObservableTests {
     }
 
     func testObserve_ObserveUInt64Enum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: UInt64Enum?
+        nonisolated(unsafe) var latest: UInt64Enum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1454,7 +1454,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1474,9 +1474,9 @@ extension KVOObservableTests {
 #if !DISABLE_SWIZZLING
 extension KVOObservableTests {
     func testObserveWeak_ObserveIntEnum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: IntEnum?
+        nonisolated(unsafe) var latest: IntEnum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1491,7 +1491,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1506,9 +1506,9 @@ extension KVOObservableTests {
     }
 
     func testObserveWeak_ObserveInt32Enum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: Int32Enum?
+        nonisolated(unsafe) var latest: Int32Enum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1523,7 +1523,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1538,9 +1538,9 @@ extension KVOObservableTests {
     }
 
     func testObserveWeak_ObserveInt64Enum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: Int64Enum?
+        nonisolated(unsafe) var latest: Int64Enum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1555,7 +1555,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1570,9 +1570,9 @@ extension KVOObservableTests {
     }
 
     func testObserveWeak_ObserveUIntEnum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: UIntEnum?
+        nonisolated(unsafe) var latest: UIntEnum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1587,7 +1587,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1602,9 +1602,9 @@ extension KVOObservableTests {
     }
 
     func testObserveWeak_ObserveUInt32Enum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: UInt32Enum?
+        nonisolated(unsafe) var latest: UInt32Enum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1619,7 +1619,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated
@@ -1634,9 +1634,9 @@ extension KVOObservableTests {
     }
 
     func testObserveWeak_ObserveUInt64Enum() {
-        var root: HasStrongProperty! = HasStrongProperty()
+        nonisolated(unsafe) var root: HasStrongProperty! = HasStrongProperty()
 
-        var latest: UInt32Enum?
+        nonisolated(unsafe) var latest: UInt32Enum?
 
         XCTAssertTrue(latest == nil)
 
@@ -1651,7 +1651,7 @@ extension KVOObservableTests {
 
         XCTAssertTrue(latest == .two)
 
-        var rootDeallocated = false
+        nonisolated(unsafe) var rootDeallocated = false
 
         _ = root
             .rx.deallocated

--- a/Tests/RxCocoaTests/RxTest+Controls.swift
+++ b/Tests/RxCocoaTests/RxTest+Controls.swift
@@ -35,10 +35,10 @@ extension RxTest {
 
         let completeExpectation = XCTestExpectation(description: "completion")
         let deallocateExpectation = XCTestExpectation(description: "deallocation")
-        var lastReturnedPropertyValue: T?
+        nonisolated(unsafe) var lastReturnedPropertyValue: T?
 
         autoreleasepool {
-            var control: C! = createControl()
+            nonisolated(unsafe) var control: C! = createControl()
 
             let property = propertySelector(control)
 
@@ -69,13 +69,13 @@ extension RxTest {
         )
     }
 
-    func ensureEventDeallocated<C, T>(_ createControl: @escaping () -> C, file: StaticString = #file, line: UInt = #line, _ eventSelector: (C) -> ControlEvent<T>) where C: NSObject {
+    func ensureEventDeallocated<C, T>(_ createControl: @escaping @Sendable () -> C, file: StaticString = #file, line: UInt = #line, _ eventSelector: (C) -> ControlEvent<T>) where C: NSObject {
         ensureEventDeallocated({ () -> (C, Disposable) in (createControl(), Disposables.create()) }, file: file, line: line, eventSelector)
     }
 
     func ensureEventDeallocated<C, T>(_ createControl: () -> (C, Disposable), file: StaticString = #file, line: UInt = #line, _ eventSelector: (C) -> ControlEvent<T>) where C: NSObject {
-        var completed = false
-        var deallocated = false
+        nonisolated(unsafe) var completed = false
+        nonisolated(unsafe) var deallocated = false
         let outerDisposable = SingleAssignmentDisposable()
 
         autoreleasepool {
@@ -101,7 +101,7 @@ extension RxTest {
     }
 
     func ensureControlObserverHasWeakReference<C, T>(file: StaticString = #file, line: UInt = #line, _ createControl: @autoclosure() -> (C), _ observerSelector: (C) -> AnyObserver<T>, _ observableSelector: () -> (Observable<T>)) where C: NSObject {
-        var deallocated = false
+        nonisolated(unsafe) var deallocated = false
 
         let disposeBag = DisposeBag()
 

--- a/Tests/RxCocoaTests/SharedSequence+Test.swift
+++ b/Tests/RxCocoaTests/SharedSequence+Test.swift
@@ -26,9 +26,9 @@ class SharedSequenceTest: RxTest {
 // * events are observed on main thread - observe(on:MainScheduler.instance)
 // * it can't error out - it needs to have catch somewhere
 extension SharedSequenceTest {
-    func subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription<Result, S>(_ xs: SharedSequence<S, Result>, expectationFulfilled: @escaping (Result) -> Bool = { _ in false }, subscribedOnBackground: () -> Void) -> [Result] {
-        var firstElements = [Result]()
-        var secondElements = [Result]()
+    func subscribeTwiceOnBackgroundSchedulerAndOnlyOneSubscription<Result, S>(_ xs: SharedSequence<S, Result>, expectationFulfilled: @escaping @Sendable (Result) -> Bool = { _ in false }, subscribedOnBackground: () -> Void) -> [Result] {
+        nonisolated(unsafe) var firstElements = [Result]()
+        nonisolated(unsafe) var secondElements = [Result]()
 
         let subscribeFinished = self.expectation(description: "subscribeFinished")
 

--- a/Tests/RxSwiftTests/RecursiveLockTest.swift
+++ b/Tests/RxSwiftTests/RecursiveLockTest.swift
@@ -16,9 +16,9 @@ import XCTest
 #endif
 
 private class StrandClosure {
-    let closure: () -> Void
+    let closure: @Sendable () -> Void
 
-    init(closure: @escaping () -> Void) {
+    init(closure: @escaping @Sendable () -> Void) {
       self.closure = closure
     }
 }
@@ -53,7 +53,7 @@ class RecursiveLockTests: RxTest {
 
     // code taken from https://github.com/ketzusaka/Strand/blob/master/Sources/Strand.swift
 
-    func thread(action: @escaping () -> ()) {
+    func thread(action: @escaping @Sendable () -> ()) {
         let holder = Unmanaged.passRetained(StrandClosure(closure: action))
         let pointer = UnsafeMutableRawPointer(holder.toOpaque())
         #if os(Linux)

--- a/Tests/RxSwiftTests/SharingSchedulerTests.swift
+++ b/Tests/RxSwiftTests/SharingSchedulerTests.swift
@@ -69,15 +69,15 @@ class Scheduler1: SchedulerType {
         fatalError()
     }
 
-    func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         fatalError()
     }
 
-    func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable) -> Disposable {
+    func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         fatalError()
     }
 
-    func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping (StateType) -> StateType) -> Disposable {
+    func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping @Sendable (StateType) -> StateType) -> Disposable {
         fatalError()
     }
 }
@@ -87,15 +87,15 @@ class Scheduler2: SchedulerType {
         fatalError()
     }
 
-    func schedule<StateType>(_ state: StateType, action: @escaping (StateType) -> Disposable) -> Disposable {
+    func schedule<StateType>(_ state: StateType, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         fatalError()
     }
 
-    func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping (StateType) -> Disposable) -> Disposable {
+    func scheduleRelative<StateType>(_ state: StateType, dueTime: RxTimeInterval, action: @escaping @Sendable (StateType) -> Disposable) -> Disposable {
         fatalError()
     }
 
-    func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping (StateType) -> StateType) -> Disposable {
+    func schedulePeriodic<StateType>(_ state: StateType, startAfter: RxTimeInterval, period: RxTimeInterval, action: @escaping @Sendable (StateType) -> StateType) -> Disposable {
         fatalError()
     }
 }

--- a/Tests/XCTest+AllTests.swift
+++ b/Tests/XCTest+AllTests.swift
@@ -80,10 +80,10 @@ func XCTAssertArraysEqual<T>(_ lhs: [T], _ rhs: [T], file: StaticString = #file,
 }
 
 
-func doOnBackgroundQueue(_ action: @escaping () -> Void) {
+func doOnBackgroundQueue(_ action: @escaping @Sendable () -> Void) {
     DispatchQueue.global(qos: .default).async(execute: action)
 }
 
-func doOnMainQueue(_ action: @escaping () -> Void) {
+func doOnMainQueue(_ action: @escaping @Sendable () -> Void) {
     DispatchQueue.main.async(execute: action)
 }


### PR DESCRIPTION
Mark Operator Closures as @Sendable to Prevent Crashes in Swift 6 Isolated Contexts #2638

In Swift 6, closures created in an isolated context automatically inherit the isolation of that context, unless they are marked as @Sendable. Because of this, creating an operation like map, flatMap, distinctUntilChanged, etc. from an isolated context, but calling it from a different thread, causes the call to crash.