### PR TITLE
feature: create map, compactMap, filter, flatMap ObservableType with with object

### DIFF
--- a/RxSwift/Observables/CompactMap.swift
+++ b/RxSwift/Observables/CompactMap.swift
@@ -19,6 +19,14 @@ extension ObservableType {
         -> Observable<Result> {
         CompactMap(source: self.asObservable(), transform: transform)
     }
+    
+    public func compactMap<Object: AnyObject, Result>(
+        with object: Object,
+        _ transform: @escaping ((Object, Element)) throws -> Result?
+    ) -> Observable<Result> {
+        withUnretained(object)
+            .compactMap(transform)
+    }
 }
 
 final private class CompactMapSink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType {

--- a/RxSwift/Observables/Filter.swift
+++ b/RxSwift/Observables/Filter.swift
@@ -20,6 +20,14 @@ extension ObservableType {
         -> Observable<Element> {
         Filter(source: self.asObservable(), predicate: predicate)
     }
+    
+    public func filter<Object: AnyObject>(
+        with object: Object,
+        _ predicate: @escaping ((Object, Element)) throws -> Bool
+    ) -> Observable<(Object, Element)> {
+        withUnretained(object)
+            .filter(predicate)
+    }
 }
 
 extension ObservableType {

--- a/RxSwift/Observables/Map.swift
+++ b/RxSwift/Observables/Map.swift
@@ -21,6 +21,14 @@ extension ObservableType {
         -> Observable<Result> {
         Map(source: self.asObservable(), transform: transform)
     }
+    
+    public func map<Object: AnyObject, Result>(
+        with object: Object,
+        _ transform: @escaping ((Object, Element)) throws -> Result
+    ) -> Observable<Result> {
+        withUnretained(object)
+            .map(transform)
+    }
 }
 
 final private class MapSink<SourceType, Observer: ObserverType>: Sink<Observer>, ObserverType {

--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -21,6 +21,13 @@ extension ObservableType {
             return FlatMap(source: self.asObservable(), selector: selector)
     }
 
+    public func flatMap<Object: AnyObject, Source: ObservableConvertibleType>(
+       with object: Object,
+       _ selector: @escaping ((Object, Element)) throws -> Source
+    ) -> Observable<Source.Element> {
+      withUnretained(object)
+         .flatMap(selector)
+     }
 }
 
 extension ObservableType {

--- a/Tests/RxSwiftTests/Observable+CompactMapTests.swift
+++ b/Tests/RxSwiftTests/Observable+CompactMapTests.swift
@@ -11,14 +11,14 @@ import RxSwift
 import RxTest
 
 #if os(Linux)
-    import Glibc
+import Glibc
 #endif
 
 class ObservableCompactMapTest : RxTest {
 }
 
 extension ObservableCompactMapTest {
-
+    
     func test_compactMapNilFromClosure() {
         let scheduler = TestScheduler(initialClock: 0)
         
@@ -66,9 +66,9 @@ extension ObservableCompactMapTest {
     
     func test_compactMapNilFromElement() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         var invoked = 0
-
+        
         let xs: TestableObservable<Int?> = scheduler.createHotObservable([
             .next(110, 1),
             .next(180, 2),
@@ -79,28 +79,28 @@ extension ObservableCompactMapTest {
             .next(410, 7),
             .error(420, testError),
             .completed(430)
-            ])
-
+        ])
+        
         let res = scheduler.start { () -> Observable<Int> in
             return xs.compactMap { num in
                 invoked += 1
                 return num
             }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(230, 3),
             .next(340, 5),
             .completed(400),
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 400)
-            ])
-
+        ])
+        
         XCTAssertEqual(3, invoked)
     }
-
+    
     func test_compactMapDisposed() {
         let scheduler = TestScheduler(initialClock: 0)
         
@@ -119,7 +119,7 @@ extension ObservableCompactMapTest {
             .next(560, 10),
             .next(580, 11),
             .completed(600)
-            ])
+        ])
         
         let res = scheduler.start(disposed: 400) { () -> Observable<Int> in
             return xs.compactMap { num in
@@ -132,13 +132,180 @@ extension ObservableCompactMapTest {
             .next(230, 3),
             .next(340, 5),
             .next(390, 7)
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 400)
-            ])
+        ])
         
         XCTAssertEqual(5, invoked)
     }
+    
+    func testCompactMapWithObject_Never() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1)
+        ])
+        
+        let res = scheduler.start {
+            xs.compactMap(with: testObject) { object, element in
+                return (object.value > element) ? element * 2 : nil
+            }
+        }
+        
+        let correctMessages: [Recorded<Event<Int>>] = []
+        let correctSubscriptions = [
+            Subscription(200, 1000)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testCompactMapWithObject_Empty() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.compactMap(with: testObject) { object, element in
+                return (object.value > element) ? element * 2 : nil
+            }
+        }
+        
+        let correctMessages = [
+            Recorded.completed(300, Int.self)
+        ]
+        
+        let correctSubscriptions = [
+            Subscription(200, 300)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testCompactMapWithObject_SomeElementsPass() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 3)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .next(240, 4),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.compactMap(with: testObject) { object, element in
+                return (object.value > element) ? element * 2 : nil
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 1 * 2),
+            .next(220, 2 * 2),
+            .completed(300)
+        )
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 300)])
+    }
+    
+    func testCompactMapWithObject_AllElementsFiltered() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 1)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .next(230, 4),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.compactMap(with: testObject) { object, element in
+                return (object.value > element) ? element * 2 : nil
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .completed(300)
+        )
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 300)])
+    }
+    
+    func testCompactMapWithObject_Error() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 3)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .error(230, testError)
+        ])
+        
+        let res = scheduler.start {
+            xs.compactMap(with: testObject) { object, element in
+                return (object.value > element) ? element * 2 : nil
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 1 * 2),
+            .next(220, 2 * 2),
+            .error(230, testError)
+        )
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 230)])
+    }
+    
+    func testCompactMapWithObject_ThrowsInTransform() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.compactMap(with: testObject) { object, element in
+                if element > 2 { throw testError }
+                return object.value + element
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 5 + 1),
+            .next(220, 5 + 2),
+            .error(230, testError)
+        )
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 230)])
+    }
+}
 
+private class TestObject: AnyObject {
+    let value: Int
+    init(value: Int) {
+        self.value = value
+    }
 }

--- a/Tests/RxSwiftTests/Observable+FilterTests.swift
+++ b/Tests/RxSwiftTests/Observable+FilterTests.swift
@@ -11,7 +11,7 @@ import RxSwift
 import RxTest
 
 #if os(Linux)
-    import Glibc
+import Glibc
 #endif
 
 class ObservableFilterTest : RxTest {
@@ -26,7 +26,7 @@ func isPrime(_ i: Int) -> Bool {
     if max <= 1 {
         return true
     }
-
+    
     for j in 2 ... max where i % j == 0 {
         return false
     }
@@ -98,7 +98,7 @@ extension ObservableFilterTest {
             .next(560, 10),
             .next(580, 11),
             .completed(600)
-            ])
+        ])
         
         let res = scheduler.start { () -> Observable<Int> in
             return xs.filter { _ -> Bool in
@@ -118,15 +118,15 @@ extension ObservableFilterTest {
             .next(560, 10),
             .next(580, 11),
             .completed(600)
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 600)
-            ])
+        ])
         
         XCTAssertEqual(9, invoked)
     }
-   
+    
     func test_filterFalse() {
         let scheduler = TestScheduler(initialClock: 0)
         
@@ -145,7 +145,7 @@ extension ObservableFilterTest {
             .next(560, 10),
             .next(580, 11),
             .completed(600)
-            ])
+        ])
         
         let res = scheduler.start { () -> Observable<Int> in
             return xs.filter { _ -> Bool in
@@ -156,11 +156,11 @@ extension ObservableFilterTest {
         
         XCTAssertEqual(res.events, [
             .completed(600)
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 600)
-            ])
+        ])
         
         XCTAssertEqual(9, invoked)
     }
@@ -183,7 +183,7 @@ extension ObservableFilterTest {
             .next(560, 10),
             .next(580, 11),
             .completed(600)
-            ])
+        ])
         
         let res = scheduler.start(disposed: 400) { () -> Observable<Int> in
             return xs.filter { (num: Int) -> Bool in
@@ -196,60 +196,227 @@ extension ObservableFilterTest {
             .next(230, 3),
             .next(340, 5),
             .next(390, 7)
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 400)
-            ])
+        ])
         
         XCTAssertEqual(5, invoked)
     }
-
-    #if TRACE_RESOURCES
-        func testFilterReleasesResourcesOnComplete() {
-            _ = Observable<Int>.just(1).filter { _ in true }.subscribe()
+    
+    func testFilterWithObject_Never() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1)
+        ])
+        
+        let res = scheduler.start {
+            xs.filter(with: testObject) { object, element in
+                object.value > element
+            }
         }
