### PR TITLE
Fix flatMap key path type inference for Package@swift-5.9.swift

### DIFF
--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -110,7 +110,7 @@ let package = Package(
         ],
         Product.rxCocoaProducts(),
         Product.allTests()
-    ] as [[Product]]).flatMap(\.self),
+    ] as [[Product]]).flatMap { $0 },
     targets: ([
         [
             .rxTarget(name: "RxSwift", dependencies: [])
@@ -123,6 +123,6 @@ let package = Package(
             .target(name: "RxTest", dependencies: ["RxSwift"])
         ],
         Target.allTests()
-    ] as [[Target]]).flatMap(\.self),
+    ] as [[Target]]).flatMap { $0 },
     swiftLanguageVersions: [.v5]
 )


### PR DESCRIPTION
It seems like https://github.com/ReactiveX/RxSwift/issues/2684 not fully fixed compilation issues for Swift 5.9 (Xcode 15.4)

```
/Package@swift-5.9.swift:113:31: error: cannot convert value of type 'WritableKeyPath<_, _>' to expected argument type '([Product]) throws -> Product?'
    ] as [[Product]]).flatMap(\.self),
                              ^
/Package@swift-5.9.swift:113:31: error: cannot infer key path type from context; consider explicitly specifying a root type
    ] as [[Product]]).flatMap(\.self),
                              ^
                               <#Root#>
/Package@swift-5.9.swift:126:30: error: cannot convert value of type 'WritableKeyPath<_, _>' to expected argument type '([Target]) throws -> Target?'
    ] as [[Target]]).flatMap(\.self),
                             ^
/Package@swift-5.9.swift:126:30: error: cannot infer key path type from context; consider explicitly specifying a root type
    ] as [[Target]]).flatMap(\.self),
                             ^
                              <#Root#> in https://github.com/ReactiveX/RxSwift
```

<details>
  <summary>Full CLI call</summary>

  ```
  Invalid manifest (compiled with: [
    "/Applications/Xcode_15.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc",
    "-vfsoverlay", "<TMP_DIR>/vfs.yaml",
    "-L", "/Applications/Xcode_15.4.app/Contents/SharedFrameworks/SwiftPM.framework/SharedSupport/ManifestAPI",
    "-lPackageDescription",
    "-Xlinker", "-rpath",
    "-Xlinker", "/Applications/Xcode_15.4.app/Contents/SharedFrameworks/SwiftPM.framework/SharedSupport/ManifestAPI",
    "-target", "arm64-apple-macos13.0",
    "-sdk", "/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk",
    "-swift-version", "5",
    "-I", "/Applications/Xcode_15.4.app/Contents/SharedFrameworks/SwiftPM.framework/SharedSupport/ManifestAPI",
    "-sdk", "/Applications/Xcode_15.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk",
    "-package-description-version", "5.9.0",
    "-Xfrontend", "-serialize-diagnostics-path",
    "-Xfrontend", "<USER_CACHE>/org.swift.swiftpm/manifests/ManifestLoading/rxswift.dia",
    "/Package@swift-5.9.swift",
    "-disallow-use-new-driver",
    "-o", "<TMP_DIR>/rxswift-manifest"
  ])
  ```
</details>