### PR TITLE
feat: Enable Swift Concurrency for Linux

### DIFF
--- a/RxCocoa/Traits/SharedSequence/SharedSequence+Concurrency.swift
+++ b/RxCocoa/Traits/SharedSequence/SharedSequence+Concurrency.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Krunoslav Zaher. All rights reserved.
 //
 
-#if swift(>=5.6) && canImport(_Concurrency) && !os(Linux)
+#if swift(>=5.6) && canImport(_Concurrency)
 import Foundation
 
 // MARK: - Shared Sequence

--- a/RxSwift/Traits/Infallible/Infallible+Concurrency.swift
+++ b/RxSwift/Traits/Infallible/Infallible+Concurrency.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Krunoslav Zaher. All rights reserved.
 //
 
-#if swift(>=5.6) && canImport(_Concurrency) && !os(Linux)
+#if swift(>=5.6) && canImport(_Concurrency)
 // MARK: - Infallible
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension InfallibleType {

--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-#if swift(>=5.6) && canImport(_Concurrency) && !os(Linux)
+#if swift(>=5.6) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension PrimitiveSequenceType where Trait == SingleTrait {
     /**

--- a/Tests/RxCocoaTests/SharedSequence+ConcurrencyTests.swift
+++ b/Tests/RxCocoaTests/SharedSequence+ConcurrencyTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Krunoslav Zaher. All rights reserved.
 //
 
-#if swift(>=5.6) && canImport(_Concurrency) && !os(Linux)
+#if swift(>=5.6) && canImport(_Concurrency)
 import Dispatch
 import RxSwift
 import RxCocoa

--- a/Tests/RxSwiftTests/Infallible+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/Infallible+ConcurrencyTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Krunoslav Zaher. All rights reserved.
 //
 
-#if swift(>=5.6) && canImport(_Concurrency) && !os(Linux)
+#if swift(>=5.6) && canImport(_Concurrency)
 import Dispatch
 import RxSwift
 import XCTest

--- a/Tests/RxSwiftTests/Observable+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/Observable+ConcurrencyTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Krunoslav Zaher. All rights reserved.
 //
 
-#if swift(>=5.6) && canImport(_Concurrency) && !os(Linux)
+#if swift(>=5.6) && canImport(_Concurrency)
 import Dispatch
 import RxSwift
 import XCTest

--- a/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2021 Krunoslav Zaher. All rights reserved.
 //
 
-#if swift(>=5.6) && canImport(_Concurrency) && !os(Linux)
+#if swift(>=5.6) && canImport(_Concurrency)
 import Dispatch
 import RxSwift
 import XCTest


### PR DESCRIPTION
Trivially removes the `!os(Linux)` guard from various concurrency related features.