### PR TITLE
Forward not under lock

### DIFF
--- a/RxSwift/Subjects/BehaviorSubject.swift
+++ b/RxSwift/Subjects/BehaviorSubject.swift
@@ -103,21 +103,21 @@ public final class BehaviorSubject<Element>
     /// - parameter observer: Observer to subscribe to the subject.
     /// - returns: Disposable object that can be used to unsubscribe the observer from the subject.
     public override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
-        self.lock.performLocked { self.synchronized_subscribe(observer) }
-    }
-
-    func synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
+        lock.lock()
         if self.isDisposed {
+            lock.unlock()
             observer.on(.error(RxError.disposed(object: self)))
             return Disposables.create()
         }
         
         if let stoppedEvent = self.stoppedEvent {
+            lock.unlock()
             observer.on(stoppedEvent)
             return Disposables.create()
         }
         
         let key = self.observers.insert(observer.on)
+        lock.unlock()
         observer.on(.next(self.element))
     
         return SubscriptionDisposable(owner: self, key: key)

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -104,6 +104,7 @@ public final class PublishSubject<Element>
         }
         
         let key = self.observers.insert(observer.on)
+        lock.unlock()
         return SubscriptionDisposable(owner: self, key: key)
     }
 

--- a/RxSwift/Subjects/PublishSubject.swift
+++ b/RxSwift/Subjects/PublishSubject.swift
@@ -90,16 +90,15 @@ public final class PublishSubject<Element>
     - returns: Disposable object that can be used to unsubscribe the observer from the subject.
     */
     public override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
-        self.lock.performLocked { self.synchronized_subscribe(observer) }
-    }
-
-    func synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
+        lock.lock()
         if let stoppedEvent = self.stoppedEvent {
+            lock.unlock()
             observer.on(stoppedEvent)
             return Disposables.create()
         }
         
         if self.isDisposed {
+            lock.unlock()
             observer.on(.error(RxError.disposed(object: self)))
             return Disposables.create()
         }

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -150,17 +150,14 @@ private class ReplayBufferBase<Element>
         
         if let stoppedEvent = self.stoppedEvent {
             lock.unlock()
-            
             self.replayBuffer(anyObserver)
             observer.on(stoppedEvent)
-            
             return Disposables.create()
-        } else {
+        }
+        else {
             let key = self.observers.insert(observer.on)
             lock.unlock()
-            
             self.replayBuffer(anyObserver)
-            
             return SubscriptionDisposable(owner: self, key: key)
         }
     }

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -236,7 +236,9 @@ private class ReplayManyBase<Element>: ReplayBufferBase<Element> {
     }
 
     override func getEventsToReplay() -> [Event<Element>] {
-        return queue.map(Event.next)
+        return queue.map { element in
+            Event.next(element)
+        }
     }
 
     override func synchronized_dispose() {


### PR DESCRIPTION
This pull request aims to fix #2653.

The original issue stems from the fact that:
- `ShareReplay1WhileConnect`, `ReplaySubject`, `BehaviorSubject` and `PublishSubject` emit their **initial events upon subscription** while holding onto their internal locks that protect their mutable state
- Their results can be forwarded to any operators
- These same operators might take decision to dispose of the upstream observables
- And these operators might do this while retaining their own locks
- And these operators might perform the handling of upstream events under the same locks

The last 3 points perfectly describe the behavior of a `zip` operator, which:
- will try to dispose of the source, while retaining its own lock
- will receive an initial event upon subscription from `ShareReplay1WhileConnect` or any `Subject`, with these sources retaining their locks
- will try to acquire its own lock to handle these events

In a multithreaded environment, these conditions can race, and this can produce a deadlock. This PR positions "emission upon subscription under lock" as the core issue and tries to fix specifically this behavior.

Special considerations:
- The current circumstances of the immediate emissions happening under lock might be both deliberate or accidental
- And with these changes, the sequentiality of these emissions will not be protected by the state lock anymore.
- Maybe I should add a separate lock to sequentialize specifically the emission of the initial elements? (as prophesied by @firecore in #2525) 
- I should say that didn't try hard enough to come up with a case in which the sequentialization of the emissions is absolutely necessary across threads.
- But I did ensure that at least the read out of the current state, and preparation of the values for the initial emission is synchronized.

Additionally:

@freak4pc I would like to say sorry for [this comment](https://github.com/ReactiveX/RxSwift/issues/2525#issuecomment-2669707983). I really wasn't planning to add anything valuable to the conversation, and my behavior was really counter productive here. This wasn't a troll comment, it was just - I was amused by the fact that RxSwift can break, I found it funny.

@danielt1263 Also I would like to say thank you for your time and the fact that you responded to me.

I would also like to say sorry to you both for [this comment](https://github.com/ReactiveX/RxSwift/issues/2653#issuecomment-2676433864) - the vagueness of my answer actually permitted an interpretation where I am not only posting nothing of value, but also deliberately try and insult you or the framework. This wasn't my intention, and I'm sorry that I came off this way.