-
-        func testFilter1ReleasesResourcesOnError() {
-            _ = Observable<Int>.error(testError).filter { _ in true }.subscribe()
+        
+        let correctMessages: [Recorded<Event<(TestObject, Int)>>] = []
+        let correctSubscriptions = [
+            Subscription(200, 1000)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testFilterWithObject_Empty() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.filter(with: testObject) { object, element in
+                object.value > element
+            }
         }
-
-        func testFilter2ReleasesResourcesOnError() {
-            _ = Observable<Int>.just(1).filter { _ -> Bool in throw testError }.subscribe()
+        
+        let correctMessages = [
+            Recorded.completed(300, (TestObject, Int).self)
+        ]
+        let correctSubscriptions = [
+            Subscription(200, 300)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testFilterWithObject_SomeElementsPass() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 2)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.filter(with: testObject) { object, element in
+                object.value > element
+            }
         }
-    #endif
+        
+        let correctMessages = Recorded.events(
+            .next(210, (testObject, 1)),
+            .completed(300)
+        )
+        let correctSubscriptions = [
+            Subscription(200, 300)
+        ]
+        
+        XCTAssertEqual(res.events.map { ($0.time, $0.value.element?.1) }, correctMessages.map { ($0.time, $0.value.element?.1) })
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testFilterWithObject_AllElementsPass() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.filter(with: testObject) { object, element in
+                object.value > element
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, (testObject, 1)),
+            .next(220, (testObject, 2)),
+            .next(230, (testObject, 3)),
+            .completed(300)
+        )
+        
+        XCTAssertEqual(res.events.map { ($0.time, $0.value.element?.1) }, correctMessages.map { ($0.time, $0.value.element?.1) })
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 300)])
+    }
+    
+    func testFilterWithObject_Error() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .error(220, testError)
+        ])
+        
+        let res = scheduler.start {
+            xs.filter(with: testObject) { object, element in
+                object.value > element
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, (testObject, 2)),
+            .error(220, testError)
+        )
+        
+        XCTAssertEqual(res.events.map { ($0.time, $0.value.element?.1) }, correctMessages.map { ($0.time, $0.value.element?.1) })
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 220)])
+    }
+    
+    func testFilterWithObject_ThrowsInPredicate() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.filter(with: testObject) { object, element in
+                if element > 2 { throw testError }
+                return object.value > element
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, (testObject, 2)),
+            .error(220, testError)
+        )
+        
+        XCTAssertEqual(res.events.map { ($0.time, $0.value.element?.1) }, correctMessages.map { ($0.time, $0.value.element?.1) })
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 220)])
+    }
+    
+#if TRACE_RESOURCES
+    func testFilterReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).filter { _ in true }.subscribe()
+    }
+    
+    func testFilter1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).filter { _ in true }.subscribe()
+    }
+    
+    func testFilter2ReleasesResourcesOnError() {
+        _ = Observable<Int>.just(1).filter { _ -> Bool in throw testError }.subscribe()
+    }
+#endif
 }
 
 extension ObservableFilterTest {
     func testIgnoreElements_DoesNotSendValues() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(210, 1),
             .next(220, 2),
             .completed(230)
-            ])
-
+        ])
+        
         let res = scheduler.start {
             xs.ignoreElements()
         }
-
+        
         XCTAssertEqual(res.events, [
             .completed(230)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 230)
-            ])
+        ])
     }
+    
+#if TRACE_RESOURCES
+    func testIgnoreElementsReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).ignoreElements().subscribe()
+    }
+    
+    func testIgnoreElementsReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).ignoreElements().subscribe()
+    }
+#endif
+}
 
-    #if TRACE_RESOURCES
-        func testIgnoreElementsReleasesResourcesOnComplete() {
-            _ = Observable<Int>.just(1).ignoreElements().subscribe()
-        }
-
-        func testIgnoreElementsReleasesResourcesOnError() {
-            _ = Observable<Int>.error(testError).ignoreElements().subscribe()
-        }
-    #endif
+private class TestObject: AnyObject {
+    let value: Int
+    init(value: Int) {
+        self.value = value
+    }
 }

--- a/Tests/RxSwiftTests/Observable+MapTests.swift
+++ b/Tests/RxSwiftTests/Observable+MapTests.swift
@@ -19,7 +19,7 @@ extension ObservableMapTest {
         
         let xs = scheduler.createHotObservable([
             .next(150, 1),
-            ])
+        ])
         
         let res = scheduler.start { xs.map { $0 * 2 } }
         
@@ -40,7 +40,7 @@ extension ObservableMapTest {
         let xs = scheduler.createHotObservable([
             .next(150, 1),
             .completed(300)
-            ])
+        ])
         
         let res = scheduler.start { xs.map { $0 * 2 } }
         
@@ -66,7 +66,7 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .completed(300)
-            ])
+        ])
         
         let res = scheduler.start { xs.map { $0 * 2 } }
         
@@ -96,7 +96,7 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .error(300, testError)
-            ])
+        ])
         
         let res = scheduler.start { xs.map { $0 * 2 } }
         
@@ -126,7 +126,7 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .error(300, testError)
-            ])
+        ])
         
         let res = scheduler.start(disposed: 290) { xs.map { $0 * 2 } }
         
@@ -155,7 +155,7 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .error(300, testError)
-            ])
+        ])
         
         let res = scheduler.start { xs.map { x throws -> Int in if x < 2 { return x * 2 } else { throw testError } } }
         
@@ -172,69 +172,69 @@ extension ObservableMapTest {
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
-
-    #if TRACE_RESOURCES
-        func testMapReleasesResourcesOnComplete() {
-            _ = Observable<Int>.just(1).map { _ in true }.subscribe()
-        }
-
-        func testMap1ReleasesResourcesOnError() {
-            _ = Observable<Int>.error(testError).map { _ in true }.subscribe()
-        }
-
-        func testMap2ReleasesResourcesOnError() {
-            _ = Observable<Int>.just(1).map { _ -> Bool in throw testError }.subscribe()
-        }
-    #endif
+    
+#if TRACE_RESOURCES
+    func testMapReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).map { _ in true }.subscribe()
+    }
+    
+    func testMap1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).map { _ in true }.subscribe()
+    }
+    
+    func testMap2ReleasesResourcesOnError() {
+        _ = Observable<Int>.just(1).map { _ -> Bool in throw testError }.subscribe()
+    }
+#endif
 }
 
 // MARK: map compose
 extension ObservableMapTest {
     func testMapCompose_Never() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(150, 1),
-            ])
-
+        ])
+        
         let res = scheduler.start { xs.map { $0 * 10 }.map { $0 + 1 } }
-
+        
         let correctMessages: [Recorded<Event<Int>>] = [
         ]
-
+        
         let correctSubscriptions = [
             Subscription(200, 1000)
         ]
-
+        
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
-
+    
     func testMapCompose_Empty() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(150, 1),
             .completed(300)
-            ])
-
+        ])
+        
         let res = scheduler.start { xs.map { $0 * 10 }.map { $0 + 1 } }
-
+        
         let correctMessages = [
             Recorded.completed(300, Int.self)
         ]
-
+        
         let correctSubscriptions = [
             Subscription(200, 300)
         ]
-
+        
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
-
+    
     func testMapCompose_Range() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(150, 1),
             .next(210, 0),
@@ -242,10 +242,10 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .completed(300)
-            ])
-
+        ])
+        
         let res = scheduler.start { xs.map { $0 * 10 }.map { $0 + 1 } }
-
+        
         let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
@@ -253,18 +253,18 @@ extension ObservableMapTest {
             .next(240, 4 * 10 + 1),
             .completed(300)
         )
-
+        
         let correctSubscriptions = [
             Subscription(200, 300)
         ]
-
+        
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
-
+    
     func testMapCompose_Error() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(150, 1),
             .next(210, 0),
@@ -272,10 +272,10 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .error(300, testError)
-            ])
-
+        ])
+        
         let res = scheduler.start { xs.map { $0 * 10 }.map { $0 + 1 } }
-
+        
         let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
@@ -283,18 +283,18 @@ extension ObservableMapTest {
             .next(240, 4 * 10 + 1),
             .error(300, testError)
         )
-
+        
         let correctSubscriptions = [
             Subscription(200, 300)
         ]
-
+        
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
-
+    
     func testMapCompose_Dispose() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(150, 1),
             .next(210, 0),
@@ -302,28 +302,28 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .error(300, testError)
-            ])
-
+        ])
+        
         let res = scheduler.start(disposed: 290) { xs.map { $0 * 10 }.map { $0 + 1 } }
-
+        
         let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
             .next(230, 2 * 10 + 1),
             .next(240, 4 * 10 + 1)
         )
-
+        
         let correctSubscriptions = [
             Subscription(200, 290)
         ]
-
+        
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
-
+    
     func testMapCompose_Selector1Throws() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(150, 1),
             .next(210, 0),
