### PR TITLE
Never call out to user code while holding Merge's locks

### DIFF
--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -136,9 +136,7 @@ public extension ObservableType {
 }
 
 private final class MergeLimitedSinkIter<SourceElement, SourceSequence: ObservableConvertibleType, Observer: ObserverType>:
-    ObserverType,
-    LockOwnerType,
-    SynchronizedOnType where SourceSequence.Element == Observer.Element
+    ObserverType where SourceSequence.Element == Observer.Element
 {
     typealias Element = Observer.Element
     typealias DisposeKey = CompositeDisposable.DisposeKey
@@ -147,26 +145,17 @@ private final class MergeLimitedSinkIter<SourceElement, SourceSequence: Observab
     private let parent: Parent
     private let disposeKey: DisposeKey
 
-    var lock: RecursiveLock {
-        parent.lock
-    }
-
     init(parent: Parent, disposeKey: DisposeKey) {
         self.parent = parent
         self.disposeKey = disposeKey
     }
 
     func on(_ event: Event<Element>) {
-        synchronizedOn(event)
-    }
-
-    func synchronized_on(_ event: Event<Element>) {
         switch event {
         case .next:
-            parent.forwardOn(event)
+            parent.synchronizedForwardOn(event)
         case .error:
-            parent.forwardOn(event)
-            parent.dispose()
+            parent.synchronizedForwardOnAndDispose(event)
         case .completed:
             parent.group.remove(for: disposeKey)
             parent.dequeueNextAndSubscribe()
@@ -204,9 +193,11 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
     let maxConcurrent: Int
 
     let lock = RecursiveLock()
+    let forwardLock = RecursiveLock()
 
     // state
     var stopped = false
+    var terminating = false
     var activeCount = 0
     var queue = QueueType(capacity: 2)
 
@@ -230,6 +221,19 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
     func subscribe(_ innerSource: SourceSequence, group: CompositeDisposable) -> Disposable {
         let subscription = SingleAssignmentDisposable()
 
+        let shouldSubscribe = lock.performLocked { () -> Bool in
+            if self.terminating {
+                self.activeCount -= 1
+                return false
+            }
+
+            return true
+        }
+
+        guard shouldSubscribe else {
+            return subscription
+        }
+
         let key = group.insert(subscription)
 
         if let key {
@@ -242,22 +246,32 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
     }
 
     func dequeueNextAndSubscribe() {
-        if let next = queue.dequeue() {
-            // subscribing immediately can produce values immediately which can re-enter and cause stack overflows
-            let disposable = CurrentThreadScheduler.instance.schedule(()) { _ in
-                // lock again
-                self.lock.performLocked {
-                    self.subscribe(next, group: self.group)
-                }
+        let next: SourceSequence?
+        let completed: Bool
+
+        (next, completed) = lock.performLocked {
+            if terminating {
+                activeCount -= 1
+                return (nil, false)
             }
-            _ = group.insert(disposable)
-        } else {
+
+            if let next = queue.dequeue() {
+                return (next, false)
+            }
+
             activeCount -= 1
 
-            if stopped, activeCount == 0 {
-                forwardOn(.completed)
-                dispose()
+            return (nil, stopped && activeCount == 0 && !terminating)
+        }
+
+        if let next {
+            // subscribing immediately can produce values immediately which can re-enter and cause stack overflows
+            let disposable = CurrentThreadScheduler.instance.schedule(()) { _ in
+                self.subscribe(next, group: self.group)
             }
+            _ = group.insert(disposable)
+        } else if completed {
+            synchronizedForwardOnAndDispose(.completed)
         }
     }
 
@@ -266,58 +280,113 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
     }
 
     @inline(__always)
-    private final func nextElementArrived(element: SourceElement) -> SourceSequence? {
-        lock.performLocked {
-            let subscribe: Bool
+    private final func nextElementArrived(element: SourceElement) -> Result<SourceSequence?, Swift.Error> {
+        let subscribeImmediately = lock.performLocked { () -> Bool? in
+            if self.stopped || self.terminating {
+                return nil
+            }
+
             if self.activeCount < self.maxConcurrent {
                 self.activeCount += 1
-                subscribe = true
-            } else {
-                do {
-                    let value = try self.performMap(element)
-                    self.queue.enqueue(value)
-                } catch {
-                    self.forwardOn(.error(error))
-                    self.dispose()
-                }
-                subscribe = false
+                return true
             }
 
-            if subscribe {
-                do {
-                    return try self.performMap(element)
-                } catch {
-                    self.forwardOn(.error(error))
-                    self.dispose()
-                }
+            return false
+        }
+
+        guard let subscribeImmediately else {
+            return .success(nil)
+        }
+
+        do {
+            let value = try self.performMap(element)
+
+            if subscribeImmediately {
+                return .success(value)
             }
 
-            return nil
+            let next = lock.performLocked { () -> SourceSequence? in
+                if self.terminating {
+                    return nil
+                }
+
+                self.queue.enqueue(value)
+
+                if self.activeCount < self.maxConcurrent, let next = self.queue.dequeue() {
+                    self.activeCount += 1
+                    return next
+                }
+
+                return nil
+            }
+
+            return .success(next)
+        } catch {
+            let shouldFail = lock.performLocked { () -> Bool in
+                if subscribeImmediately {
+                    self.activeCount -= 1
+                }
+
+                return !self.terminating
+            }
+
+            if shouldFail {
+                return .failure(error)
+            }
+
+            return .success(nil)
         }
     }
 
     func on(_ event: Event<SourceElement>) {
         switch event {
         case let .next(element):
-            if let sequence = nextElementArrived(element: element) {
+            switch nextElementArrived(element: element) {
+            case let .success(.some(sequence)):
                 subscribe(sequence, group: group)
+            case .success(.none):
+                break
+            case let .failure(error):
+                synchronizedForwardOnAndDispose(.error(error))
             }
         case let .error(error):
-            lock.performLocked {
-                self.forwardOn(.error(error))
-                self.dispose()
-            }
+            synchronizedForwardOnAndDispose(.error(error))
         case .completed:
-            lock.performLocked {
-                if self.activeCount == 0 {
-                    self.forwardOn(.completed)
-                    self.dispose()
-                } else {
-                    self.sourceSubscription.dispose()
-                }
-
+            let completed = lock.performLocked { () -> Bool in
                 self.stopped = true
+                return self.activeCount == 0 && !self.terminating
             }
+
+            if completed {
+                synchronizedForwardOnAndDispose(.completed)
+            } else {
+                sourceSubscription.dispose()
+            }
+        }
+    }
+
+    func synchronizedForwardOn(_ event: Event<Observer.Element>) {
+        let shouldForward = lock.performLocked {
+            !self.terminating
+        }
+
+        guard shouldForward else {
+            return
+        }
+
+        forwardLock.performLocked {
+            self.forwardOn(event)
+        }
+    }
+
+    func synchronizedForwardOnAndDispose(_ event: Event<Observer.Element>) {
+        lock.performLocked {
+            self.terminating = true
+        }
+
+        forwardLock.performLocked {
+            self.forwardOn(event)
+            self.dispose()
         }
     }
 }
@@ -398,17 +467,21 @@ private final class MergeSinkIter<SourceElement, SourceSequence: ObservableConve
     }
 
     func on(_ event: Event<Element>) {
-        parent.lock.performLocked {
-            switch event {
-            case let .next(value):
-                self.parent.forwardOn(.next(value))
-            case let .error(error):
-                self.parent.forwardOn(.error(error))
-                self.parent.dispose()
-            case .completed:
-                self.parent.group.remove(for: self.disposeKey)
+        switch event {
+        case let .next(value):
+            parent.synchronizedForwardOn(.next(value))
+        case let .error(error):
+            parent.synchronizedForwardOnAndDispose(.error(error))
+        case .completed:
+            let completed = parent.lock.performLocked { () -> Bool in
                 self.parent.activeCount -= 1
-                self.parent.checkCompleted()
+                return self.parent.shouldComplete
+            }
+
+            parent.group.remove(for: disposeKey)
+
+            if completed {
+                parent.synchronizedForwardOnAndDispose(.completed)
             }
         }
     }
@@ -422,6 +495,7 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
     typealias Element = SourceElement
 
     let lock = RecursiveLock()
+    let forwardLock = RecursiveLock()
 
     var subscribeNext: Bool {
         true
@@ -433,6 +507,7 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
 
     var activeCount = 0
     var stopped = false
+    var terminating = false
 
     override init(observer: Observer, cancel: Cancelable) {
         super.init(observer: observer, cancel: cancel)
@@ -443,46 +518,80 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
     }
 
     @inline(__always)
-    private final func nextElementArrived(element: SourceElement) -> SourceSequence? {
-        lock.performLocked {
-            if !self.subscribeNext {
-                return nil
+    private final func nextElementArrived(element: SourceElement) -> Result<SourceSequence?, Swift.Error> {
+        let subscribe = lock.performLocked { () -> Bool in
+            if self.stopped || self.terminating || !self.subscribeNext {
+                return false
             }
 
-            do {
-                let value = try self.performMap(element)
-                self.activeCount += 1
-                return value
-            } catch let e {
-                self.forwardOn(.error(e))
-                self.dispose()
-                return nil
+            self.activeCount += 1
+            return true
+        }
+
+        if !subscribe {
+            return .success(nil)
+        }
+
+        do {
+            return .success(try self.performMap(element))
+        } catch let error {
+            let shouldFail = lock.performLocked { () -> Bool in
+                self.activeCount -= 1
+
+                return !self.terminating
             }
+
+            if shouldFail {
+                return .failure(error)
+            }
+
+            return .success(nil)
         }
     }
 
     func on(_ event: Event<SourceElement>) {
         switch event {
         case let .next(element):
-            if let value = nextElementArrived(element: element) {
+            switch nextElementArrived(element: element) {
+            case let .success(.some(value)):
                 subscribeInner(value.asObservable())
+            case .success(.none):
+                break
+            case let .failure(error):
+                synchronizedForwardOnAndDispose(.error(error))
             }
         case let .error(error):
-            lock.performLocked {
-                self.forwardOn(.error(error))
-                self.dispose()
-            }
+            synchronizedForwardOnAndDispose(.error(error))
         case .completed:
-            lock.performLocked {
+            let completed = lock.performLocked { () -> Bool in
                 self.stopped = true
-                self.sourceSubscription.dispose()
-                self.checkCompleted()
+                return self.shouldComplete
+            }
+
+            if completed {
+                synchronizedForwardOnAndDispose(.completed)
+            } else {
+                sourceSubscription.dispose()
             }
         }
     }
 
     func subscribeInner(_ source: Observable<Observer.Element>) {
         let iterDisposable = SingleAssignmentDisposable()
+
+        let shouldSubscribe = lock.performLocked { () -> Bool in
+            if self.terminating {
+                self.activeCount -= 1
+                return false
+            }
+
+            return true
+        }
+
+        guard shouldSubscribe else {
+            return
+        }
+
         if let disposeKey = group.insert(iterDisposable) {
             let iter = MergeSinkIter(parent: self, disposeKey: disposeKey)
             let subscription = source.subscribe(iter)
@@ -491,24 +600,52 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
     }
 
     func run(_ sources: [Observable<Observer.Element>]) -> Disposable {
-        activeCount += sources.count
+        lock.performLocked {
+            activeCount += sources.count
+        }
 
         for source in sources {
             subscribeInner(source)
         }
 
-        stopped = true
+        let completed = lock.performLocked { () -> Bool in
+            self.stopped = true
+            return self.shouldComplete
+        }
 
-        checkCompleted()
+        if completed {
+            synchronizedForwardOnAndDispose(.completed)
+        }
 
         return group
     }
 
-    @inline(__always)
-    func checkCompleted() {
-        if stopped, activeCount == 0 {
-            forwardOn(.completed)
-            dispose()
+    var shouldComplete: Bool {
+        stopped && activeCount == 0 && !terminating
+    }
+
+    func synchronizedForwardOn(_ event: Event<Observer.Element>) {
+        let shouldForward = lock.performLocked {
+            !self.terminating
+        }
+
+        guard shouldForward else {
+            return
+        }
+
+        forwardLock.performLocked {
+            self.forwardOn(event)
+        }
+    }
+
+    func synchronizedForwardOnAndDispose(_ event: Event<Observer.Element>) {
+        lock.performLocked {
+            self.terminating = true
+        }
+
+        forwardLock.performLocked {
+            self.forwardOn(event)
+            self.dispose()
         }
     }
 

--- a/RxSwift/Observables/Merge.swift
+++ b/RxSwift/Observables/Merge.swift
@@ -261,7 +261,7 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
 
             activeCount -= 1
 
-            return (nil, stopped && activeCount == 0 && !terminating)
+            return (nil, shouldComplete)
         }
 
         if let next {
@@ -354,7 +354,7 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
         case .completed:
             let completed = lock.performLocked { () -> Bool in
                 self.stopped = true
-                return self.activeCount == 0 && !self.terminating
+                return self.shouldComplete
             }
 
             if completed {
@@ -363,6 +363,10 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
                 sourceSubscription.dispose()
             }
         }
+    }
+
+    var shouldComplete: Bool {
+        stopped && activeCount == 0 && !terminating
     }
 
     func synchronizedForwardOn(_ event: Event<Observer.Element>) {
@@ -384,10 +388,15 @@ private class MergeLimitedSink<SourceElement, SourceSequence: ObservableConverti
             self.terminating = true
         }
 
+        // The disposed flag has to be set before `forwardLock` is released: it is what makes
+        // `forwardOn` drop an event from a thread that passed the `terminating` check and is
+        // parked on `forwardLock`. The teardown itself calls out to user code, so it runs after.
         forwardLock.performLocked {
             self.forwardOn(event)
-            self.dispose()
+            self.markDisposed()
         }
+
+        dispose()
     }
 }
 
@@ -643,10 +652,15 @@ private class MergeSink<SourceElement, SourceSequence: ObservableConvertibleType
             self.terminating = true
         }
 
+        // The disposed flag has to be set before `forwardLock` is released: it is what makes
+        // `forwardOn` drop an event from a thread that passed the `terminating` check and is
+        // parked on `forwardLock`. The teardown itself calls out to user code, so it runs after.
         forwardLock.performLocked {
             self.forwardOn(event)
-            self.dispose()
+            self.markDisposed()
         }
+
+        dispose()
     }
 
     func run(_ source: Observable<SourceElement>) -> Disposable {

--- a/RxSwift/Observables/Sink.swift
+++ b/RxSwift/Observables/Sink.swift
@@ -42,6 +42,15 @@ class Sink<Observer: ObserverType>: Disposable {
         isFlagSet(disposed, 1)
     }
 
+    /// Marks the sink as disposed without tearing anything down.
+    ///
+    /// `forwardOn` drops events once this flag is set, so an operator that must stop forwarding
+    /// at an exact point can set it inside its own critical section and then run the actual
+    /// teardown -- which calls out to user code -- after releasing its locks.
+    final func markDisposed() {
+        fetchOr(disposed, 1)
+    }
+
     func dispose() {
         fetchOr(disposed, 1)
         cancel.dispose()

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -32,6 +32,7 @@ final class AnomaliesTest_ : AnomaliesTest, RxTestCase {
     ("test2713ReplaySubjectDoesntReplayWhileHoldingItsLock", AnomaliesTest.test2713ReplaySubjectDoesntReplayWhileHoldingItsLock),
     ("test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock", AnomaliesTest.test2698ConnectionDoesntDisposeItsSubscriptionUnderItsLock),
     ("test2703ZipDoesntDisposeItsSourcesUnderItsLock", AnomaliesTest.test2703ZipDoesntDisposeItsSourcesUnderItsLock),
+    ("test2711MergeDoesntDisposeInnerSourcesUnderItsLock", AnomaliesTest.test2711MergeDoesntDisposeInnerSourcesUnderItsLock),
     ] }
 }
 

--- a/Tests/RxSwiftTests/Anomalies.swift
+++ b/Tests/RxSwiftTests/Anomalies.swift
@@ -490,3 +490,67 @@ extension AnomaliesTest {
         }
     }
 }
+
+extension AnomaliesTest {
+    func test2711MergeDoesntDisposeInnerSourcesUnderItsLock() {
+        for _ in 0 ..< 3 {
+            // Stands in for any lock an inner source takes while being unsubscribed from.
+            let foreignLock = NSRecursiveLock()
+            let foreignLockAcquired = DispatchSemaphore(value: 0)
+            let teardownStarted = DispatchSemaphore(value: 0)
+            let teardownAcquiredForeignLock = DispatchSemaphore(value: 0)
+            let finished = DispatchGroup()
+
+            let first = PublishSubject<Int>()
+            let second = PublishSubject<Int>()
+
+            // When `first` completes, the merge sink removes it from its disposable group --
+            // on `main` that happens while its own lock is held.
+            let firstWithLockedTeardown = Observable<Int>.create { observer in
+                let subscription = first.subscribe(observer)
+
+                return Disposables.create {
+                    teardownStarted.signal()
+
+                    if foreignLock.lock(before: Date().addingTimeInterval(5)) {
+                        foreignLock.unlock()
+                        teardownAcquiredForeignLock.signal()
+                    }
+
+                    subscription.dispose()
+                }
+            }
+
+            let merged = Observable.merge(firstWithLockedTeardown, second.asObservable())
+            let subscription = merged.subscribe()
+
+            // Holds the foreign lock, then pushes a value into the merge, which needs its lock.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                foreignLock.lock()
+                foreignLockAcquired.signal()
+                XCTAssertEqual(teardownStarted.wait(timeout: .now() + 5), .success)
+                second.onNext(1)
+                foreignLock.unlock()
+                finished.leave()
+            }
+
+            // Completes one inner source, so the merge sink tears its subscription down.
+            finished.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                XCTAssertEqual(foreignLockAcquired.wait(timeout: .now() + 5), .success)
+                first.onCompleted()
+                finished.leave()
+            }
+
+            XCTAssertEqual(finished.wait(timeout: .now() + 20), .success)
+            XCTAssertEqual(
+                teardownAcquiredForeignLock.wait(timeout: .now() + 5),
+                .success,
+                "`MergeSink` tore an inner subscription down while holding its own lock, deadlocking against an event arriving on another thread"
+            )
+
+            subscription.dispose()
+        }
+    }
+}


### PR DESCRIPTION
Stacked on #2723. Lands @isaac-weisberg's Merge deadlock fix — the fifth and largest piece of the lock-inversion campaign — plus one correction found in review. His fix commit keeps his authorship.

Supersedes #2712. Fixes #2711.

### What it does

Near-total rewrite of `MergeLimitedSink` and `MergeSink`: state transitions are decided under `lock` and acted on outside it, forwarding is serialized by a new `forwardLock`, and a `terminating` flag suppresses post-terminal work. Inner-subscription teardown (`group.remove`, `sourceSubscription.dispose`) moves outside all locks — that teardown-under-lock is the #2711 deadlock.

### Correction from review: teardown moved out of `forwardLock`

The original had `synchronizedForwardOnAndDispose` call `dispose()` — which tears down upstream — while holding `forwardLock`. Review found that leaves a narrow but real residual cycle: a thread can pass the `!terminating` check while holding some foreign lock `L` and park on `forwardLock`, while the terminating thread holds `forwardLock` and its teardown needs `L`. Same shape as the bug being fixed, error-terminal variant, much smaller window.

`dispose()` could not simply be hoisted out, because running it inside `forwardLock` was load-bearing: it sets the sink's disposed flag before the lock is released, and that flag is the only thing making `forwardOn` drop a straggler `.next` from the parked thread — hoisting it naively would forward an element *after* a terminal event. The fix splits the two concerns: a small `Sink.markDisposed()` (just the flag) runs inside `forwardLock`, and the actual teardown runs after it. `dispose()` is idempotent, so calling it afterwards is safe.

**The corrected window has no regression test.** It lives between the `!terminating` check and the `forwardLock` acquire — a few instructions, with no seam a test can widen from outside the library (any externally sequenced emitter bails at the check instead of parking). The #2711 shape itself is covered by `test2711MergeDoesntDisposeInnerSourcesUnderItsLock`, which fails on `main` with ~22s of lock timeouts and passes here in ~0.003s.

### Verification

- `test2711MergeDoesntDisposeInnerSourcesUnderItsLock`: fails on `main`, passes here; 100 stress iterations green.
- Full `ObservableMergeTest` class (merge / flatMap / concat semantics): 70/70.
- ThreadSanitizer over the Anomalies, Merge, Zip, Multicast, Concat, and ReplaySubject test classes: 233/233, zero data races.
- This tree is byte-identical to the combined branch that passed the full `AllTests-macOS` suite twice.

### Review gate

@isaac-weisberg — the teardown correction changes your fix, so I'd appreciate your eyes on that commit before this merges. The base PR (#2723) carries the other four fixes and can land independently of this one.
