### PR TITLE
fix: AtomicInt NSLock inheritance

### DIFF
--- a/Platform/AtomicInt.swift
+++ b/Platform/AtomicInt.swift
@@ -6,6 +6,9 @@
 //  Copyright © 2018 Krunoslav Zaher. All rights reserved.
 //
 
+import CoreFoundation
+// This CoreFoundation import can be dropped when this issue is resolved:
+// https://github.com/swiftlang/swift-corelibs-foundation/pull/5122
 import Foundation
 
 final class AtomicInt: NSLock, @unchecked Sendable {


### PR DESCRIPTION
Import CoreFoundation as a temporary workaround. This was suggested as a possible workaround (https://github.com/swiftlang/swift-corelibs-foundation/issues/5108#issuecomment-2412118270), and requires minimal code changes.

Resolves https://github.com/ReactiveX/RxSwift/issues/2621