@@ -331,31 +331,31 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .error(300, testError)
-            ])
-
+        ])
+        
         let res = scheduler.start {
             xs
-            .map { x throws -> Int in if x < 2 { return x * 10 } else { throw testError } }
-            .map { $0 + 1 }
+                .map { x throws -> Int in if x < 2 { return x * 10 } else { throw testError } }
+                .map { $0 + 1 }
         }
-
+        
         let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
             .error(230, testError)
         )
-
+        
         let correctSubscriptions = [
             Subscription(200, 230)
         ]
-
+        
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
     }
-
+    
     func testMapCompose_Selector2Throws() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(150, 1),
             .next(210, 0),
@@ -363,25 +363,218 @@ extension ObservableMapTest {
             .next(230, 2),
             .next(240, 4),
             .error(300, testError)
-            ])
-
+        ])
+        
         let res = scheduler.start {
             xs
                 .map { $0 * 10 }
                 .map { x throws -> Int in if x < 20 { return x + 1 } else { throw testError } }
         }
-
+        
         let correctMessages = Recorded.events(
             .next(210, 0 * 10 + 1),
             .next(220, 1 * 10 + 1),
             .error(230, testError)
         )
-
+        
         let correctSubscriptions = [
             Subscription(200, 230)
         ]
-
+        
         XCTAssertEqual(res.events, correctMessages)
         XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testMapWithObject_Never() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1)
+        ])
+        
+        let res = scheduler.start {
+            xs.map(with: testObject) { object, element in
+                object.value + element
+            }
+        }
+        
+        let correctMessages: [Recorded<Event<Int>>] = []
+        
+        let correctSubscriptions = [
+            Subscription(200, 1000)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testMapWithObject_Empty() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.map(with: testObject) { object, element in
+                object.value + element
+            }
+        }
+        
+        let correctMessages = [
+            Recorded.completed(300, Int.self)
+        ]
+        
+        let correctSubscriptions = [
+            Subscription(200, 300)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testMapWithObject_Range() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.map(with: testObject) { object, element in
+                object.value + element
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 10 + 1),
+            .next(220, 10 + 2),
+            .next(230, 10 + 3),
+            .completed(300)
+        )
+        
+        let correctSubscriptions = [
+            Subscription(200, 300)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testMapWithObject_Error() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .error(230, testError)
+        ])
+        
+        let res = scheduler.start {
+            xs.map(with: testObject) { object, element in
+                object.value + element
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 5 + 1),
+            .next(220, 5 + 2),
+            .error(230, testError)
+        )
+        
+        let correctSubscriptions = [
+            Subscription(200, 230)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testMapWithObject_Dispose() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start(disposed: 225) {
+            xs.map(with: testObject) { object, element in
+                object.value + element
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 5 + 1),
+            .next(220, 5 + 2)
+        )
+        
+        let correctSubscriptions = [
+            Subscription(200, 225)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testMapWithObject_SelectorThrows() {
+        let scheduler = TestScheduler(initialClock: 0)
+        
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.map(with: testObject) { object, element in
+                if element > 2 { throw testError }
+                return object.value + element
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 5 + 1),
+            .next(220, 5 + 2),
+            .error(230, testError)
+        )
+        
+        let correctSubscriptions = [
+            Subscription(200, 230)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+}
+
+private class TestObject: AnyObject {
+    let value: Int
+    
+    init(value: Int) {
+        self.value = value
     }
 }

--- a/Tests/RxSwiftTests/Observable+MergeTests.swift
+++ b/Tests/RxSwiftTests/Observable+MergeTests.swift
@@ -52,7 +52,7 @@ extension ObservableMergeTest {
         let observable: Observable<Observable<Int>> = Observable.just(
             Observable.error(testError)
         ).merge()
-
+        
         _ = observable.subscribe(onError: { _ in
             nEvents += 1
         })
@@ -120,7 +120,7 @@ extension ObservableMergeTest {
         let observable: Observable<Observable<Int>> = Observable.just(
             Observable.error(testError)
         ).merge(maxConcurrent: 1)
-
+        
         _ = observable.subscribe(onError: { _ in
             nEvents += 1
         })
@@ -132,7 +132,7 @@ extension ObservableMergeTest {
         var nEvents = 0
         
         let observable: Observable<Int> = Observable<Observable<Int>>.empty().merge(maxConcurrent: 1)
-
+        
         _ = observable.subscribe(onCompleted: {
             nEvents += 1
         })
@@ -144,7 +144,7 @@ extension ObservableMergeTest {
         var nEvents = 0
         
         let observable: Observable<Int> = Observable.just(Observable.empty()).merge(maxConcurrent: 1)
-
+        
         _ = observable.subscribe(onCompleted: {
             nEvents += 1
         })
@@ -163,7 +163,7 @@ extension ObservableMergeTest {
             .next(210, 105),
             .next(220, 106),
             .completed(230)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(10, 201),
@@ -171,7 +171,7 @@ extension ObservableMergeTest {
             .next(30, 203),
             .next(40, 204),
             .completed(50)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 301),
@@ -211,20 +211,20 @@ extension ObservableMergeTest {
             .next(620, 305),
             .completed(650)
         )
-
+        
         XCTAssertEqual(res.events, messages)
-
+        
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(300, 530),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(400, 450),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(500, 650),
-            ])
+        ])
     }
     
     func testMerge_ObservableOfObservable_Data_NotOverlapped() {
@@ -234,7 +234,7 @@ extension ObservableMergeTest {
             .next(10, 101),
             .next(20, 102),
             .completed(230)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(10, 201),
@@ -242,7 +242,7 @@ extension ObservableMergeTest {
             .next(30, 203),
             .next(40, 204),
             .completed(50)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 301),
@@ -250,14 +250,14 @@ extension ObservableMergeTest {
             .next(30, 303),
             .next(40, 304),
             .completed(50)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(300, ys1),
             .next(400, ys2),
             .next(500, ys3),
             .completed(600)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge()
@@ -276,24 +276,24 @@ extension ObservableMergeTest {
             .next(540, 304),
             .completed(600)
         )
-
+        
         XCTAssertEqual(res.events, messages)
-
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 600),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(300, 530),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(400, 450),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(500, 550),
-            ])
+        ])
     }
     
     func testMerge_ObservableOfObservable_InnerThrows() {
@@ -307,7 +307,7 @@ extension ObservableMergeTest {
             .next(210, 105),
             .next(220, 106),
             .completed(230)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(10, 201),
@@ -315,7 +315,7 @@ extension ObservableMergeTest {
             .next(30, 203),
             .next(40, 204),
             .error(50, testError1)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 301),
@@ -323,14 +323,14 @@ extension ObservableMergeTest {
             .next(30, 303),
             .next(40, 304),
             .completed(150)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(300, ys1),
             .next(400, ys2),
             .next(500, ys3),
             .completed(600)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge()
@@ -347,23 +347,23 @@ extension ObservableMergeTest {
             .next(440, 204),
             .error(450, testError1)
         )
-
+        
         XCTAssertEqual(res.events, messages)
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 450),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(300, 450),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(400, 450),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
-            ])
+        ])
     }
     
     func testMerge_ObservableOfObservable_OuterThrows() {
@@ -377,7 +377,7 @@ extension ObservableMergeTest {
             .next(210, 105),
             .next(220, 106),
             .completed(230)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(10, 201),
@@ -385,13 +385,13 @@ extension ObservableMergeTest {
             .next(30, 203),
             .next(40, 204),
             .completed(50)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(300, ys1),
             .next(400, ys2),
             .error(500, testError1),
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge()
@@ -408,20 +408,20 @@ extension ObservableMergeTest {
             .next(440, 204),
             .error(500, testError1)
         )
-
+        
         XCTAssertEqual(res.events, messages)
-
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 500),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(300, 500),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(400, 450),
-            ])
+        ])
     }
     
     func testMerge_MergeConcat_Basic() {
@@ -432,26 +432,26 @@ extension ObservableMergeTest {
             .next(100, 2),
             .next(120, 3),
             .completed(140)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(20, 4),
             .next(70, 5),
             .completed(200)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 6),
             .next(90, 7),
             .next(110, 8),
             .completed(130)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .next(210, 9),
             .next(240, 10),
             .completed(300)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(210, ys1),
@@ -459,7 +459,7 @@ extension ObservableMergeTest {
             .next(270, ys3),
             .next(320, ys4),
             .completed(400)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge(maxConcurrent: 2)
@@ -478,28 +478,28 @@ extension ObservableMergeTest {
             .next(700, 10),
             .completed(760)
         )
-
+        
         XCTAssertEqual(res.events, messages)
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(210, 350),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(260, 460),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(350, 480),
-            ])
+        ])
         
         XCTAssertEqual(ys4.subscriptions, [
             Subscription(460, 760),
-            ])
+        ])
     }
     
     func testMerge_MergeConcat_BasicLong() {
@@ -510,26 +510,26 @@ extension ObservableMergeTest {
             .next(100, 2),
             .next(120, 3),
             .completed(140)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(20, 4),
             .next(70, 5),
             .completed(300)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 6),
             .next(90, 7),
             .next(110, 8),
             .completed(130)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .next(210, 9),
             .next(240, 10),
             .completed(300)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(210, ys1),
@@ -537,7 +537,7 @@ extension ObservableMergeTest {
             .next(270, ys3),
             .next(320, ys4),
             .completed(400)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge(maxConcurrent: 2)
@@ -556,28 +556,28 @@ extension ObservableMergeTest {
             .next(720, 10),
             .completed(780)
         )
-
+        
         XCTAssertEqual(res.events, messages)
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(210, 350),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(260, 560),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(350, 480),
-            ])
+        ])
         
         XCTAssertEqual(ys4.subscriptions, [
             Subscription(480, 780),
-            ])
+        ])
     }
     
     func testMerge_MergeConcat_BasicWide() {
@@ -588,26 +588,26 @@ extension ObservableMergeTest {
             .next(100, 2),
             .next(120, 3),
             .completed(140)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(20, 4),
             .next(70, 5),
             .completed(300)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 6),
             .next(90, 7),
             .next(110, 8),
             .completed(130)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .next(210, 9),
             .next(240, 10),
             .completed(300)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(210, ys1),
@@ -615,7 +615,7 @@ extension ObservableMergeTest {
             .next(270, ys3),
             .next(420, ys4),
             .completed(450)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge(maxConcurrent: 3)
@@ -634,28 +634,28 @@ extension ObservableMergeTest {
             .next(660, 10),
             .completed(720)
         )
-
+        
         XCTAssertEqual(res.events, messages)
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 450),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(210, 350),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(260, 560),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(270, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys4.subscriptions, [
             Subscription(420, 720),
-            ])
+        ])
     }
     
     func testMerge_MergeConcat_BasicLate() {
@@ -666,26 +666,26 @@ extension ObservableMergeTest {
             .next(100, 2),
             .next(120, 3),
             .completed(140)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(20, 4),
             .next(70, 5),
             .completed(300)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 6),
             .next(90, 7),
             .next(110, 8),
             .completed(130)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .next(210, 9),
             .next(240, 10),
             .completed(300)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(210, ys1),
@@ -693,7 +693,7 @@ extension ObservableMergeTest {
             .next(270, ys3),
             .next(420, ys4),
             .completed(750)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge(maxConcurrent: 3)
@@ -712,28 +712,28 @@ extension ObservableMergeTest {
             .next(660, 10),
             .completed(750)
         )
-
+        
         XCTAssertEqual(res.events, messages)
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 750),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(210, 350),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(260, 560),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(270, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys4.subscriptions, [
             Subscription(420, 720),
-            ])
+        ])
     }
     
     func testMerge_MergeConcat_Disposed() {
@@ -744,26 +744,26 @@ extension ObservableMergeTest {
             .next(100, 2),
             .next(120, 3),
             .completed(140)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(20, 4),
             .next(70, 5),
             .completed(200)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 6),
             .next(90, 7),
             .next(110, 8),
             .completed(130)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .next(210, 9),
             .next(240, 10),
             .completed(300)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(210, ys1),
@@ -771,12 +771,12 @@ extension ObservableMergeTest {
             .next(270, ys3),
             .next(320, ys4),
             .completed(400)
-            ])
+        ])
         
         let res = scheduler.start(disposed: 450) {
             xs.merge(maxConcurrent: 2)
         }
