### PR TITLE
Select Xcode 26.6 for CI on the macOS 26 runner image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.2.app
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
       - name: Run Tests
         run: CI=1 ./scripts/all-tests.sh "${{ matrix.environment }}"
 


### PR DESCRIPTION
Fixes the `Xcode 26 (Unix)` job, red on every branch since GitHub rolled the `macos-latest` alias from **macos-15-arm64** to **macos-26-arm64** (between June 3 and July 22 — no repo change involved; the same SHA is green on the old image and red on the new one).

Xcode 26.2 still exists on the new image, but its macOS-host xctest runner crashes at session bootstrap on a macOS 26 host (`Early unexpected exit, operation never finished bootstrapping`). That is why only the Unix leg went red: it is the only leg running native macOS test bundles — the simulator and build-only legs are unaffected.

Xcode 26.6 is the new image's default toolchain and runs the full suite green on a macOS 26 host locally.

This PR's own CI run is the validation: `pull_request` runs use the workflow from the head branch, so the `Xcode 26 (Unix)` check below exercises the fix directly.