### PR TITLE
Fix race conditions in PrimitiveSequence+Concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 * Provides `Infallible` versions of `CombineLatest+Collection` helpers.
 * Explicitly declare `APPLICATION_EXTENSION_API_ONLY` for CocoaPods 
 
+### Anomalies
+
+* Fixes a crash that could occur when awaiting a `Single`, `Maybe`, or `Completable` that was disposed.
+
 ## 6.5.0
 
 You can now use `await` on `Observable`-conforming objects (as well as `Driver`, `Signal`, `Infallible`, `Single`, `Completable`) using the following syntax:


### PR DESCRIPTION
This caused continuations to be resumed more than once, crashing clients due to a violation of the Swift Concurrency contract.

I added tests that make it easy to reproduce the issue under the previous implementation

<img width="1193" alt="Screenshot 2024-11-04 at 09 38 15" src="https://github.com/user-attachments/assets/56d66ee9-ec48-4f34-8a39-c60ebbad6e51">

This should fix https://github.com/ReactiveX/RxSwift/issues/2563