### PR TITLE
Fix concurrent subscriptions to share without replay

### DIFF
--- a/RxSwift/Observables/ShareReplayScope.swift
+++ b/RxSwift/Observables/ShareReplayScope.swift
@@ -408,8 +408,8 @@ private final class ShareWhileConnected<Element>:
         let connection = synchronized_subscribe(observer)
         let count = connection.observers.count
 
-        lock.unlock()
         let disposable = connection.synchronized_subscribe(observer)
+        lock.unlock()
 
         if count == 0 {
             connection.connect()

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -24,6 +24,7 @@ final class AnomaliesTest_ : AnomaliesTest, RxTestCase {
     ("test1323", AnomaliesTest.test1323),
     ("test1344", AnomaliesTest.test1344),
     ("testSeparationBetweenOnAndSubscriptionLocks", AnomaliesTest.testSeparationBetweenOnAndSubscriptionLocks),
+    ("test2718ShareWithoutReplayConnectsOnceForConcurrentFirstSubscriptions", AnomaliesTest.test2718ShareWithoutReplayConnectsOnceForConcurrentFirstSubscriptions),
     ("test2653ShareReplayOneInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayOneInitialEmissionDeadlock),
     ("test2653ShareReplayMoreInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayMoreInitialEmissionDeadlock),
     ("test2653ShareReplayOneForeverInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayOneForeverInitialEmissionDeadlock),

--- a/Tests/RxSwiftTests/Anomalies.swift
+++ b/Tests/RxSwiftTests/Anomalies.swift
@@ -176,6 +176,60 @@ extension AnomaliesTest {
         }
     }
 
+    func test2718ShareWithoutReplayConnectsOnceForConcurrentFirstSubscriptions() {
+        let subscriberCount = 32
+
+        for _ in 0 ..< 100 {
+            let subscriptionsLock = NSLock()
+            var sourceSubscriptionCount = 0
+            var subscriptions = [Disposable]()
+
+            let shared = Observable<Never>.never()
+                .do(onSubscribe: {
+                    subscriptionsLock.lock()
+                    sourceSubscriptionCount += 1
+                    subscriptionsLock.unlock()
+                })
+                .share(replay: 0, scope: .whileConnected)
+
+            let ready = DispatchGroup()
+            let finished = DispatchGroup()
+            let start = DispatchSemaphore(value: 0)
+
+            for _ in 0 ..< subscriberCount {
+                ready.enter()
+                finished.enter()
+
+                DispatchQueue.global(qos: .userInitiated).async {
+                    ready.leave()
+                    start.wait()
+
+                    let subscription = shared.subscribe()
+
+                    subscriptionsLock.lock()
+                    subscriptions.append(subscription)
+                    subscriptionsLock.unlock()
+
+                    finished.leave()
+                }
+            }
+
+            XCTAssertEqual(ready.wait(timeout: .now() + 5), .success)
+            for _ in 0 ..< subscriberCount {
+                start.signal()
+            }
+            XCTAssertEqual(finished.wait(timeout: .now() + 5), .success)
+
+            subscriptionsLock.lock()
+            let subscriptionCount = sourceSubscriptionCount
+            let subscriptionsToDispose = subscriptions
+            subscriptionsLock.unlock()
+
+            XCTAssertEqual(subscriptionCount, 1)
+            subscriptionsToDispose.forEach { $0.dispose() }
+        }
+    }
+
     func test2653ShareReplayOneInitialEmissionDeadlock() {
         let immediatelyEmittingSource = Observable<Void>.create { observer in
             observer.on(.next(()))


### PR DESCRIPTION
## Summary

- make first-subscriber detection and observer insertion atomic for `share(replay: 0, scope: .whileConnected)`
- add a gated concurrent regression test that verifies a cold source is connected exactly once
- register the regression test in the generated SwiftPM test entry point

## Root cause and impact

The optimized no-replay sharing path released its recursive lock before inserting the observer. Concurrent first subscribers could therefore both observe an empty observer bag and both call `connect()` on the same connection. The second call assigned the connection's `SingleAssignmentDisposable` again and crashed with `Fatal error: oldState.disposable != nil`.

This change inserts the observer before releasing the lock, keeping the observer count and insertion in one critical section. Connecting to the source still happens after unlocking, so source subscription and user code remain outside the lock and the previous replay deadlock is not reintroduced.

## Validation

- focused `test2718ShareWithoutReplayConnectsOnceForConcurrentFirstSubscriptions` macOS test
- complete `AnomaliesTest` and `ObservableShareReplayScopeTests` macOS suites (18 tests), including the four existing #2653 deadlock regressions
- `swift build --product RxSwift`
- `./scripts/package-spm.swift`
- `git diff --check`

Fixes #2718
