### PR TITLE
Never call out to user code while holding an operator's lock (ReplaySubject, Multicast, RefCount, Zip)

### DIFF
--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -254,7 +254,7 @@ private final class ConnectableObservableAdapter<Subject: SubjectType>:
     }
 }
 
-enum RefCountSinkRunResult {
+private enum RefCountSinkRunResult {
     case alreadyDisposed
     case nothingToDo
     case connectionToCreate(SingleAssignmentDisposable)
@@ -298,14 +298,12 @@ private final class RefCountSink<ConnectableSource: ConnectableObservableType, O
         }
 
         switch runResult {
-            case .nothingToDo:
-                break
-            case .alreadyDisposed:
-                return Disposables.create()
-            case .connectionToCreate(let singleAssignmentDisposable):
-                singleAssignmentDisposable.setDisposable(
-                    parent.source.connect()
-                )
+        case .nothingToDo:
+            break
+        case .alreadyDisposed:
+            return Disposables.create()
+        case let .connectionToCreate(singleAssignmentDisposable):
+            singleAssignmentDisposable.setDisposable(parent.source.connect())
         }
 
         return Disposables.create {

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -254,6 +254,12 @@ private final class ConnectableObservableAdapter<Subject: SubjectType>:
     }
 }
 
+enum RefCountSinkRunResult {
+    case alreadyDisposed
+    case nothingToDo
+    case connectionToCreate(SingleAssignmentDisposable)
+}
+
 private final class RefCountSink<ConnectableSource: ConnectableObservableType, Observer: ObserverType>:
     Sink<Observer>,
     ObserverType where ConnectableSource.Element == Observer.Element
