### PR TITLE
Avoid primitive sequence cancellation deadlock

### DIFF
--- a/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
+++ b/RxSwift/Traits/PrimitiveSequence/PrimitiveSequence+Concurrency.swift
@@ -61,30 +61,20 @@ public extension PrimitiveSequenceType where Trait == SingleTrait {
             return try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
-                        var didResume = false
-                        let lock = RecursiveLock()
+                        let didResume = AtomicInt(0)
                         disposable.setDisposable(
                             self.subscribe(
                                 onSuccess: { value in
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(returning: value)
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(returning: value)
                                 },
                                 onFailure: { error in
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(throwing: error)
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(throwing: error)
                                 },
                                 onDisposed: {
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(throwing: CancellationError())
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(throwing: CancellationError())
                                 }
                             )
                         )
@@ -121,37 +111,24 @@ public extension PrimitiveSequenceType where Trait == MaybeTrait {
             return try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
-                        var didResume = false
-                        let lock = RecursiveLock()
+                        let didResume = AtomicInt(0)
                         disposable.setDisposable(
                             self.subscribe(
                                 onSuccess: { value in
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(returning: value)
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(returning: value)
                                 },
                                 onError: { error in
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(throwing: error)
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(throwing: error)
                                 },
                                 onCompleted: {
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(returning: nil)
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(returning: nil)
                                 },
                                 onDisposed: {
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(throwing: CancellationError())
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(throwing: CancellationError())
                                 }
                             )
                         )
@@ -187,30 +164,20 @@ public extension PrimitiveSequenceType where Trait == CompletableTrait, Element 
             return try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
-                        var didResume = false
-                        let lock = RecursiveLock()
+                        let didResume = AtomicInt(0)
                         disposable.setDisposable(
                             self.subscribe(
                                 onCompleted: {
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume()
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume()
                                 },
                                 onError: { error in
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(throwing: error)
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(throwing: error)
                                 },
                                 onDisposed: {
-                                    lock.withLock {
-                                        guard !didResume else { return }
-                                        didResume = true
-                                        continuation.resume(throwing: CancellationError())
-                                    }
+                                    guard fetchOr(didResume, 1) == 0 else { return }
+                                    continuation.resume(throwing: CancellationError())
                                 }
                             )
                         )

--- a/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
+++ b/Tests/RxSwiftTests/PrimitiveSequence+ConcurrencyTests.swift
@@ -88,13 +88,14 @@ extension PrimitiveSequenceConcurrencyTests {
         )
     }
 
-    /// A previous implementation of the `Single` to swift concurrency bridge had a bug where it would sometimes call the continuation twice.
+    /// A previous implementation of the `Single` to swift concurrency bridge could call the continuation twice or deadlock when completion raced cancellation.
     /// The current number of iterations is a sweet spot to not make the tests too slow while still catching the bug in most runs.
     /// If you are debugging this issue you might want to increase the iterations and/or run this test repeatedly.
-    func testSingleContinuationIsNotResumedTwice() {
+    func testSingleCancellationRaceCompletesExactlyOnce() {
         let expectation = XCTestExpectation()
         let iterations = 10000
-        for i in 0 ..< iterations {
+        expectation.expectedFulfillmentCount = iterations
+        for _ in 0 ..< iterations {
             DispatchQueue.global(qos: .userInitiated).async {
                 let single = Single<Int>.create { observer in
                     DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.005) {
@@ -104,6 +105,7 @@ extension PrimitiveSequenceConcurrencyTests {
                 }
 
                 let task = Task {
+                    defer { expectation.fulfill() }
                     _ = try await single.value
                 }
 
@@ -111,11 +113,6 @@ extension PrimitiveSequenceConcurrencyTests {
                     task.cancel()
                 }
 
-                self.sleep(Double.random(in: 0.004 ... 0.006))
-
-                if i == iterations - 1 {
-                    expectation.fulfill()
-                }
             }
         }
 
@@ -204,13 +201,14 @@ extension PrimitiveSequenceConcurrencyTests {
         task.cancel()
     }
 
-    /// A previous implementation of the `Single` to swift concurrency bridge had a bug where it would sometimes call the continuation twice.
+    /// A previous implementation of the `Maybe` to swift concurrency bridge could call the continuation twice or deadlock when completion raced cancellation.
     /// The current number of iterations is a sweet spot to not make the tests too slow while still catching the bug in most runs.
     /// If you are debugging this issue you might want to increase the iterations and/or run this test repeatedly.
-    func testMaybeContinuationIsNotResumedTwice() {
+    func testMaybeCancellationRaceCompletesExactlyOnce() {
         let expectation = XCTestExpectation()
         let iterations = 10000
-        for i in 0 ..< iterations {
+        expectation.expectedFulfillmentCount = iterations
+        for _ in 0 ..< iterations {
             DispatchQueue.global(qos: .userInitiated).async {
                 let maybe = Maybe<Bool>.create { observer in
                     DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.005) {
@@ -220,6 +218,7 @@ extension PrimitiveSequenceConcurrencyTests {
                 }
 
                 let task = Task {
+                    defer { expectation.fulfill() }
                     _ = try await maybe.value
                 }
 
@@ -227,11 +226,6 @@ extension PrimitiveSequenceConcurrencyTests {
                     task.cancel()
                 }
 
-                self.sleep(Double.random(in: 0.004 ... 0.006))
-
-                if i == iterations - 1 {
-                    expectation.fulfill()
-                }
             }
         }
 
@@ -292,13 +286,14 @@ extension PrimitiveSequenceConcurrencyTests {
         }.cancel()
     }
 
-    /// A previous implementation of the `Single` to swift concurrency bridge had a bug where it would sometimes call the continuation twice.
+    /// A previous implementation of the `Completable` to swift concurrency bridge could call the continuation twice or deadlock when completion raced cancellation.
     /// The current number of iterations is a sweet spot to not make the tests too slow while still catching the bug in most runs.
     /// If you are debugging this issue you might want to increase the iterations and/or run this test repeatedly.
-    func testCompletableContinuationIsNotResumedTwice() {
+    func testCompletableCancellationRaceCompletesExactlyOnce() {
         let expectation = XCTestExpectation()
         let iterations = 10000
-        for i in 0 ..< iterations {
+        expectation.expectedFulfillmentCount = iterations
+        for _ in 0 ..< iterations {
             DispatchQueue.global(qos: .userInitiated).async {
                 let completable = Completable.create { observer in
                     DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 0.005) {
@@ -308,6 +303,7 @@ extension PrimitiveSequenceConcurrencyTests {
                 }
 
                 let task = Task {
+                    defer { expectation.fulfill() }
                     _ = try await completable.value
                 }
 
@@ -315,11 +311,6 @@ extension PrimitiveSequenceConcurrencyTests {
                     task.cancel()
                 }
 
-                self.sleep(Double.random(in: 0.004 ... 0.006))
-
-                if i == iterations - 1 {
-                    expectation.fulfill()
-                }
             }
         }
 


### PR DESCRIPTION
`Single.value`, `Maybe.value`, and `Completable.value` currently resume their continuations while holding the bridge lock. If completion races task cancellation, that can invert the bridge and Swift task locks and deadlock.

This is showing up frequently as an app hang in Goodnotes production.

This uses RxSwift's existing `AtomicInt` latch to select one callback, then resumes after the latch has released its lock. The race tests now wait for all 10,000 bridged tasks, so a stuck task cannot pass unnoticed. They are also faster: 1.87 seconds combined instead of 4.07 seconds, averaged across five isolated runs on my machine.

On RxSwift 6.10.2, the updated tests timed out in 5 of 30 race runs on an iOS 26 simulator. With this change, the full test class passed 180 of 180 runs.

This follows up on [#2641](https://github.com/ReactiveX/RxSwift/pull/2641), which added the bridge lock to prevent continuations from being resumed more than once.
