### PR TITLE
Never call `dispose` and `subscribe` under lock in `Connection` and `ConnectionObservableAdapter`

### DIFF
--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -176,20 +176,24 @@ private final class Connection<Subject: SubjectType>: ObserverType, Disposable {
     }
 
     func dispose() {
-        lock.lock(); defer { lock.unlock() }
-        fetchOr(disposed, 1)
-        guard let parent else {
-            return
-        }
+        let subscriptionToDispose: Disposable? = lock.withLock {
+            fetchOr(disposed, 1)
+            guard let parent else {
+                return nil
+            }
 
-        if parent.connection === self {
-            parent.connection = nil
-            parent.subject = nil
-        }
-        self.parent = nil
+            if parent.connection === self {
+                parent.connection = nil
+                parent.subject = nil
+            }
+            self.parent = nil
 
-        subscription?.dispose()
-        subscription = nil
+            let subscriptionToDispose = subscription
+            subscription = nil
+            return subscriptionToDispose
+        }
+        
+        subscriptionToDispose?.dispose()
     }
 }
 
@@ -215,18 +219,22 @@ private final class ConnectableObservableAdapter<Subject: SubjectType>:
     }
 
     override func connect() -> Disposable {
-        lock.performLocked {
+        let (singleAssignmentDisposableToSubscribe, connectionToReturn): (SingleAssignmentDisposable?, Connection) = lock.performLocked {
             if let connection = self.connection {
-                return connection
+                return (nil, connection)
             }
 
             let singleAssignmentDisposable = SingleAssignmentDisposable()
             let connection = Connection(parent: self, subjectObserver: self.lazySubject.asObserver(), lock: self.lock, subscription: singleAssignmentDisposable)
             self.connection = connection
-            let subscription = self.source.subscribe(connection)
-            singleAssignmentDisposable.setDisposable(subscription)
-            return connection
+            return (singleAssignmentDisposable, connection)
         }
+        if let singleAssignmentDisposableToSubscribe {
+            let subscription = self.source.subscribe(connectionToReturn)
+            singleAssignmentDisposableToSubscribe.setDisposable(subscription)
+        }
+        
+        return connectionToReturn
     }
 
     private var lazySubject: Subject {


### PR DESCRIPTION
Fixes [2698](https://github.com/ReactiveX/RxSwift/issues/2698)