### PR TITLE
Fix typo: `MutlicastType` -> `MulticastType`

### DIFF
--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -345,11 +345,11 @@ final private class RefCount<ConnectableSource: ConnectableObservableType>: Prod
 final private class MulticastSink<Subject: SubjectType, Observer: ObserverType>: Sink<Observer>, ObserverType {
     typealias Element = Observer.Element 
     typealias ResultType = Element
-    typealias MutlicastType = Multicast<Subject, Observer.Element>
+    typealias MulticastType = Multicast<Subject, Observer.Element>
 
-    private let parent: MutlicastType
+    private let parent: MulticastType
 
-    init(parent: MutlicastType, observer: Observer, cancel: Cancelable) {
+    init(parent: MulticastType, observer: Observer, cancel: Cancelable) {
         self.parent = parent
         super.init(observer: observer, cancel: cancel)
     }


### PR DESCRIPTION
- No functional changes, only spelling correction