-
+        
         let messages = Recorded.events(
             .next(260, 1),
             .next(280, 4),
@@ -786,27 +786,27 @@ extension ObservableMergeTest {
             .next(360, 6),
             .next(440, 7)
         )
-
+        
         XCTAssertEqual(res.events, messages)
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(210, 350),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(260, 450),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(350, 450),
-            ])
+        ])
         
         XCTAssertEqual(ys4.subscriptions, [
-            ])
+        ])
     }
     
     func testMerge_MergeConcat_OuterError() {
@@ -817,26 +817,26 @@ extension ObservableMergeTest {
             .next(100, 2),
             .next(120, 3),
             .completed(140)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(20, 4),
             .next(70, 5),
             .completed(200)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 6),
             .next(90, 7),
             .next(110, 8),
             .completed(130)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .next(210, 9),
             .next(240, 10),
             .completed(300)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(210, ys1),
@@ -844,7 +844,7 @@ extension ObservableMergeTest {
             .next(270, ys3),
             .next(320, ys4),
             .error(400, testError1)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge(maxConcurrent: 2)
@@ -859,27 +859,27 @@ extension ObservableMergeTest {
             .next(360, 6),
             .error(400, testError1)
         )
-
+        
         XCTAssertEqual(res.events, messages)
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(210, 350),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(260, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(350, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys4.subscriptions, [
-            ])
+        ])
     }
     
     func testMerge_MergeConcat_InnerError() {
@@ -890,26 +890,26 @@ extension ObservableMergeTest {
             .next(100, 2),
             .next(120, 3),
             .completed(140)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(20, 4),
             .next(70, 5),
             .completed(200)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 6),
             .next(90, 7),
             .next(110, 8),
             .error(140, testError1)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .next(210, 9),
             .next(240, 10),
             .completed(300)
-            ])
+        ])
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(210, ys1),
@@ -917,7 +917,7 @@ extension ObservableMergeTest {
             .next(270, ys3),
             .next(320, ys4),
             .completed(400)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.merge(maxConcurrent: 2)
@@ -934,182 +934,182 @@ extension ObservableMergeTest {
             .next(460, 8),
             .error(490, testError1)
         )
-
+        
         XCTAssertEqual(res.events, messages)
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 400),
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(210, 350),
-            ])
+        ])
         
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(260, 460),
-            ])
+        ])
         
         XCTAssertEqual(ys3.subscriptions, [
             Subscription(350, 490),
-            ])
+        ])
         
         XCTAssertEqual(ys4.subscriptions, [
             Subscription(460, 490),
-            ])
+        ])
     }
-
-    #if TRACE_RESOURCES
-        func testMerge1ReleasesResourcesOnComplete() {
-            let scheduler = TestScheduler(initialClock: 0)
-            _ = Observable<Observable<Int>>.of(Observable.just(1), Observable.just(1).delay(.seconds(10), scheduler: scheduler))
-                .merge()
-                .subscribe()
-            scheduler.start()
-        }
-
-        func testMerge2ReleasesResourcesOnComplete() {
-            let scheduler = TestScheduler(initialClock: 0)
-            _ = Observable<Observable<Int>>.of(Observable.just(1), Observable.just(1))
-                .concat(Observable<Int>.timer(.seconds(20), scheduler: scheduler).flatMapLatest { _ in return Observable<Observable<Int>>.empty() })
-                .merge()
-                .subscribe()
-            scheduler.start()
-        }
-
-        func testMerge1ReleasesResourcesOnError() {
-            let scheduler = TestScheduler(initialClock: 0)
-            _ = Observable<Observable<Int>>.of(Observable.just(1), Observable.never().timeout(.seconds(10), scheduler: scheduler))
-                .merge()
-                .subscribe()
-            scheduler.start()
-        }
-
-        func testMerge2ReleasesResourcesOnError() {
-            let scheduler = TestScheduler(initialClock: 0)
-            _ = Observable<Observable<Int>>.of(Observable.just(1), Observable.just(1))
-                .concat(Observable.never().timeout(.seconds(20), scheduler: scheduler))
-                .merge()
-                .subscribe()
-            scheduler.start()
-        }
-    #endif
+    
+#if TRACE_RESOURCES
+    func testMerge1ReleasesResourcesOnComplete() {
+        let scheduler = TestScheduler(initialClock: 0)
+        _ = Observable<Observable<Int>>.of(Observable.just(1), Observable.just(1).delay(.seconds(10), scheduler: scheduler))
+            .merge()
+            .subscribe()
+        scheduler.start()
+    }
+    
+    func testMerge2ReleasesResourcesOnComplete() {
+        let scheduler = TestScheduler(initialClock: 0)
+        _ = Observable<Observable<Int>>.of(Observable.just(1), Observable.just(1))
+            .concat(Observable<Int>.timer(.seconds(20), scheduler: scheduler).flatMapLatest { _ in return Observable<Observable<Int>>.empty() })
+            .merge()
+            .subscribe()
+        scheduler.start()
+    }
+    
+    func testMerge1ReleasesResourcesOnError() {
+        let scheduler = TestScheduler(initialClock: 0)
+        _ = Observable<Observable<Int>>.of(Observable.just(1), Observable.never().timeout(.seconds(10), scheduler: scheduler))
+            .merge()
+            .subscribe()
+        scheduler.start()
+    }
+    
+    func testMerge2ReleasesResourcesOnError() {
+        let scheduler = TestScheduler(initialClock: 0)
+        _ = Observable<Observable<Int>>.of(Observable.just(1), Observable.just(1))
+            .concat(Observable.never().timeout(.seconds(20), scheduler: scheduler))
+            .merge()
+            .subscribe()
+        scheduler.start()
+    }
+#endif
 }
 
 extension ObservableMergeTest {
     func testMergeSync_Empty() {
         let factories: [() -> Observable<Int>] =
-            [
-                { Observable.merge() },
-                { Observable.merge(AnyCollection([])) },
-                { Observable.merge([]) },
-            ]
+        [
+            { Observable.merge() },
+            { Observable.merge(AnyCollection([])) },
+            { Observable.merge([]) },
+        ]
         for factory in factories {
             let scheduler = TestScheduler(initialClock: 0)
-
+            
             let res = scheduler.start(factory)
-
+            
             let messages = [
                 Recorded.completed(200, Int.self)
             ]
-
+            
             XCTAssertEqual(res.events, messages)
         }
     }
-
+    
     func testMergeSync_EmptyData_DoesntCompleteImmediately() {
         let factories: [(Observable<Int>, Observable<Int>) -> Observable<Int>] =
-            [
-                { ys1, ys2 in Observable.merge(ys1, ys2) },
-                { ys1, ys2 in Observable.merge(AnyCollection([ys1, ys2])) },
-                { ys1, ys2 in Observable.merge([ys1, ys2]) },
-                ]
+        [
+            { ys1, ys2 in Observable.merge(ys1, ys2) },
+            { ys1, ys2 in Observable.merge(AnyCollection([ys1, ys2])) },
+            { ys1, ys2 in Observable.merge([ys1, ys2]) },
+        ]
         for factory in factories {
             let scheduler = TestScheduler(initialClock: 0)
-
+            
             let ys1 = Observable<Int>.empty()
-
+            
             let ys2 = scheduler.createColdObservable([
                 .next(10, 201),
                 .next(20, 202),
                 .completed(50)
-                ])
-
+            ])
+            
             let res = scheduler.start {
                 factory(ys1.asObservable(), ys2.asObservable())
             }
-
+            
             let messages = Recorded.events(
                 .next(210, 201),
                 .next(220, 202),
                 .completed(250)
             )
-
+            
             XCTAssertEqual(res.events, messages)
-
+            
             XCTAssertEqual(ys2.subscriptions, [
                 Subscription(200, 250),
-                ])
+            ])
         }
     }
