### PR TITLE
Replay ReplaySubject's buffer without holding its lock

### DIFF
--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -103,7 +103,7 @@ private class ReplayBufferBase<Element>:
         rxAbstractMethod()
     }
 
-    func replayBuffer<Observer: ObserverType>(_: Observer) where Observer.Element == Element {
+    func replayBuffer() -> ReplayBufferSnapshot<Element> {
         rxAbstractMethod()
     }
 
@@ -140,24 +140,33 @@ private class ReplayBufferBase<Element>:
     }
 
     override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
-        lock.performLocked { self.synchronized_subscribe(observer) }
-    }
+        let subscription = lock.performLocked { self.synchronized_subscribe(observer) }
 
-    func synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
-        if isDisposed {
-            observer.on(.error(RxError.disposed(object: self)))
-            return Disposables.create()
+        if let replayObserver = subscription.replayObserver {
+            replayObserver.replay(subscription.replayBuffer)
+        } else {
+            subscription.replayBuffer.replay(observer)
+
+            if let stoppedEvent = subscription.stoppedEvent {
+                observer.on(stoppedEvent)
+            }
         }
 
-        let anyObserver = observer.asObserver()
+        return subscription.disposable
+    }
 
-        replayBuffer(anyObserver)
+    func synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> (replayBuffer: ReplayBufferSnapshot<Element>, stoppedEvent: Event<Element>?, disposable: Disposable, replayObserver: ReplaySubjectSubscriptionObserver<Observer>?) where Observer.Element == Element {
+        if isDisposed {
+            return (.empty, .error(RxError.disposed(object: self)), Disposables.create(), nil)
+        }
+
+        let replayBuffer = self.replayBuffer()
         if let stoppedEvent {
-            observer.on(stoppedEvent)
-            return Disposables.create()
+            return (replayBuffer, stoppedEvent, Disposables.create(), nil)
         } else {
-            let key = observers.insert(observer.on)
-            return SubscriptionDisposable(owner: self, key: key)
+            let replayObserver = ReplaySubjectSubscriptionObserver(observer: observer)
+            let key = observers.insert(replayObserver.on)
+            return (replayBuffer, nil, SubscriptionDisposable(owner: self, key: key), replayObserver)
         }
     }
 
@@ -189,6 +198,76 @@ private class ReplayBufferBase<Element>:
     }
 }
 
