### PR TITLE
Fix typo in SwiftConcurrency.md

### DIFF
--- a/Documentation/SwiftConcurrency.md
+++ b/Documentation/SwiftConcurrency.md
@@ -66,10 +66,10 @@ stream.asObservable()
 
 ### Wrapping an `async` result as a `Single`
 
-If you already have an async piece of work that returns a single result you wish to await, you can bridge it back to the Rx wordl by using `Single.create`, a special overload which takes an `async throws` closure where you can simply await your async work:
+If you already have an async piece of work that returns a single result you wish to await, you can bridge it back to the Rx world by using `Single.create`, a special overload which takes an `async throws` closure where you can simply await your async work:
 
 ```swift
-func doIncredibleWork() async throws -> AmazingRespones {
+func doIncredibleWork() async throws -> AmazingResponse {
     ...
 }
 


### PR DESCRIPTION
This PR corrects two spelling errors in the SwiftConcurrency.md file:
- fixed "wordl" to "world"
- fixed "AmazingRespones" to "AmazingResponse"