-
+    
     func testMergeSync_EmptyEmpty_Completes() {
         let factories: [(Observable<Int>, Observable<Int>) -> Observable<Int>] =
-            [
-                { ys1, ys2 in Observable.merge(ys1, ys2) },
-                { ys1, ys2 in Observable.merge(AnyCollection([ys1, ys2])) },
-                { ys1, ys2 in Observable.merge([ys1, ys2]) },
-                ]
+        [
+            { ys1, ys2 in Observable.merge(ys1, ys2) },
+            { ys1, ys2 in Observable.merge(AnyCollection([ys1, ys2])) },
+            { ys1, ys2 in Observable.merge([ys1, ys2]) },
+        ]
         for factory in factories {
             let scheduler = TestScheduler(initialClock: 0)
-
+            
             let ys1 = Observable<Int>.empty()
-
+            
             let ys2 = Observable<Int>.empty()
-
+            
             let res = scheduler.start {
                 factory(ys1.asObservable(), ys2.asObservable())
             }
-
+            
             let messages = [
                 Recorded.completed(200, Int.self)
             ]
-
+            
             XCTAssertEqual(res.events, messages)
         }
     }
     
     func testMergeSync_Data() {
         let factories: [(Observable<Int>, Observable<Int>, Observable<Int>) -> Observable<Int>] =
-            [
-                { ys1, ys2, ys3 in Observable.merge(ys1, ys2, ys3) },
-                { ys1, ys2, ys3 in Observable.merge(AnyCollection([ys1, ys2, ys3])) },
-                { ys1, ys2, ys3 in Observable.merge([ys1, ys2, ys3]) },
-            ]
+        [
+            { ys1, ys2, ys3 in Observable.merge(ys1, ys2, ys3) },
+            { ys1, ys2, ys3 in Observable.merge(AnyCollection([ys1, ys2, ys3])) },
+            { ys1, ys2, ys3 in Observable.merge([ys1, ys2, ys3]) },
+        ]
         for factory in factories {
             let scheduler = TestScheduler(initialClock: 0)
-
+            
             let ys1 = scheduler.createColdObservable([
                 .next(10, 101),
                 .next(20, 102),
                 .completed(230)
-                ])
-
+            ])
+            
             let ys2 = scheduler.createColdObservable([
                 .next(10, 201),
                 .next(20, 202),
                 .completed(50)
-                ])
-
+            ])
+            
             let ys3 = scheduler.createColdObservable([
                 .next(10, 301),
                 .next(20, 302),
                 .completed(150)
-                ])
-
+            ])
+            
             let res = scheduler.start {
                 factory(ys1.asObservable(), ys2.asObservable(), ys3.asObservable())
             }
-
+            
             let messages = Recorded.events(
                 .next(210, 101),
                 .next(210, 201),
@@ -1119,109 +1119,109 @@ extension ObservableMergeTest {
                 .next(220, 302),
                 .completed(430)
             )
-
+            
             XCTAssertEqual(res.events, messages)
-
+            
             XCTAssertEqual(ys1.subscriptions, [
                 Subscription(200, 430),
-                ])
-
+            ])
+            
             XCTAssertEqual(ys2.subscriptions, [
                 Subscription(200, 250),
-                ])
-
+            ])
+            
             XCTAssertEqual(ys3.subscriptions, [
                 Subscription(200, 350),
-                ])
+            ])
         }
     }
-
+    
     func testMergeSync_ObservableOfObservable_InnerThrows() {
         let factories: [(Observable<Int>, Observable<Int>, Observable<Int>) -> Observable<Int>] =
-            [
-                { ys1, ys2, ys3 in Observable.merge(ys1, ys2, ys3) },
-                { ys1, ys2, ys3 in Observable.merge(AnyCollection([ys1, ys2, ys3])) },
-                { ys1, ys2, ys3 in Observable.merge([ys1, ys2, ys3]) },
-            ]
+        [
+            { ys1, ys2, ys3 in Observable.merge(ys1, ys2, ys3) },
+            { ys1, ys2, ys3 in Observable.merge(AnyCollection([ys1, ys2, ys3])) },
+            { ys1, ys2, ys3 in Observable.merge([ys1, ys2, ys3]) },
+        ]
         for factory in factories {
             let scheduler = TestScheduler(initialClock: 0)
-
+            
             let ys1 = scheduler.createColdObservable([
                 .next(10, 101),
                 .next(20, 102),
                 .completed(230)
-                ])
-
+            ])
+            
             let ys2 = scheduler.createColdObservable([
                 .next(10, 201),
                 .error(15, testError)
-                ])
-
+            ])
+            
             let ys3 = scheduler.createColdObservable([
                 .next(10, 301),
                 .next(20, 302),
                 .completed(150)
-                ])
-
+            ])
+            
             let res = scheduler.start {
                 factory(ys1.asObservable(), ys2.asObservable(), ys3.asObservable())
             }
-
+            
             let messages = Recorded.events(
                 .next(210, 101),
                 .next(210, 201),
                 .next(210, 301),
                 .error(215, testError)
             )
-
+            
             XCTAssertEqual(res.events, messages)
-
+            
             XCTAssertEqual(ys1.subscriptions, [
                 Subscription(200, 215),
-                ])
-
+            ])
+            
             XCTAssertEqual(ys2.subscriptions, [
                 Subscription(200, 215),
-                ])
-
+            ])
+            
             XCTAssertEqual(ys3.subscriptions, [
                 Subscription(200, 215),
-                ])
+            ])
         }
     }
-
-    #if TRACE_RESOURCES
-        func testMergeSyncReleasesResourcesOnComplete() {
-            _ = Observable.merge(Observable.just(1))
-                .subscribe()
-
-            _ = Observable.merge([Observable.just(1)])
-                .subscribe()
-
-            _ = Observable.merge(AnyCollection([Observable.just(1)]))
-                .subscribe()
-        }
     
-        func testMergeSyncReleasesResourcesOnError() {
-            _ = Observable.merge(Observable<Int>.error(testError))
-                .subscribe()
-
-            _ = Observable.merge([Observable<Int>.error(testError)])
-                .subscribe()
-
-            _ = Observable.merge(AnyCollection([Observable<Int>.error(testError)]))
-                .subscribe()
-        }
-
-    #endif
+#if TRACE_RESOURCES
+    func testMergeSyncReleasesResourcesOnComplete() {
+        _ = Observable.merge(Observable.just(1))
+            .subscribe()
+        
+        _ = Observable.merge([Observable.just(1)])
+            .subscribe()
+        
+        _ = Observable.merge(AnyCollection([Observable.just(1)]))
+            .subscribe()
+    }
+    
+    func testMergeSyncReleasesResourcesOnError() {
+        _ = Observable.merge(Observable<Int>.error(testError))
+            .subscribe()
+        
+        _ = Observable.merge([Observable<Int>.error(testError)])
+            .subscribe()
+        
+        _ = Observable.merge(AnyCollection([Observable<Int>.error(testError)]))
+            .subscribe()
+    }
+    
+#endif
 }
 
 
 extension ObservableMergeTest {
-
+    
     func testFlatMapFirst_Complete() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
@@ -1260,11 +1260,11 @@ extension ObservableMergeTest {
             ])),
             .completed(900)
         ])
