### PR TITLE
Don't treat \0 in description as literal null

### DIFF
--- a/RxSwift.podspec
+++ b/RxSwift.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name             = "RxSwift"
   s.version          = "6.8.0"
   s.summary          = "RxSwift is a Swift implementation of Reactive Extensions"
-  s.description      = <<-DESC
+  s.description      = <<-'DESC'
 This is a Swift port of [ReactiveX.io](https://github.com/ReactiveX)
 
 Like the original [Rx](https://github.com/Reactive-extensions/Rx.Net), its intention is to enable easy composition of asynchronous operations and event streams.


### PR DESCRIPTION
I think in the Gem description you meant to write `\0` as human-readable text instead of a literal null byte. Heredoc strings interpret escapes unless you put single quotes like this. You can see it happening in the JSON version here where it says `\u0000` instead: https://github.com/CocoaPods/Specs/blob/98a5cfac82ecccd406eeff0d549c8eccadf1b699/Specs/2/e/c/RxSwift/6.8.0/RxSwift.podspec.json#L5

https://docs.ruby-lang.org/en/master/syntax/literals_rdoc.html#label-Here+Document+Literals