### PR TITLE
Update cURL command for easier copy-pasting

### DIFF
--- a/RxCocoa/Foundation/URLSession+Rx.swift
+++ b/RxCocoa/Foundation/URLSession+Rx.swift
@@ -61,12 +61,12 @@ private func convertURLRequestToCurlCommand(_ request: URLRequest) -> String {
     for (key, value) in request.allHTTPHeaderFields ?? [:] {
         let escapedKey = escapeTerminalString(key as String)
         let escapedValue = escapeTerminalString(value as String)
-        returnValue += "\n    -H \"\(escapedKey): \(escapedValue)\" "
+        returnValue += "\\\n    -H \"\(escapedKey): \(escapedValue)\" "
     }
 
     let URLString = request.url?.absoluteString ?? "<unknown url>"
 
-    returnValue += "\n\"\(escapeTerminalString(URLString))\""
+    returnValue += "\\\n\"\(escapeTerminalString(URLString))\""
 
     returnValue += " -i -v"
 


### PR DESCRIPTION
Print a backslash at the end of each line in the cURL command printed by URLSession requests, so that the command can be directly copy-pasted in the Terminal