-
+        
         let res = scheduler.start {
             xs.flatMapFirst { $0 }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(310, 102),
             .next(390, 103),
@@ -1275,37 +1275,37 @@ extension ObservableMergeTest {
             .next(940, 402),
             .completed(950)
         ])
-
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 900)
         ])
-
+        
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
         ])
-
+        
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
             Subscription(850, 950)
         ])
     }
-
-
+    
+    
     func testFlatMapFirst_Complete_InnerNotComplete() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -1313,12 +1313,12 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
                 .completed(205)
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -1326,21 +1326,21 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
-            ])
-
+            ])),
+        ])
+        
         let res = scheduler.start {
             xs.flatMapFirst { $0 }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(310, 102),
             .next(390, 103),
@@ -1349,37 +1349,37 @@ extension ObservableMergeTest {
             .next(740, 106),
             .next(930, 401),
             .next(940, 402),
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 1000)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
             Subscription(850, 950)
-            ])
+        ])
     }
-
+    
     func testFlatMapFirst_Complete_OuterNotComplete() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -1387,11 +1387,11 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -1399,22 +1399,22 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .completed(900)
-            ])
-
+        ])
+        
         let res = scheduler.start {
             xs.flatMapFirst { $0 }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(310, 102),
             .next(390, 103),
@@ -1424,38 +1424,38 @@ extension ObservableMergeTest {
             .next(930, 401),
             .next(940, 402),
             .completed(950),
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 900)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
             Subscription(850, 950)
-            ])
+        ])
     }
-
-
+    
+    
     func testFlatMapFirst_Complete_ErrorOuter() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -1463,11 +1463,11 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -1475,22 +1475,22 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .error(900, testError)
-            ])
-
+        ])
+        
         let res = scheduler.start {
             xs.flatMapFirst { $0 }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(310, 102),
             .next(390, 103),
@@ -1498,37 +1498,37 @@ extension ObservableMergeTest {
             .next(490, 105),
             .next(740, 106),
             .error(900, testError)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 900)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
             Subscription(850, 900)
-            ])
+        ])
     }
-
+    
     func testFlatMapFirst_Error_Inner() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -1536,12 +1536,12 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .error(460, testError)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
                 .completed(205)
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -1549,22 +1549,22 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .completed(900)
-            ])
-
+        ])
+        
         let res = scheduler.start {
             xs.flatMapFirst { $0 }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(310, 102),
             .next(390, 103),
@@ -1572,36 +1572,36 @@ extension ObservableMergeTest {
             .next(490, 105),
             .next(740, 106),
             .error(760, testError)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 760)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
-            ])
+        ])
     }
-
+    
     func testFlatMapFirst_Dispose() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -1609,12 +1609,12 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
                 .completed(205)
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -1622,56 +1622,56 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .completed(900)
-            ])
-
+        ])
+        
         let res = scheduler.start(disposed: 700) {
             xs.flatMapFirst { $0 }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(310, 102),
             .next(390, 103),
             .next(410, 104),
             .next(490, 105),
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 700)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 700)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [])
     }
-
+    
     func testFlatMapFirst_SelectorThrows() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -1679,12 +1679,12 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
                 .completed(205)
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -1692,18 +1692,18 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .completed(900)
-            ])
-
+        ])
+        
         var invoked = 0
         let res = scheduler.start {
             return xs.flatMapFirst { (x: TestableObservable<Int>) -> TestableObservable<Int> in
@@ -1714,7 +1714,7 @@ extension ObservableMergeTest {
                 return x
             }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(310, 102),
             .next(390, 103),
@@ -1722,42 +1722,42 @@ extension ObservableMergeTest {
             .next(490, 105),
             .next(740, 106),
             .error(850, testError)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 850)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [])
-
+        
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [])
     }
-
+    
     func testFlatMapFirst_UseFunction() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let xs = scheduler.createHotObservable([
             .next(210, 4),
             .next(220, 3),
             .next(250, 5),
             .next(270, 1),
             .completed(290)
-            ])
-
+        ])
+        
         let res = scheduler.start {
             xs.flatMapFirst { x in
                 return Observable<Int64>.interval(.seconds(10), scheduler: scheduler).map { _ in x } .take(x)
             }
         }
-
+        
         XCTAssertEqual(res.events, [
             .next(220, 4),
             .next(230, 4),
@@ -1765,30 +1765,30 @@ extension ObservableMergeTest {
             .next(250, 4),
             .next(280, 1),
             .completed(290)
-            ])
-
+        ])
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 290)
-            ])
+        ])
     }
-
-    #if TRACE_RESOURCES
-        func testFlatMapFirstReleasesResourcesOnComplete() {
-            _ = Observable<Int>.just(1).flatMapFirst { _ in Observable.just(1) }.subscribe()
-        }
-
-        func testFlatMapFirst1ReleasesResourcesOnError() {
-            _ = Observable<Int>.error(testError).flatMapFirst { _ in Observable.just(1) }.subscribe()
-        }
-
-        func testFlatMapFirst2ReleasesResourcesOnError() {
-            _ = Observable<Int>.just(1).flatMapFirst { _ -> Observable<Int> in throw testError }.subscribe()
-        }
-
-        func testFlatMapFirst3ReleasesResourcesOnError() {
-            _ = Observable<Int>.just(1).flatMapFirst { _ -> Observable<Int> in Observable.error(testError) }.subscribe()
-        }
-    #endif
+    
+#if TRACE_RESOURCES
+    func testFlatMapFirstReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).flatMapFirst { _ in Observable.just(1) }.subscribe()
+    }
+    
+    func testFlatMapFirst1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).flatMapFirst { _ in Observable.just(1) }.subscribe()
+    }
+    
+    func testFlatMapFirst2ReleasesResourcesOnError() {
+        _ = Observable<Int>.just(1).flatMapFirst { _ -> Observable<Int> in throw testError }.subscribe()
+    }
+    
+    func testFlatMapFirst3ReleasesResourcesOnError() {
+        _ = Observable<Int>.just(1).flatMapFirst { _ -> Observable<Int> in Observable.error(testError) }.subscribe()
+    }
+#endif
 }
 
 // MARK: flatMap
@@ -1861,16 +1861,16 @@ extension ObservableMergeTest {
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 900)
         ])
-
-    
+        
+        
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
         ])
-
+        
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [
             Subscription(400, 605)
         ])
-
+        
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [
             Subscription(550, 960)
         ])
@@ -1878,7 +1878,7 @@ extension ObservableMergeTest {
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [
             Subscription(750, 790)
         ])
-
+        
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
             Subscription(850, 950)
         ])
@@ -1890,10 +1890,10 @@ extension ObservableMergeTest {
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -1901,12 +1901,12 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
                 .completed(205)
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -1914,16 +1914,16 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
-            ])
+            ])),
+        ])
         
         let res = scheduler.start {
             xs.flatMap { $0 }
@@ -1944,31 +1944,31 @@ extension ObservableMergeTest {
             .next(860, 305),
             .next(930, 401),
             .next(940, 402),
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 1000)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [
             Subscription(400, 605)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [
             Subscription(550, 960)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [
             Subscription(750, 790)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
             Subscription(850, 950)
-            ])
+        ])
     }
     
     func testFlatMap_Complete_OuterNotComplete() {
@@ -1977,10 +1977,10 @@ extension ObservableMergeTest {
         let xs = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -1988,11 +1988,11 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -2000,17 +2000,17 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .completed(900)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.flatMap { $0 }
@@ -2031,31 +2031,31 @@ extension ObservableMergeTest {
             .next(860, 305),
             .next(930, 401),
             .next(940, 402),
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 900)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [
             Subscription(400, 1000)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [
             Subscription(550, 960)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [
             Subscription(750, 790)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
             Subscription(850, 950)
-            ])
+        ])
     }
     
     func testFlatMap_Complete_ErrorOuter() {
@@ -2064,10 +2064,10 @@ extension ObservableMergeTest {
         let xs = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -2075,11 +2075,11 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -2087,17 +2087,17 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .error(900, testError)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.flatMap { $0 }
@@ -2117,31 +2117,31 @@ extension ObservableMergeTest {
             .next(810, 304),
             .next(860, 305),
             .error(900, testError)
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 900)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [
             Subscription(400, 900)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [
             Subscription(550, 900)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [
             Subscription(750, 790)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
             Subscription(850, 900)
-            ])
+        ])
     }
     
     func testFlatMap_Error_Inner() {
@@ -2150,10 +2150,10 @@ extension ObservableMergeTest {
         let xs = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -2161,12 +2161,12 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .error(460, testError)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
                 .completed(205)
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -2174,17 +2174,17 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .completed(900)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.flatMap { $0 }
@@ -2202,30 +2202,30 @@ extension ObservableMergeTest {
             .next(620, 303),
             .next(740, 106),
             .error(760, testError)
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 760)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 760)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [
             Subscription(400, 605)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [
             Subscription(550, 760)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [
             Subscription(750, 760)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
-            ])
+        ])
     }
     
     func testFlatMap_Dispose() {
@@ -2234,10 +2234,10 @@ extension ObservableMergeTest {
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -2245,12 +2245,12 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
                 .completed(205)
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -2258,17 +2258,17 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .completed(900)
-            ])
+        ])
         
         let res = scheduler.start(disposed: 700) {
             xs.flatMap { $0 }
@@ -2284,41 +2284,41 @@ extension ObservableMergeTest {
             .next(590, 203),
             .next(600, 302),
             .next(620, 303),
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 700)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 700)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [
             Subscription(400, 605)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [
             Subscription(550, 700)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
-            ])
+        ])
     }