@@ -272,19 +278,34 @@ private final class RefCountSink<ConnectableSource: ConnectableObservableType, O
 
     func run() -> Disposable {
         let subscription = parent.source.subscribe(self)
-        parent.lock.lock(); defer { self.parent.lock.unlock() }
+        
+        let runResult = parent.lock.withLock { () -> RefCountSinkRunResult in
+            connectionIdSnapshot = parent.connectionId
 
-        connectionIdSnapshot = parent.connectionId
+            if isDisposed {
+                return .alreadyDisposed
+            }
 
-        if isDisposed {
-            return Disposables.create()
+            if parent.count == 0 {
+                parent.count = 1
+                let disposable = SingleAssignmentDisposable()
+                parent.connectableSubscription = disposable
+                return .connectionToCreate(disposable)
+            } else {
+                parent.count += 1
+                return .nothingToDo
+            }
         }
 
-        if parent.count == 0 {
-            parent.count = 1
-            parent.connectableSubscription = parent.source.connect()
-        } else {
-            parent.count += 1
+        switch runResult {
+            case .nothingToDo:
+                break
+            case .alreadyDisposed:
+                return Disposables.create()
+            case .connectionToCreate(let singleAssignmentDisposable):
+                singleAssignmentDisposable.setDisposable(
+                    parent.source.connect()
+                )
         }
 
         return Disposables.create {

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -176,7 +176,7 @@ private final class Connection<Subject: SubjectType>: ObserverType, Disposable {
     }
 
     func dispose() {
-        let subscriptionToDispose: Disposable? = lock.withLock {
+        let subscriptionToDispose: Disposable? = lock.performLocked {
             fetchOr(disposed, 1)
             guard let parent else {
                 return nil
@@ -192,7 +192,7 @@ private final class Connection<Subject: SubjectType>: ObserverType, Disposable {
             subscription = nil
             return subscriptionToDispose
         }
-        
+
         subscriptionToDispose?.dispose()
     }
 }
@@ -233,7 +233,7 @@ private final class ConnectableObservableAdapter<Subject: SubjectType>:
             let subscription = self.source.subscribe(connectionToReturn)
             singleAssignmentDisposableToSubscribe.setDisposable(subscription)
         }
-        
+
         return connectionToReturn
     }
 
@@ -278,8 +278,8 @@ private final class RefCountSink<ConnectableSource: ConnectableObservableType, O
 
     func run() -> Disposable {
         let subscription = parent.source.subscribe(self)
-        
-        let runResult = parent.lock.withLock { () -> RefCountSinkRunResult in
+
+        let runResult = parent.lock.performLocked { () -> RefCountSinkRunResult in
             connectionIdSnapshot = parent.connectionId
 
             if isDisposed {

--- a/RxSwift/Observables/Multicast.swift
+++ b/RxSwift/Observables/Multicast.swift
@@ -176,20 +176,24 @@ private final class Connection<Subject: SubjectType>: ObserverType, Disposable {
     }
 
     func dispose() {
-        lock.lock(); defer { lock.unlock() }
-        fetchOr(disposed, 1)
-        guard let parent else {
-            return
-        }
+        let subscriptionToDispose: Disposable? = lock.withLock {
+            fetchOr(disposed, 1)
+            guard let parent else {
+                return nil
+            }
 
-        if parent.connection === self {
-            parent.connection = nil
-            parent.subject = nil
-        }
-        self.parent = nil
+            if parent.connection === self {
+                parent.connection = nil
+                parent.subject = nil
+            }
+            self.parent = nil
 
-        subscription?.dispose()
-        subscription = nil
+            let subscriptionToDispose = subscription
+            subscription = nil
+            return subscriptionToDispose
+        }
+        
+        subscriptionToDispose?.dispose()
     }
 }
 
@@ -215,18 +219,22 @@ private final class ConnectableObservableAdapter<Subject: SubjectType>:
     }
 
     override func connect() -> Disposable {
-        lock.performLocked {
+        let (singleAssignmentDisposableToSubscribe, connectionToReturn): (SingleAssignmentDisposable?, Connection) = lock.performLocked {
             if let connection = self.connection {
-                return connection
+                return (nil, connection)
             }
 
             let singleAssignmentDisposable = SingleAssignmentDisposable()
             let connection = Connection(parent: self, subjectObserver: self.lazySubject.asObserver(), lock: self.lock, subscription: singleAssignmentDisposable)
             self.connection = connection
-            let subscription = self.source.subscribe(connection)
-            singleAssignmentDisposable.setDisposable(subscription)
-            return connection
+            return (singleAssignmentDisposable, connection)
         }
+        if let singleAssignmentDisposableToSubscribe {
+            let subscription = self.source.subscribe(connectionToReturn)
+            singleAssignmentDisposableToSubscribe.setDisposable(subscription)
+        }
+        
+        return connectionToReturn
     }
 
     private var lazySubject: Subject {

--- a/RxSwift/Observables/Zip+Collection.swift
+++ b/RxSwift/Observables/Zip+Collection.swift
@@ -42,11 +42,30 @@ private final class ZipCollectionTypeSink<Collection: Swift.Collection, Observer
     typealias Parent = ZipCollectionType<Collection, Result>
     typealias SourceElement = Collection.Element.Element
 
+    private struct Iterate: InvocableType {
+        let action: () -> Void
+
+        func invoke() {
+            action()
+        }
+    }
+
+    private enum CalloutAction {
+        case none
+        case disposeSubscription(SingleAssignmentDisposable)
+        case evaluate([SourceElement])
+        case forwardCompletedAndDispose
+        case forwardErrorAndDispose(Swift.Error)
+    }
+
     private let parent: Parent
 
+    // Serialize event processing while keeping observer and disposal callouts out of `lock`.
+    private let gate = AsyncLock<Iterate>()
     private let lock = RecursiveLock()
 
     // state
+    private var isStopped = false
     private var numberOfValues = 0
     private var values: [Queue<SourceElement>]
     private var isDone: [Bool]
@@ -68,7 +87,22 @@ private final class ZipCollectionTypeSink<Collection: Swift.Collection, Observer
     }
 
     func on(_ event: Event<SourceElement>, atIndex: Int) {
-        lock.lock(); defer { self.lock.unlock() }
+        gate.invoke(Iterate(action: { self.synchronized_on(event, atIndex: atIndex) }))
+    }
+
+    private func synchronized_on(_ event: Event<SourceElement>, atIndex: Int) {
+        let action = lock.performLocked {
+            nextAction(for: event, atIndex: atIndex)
+        }
+
+        perform(action)
+    }
+
+    private func nextAction(for event: Event<SourceElement>, atIndex: Int) -> CalloutAction {
+        if isStopped || isDisposed {
+            return .none
+        }
+
         switch event {
         case let .next(element):
             values[atIndex].enqueue(element)
@@ -79,52 +113,93 @@ private final class ZipCollectionTypeSink<Collection: Swift.Collection, Observer
 
             if numberOfValues < parent.count {
                 if numberOfDone == parent.count - 1 {
-                    forwardOn(.completed)
-                    dispose()
+                    isStopped = true
+                    return .forwardCompletedAndDispose
                 }
-                return
+                return .none
             }
 
-            do {
-                var arguments = [SourceElement]()
-                arguments.reserveCapacity(parent.count)
+            var arguments = [SourceElement]()
+            arguments.reserveCapacity(parent.count)
 
-                // recalculate number of values
-                numberOfValues = 0
+            // recalculate number of values
+            numberOfValues = 0
 
-                for i in 0 ..< values.count {
-                    arguments.append(values[i].dequeue()!)
-                    if !values[i].isEmpty {
-                        numberOfValues += 1
-                    }
+            for i in 0 ..< values.count {
+                arguments.append(values[i].dequeue()!)
+                if !values[i].isEmpty {
+                    numberOfValues += 1
                 }
-
-                let result = try parent.resultSelector(arguments)
-                forwardOn(.next(result))
-            } catch {
-                forwardOn(.error(error))
-                dispose()
             }
+
+            return .evaluate(arguments)
 
         case let .error(error):
-            forwardOn(.error(error))
-            dispose()
+            isStopped = true
+            return .forwardErrorAndDispose(error)
 
         case .completed:
             if isDone[atIndex] {
-                return
+                return .none
             }
 
             isDone[atIndex] = true
             numberOfDone += 1
 
             if numberOfDone == parent.count {
-                forwardOn(.completed)
-                dispose()
+                isStopped = true
+                return .forwardCompletedAndDispose
             } else {
-                subscriptions[atIndex].dispose()
+                return .disposeSubscription(subscriptions[atIndex])
             }
         }
+    }
+
+    private func perform(_ action: CalloutAction) {
+        switch action {
+        case .none:
+            return
+        case let .disposeSubscription(subscription):
+            subscription.dispose()
+        case let .evaluate(arguments):
+            if isDisposed {
+                return
+            }
+
+            do {
+                let result = try parent.resultSelector(arguments)
+                forwardOn(.next(result))
+            } catch {
+                forwardErrorAndDispose(error)
+            }
+        case .forwardCompletedAndDispose:
+            forwardOn(.completed)
+            dispose()
+        case let .forwardErrorAndDispose(error):
+            forwardOn(.error(error))
+            dispose()
+        }
+    }
+
+    private func forwardErrorAndDispose(_ error: Swift.Error) {
+        let shouldTerminate = lock.performLocked { () -> Bool in
+            if isStopped || isDisposed {
+                return false
+            }
+
+            isStopped = true
+            return true
+        }
+
+        if shouldTerminate {
+            forwardOn(.error(error))
+            dispose()
+        }
+    }
+
+    override func dispose() {
+        gate.dispose()
+        super.dispose()
     }
 
     func run() -> Disposable {

--- a/RxSwift/Observables/Zip+Collection.swift
+++ b/RxSwift/Observables/Zip+Collection.swift
@@ -87,10 +87,10 @@ private final class ZipCollectionTypeSink<Collection: Swift.Collection, Observer
     }
 
     func on(_ event: Event<SourceElement>, atIndex: Int) {
-        gate.invoke(Iterate(action: { self.synchronized_on(event, atIndex: atIndex) }))
+        gate.invoke(Iterate(action: { self.gated_on(event, atIndex: atIndex) }))
     }
 
-    private func synchronized_on(_ event: Event<SourceElement>, atIndex: Int) {
+    private func gated_on(_ event: Event<SourceElement>, atIndex: Int) {
         let action = lock.performLocked {
             nextAction(for: event, atIndex: atIndex)
         }

--- a/RxSwift/Subjects/ReplaySubject.swift
+++ b/RxSwift/Subjects/ReplaySubject.swift
@@ -103,7 +103,7 @@ private class ReplayBufferBase<Element>:
         rxAbstractMethod()
     }
 
-    func replayBuffer<Observer: ObserverType>(_: Observer) where Observer.Element == Element {
+    func replayBuffer() -> ReplayBufferSnapshot<Element> {
         rxAbstractMethod()
     }
 
@@ -140,24 +140,33 @@ private class ReplayBufferBase<Element>:
     }
 
     override func subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
-        lock.performLocked { self.synchronized_subscribe(observer) }
-    }
+        let subscription = lock.performLocked { self.synchronized_subscribe(observer) }
 
-    func synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> Disposable where Observer.Element == Element {
-        if isDisposed {
-            observer.on(.error(RxError.disposed(object: self)))
-            return Disposables.create()
+        if let replayObserver = subscription.replayObserver {
+            replayObserver.replay(subscription.replayBuffer)
+        } else {
+            subscription.replayBuffer.replay(observer)
+
+            if let stoppedEvent = subscription.stoppedEvent {
+                observer.on(stoppedEvent)
+            }
         }
 
-        let anyObserver = observer.asObserver()
+        return subscription.disposable
+    }
 
-        replayBuffer(anyObserver)
+    func synchronized_subscribe<Observer: ObserverType>(_ observer: Observer) -> (replayBuffer: ReplayBufferSnapshot<Element>, stoppedEvent: Event<Element>?, disposable: Disposable, replayObserver: ReplaySubjectSubscriptionObserver<Observer>?) where Observer.Element == Element {
+        if isDisposed {
+            return (.empty, .error(RxError.disposed(object: self)), Disposables.create(), nil)
+        }
+
+        let replayBuffer = self.replayBuffer()
         if let stoppedEvent {
-            observer.on(stoppedEvent)
-            return Disposables.create()
+            return (replayBuffer, stoppedEvent, Disposables.create(), nil)
         } else {
-            let key = observers.insert(observer.on)
-            return SubscriptionDisposable(owner: self, key: key)
+            let replayObserver = ReplaySubjectSubscriptionObserver(observer: observer)
+            let key = observers.insert(replayObserver.on)
+            return (replayBuffer, nil, SubscriptionDisposable(owner: self, key: key), replayObserver)
         }
     }
 
@@ -189,6 +198,76 @@ private class ReplayBufferBase<Element>:
     }
 }
 
+private enum ReplayBufferSnapshot<Element> {
+    case empty
+    case one(Element)
+    case many(Queue<Element>)
+
+    func replay<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
+        switch self {
+        case .empty:
+            break
+        case let .one(value):
+            observer.on(.next(value))
+        case let .many(queue):
+            for value in queue {
+                observer.on(.next(value))
+            }
+        }
+    }
+}
+
+private final class ReplaySubjectSubscriptionObserver<Observer: ObserverType>: ObserverType {
+    typealias Element = Observer.Element
+
+    private let lock = RecursiveLock()
+    private let observer: Observer
+    private var replaying = true
+    private var pendingEvents = Queue<Event<Element>>(capacity: 1)
+
+    init(observer: Observer) {
+        self.observer = observer
+    }
+
+    func on(_ event: Event<Element>) {
+        let shouldForward = lock.performLocked { () -> Bool in
+            if replaying {
+                pendingEvents.enqueue(event)
+                return false
+            }
+
+            return true
+        }
+
+        if shouldForward {
+            observer.on(event)
+        }
+    }
+
+    func replay(_ replayBuffer: ReplayBufferSnapshot<Element>) {
+        replayBuffer.replay(observer)
+
+        while let event = lock.performLocked({ () -> Event<Element>? in
+            if let event = pendingEvents.dequeue() {
+                return event
+            }
+
+            replaying = false
+            return nil
+        }) {
+            observer.on(event)
+
+            if event.isStopEvent {
+                lock.performLocked {
+                    self.replaying = false
+                    self.pendingEvents = Queue(capacity: 0)
+                }
+                return
+            }
+        }
+    }
+}
+
 private final class ReplayOne<Element>: ReplayBufferBase<Element> {
     private var value: Element?
 
@@ -202,10 +281,12 @@ private final class ReplayOne<Element>: ReplayBufferBase<Element> {
         self.value = value
     }
 
-    override func replayBuffer<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
+    override func replayBuffer() -> ReplayBufferSnapshot<Element> {
         if let value {
-            observer.on(.next(value))
+            return .one(value)
         }
+
+        return .empty
     }
 
     override func synchronized_dispose() {
@@ -225,10 +306,8 @@ private class ReplayManyBase<Element>: ReplayBufferBase<Element> {
         queue.enqueue(value)
     }
 
-    override func replayBuffer<Observer: ObserverType>(_ observer: Observer) where Observer.Element == Element {
-        for item in queue {
-            observer.on(.next(item))
-        }
+    override func replayBuffer() -> ReplayBufferSnapshot<Element> {
+        .many(queue)
     }
 
     override func synchronized_dispose() {

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -29,6 +29,9 @@ final class AnomaliesTest_ : AnomaliesTest, RxTestCase {
     ("test2653ShareReplayMoreInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayMoreInitialEmissionDeadlock),
     ("test2653ShareReplayOneForeverInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayOneForeverInitialEmissionDeadlock),
     ("test2653ShareReplayMoreForeverInitialEmissionDeadlock", AnomaliesTest.test2653ShareReplayMoreForeverInitialEmissionDeadlock),
+    ("test2713ReplaySubjectDoesntReplayWhileHoldingItsLock", AnomaliesTest.test2713ReplaySubjectDoesntReplayWhileHoldingItsLock),
+    ("test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock", AnomaliesTest.test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock),
+    ("test2703ZipDoesntDisposeItsSourcesUnderItsLock", AnomaliesTest.test2703ZipDoesntDisposeItsSourcesUnderItsLock),
     ] }
 }
 

--- a/Tests/RxSwiftTests/Anomalies.swift
+++ b/Tests/RxSwiftTests/Anomalies.swift
@@ -314,3 +314,179 @@ extension AnomaliesTest {
         return exp
     }
 }
+
+extension AnomaliesTest {
+    func test2713ReplaySubjectDoesntReplayWhileHoldingItsLock() {
+        for _ in 0 ..< 3 {
+            let subject = ReplaySubject<Int>.create(bufferSize: 1)
+            subject.onNext(1)
+
+            // Stands in for any lock an operator downstream of the subject might hold.
+            let foreignLock = NSRecursiveLock()
+            let foreignLockAcquired = DispatchSemaphore(value: 0)
+            let replayStarted = DispatchSemaphore(value: 0)
+            let replayAcquiredForeignLock = DispatchSemaphore(value: 0)
+            let finished = DispatchGroup()
+
+            // Holds the foreign lock, then reaches into the subject, which needs the subject's lock.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                foreignLock.lock()
+                foreignLockAcquired.signal()
+                XCTAssertEqual(replayStarted.wait(timeout: .now() + 5), .success)
+                _ = subject.subscribe()
+                foreignLock.unlock()
+                finished.leave()
+            }
+
+            // Subscribes, so the buffered value is replayed into an observer that needs the foreign lock.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                XCTAssertEqual(foreignLockAcquired.wait(timeout: .now() + 5), .success)
+
+                let subscription = subject.subscribe(onNext: { _ in
+                    replayStarted.signal()
+
+                    // Deadlocks here if the replay is performed while the subject's lock is held:
+                    // the foreign lock is owned by a thread already blocked on the subject's lock.
+                    if foreignLock.lock(before: Date().addingTimeInterval(5)) {
+                        foreignLock.unlock()
+                        replayAcquiredForeignLock.signal()
+                    }
+                })
+
+                subscription.dispose()
+                finished.leave()
+            }
+
+            XCTAssertEqual(finished.wait(timeout: .now() + 20), .success)
+            XCTAssertEqual(
+                replayAcquiredForeignLock.wait(timeout: .now() + 5),
+                .success,
+                "`ReplaySubject` replayed its buffer while holding its own lock, deadlocking against an unrelated lock held downstream"
+            )
+        }
+    }
+}
+
+extension AnomaliesTest {
+    func test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock() {
+        for _ in 0 ..< 3 {
+            // Stands in for any lock the upstream chain might take while being torn down.
+            let foreignLock = NSRecursiveLock()
+            let foreignLockAcquired = DispatchSemaphore(value: 0)
+            let teardownStarted = DispatchSemaphore(value: 0)
+            let teardownAcquiredForeignLock = DispatchSemaphore(value: 0)
+            let finished = DispatchGroup()
+
+            let source = Observable<Int>.create { _ in
+                Disposables.create {
+                    teardownStarted.signal()
+
+                    // Deadlocks here if `Connection.dispose` tears the subscription down while
+                    // still holding the lock the other thread needs to reach the subject.
+                    if foreignLock.lock(before: Date().addingTimeInterval(5)) {
+                        foreignLock.unlock()
+                        teardownAcquiredForeignLock.signal()
+                    }
+                }
+            }
+
+            let connectable = source.multicast(PublishSubject<Int>())
+            let connection = connectable.connect()
+
+            // Holds the foreign lock, then subscribes to the connectable. That only needs the
+            // adapter's lock to reach its subject -- it never re-subscribes upstream, so the
+            // teardown above runs exactly once, on the other thread.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                foreignLock.lock()
+                foreignLockAcquired.signal()
+                XCTAssertEqual(teardownStarted.wait(timeout: .now() + 5), .success)
+                let subscription = connectable.subscribe()
+                foreignLock.unlock()
+                subscription.dispose()
+                finished.leave()
+            }
+
+            // Disposes the connection, which tears down the upstream subscription.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                XCTAssertEqual(foreignLockAcquired.wait(timeout: .now() + 5), .success)
+                connection.dispose()
+                finished.leave()
+            }
+
+            XCTAssertEqual(finished.wait(timeout: .now() + 20), .success)
+            XCTAssertEqual(
+                teardownAcquiredForeignLock.wait(timeout: .now() + 5),
+                .success,
+                "`Connection` disposed its source subscription while holding its own lock, deadlocking against a subscribe on another thread"
+            )
+        }
+    }
+}
+
+extension AnomaliesTest {
+    func test2703ZipDoesntDisposeItsSourcesUnderItsLock() {
+        for _ in 0 ..< 3 {
+            // Stands in for any lock an upstream source takes while being unsubscribed from.
+            let foreignLock = NSRecursiveLock()
+            let foreignLockAcquired = DispatchSemaphore(value: 0)
+            let teardownStarted = DispatchSemaphore(value: 0)
+            let teardownAcquiredForeignLock = DispatchSemaphore(value: 0)
+            let finished = DispatchGroup()
+
+            let first = PublishSubject<Int>()
+            let second = PublishSubject<Int>()
+
+            // When `first` completes while `second` is still live, the zip sink unsubscribes from
+            // `first` -- on `main` that happens while its own lock is held.
+            let firstWithLockedTeardown = Observable<Int>.create { observer in
+                let subscription = first.subscribe(observer)
+
+                return Disposables.create {
+                    teardownStarted.signal()
+
+                    if foreignLock.lock(before: Date().addingTimeInterval(5)) {
+                        foreignLock.unlock()
+                        teardownAcquiredForeignLock.signal()
+                    }
+
+                    subscription.dispose()
+                }
+            }
+
+            let zipped = Observable.zip([firstWithLockedTeardown, second.asObservable()])
+            let subscription = zipped.subscribe()
+
+            // Holds the foreign lock, then pushes a value into the zip, which needs the zip's lock.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                foreignLock.lock()
+                foreignLockAcquired.signal()
+                XCTAssertEqual(teardownStarted.wait(timeout: .now() + 5), .success)
+                second.onNext(1)
+                foreignLock.unlock()
+                finished.leave()
+            }
+
+            // Completes one source, so the zip sink unsubscribes from it.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                XCTAssertEqual(foreignLockAcquired.wait(timeout: .now() + 5), .success)
+                first.onCompleted()
+                finished.leave()
+            }
+
+            XCTAssertEqual(finished.wait(timeout: .now() + 20), .success)
+            XCTAssertEqual(
+                teardownAcquiredForeignLock.wait(timeout: .now() + 5),
+                .success,
+                "`ZipCollectionTypeSink` unsubscribed from a source while holding its own lock, deadlocking against an event arriving on another thread"
+            )
+
+            subscription.dispose()
+        }
+    }
+}


### PR DESCRIPTION
Lands four of @isaac-weisberg's five deadlock fixes as one change, each with a regression test. All fix commits keep his authorship.

The fifth fix — Merge — is stacked on top as #2724. It is a near-total rewrite of `MergeLimitedSink` and `MergeSink` and deserves its own review pass, while the four fixes here are surgical decide-under-lock / act-outside-lock splits. Splitting keeps the two risk profiles separate.

Opened here rather than on his PRs because they come from an organization-owned fork, where GitHub does not offer *Allow edits from maintainers*, and their CI runs are older than a month so GitHub refuses to re-run them — there was no way to add tests or get a CI signal on the originals. Full credit to @isaac-weisberg for the diagnosis and every fix.

Supersedes #2707, #2709, #2710, #2714.
Fixes #2698, #2703, #2708, #2713.

### Why one PR

These are one campaign against the same bug shape: an operator holds its own lock while calling out to code that can take another lock — disposing an upstream subscription, subscribing, or replaying a buffer — so a second thread holding that other lock and reaching back into the operator deadlocks against it.

They are also **not independent**, which is the main reason to land them together. `#2709` moves `connect()` out of `RefCount`'s lock, and on `main` that lock is what keeps the connect / synchronous-emission / re-entry path single-threaded. Merged with `#2707` but **without** `#2714`, the pair deadlocks the library deterministically:

| combination | AnomaliesTest ×2 |
|---|---|
| #2709 | pass · pass |
| **#2707 + #2709** | **fail · fail** |
| #2709 + #2714 | pass · pass |
| #2707 + #2709 + #2714 | pass · pass |
| all four (this PR) | pass · pass |

Sampling the hung process showed 72 threads blocked on a mutex, every one parked in `ReplayBufferBase.subscribe` — the replay-under-lock that `#2714` removes. Landing them atomically makes that ordering hazard unreachable.

### The regression tests

Three new tests in `Anomalies.swift`, one per inversion. Each holds an unrelated lock on one thread and drives the operator into its locked callout on another. They use `lock(before:)` so a regression fails the assertion instead of hanging the suite.

| test | issue | on `main` | with the fix |
|---|---|---|---|
| `test2713ReplaySubjectDoesntReplayWhileHoldingItsLock` | #2713 | fails, ~22s | passes, 0.002s |
| `test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock` | #2698 | fails, ~22s | passes, 0.002s |
| `test2703ZipDoesntDisposeItsSourcesUnderItsLock` | #2703 | fails, ~22s | passes, 0.003s |

The test for the Merge inversion (#2711) ships with #2724.

`#2709` has no test of its own — it has no observable behaviour to assert beyond the combination above, which the existing `#2653` regressions already cover once the other fixes are in place.

### Cleanups

- `lock.withLock` → `performLocked` in `Multicast.swift`, matching every other lock site in the codebase.
- Review cleanups: `RefCountSinkRunResult` made `private`, house switch-case style, and Zip's gate handler renamed to `gated_on` (it runs under the `AsyncLock` gate, not the lock, so the `synchronized_on` convention name didn't fit).

### Verification

- On this branch: `AnomaliesTest` (including the `#2653` family, which exercises exactly the RefCount + ReplaySubject combination from the matrix above) plus the full `ObservableMulticastTest`, `ObservableZipTest`, and `ReplaySubjectTest` classes — 141/141.
- With #2724 applied on top, the combined tree additionally passed the full `AllTests-macOS` suite twice, a ThreadSanitizer pass over the concurrency-heavy classes (233/233, zero data races), and 100 stress iterations of every regression test (400/400).