+private enum ReplayBufferSnapshot<Element> {
+    case empty
+    case one(Element)
+    case many(Queue<Element>)
+
+    func replay<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
+        switch self {
+        case .empty:
+            break
+        case let .one(value):
+            observer.on(.next(value))
+        case let .many(queue):
+            for value in queue {
+                observer.on(.next(value))
+            }
+        }
+    }
+}
+
+private final class ReplaySubjectSubscriptionObserver<Observer: ObserverType>: ObserverType {
+    typealias Element = Observer.Element
+
+    private let lock = RecursiveLock()
+    private let observer: Observer
+    private var replaying = true
+    private var pendingEvents = Queue<Event<Element>>(capacity: 1)
+
+    init(observer: Observer) {
+        self.observer = observer
+    }
+
+    func on(_ event: Event<Element>) {
+        let shouldForward = lock.performLocked { () -> Bool in
+            if replaying {
+                pendingEvents.enqueue(event)
+                return false
+            }
+
+            return true
+        }
+
+        if shouldForward {
+            observer.on(event)
+        }
+    }
+
+    func replay(_ replayBuffer: ReplayBufferSnapshot<Element>) {
+        replayBuffer.replay(observer)
+
+        while let event = lock.performLocked({ () -> Event<Element>? in
+            if let event = pendingEvents.dequeue() {
+                return event
+            }
+
+            replaying = false
+            return nil
+        }) {
+            observer.on(event)
+
+            if event.isStopEvent {
+                lock.performLocked {
+                    self.replaying = false
+                    self.pendingEvents = Queue(capacity: 0)
+                }
+                return
+            }
+        }
+    }
+}
+
 private final class ReplayOne<Element>: ReplayBufferBase<Element> {
     private var value: Element?
 
@@ -202,10 +281,12 @@ private final class ReplayOne<Element>: ReplayBufferBase<Element> {
         self.value = value
     }
 
-    override func replayBuffer<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
+    override func replayBuffer() -> ReplayBufferSnapshot<Element> {
         if let value {
-            observer.on(.next(value))
+            return .one(value)
         }
+
+        return .empty
     }
 
     override func synchronized_dispose() {
@@ -225,10 +306,8 @@ private class ReplayManyBase<Element>: ReplayBufferBase<Element> {
         queue.enqueue(value)
     }
 
-    override func replayBuffer<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
-        for item in queue {
-            observer.on(.next(item))
-        }
+    override func replayBuffer() -> ReplayBufferSnapshot<Element> {
+        .many(queue)
     }
 
     override func synchronized_dispose() {

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -28,6 +28,7 @@ final class AnomaliesTest_ : AnomaliesTest, RxTestCase {
     ("test2653ShareReplayMoreInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayMoreInitialEmissionDeadlock),
     ("test2653ShareReplayOneForeverInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayOneForeverInitialEmissionDeadlock),
     ("test2653ShareReplayMoreForeverInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayMoreForeverInitialEmissionDeadlock),
+    ("test2713ReplaySubjectDoesntReplayWhileHoldingItsLock", AnomaliesTest.test2713ReplaySubjectDoesntReplayWhileHoldingItsLock),
     ] }
 }
 

--- a/Tests/RxSwiftTests/Anomalies.swift
+++ b/Tests/RxSwiftTests/Anomalies.swift
@@ -260,3 +260,57 @@ extension AnomaliesTest {
         return exp
     }
 }
+
+extension AnomaliesTest {
+    func test2713ReplaySubjectDoesntReplayWhileHoldingItsLock() {
+        for _ in 0 ..< 3 {
+            let subject = ReplaySubject<Int>.create(bufferSize: 1)
+            subject.onNext(1)
+
+            // Stands in for any lock an operator downstream of the subject might hold.
+            let foreignLock = NSRecursiveLock()
+            let foreignLockAcquired = DispatchSemaphore(value: 0)
+            let replayStarted = DispatchSemaphore(value: 0)
+            let replayAcquiredForeignLock = DispatchSemaphore(value: 0)
+            let finished = DispatchGroup()
+
+            // Holds the foreign lock, then reaches into the subject, which needs the subject's lock.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                foreignLock.lock()
+                foreignLockAcquired.signal()
+                XCTAssertEqual(replayStarted.wait(timeout: .now() + 5), .success)
+                _ = subject.subscribe()
+                foreignLock.unlock()
+                finished.leave()
+            }
+
+            // Subscribes, so the buffered value is replayed into an observer that needs the foreign lock.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                XCTAssertEqual(foreignLockAcquired.wait(timeout: .now() + 5), .success)
+
+                let subscription = subject.subscribe(onNext: { _ in
+                    replayStarted.signal()
+
+                    // Deadlocks here if the replay is performed while the subject's lock is held:
+                    // the foreign lock is owned by a thread already blocked on the subject's lock.
+                    if foreignLock.lock(before: Date().addingTimeInterval(2)) {
+                        foreignLock.unlock()
+                        replayAcquiredForeignLock.signal()
+                    }
+                })
+
+                subscription.dispose()
+                finished.leave()
+            }
+
+            XCTAssertEqual(finished.wait(timeout: .now() + 20), .success)
+            XCTAssertEqual(
+                replayAcquiredForeignLock.wait(timeout: .now() + 5),
+                .success,
+                "`ReplaySubject` replayed its buffer while holding its own lock, deadlocking against an unrelated lock held downstream"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Lands @isaac-weisberg's fix from #2714 (commit authorship preserved) together with a regression test.

Opened here rather than on #2714 because that PR comes from an organization-owned fork, where GitHub does not offer *Allow edits from maintainers*, and its CI run is too old for GitHub to re-run — so there was no way to add the test or get a fresh CI matrix on the original PR. Full credit to @isaac-weisberg for the diagnosis and the fix.

Fixes #2713.

### The bug

`ReplayBufferBase.synchronized_subscribe` replays the buffer to a new observer **while holding the subject's lock**. Any lock a downstream observer takes during that replay is therefore acquired underneath the subject's lock, so a thread that holds that other lock and then reaches into the subject deadlocks against it.

### The fix

The buffer is snapshotted under the lock and replayed outside it. A per-subscription wrapper observer queues events that arrive during the replay and drains them afterwards, so ordering is preserved and no event can slip between registration and replay.

### The test

`test2713ReplaySubjectDoesntReplayWhileHoldingItsLock` reproduces the inversion directly: one thread holds an unrelated lock and then subscribes to the subject, while another subscribes and has the replayed value delivered into an observer that needs that same lock.

It uses `lock(before:)` so a regression fails the assertion instead of hanging the suite.

| | result |
|---|---|
| on `main`, without the fix | **fails** after ~22s of lock timeouts |
| with the fix | **passes** in 0.002s |

Verified locally on the full `AllTests-macOS` suite (green ×2).