-   
+    
     func testFlatMap_SelectorThrows() {
         let scheduler = TestScheduler(initialClock: 0)
         
         let xs: TestableObservable<TestableObservable<Int>> = scheduler.createHotObservable([
             .next(5, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(105, scheduler.createColdObservable([
                 .error(1, testError)
-                ])),
+            ])),
             .next(300, scheduler.createColdObservable([
                 .next(10, 102),
                 .next(90, 103),
@@ -2326,12 +2326,12 @@ extension ObservableMergeTest {
                 .next(190, 105),
                 .next(440, 106),
                 .completed(460)
-                ])),
+            ])),
             .next(400, scheduler.createColdObservable([
                 .next(180, 202),
                 .next(190, 203),
                 .completed(205)
-                ])),
+            ])),
             .next(550, scheduler.createColdObservable([
                 .next(10, 301),
                 .next(50, 302),
@@ -2339,17 +2339,17 @@ extension ObservableMergeTest {
                 .next(260, 304),
                 .next(310, 305),
                 .completed(410)
-                ])),
+            ])),
             .next(750, scheduler.createColdObservable([
                 .completed(40)
-                ])),
+            ])),
             .next(850, scheduler.createColdObservable([
                 .next(80, 401),
                 .next(90, 402),
                 .completed(100)
-                ])),
+            ])),
             .completed(900)
-            ])
+        ])
         
         var invoked = 0
         let res = scheduler.start {
@@ -2368,28 +2368,28 @@ extension ObservableMergeTest {
             .next(410, 104),
             .next(490, 105),
             .error(550, testError)
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 550)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[2].value.element!.subscriptions, [
             Subscription(300, 550)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[3].value.element!.subscriptions, [
             Subscription(400, 550)
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[4].value.element!.subscriptions, [
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[5].value.element!.subscriptions, [
-            ])
+        ])
         
         XCTAssertEqual(xs.recordedEvents[6].value.element!.subscriptions, [
-            ])
+        ])
     }
     
     func testFlatMap_UseFunction() {
@@ -2401,7 +2401,7 @@ extension ObservableMergeTest {
             .next(250, 5),
             .next(270, 1),
             .completed(290)
-            ])
+        ])
         
         let res = scheduler.start {
             xs.flatMap { x in
@@ -2424,121 +2424,284 @@ extension ObservableMergeTest {
             .next(290, 5),
             .next(300, 5),
             .completed(300)
-            ])
+        ])
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 290)
-            ])
+        ])
     }
-
-    #if TRACE_RESOURCES
-        func testFlatMapReleasesResourcesOnComplete() {
-            _ = Observable<Int>.just(1).flatMap { _ in Observable.just(1) }.subscribe()
+    
+    func testFlatMapWithObject_Never() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1)
+        ])
+        
+        let res = scheduler.start {
+            xs.flatMap(with: testObject) { object, element in
+                Observable.just(object.value + element)
+            }
         }
-
-        func testFlatMap1ReleasesResourcesOnError() {
-            _ = Observable<Int>.error(testError).flatMap { _ in Observable.just(1) }.subscribe()
+        
+        let correctMessages: [Recorded<Event<Int>>] = []
+        let correctSubscriptions = [
+            Subscription(200, 1000)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testFlatMapWithObject_Empty() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 10)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.flatMap(with: testObject) { object, element in
+                Observable.just(object.value + element)
+            }
         }
-
-        func testFlatMap2ReleasesResourcesOnError() {
-            _ = Observable<Int>.just(1).flatMap { _ -> Observable<Int> in throw testError }.subscribe()
+        
+        let correctMessages = [
+            Recorded.completed(300, Int.self)
+        ]
+        let correctSubscriptions = [
+            Subscription(200, 300)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testFlatMapWithObject_MultipleValues() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.flatMap(with: testObject) { object, element in
+                Observable.just(object.value + element)
+            }
         }
-
-        func testFlatMap3ReleasesResourcesOnError() {
-            _ = Observable<Int>.just(1).flatMap { _ -> Observable<Int> in Observable.error(testError) }.subscribe()
+        
+        let correctMessages = Recorded.events(
+            .next(210, 5 + 1),
+            .next(220, 5 + 2),
+            .next(230, 5 + 3),
+            .completed(300)
+        )
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 300)])
+    }
+    
+    func testFlatMapWithObject_Error() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .error(220, testError)
+        ])
+        
+        let res = scheduler.start {
+            xs.flatMap(with: testObject) { object, element in
+                Observable.just(object.value + element)
+            }
         }
-    #endif
+        
+        let correctMessages = Recorded.events(
+            .next(210, 5 + 2),
+            .error(220, testError)
+        )
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 220)])
+    }
+    
+    func testFlatMapWithObject_Dispose() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 1),
+            .next(220, 2),
+            .next(230, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start(disposed: 225) {
+            xs.flatMap(with: testObject) { object, element in
+                Observable.just(object.value + element)
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 5 + 1),
+            .next(220, 5 + 2)
+        )
+        
+        let correctSubscriptions = [
+            Subscription(200, 225)
+        ]
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, correctSubscriptions)
+    }
+    
+    func testFlatMapWithObject_ThrowsInSelector() {
+        let scheduler = TestScheduler(initialClock: 0)
+        let testObject = TestObject(value: 5)
+        
+        let xs = scheduler.createHotObservable([
+            .next(150, 1),
+            .next(210, 2),
+            .next(220, 3),
+            .completed(300)
+        ])
+        
+        let res = scheduler.start {
+            xs.flatMap(with: testObject) { object, element in
+                if element > 2 {
+                    throw testError
+                }
+                return Observable.just(object.value + element)
+            }
+        }
+        
+        let correctMessages = Recorded.events(
+            .next(210, 5 + 2),
+            .error(220, testError)
+        )
+        
+        XCTAssertEqual(res.events, correctMessages)
+        XCTAssertEqual(xs.subscriptions, [Subscription(200, 220)])
+    }
+    
+#if TRACE_RESOURCES
+    func testFlatMapReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).flatMap { _ in Observable.just(1) }.subscribe()
+    }
+    
+    func testFlatMap1ReleasesResourcesOnError() {
+        _ = Observable<Int>.error(testError).flatMap { _ in Observable.just(1) }.subscribe()
+    }
+    
+    func testFlatMap2ReleasesResourcesOnError() {
+        _ = Observable<Int>.just(1).flatMap { _ -> Observable<Int> in throw testError }.subscribe()
+    }
+    
+    func testFlatMap3ReleasesResourcesOnError() {
+        _ = Observable<Int>.just(1).flatMap { _ -> Observable<Int> in Observable.error(testError) }.subscribe()
+    }
+#endif
 }
 
 // MARK: concatMap
 
 extension ObservableMergeTest {
-
+    
     func testConcatMap_InnerCompleteFasterThanOuterElementsAreProduced() {
         
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let ys1 = scheduler.createColdObservable([
             .next(10, 102),
             .completed(20)
-            ])
-
+        ])
+        
         let ys2 = scheduler.createColdObservable([
             .next(20, 202),
             .completed(25)
-            ])
-
+        ])
+        
         let xs = scheduler.createHotObservable([
             .next(250, ys1),
             .next(300, ys2),
             .completed(900)
-            ])
-
+        ])
+        
         let results = scheduler.start {
             return xs.concatMap {
                 return $0
             }
         }
-
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 900)
-            ])
-
+        ])
+        
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(250, 270)
-            ])
-
+        ])
+        
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(300, 325)
-            ])
-
+        ])
+        
         XCTAssertEqual(results.events, [
             .next(260, 102),
             .next(320, 202),
             .completed(900)
-            ])
+        ])
     }
