### PR TITLE
Issue 2684 Syntax Issue in Package 5.9 file

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -47,7 +47,7 @@ extension Target {
         .target(
             name: name,
             dependencies: dependencies,
-            resources: [.copy("PrivacyInfo.xcprivacy")],
+            resources: [.copy("PrivacyInfo.xcprivacy")]
         )
     }
 }
@@ -65,7 +65,7 @@ extension Target {
                         "RxRelay",
                         .target(name: "RxCocoaRuntime", condition: .when(platforms: [.iOS, .macOS, .tvOS, .watchOS, .visionOS])),
                     ],
-                    resources: [.copy("PrivacyInfo.xcprivacy")],
+                    resources: [.copy("PrivacyInfo.xcprivacy")]
                 ),
             ]
         }
@@ -79,7 +79,7 @@ extension Target {
                 .target(
                     name: "RxCocoaRuntime",
                     dependencies: ["RxSwift"],
-                    resources: [.copy("PrivacyInfo.xcprivacy")],
+                    resources: [.copy("PrivacyInfo.xcprivacy")]
                 ),
             ]
         }
@@ -124,5 +124,5 @@ let package = Package(
         ],
         Target.allTests(),
     ] as [[Target]]).flatMap(\.self),
-    swiftLanguageVersions: [.v5],
+    swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
**Summary of Changes**

Remove the trailing comma from:
- Line 50: After resources parameter in rxTarget
- Line 68: After resources parameter in RxCocoa target
- Line 82: After resources parameter in RxCocoaRuntime target
- Line 127: After swiftLanguageVersions parameter

👀 The issue is that Swift allows trailing commas in arrays and argument lists, but not after the last parameter in a function call when it's the final argument.