### PR TITLE
Fix default error handling for subscribe(with:)

### DIFF
--- a/RxSwift/ObservableType+Extensions.swift
+++ b/RxSwift/ObservableType+Extensions.swift
@@ -51,9 +51,11 @@ public extension ObservableType {
                 guard let object else { return }
                 onNext?(object, $0)
             },
-            onError: { [weak object] in
-                guard let object else { return }
-                onError?(object, $0)
+            onError: onError.map { onError in
+                { [weak object] in
+                    guard let object else { return }
+                    onError(object, $0)
+                }
             },
             onCompleted: { [weak object] in
                 guard let object else { return }

--- a/RxSwift/Traits/PrimitiveSequence/Completable.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Completable.swift
@@ -95,9 +95,11 @@ public extension PrimitiveSequenceType where Trait == CompletableTrait, Element 
             onCompleted: { [weak object] in
                 guard let object else { return }
                 onCompleted?(object)
-            }, onError: { [weak object] in
-                guard let object else { return }
-                onError?(object, $0)
+            }, onError: onError.map { onError in
+                { [weak object] in
+                    guard let object else { return }
+                    onError(object, $0)
+                }
             }, onDisposed: { [weak object] in
                 guard let object else { return }
                 onDisposed?(object)

--- a/RxSwift/Traits/PrimitiveSequence/Maybe.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Maybe.swift
@@ -104,9 +104,11 @@ public extension PrimitiveSequenceType where Trait == MaybeTrait {
                 guard let object else { return }
                 onSuccess?(object, $0)
             },
-            onError: { [weak object] in
-                guard let object else { return }
-                onError?(object, $0)
+            onError: onError.map { onError in
+                { [weak object] in
+                    guard let object else { return }
+                    onError(object, $0)
+                }
             },
             onCompleted: { [weak object] in
                 guard let object else { return }

--- a/RxSwift/Traits/PrimitiveSequence/Single.swift
+++ b/RxSwift/Traits/PrimitiveSequence/Single.swift
@@ -108,9 +108,11 @@ public extension PrimitiveSequenceType where Trait == SingleTrait {
                 guard let object else { return }
                 onSuccess?(object, $0)
             },
-            onFailure: { [weak object] in
-                guard let object else { return }
-                onFailure?(object, $0)
+            onFailure: onFailure.map { onFailure in
+                { [weak object] in
+                    guard let object else { return }
+                    onFailure(object, $0)
+                }
             },
             onDisposed: { [weak object] in
                 guard let object else { return }

--- a/Sources/AllTestz/main.swift
+++ b/Sources/AllTestz/main.swift
@@ -179,6 +179,7 @@ final class CompletableTest_ : CompletableTest, RxTestCase {
     ("test_zip_array", CompletableTest.test_zip_array),
     ("test_zip_variadic", CompletableTest.test_zip_variadic),
     ("testDefaultErrorHandler", CompletableTest.testDefaultErrorHandler),
+    ("testDefaultErrorHandlerWithObject", CompletableTest.testDefaultErrorHandlerWithObject),
     ] }
 }
 
@@ -436,6 +437,7 @@ final class MaybeTest_ : MaybeTest, RxTestCase {
     ("test_zip_tuple", MaybeTest.test_zip_tuple),
     ("test_zip_resultSelector", MaybeTest.test_zip_resultSelector),
     ("testDefaultErrorHandler", MaybeTest.testDefaultErrorHandler),
+    ("testDefaultErrorHandlerWithObject", MaybeTest.testDefaultErrorHandlerWithObject),
     ("testZip2_selector", MaybeTest.testZip2_selector),
     ("testZip2_tuple", MaybeTest.testZip2_tuple),
     ("testZip3_selector", MaybeTest.testZip3_selector),
@@ -1496,6 +1498,7 @@ final class ObservableSubscriptionTest_ : ObservableSubscriptionTest, RxTestCase
 
     static var allTests: [(String, (ObservableSubscriptionTest_) -> () -> Void)] { return [
     ("testDefaultErrorHandler", ObservableSubscriptionTest.testDefaultErrorHandler),
+    ("testDefaultErrorHandlerWithObject", ObservableSubscriptionTest.testDefaultErrorHandlerWithObject),
     ("testCustomCaptureSubscriptionCallstack", ObservableSubscriptionTest.testCustomCaptureSubscriptionCallstack),
     ] }
 }
@@ -2175,6 +2178,7 @@ final class SingleTest_ : SingleTest, RxTestCase {
     ("testZipCollection_tuple", SingleTest.testZipCollection_tuple),
     ("testZipCollection_tuple_when_empty", SingleTest.testZipCollection_tuple_when_empty),
     ("testDefaultErrorHandler", SingleTest.testDefaultErrorHandler),
+    ("testDefaultErrorHandlerWithObject", SingleTest.testDefaultErrorHandlerWithObject),
     ] }
 }
 

--- a/Tests/RxSwiftTests/CompletableTest.swift
+++ b/Tests/RxSwiftTests/CompletableTest.swift
@@ -601,6 +601,28 @@ extension CompletableTest {
         _ = Completable.error(testError).subscribe()
         XCTAssertEqual(loggedErrors, [testError])
     }
+
+    func testDefaultErrorHandlerWithObject() {
+        var loggedErrors = [TestError]()
+        var handledErrors = [TestError]()
+        let originalErrorHandler = Hooks.defaultErrorHandler
+        defer { Hooks.defaultErrorHandler = originalErrorHandler }
+
+        Hooks.defaultErrorHandler = { _, error in
+            loggedErrors.append(error as! TestError)
+        }
+
+        _ = Completable.error(testError).subscribe(with: self, onError: { _, error in
+            handledErrors.append(error as! TestError)
+        })
+
+        XCTAssertEqual(handledErrors, [testError])
+        XCTAssertEqual(loggedErrors, [])
+
+        _ = Completable.error(testError).subscribe(with: self)
+
+        XCTAssertEqual(loggedErrors, [testError])
+    }
 }
 
 public func == (_: Never, _: Never) -> Bool {}

--- a/Tests/RxSwiftTests/MaybeTest.swift
+++ b/Tests/RxSwiftTests/MaybeTest.swift
@@ -774,4 +774,26 @@ extension MaybeTest {
         _ = Maybe<Int>.error(testError).subscribe()
         XCTAssertEqual(loggedErrors, [testError])
     }
+
+    func testDefaultErrorHandlerWithObject() {
+        var loggedErrors = [TestError]()
+        var handledErrors = [TestError]()
+        let originalErrorHandler = Hooks.defaultErrorHandler
+        defer { Hooks.defaultErrorHandler = originalErrorHandler }
+
+        Hooks.defaultErrorHandler = { _, error in
+            loggedErrors.append(error as! TestError)
+        }
+
+        _ = Maybe<Int>.error(testError).subscribe(with: self, onError: { _, error in
+            handledErrors.append(error as! TestError)
+        })
+
+        XCTAssertEqual(handledErrors, [testError])
+        XCTAssertEqual(loggedErrors, [])
+
+        _ = Maybe<Int>.error(testError).subscribe(with: self)
+
+        XCTAssertEqual(loggedErrors, [testError])
+    }
 }

--- a/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
+++ b/Tests/RxSwiftTests/ObservableType+SubscriptionTests.swift
@@ -34,8 +34,38 @@ extension ObservableSubscriptionTest {
         XCTAssertEqual(loggedErrors, [testError])
     }
 
+    func testDefaultErrorHandlerWithObject() {
+        var loggedErrors = [TestError]()
+        var handledErrors = [TestError]()
+        let originalErrorHandler = Hooks.defaultErrorHandler
+        defer { Hooks.defaultErrorHandler = originalErrorHandler }
+
+        Hooks.defaultErrorHandler = { _, error in
+            loggedErrors.append(error as! TestError)
+        }
+
+        _ = Observable<Int>.error(testError).subscribe(with: self, onError: { _, error in
+            handledErrors.append(error as! TestError)
+        })
+
+        XCTAssertEqual(handledErrors, [testError])
+        XCTAssertEqual(loggedErrors, [])
+
+        _ = Observable<Int>.error(testError).subscribe(with: self)
+
+        XCTAssertEqual(loggedErrors, [testError])
+    }
+
     func testCustomCaptureSubscriptionCallstack() {
         var resultCallstack = [String]()
+        let originalErrorHandler = Hooks.defaultErrorHandler
+        let originalCaptureSubscriptionCallstack = Hooks.customCaptureSubscriptionCallstack
+        let originalRecordCallStackOnError = Hooks.recordCallStackOnError
+        defer {
+            Hooks.defaultErrorHandler = originalErrorHandler
+            Hooks.customCaptureSubscriptionCallstack = originalCaptureSubscriptionCallstack
+            Hooks.recordCallStackOnError = originalRecordCallStackOnError
+        }
 
         Hooks.defaultErrorHandler = { callstack, _ in
             resultCallstack = callstack

--- a/Tests/RxSwiftTests/SingleTest.swift
+++ b/Tests/RxSwiftTests/SingleTest.swift
@@ -780,4 +780,26 @@ extension SingleTest {
         _ = Single<Int>.error(testError).subscribe()
         XCTAssertEqual(loggedErrors, [testError])
     }
+
+    func testDefaultErrorHandlerWithObject() {
+        var loggedErrors = [TestError]()
+        var handledErrors = [TestError]()
+        let originalErrorHandler = Hooks.defaultErrorHandler
+        defer { Hooks.defaultErrorHandler = originalErrorHandler }
+
+        Hooks.defaultErrorHandler = { _, error in
+            loggedErrors.append(error as! TestError)
+        }
+
+        _ = Single<Int>.error(testError).subscribe(with: self, onFailure: { _, error in
+            handledErrors.append(error as! TestError)
+        })
+
+        XCTAssertEqual(handledErrors, [testError])
+        XCTAssertEqual(loggedErrors, [])
+
+        _ = Single<Int>.error(testError).subscribe(with: self)
+
+        XCTAssertEqual(loggedErrors, [testError])
+    }
 }


### PR DESCRIPTION
Closes #2730

## Summary

`subscribe(with:)` always passed a weak error-forwarding closure to its underlying subscription, even when the caller omitted `onError` or `onFailure`. That closure prevented unhandled terminal errors from reaching `Hooks.defaultErrorHandler`.

This change forwards an error closure only when the caller provides one. Without an explicit callback, the existing subscription implementation receives `nil` and invokes `Hooks.defaultErrorHandler`.

The behavior is aligned across `Observable`, `Single`, `Maybe`, and `Completable`.

## Root cause and impact

The object-based overload previously converted an optional error callback into a non-optional closure. When the callback was absent, the closure simply returned, but its presence still made the underlying subscription consider the error handled.

Explicit `onError` and `onFailure` callbacks retain their existing behavior, including their weak object capture. The only observable change is that an error without an explicit callback is now handled through the configured default hook, as with the corresponding non-object subscription overload.

The test that customizes global hook state now restores that state after it finishes.

## Validation

- Added regression coverage for all four affected types.
- Verified that explicit error callbacks receive the original error and do not invoke the default hook.
- Verified that omitted error callbacks invoke `Hooks.defaultErrorHandler`.
- Ran `ObservableSubscriptionTest`, `SingleTest`, `MaybeTest`, and `CompletableTest` with the macOS `AllTests-macOS` scheme.
- Ran `git diff --check`.