-
+    
     func testConcatMap_Disposed() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let ys1 = scheduler.createColdObservable([
             .next(10, 102),
             .completed(20)
-            ])
-
+        ])
+        
         let ys2 = scheduler.createColdObservable([
             .next(20, 202),
             .completed(25)
-            ])
-
+        ])
+        
         let xs = scheduler.createHotObservable([
             .next(250, ys1),
             .next(300, ys2),
             .completed(900)
-            ])
-
+        ])
+        
         let results = scheduler.start(disposed: 310) {
             return xs.concatMap {
                 return $0
             }
         }
-
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 310)
-            ])
-
+        ])
+        
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(250, 270)
-            ])
-
+        ])
+        
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(300, 310)
-            ])
-
+        ])
+        
         XCTAssertEqual(results.events, [
             .next(260, 102),
-            ])
+        ])
     }
     
     func testConcatMap_OuterComplete_InnerNotComplete() {
@@ -2628,18 +2791,18 @@ extension ObservableMergeTest {
             .next(190, 105),
             .next(440, 106),
             .completed(460)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(180, 202),
             .next(190, 203),
             .completed(205)
-            ])
+        ])
         
         let xs = scheduler.createHotObservable([
             .next(300, ys1),
             .next(400, ys2),
-            ])
+        ])
         
         let results = scheduler.start {
             return xs.concatMap {
@@ -2669,10 +2832,10 @@ extension ObservableMergeTest {
             .next(950, 203),
         ])
     }
-
+    
     func testConcatMap_InnerComplete_OuterCompleteBeforeInner() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let ys1 = scheduler.createColdObservable([
             .next(10, 102),
             .next(90, 103),
@@ -2680,38 +2843,38 @@ extension ObservableMergeTest {
             .next(190, 105),
             .next(440, 106),
             .completed(460)
-            ])
-
+        ])
+        
         let ys2 = scheduler.createColdObservable([
             .next(180, 202),
             .next(190, 203),
             .completed(195)
-            ])
-
+        ])
+        
         let xs = scheduler.createHotObservable([
             .next(300, ys1),
             .next(400, ys2),
             .completed(405)
-            ])
-
+        ])
+        
         let results = scheduler.start {
             return xs.concatMap {
                 return $0
             }
         }
-
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 405)
-            ])
-
+        ])
+        
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(300, 760)
-            ])
-
+        ])
+        
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(760, 955)
-            ])
-
+        ])
+        
         XCTAssertEqual(results.events, [
             .next(310, 102),
             .next(390, 103),
@@ -2721,12 +2884,12 @@ extension ObservableMergeTest {
             .next(940, 202),
             .next(950, 203),
             .completed(955)
-            ])
+        ])
     }
-
+    
     func testConcatMap_InnerComplete_OuterCompleteAfterInner() {
         let scheduler = TestScheduler(initialClock: 0)
-
+        
         let ys1 = scheduler.createColdObservable([
             .next(10, 102),
             .next(90, 103),
@@ -2734,38 +2897,38 @@ extension ObservableMergeTest {
             .next(190, 105),
             .next(440, 106),
             .completed(460)
-            ])
-
+        ])
+        
         let ys2 = scheduler.createColdObservable([
             .next(180, 202),
             .next(190, 203),
             .completed(195)
-            ])
-
+        ])
+        
         let xs = scheduler.createHotObservable([
             .next(300, ys1),
             .next(400, ys2),
             .completed(980)
-            ])
-
+        ])
+        
         let results = scheduler.start {
             return xs.concatMap {
                 return $0
             }
         }
-
+        
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 980)
-            ])
-
+        ])
+        
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(300, 760)
-            ])
-
+        ])
+        
         XCTAssertEqual(ys2.subscriptions, [
             Subscription(760, 955)
-            ])
-
+        ])
+        
         XCTAssertEqual(results.events, [
             .next(310, 102),
             .next(390, 103),
@@ -2775,7 +2938,7 @@ extension ObservableMergeTest {
             .next(940, 202),
             .next(950, 203),
             .completed(980)
-            ])
+        ])
     }
     
     func testConcatMap_Error_Outer() {
@@ -2862,29 +3025,29 @@ extension ObservableMergeTest {
             .next(190, 105),
             .next(440, 106),
             .error(460, testError)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(180, 202),
             .next(190, 203),
             .completed(205)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 301),
             .next(50, 302),
             .completed(60)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .completed(40, Int.self)
-            ])
+        ])
         
         let ys5 = scheduler.createColdObservable([
             .next(80, 401),
             .next(90, 402),
             .completed(100)
-            ])
+        ])
         
         let xs = scheduler.createHotObservable([
             .next(300, ys1),
@@ -2893,7 +3056,7 @@ extension ObservableMergeTest {
             .next(750, ys4),
             .next(850, ys5),
             .error(900, testError)
-            ])
+        ])
         
         let results = scheduler.start {
             return xs.concatMap {
@@ -2934,29 +3097,29 @@ extension ObservableMergeTest {
             .next(190, 105),
             .next(440, 106),
             .completed(460)
-            ])
+        ])
         
         let ys2 = scheduler.createColdObservable([
             .next(180, 202),
             .next(190, 203),
             .completed(205)
-            ])
+        ])
         
         let ys3 = scheduler.createColdObservable([
             .next(10, 301),
             .next(50, 302),
             .completed(60)
-            ])
+        ])
         
         let ys4 = scheduler.createColdObservable([
             .completed(40, Int.self)
-            ])
+        ])
         
         let ys5 = scheduler.createColdObservable([
             .next(80, 401),
             .next(90, 402),
             .completed(100)
-            ])
+        ])
         
         let xs = scheduler.createHotObservable([
             .next(300, ys1),
@@ -2965,7 +3128,7 @@ extension ObservableMergeTest {
             .next(750, ys4),
             .next(850, ys5),
             .completed(900)
-            ])
+        ])
         
         var invoked = 0
         
@@ -2981,7 +3144,7 @@ extension ObservableMergeTest {
         
         XCTAssertEqual(xs.subscriptions, [
             Subscription(200, 550)
-            ])
+        ])
         
         XCTAssertEqual(ys1.subscriptions, [
             Subscription(300, 550)
@@ -3043,22 +3206,29 @@ extension ObservableMergeTest {
             .completed(340)
         ])
     }
+    
+#if TRACE_RESOURCES
+    func testConcatMapReleasesResourcesOnComplete() {
+        _ = Observable<Int>.just(1).concatMap { _ in Observable.just(1) }.subscribe()
+    }
+    
+    func testConcatMapReleasesResourcesOnError1() {
+        _ = Observable<Int>.error(testError).concatMap { _ in Observable.just(1) }.subscribe()
+    }
+    
+    func testConcatMapReleasesResourcesOnError2() {
+        _ = Observable<Int>.just(1).concatMap { _ -> Observable<Int> in throw testError }.subscribe()
+    }
+    
+    func testConcatMapReleasesResourcesOnError3() {
+        _ = Observable<Int>.just(1).concatMap { _ -> Observable<Int> in Observable.error(testError) }.subscribe()
+    }
+#endif
+}
 
-    #if TRACE_RESOURCES
-        func testConcatMapReleasesResourcesOnComplete() {
-            _ = Observable<Int>.just(1).concatMap { _ in Observable.just(1) }.subscribe()
-        }
-
-        func testConcatMapReleasesResourcesOnError1() {
-            _ = Observable<Int>.error(testError).concatMap { _ in Observable.just(1) }.subscribe()
-        }
-
-        func testConcatMapReleasesResourcesOnError2() {
-            _ = Observable<Int>.just(1).concatMap { _ -> Observable<Int> in throw testError }.subscribe()
-        }
-
-        func testConcatMapReleasesResourcesOnError3() {
-            _ = Observable<Int>.just(1).concatMap { _ -> Observable<Int> in Observable.error(testError) }.subscribe()
-        }
-    #endif
+private class TestObject: AnyObject {
+    let value: Int
+    init(value: Int) {
+        self.value = value
+    }
 }


### PR DESCRIPTION
To facilitate chaining methods of `Observable`, a method with a `with` parameter has been overloaded.

When using `withUnretained`, it requires two different approaches.
1. Keep returning owner.
```swift
Observable.just<1>
  .withUnretained(self)
  .map { (owner, value) in
        return (owner, value * 2)
  }
  .map { (owner, value) in
        return (owner, value + 1)
  }
```
2. Continue using the withUnretained method.
```swift   
Observable.just<1>
  .withUnretained(self)
  .map { (owner, value) in
         return (value * 2)
  }
  .withUnretained(self)
  .map { (owner, value) in
        return (value + 1)
  }
```
However, to eliminate such inconvenience, the method has been overloaded with a `with` parameter.
```swift
Observable.just<1>
  .map(with: self) { $1 * 2 }
  .map(with: self) { $1 + 1 }
```