### PR TITLE
Never dispose or subscribe under Connection's lock

### DIFF
--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -176,7 +176,7 @@ private final class Connection<Subject: SubjectType>: ObserverType, Disposable {
     }
 
     func dispose() {
-        let subscriptionToDispose: Disposable? = lock.withLock {
+        let subscriptionToDispose: Disposable? = lock.performLocked {
             fetchOr(disposed, 1)
             guard let parent else {
                 return nil
@@ -192,7 +192,7 @@ private final class Connection<Subject: SubjectType>: ObserverType, Disposable {
             subscription = nil
             return subscriptionToDispose
         }
-        
+
         subscriptionToDispose?.dispose()
     }
 }
@@ -233,7 +233,7 @@ private final class ConnectableObservableAdapter<Subject: SubjectType>:
             let subscription = self.source.subscribe(connectionToReturn)
             singleAssignmentDisposableToSubscribe.setDisposable(subscription)
         }
-        
+
         return connectionToReturn
     }
 

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -176,20 +176,24 @@ private final class Connection<Subject: SubjectType>: ObserverType, Disposable {
     }
 
     func dispose() {
-        lock.lock(); defer { lock.unlock() }
-        fetchOr(disposed, 1)
-        guard let parent else {
-            return
-        }
+        let subscriptionToDispose: Disposable? = lock.withLock {
+            fetchOr(disposed, 1)
+            guard let parent else {
+                return nil
+            }
 
-        if parent.connection === self {
-            parent.connection = nil
-            parent.subject = nil
-        }
-        self.parent = nil
+            if parent.connection === self {
+                parent.connection = nil
+                parent.subject = nil
+            }
+            self.parent = nil
 
-        subscription?.dispose()
-        subscription = nil
+            let subscriptionToDispose = subscription
+            subscription = nil
+            return subscriptionToDispose
+        }
+        
+        subscriptionToDispose?.dispose()
     }
 }
 
@@ -215,18 +219,22 @@ private final class ConnectableObservableAdapter<Subject: SubjectType>:
     }
 
     override func connect() -> Disposable {
-        lock.performLocked {
+        let (singleAssignmentDisposableToSubscribe, connectionToReturn): (SingleAssignmentDisposable?, Connection) = lock.performLocked {
             if let connection = self.connection {
-                return connection
+                return (nil, connection)
             }
 
             let singleAssignmentDisposable = SingleAssignmentDisposable()
             let connection = Connection(parent: self, subjectObserver: self.lazySubject.asObserver(), lock: self.lock, subscription: singleAssignmentDisposable)
             self.connection = connection
-            let subscription = self.source.subscribe(connection)
-            singleAssignmentDisposable.setDisposable(subscription)
-            return connection
+            return (singleAssignmentDisposable, connection)
         }
+        if let singleAssignmentDisposableToSubscribe {
+            let subscription = self.source.subscribe(connectionToReturn)
+            singleAssignmentDisposableToSubscribe.setDisposable(subscription)
+        }
+        
+        return connectionToReturn
     }
 
     private var lazySubject: Subject {

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -28,6 +28,7 @@ final class AnomaliesTest_ : AnomaliesTest, RxTestCase {
     ("test2653ShareReplayMoreInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayMoreInitialEmissionDeadlock),
     ("test2653ShareReplayOneForeverInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayOneForeverInitialEmissionDeadlock),
     ("test2653ShareReplayMoreForeverInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayMoreForeverInitialEmissionDeadlock),
+    ("test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock", AnomaliesTest.test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock),
     ] }
 }
 

--- a/Tests/RxSwiftTests/Anomalies.swift
+++ b/Tests/RxSwiftTests/Anomalies.swift
@@ -260,3 +260,61 @@ extension AnomaliesTest {
         return exp
     }
 }
+
+extension AnomaliesTest {
+    func test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock() {
+        for _ in 0 ..< 3 {
+            // Stands in for any lock the upstream chain might take while being torn down.
+            let foreignLock = NSRecursiveLock()
+            let foreignLockAcquired = DispatchSemaphore(value: 0)
+            let teardownStarted = DispatchSemaphore(value: 0)
+            let teardownAcquiredForeignLock = DispatchSemaphore(value: 0)
+            let finished = DispatchGroup()
+
+            let source = Observable<Int>.create { _ in
+                Disposables.create {
+                    teardownStarted.signal()
+
+                    // Deadlocks here if `Connection.dispose` tears the subscription down while
+                    // still holding the lock the other thread needs to reach the subject.
+                    if foreignLock.lock(before: Date().addingTimeInterval(2)) {
+                        foreignLock.unlock()
+                        teardownAcquiredForeignLock.signal()
+                    }
+                }
+            }
+
+            let connectable = source.multicast(PublishSubject<Int>())
+            let connection = connectable.connect()
+
+            // Holds the foreign lock, then subscribes to the connectable. That only needs the
+            // adapter's lock to reach its subject -- it never re-subscribes upstream, so the
+            // teardown above runs exactly once, on the other thread.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                foreignLock.lock()
+                foreignLockAcquired.signal()
+                XCTAssertEqual(teardownStarted.wait(timeout: .now() + 5), .success)
+                let subscription = connectable.subscribe()
+                foreignLock.unlock()
+                subscription.dispose()
+                finished.leave()
+            }
+
+            // Disposes the connection, which tears down the upstream subscription.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                XCTAssertEqual(foreignLockAcquired.wait(timeout: .now() + 5), .success)
+                connection.dispose()
+                finished.leave()
+            }
+
+            XCTAssertEqual(finished.wait(timeout: .now() + 20), .success)
+            XCTAssertEqual(
+                teardownAcquiredForeignLock.wait(timeout: .now() + 5),
+                .success,
+                "`Connection` disposed its source subscription while holding its own lock, deadlocking against a subscribe on another thread"
+            )
+        }
+    }
+}


### PR DESCRIPTION
Lands @isaac-weisberg's fix from #2707 (commit authorship preserved) together with a regression test and two small cleanups.

Opened here rather than on #2707 because that PR comes from an organization-owned fork, where GitHub does not offer *Allow edits from maintainers*, and its CI run is too old to re-run. Full credit to @isaac-weisberg for the diagnosis and the fix.

Fixes #2698.

### The bug

`Connection.dispose()` disposes its source subscription while holding the adapter's lock, and `ConnectableObservableAdapter.connect()` subscribes to the source while holding that same lock. Any lock the upstream chain takes during teardown is therefore acquired underneath the adapter's lock, so a thread holding that other lock and reaching into the connectable deadlocks against it.

### The fix

Both callouts move outside the critical section. The subscription is handed out of the locked region and disposed after unlocking; `connect()` subscribes after releasing the lock and assigns into the `SingleAssignmentDisposable`, which already handles being disposed before assignment.

### The test

`test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock` reproduces the inversion: one thread holds an unrelated lock and then subscribes to the connectable, while another disposes the connection so its upstream teardown needs that same lock.

The second thread subscribes rather than connecting, so it needs the adapter's lock without re-subscribing upstream — that keeps the teardown running exactly once, on the other thread. `lock(before:)` makes a regression fail the assertion instead of hanging the suite.

| | result |
|---|---|
| on `main`, without the fix | **fails** after ~22s of lock timeouts |
| with the fix | **passes** in 0.002s |

### Cleanups

- `lock.withLock` → `performLocked`, matching every other lock site in the codebase.
- Stripped the trailing whitespace the original commit introduced.

Verified locally: `AnomaliesTest` + `ObservableMulticastTest` green, and the full `AllTests-macOS` suite green ×2 on the underlying fix.
